### PR TITLE
fix: require explicit local web auth bypass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,7 +206,7 @@ All FastAPI routes are protected by Clerk JWT middleware. Next.js routes are pro
 
 **Localhost bypass:** Both the auth middleware and `verify_clerk_jwt` dependency skip validation for requests from `127.0.0.1`/`::1` (server-to-server). The WS relay also skips ticket validation for localhost connections. This enables local dev without Clerk sign-in.
 
-**Graceful fallback:** When `CLERK_JWKS_URL` is not set, auth middleware passes all requests through (local dev without Clerk).
+**Local UI bypass:** Set `RADON_BYPASS_WEB_AUTH=1` in `web/.env` to skip Clerk protection on Next.js routes during local development. The bypass is ignored when `NODE_ENV=production`.
 
 **Public share routes:** `/api/regime/share`, `/api/vcg/share`, `/api/internals/share`, `/api/menthorq/cta/share` are public (no auth).
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Visit `http://localhost:3000`.
 
 ### Authentication
 
-Radon uses [Clerk](https://clerk.com) for authentication. All Next.js routes are protected by Clerk middleware (public share routes are exempt). The FastAPI backend validates Clerk JWTs on every request. WebSocket connections use a short-lived ticket flow (30s TTL, single-use) to avoid passing JWTs in URLs. When Clerk is not configured (`CLERK_JWKS_URL` unset), auth is bypassed for local development.
+Radon uses [Clerk](https://clerk.com) for authentication. All Next.js routes are protected by Clerk middleware (public share routes are exempt). The FastAPI backend validates Clerk JWTs on every request. WebSocket connections use a short-lived ticket flow (30s TTL, single-use) to avoid passing JWTs in URLs. For local-only UI development, set `RADON_BYPASS_WEB_AUTH=1` in `web/.env`; the bypass is ignored in production builds.
 
 **Key capabilities**
 

--- a/web/.env.example
+++ b/web/.env.example
@@ -22,6 +22,11 @@ EXA_API_KEY=
 # Optional: websocket URL for the Node realtime price server.
 IB_REALTIME_WS_URL=ws://localhost:8765
 
+# Optional: explicit local-only bypass for Clerk on protected UI routes.
+# Ignored in production builds. Leave unset unless you intentionally want
+# unauthenticated local development.
+# RADON_BYPASS_WEB_AUTH=1
+
 # Clerk Authentication
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
 CLERK_SECRET_KEY=

--- a/web/app/sign-in/[[...sign-in]]/page.tsx
+++ b/web/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,6 +1,12 @@
 import { SignIn } from "@clerk/nextjs";
+import { redirect } from "next/navigation";
+import { isWebAuthBypassEnabled } from "@/lib/webAuthMode";
 
 export default function SignInPage() {
+  if (isWebAuthBypassEnabled()) {
+    redirect("/");
+  }
+
   return (
     <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minHeight: "100vh" }}>
       <SignIn />

--- a/web/app/sign-up/[[...sign-up]]/page.tsx
+++ b/web/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,6 +1,12 @@
 import { SignUp } from "@clerk/nextjs";
+import { redirect } from "next/navigation";
+import { isWebAuthBypassEnabled } from "@/lib/webAuthMode";
 
 export default function SignUpPage() {
+  if (isWebAuthBypassEnabled()) {
+    redirect("/");
+  }
+
   return (
     <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minHeight: "100vh" }}>
       <SignUp />

--- a/web/e2e/local-auth-bypass.spec.ts
+++ b/web/e2e/local-auth-bypass.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "@playwright/test";
+
+test("local dev protected pages stay on localhost when web auth bypass is active", async ({ page }) => {
+  await page.goto("http://127.0.0.1:3000/kit");
+  await page.waitForLoadState("domcontentloaded");
+
+  await expect(page).toHaveURL(/\/kit$/);
+  await expect(page.locator("text=Radon Contributor Kit / Component Spec")).toBeVisible();
+});
+
+test("local sign-in route redirects back into the app when web auth bypass is active", async ({ page }) => {
+  await page.goto("http://127.0.0.1:3000/sign-in");
+  await page.waitForURL("http://127.0.0.1:3000/");
+
+  expect(page.url()).toBe("http://127.0.0.1:3000/");
+});

--- a/web/lib/webAuthMode.ts
+++ b/web/lib/webAuthMode.ts
@@ -1,0 +1,10 @@
+const TRUTHY = new Set(["1", "true", "yes", "on"]);
+const FALSY = new Set(["0", "false", "no", "off"]);
+
+export function isWebAuthBypassEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const explicit = env.RADON_BYPASS_WEB_AUTH?.trim().toLowerCase();
+  if (!explicit || FALSY.has(explicit)) return false;
+  if (!TRUTHY.has(explicit)) return false;
+
+  return env.NODE_ENV !== "production";
+}

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -1,4 +1,5 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+import { isWebAuthBypassEnabled } from "@/lib/webAuthMode";
 
 // API routes are public at the middleware level because server-side page
 // fetches don't carry Clerk session cookies. External API access is still
@@ -10,6 +11,10 @@ const isPublicRoute = createRouteMatcher([
 ]);
 
 export default clerkMiddleware(async (auth, request) => {
+  if (isWebAuthBypassEnabled()) {
+    return;
+  }
+
   if (!isPublicRoute(request)) {
     await auth.protect();
   }

--- a/web/tests/local-web-auth-bypass.test.ts
+++ b/web/tests/local-web-auth-bypass.test.ts
@@ -13,12 +13,18 @@ vi.mock("@clerk/nextjs/server", () => ({
 }));
 
 describe("web auth bypass middleware", () => {
+  type MiddlewareHandler = (
+    auth: { protect: () => Promise<void> | void },
+    request: { nextUrl: { pathname: string } },
+  ) => Promise<void> | void;
+
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
-    delete process.env.CLERK_JWKS_URL;
-    delete process.env.RADON_BYPASS_WEB_AUTH;
-    delete process.env.NODE_ENV;
+    vi.unstubAllEnvs();
+    Reflect.deleteProperty(process.env, "CLERK_JWKS_URL");
+    Reflect.deleteProperty(process.env, "RADON_BYPASS_WEB_AUTH");
+    Reflect.deleteProperty(process.env, "NODE_ENV");
 
     clerkMiddlewareMock.mockImplementation((handler: unknown) => handler);
     createRouteMatcherMock.mockImplementation((patterns: string[]) => {
@@ -30,10 +36,7 @@ describe("web auth bypass middleware", () => {
 
   it("protects local app routes by default when bypass is not explicitly enabled", async () => {
     const protect = vi.fn();
-    const middleware = (await import("@/middleware")).default as (
-      auth: { protect: () => Promise<void> },
-      request: { nextUrl: { pathname: string } },
-    ) => Promise<void>;
+    const middleware = (await import("@/middleware")).default as unknown as MiddlewareHandler;
 
     await middleware({ protect }, { nextUrl: { pathname: "/kit" } });
 
@@ -41,13 +44,10 @@ describe("web auth bypass middleware", () => {
   });
 
   it("does not protect local app routes when bypass is explicitly enabled", async () => {
-    process.env.RADON_BYPASS_WEB_AUTH = "1";
+    vi.stubEnv("RADON_BYPASS_WEB_AUTH", "1");
 
     const protect = vi.fn();
-    const middleware = (await import("@/middleware")).default as (
-      auth: { protect: () => Promise<void> },
-      request: { nextUrl: { pathname: string } },
-    ) => Promise<void>;
+    const middleware = (await import("@/middleware")).default as unknown as MiddlewareHandler;
 
     await middleware({ protect }, { nextUrl: { pathname: "/kit" } });
 
@@ -55,13 +55,10 @@ describe("web auth bypass middleware", () => {
   });
 
   it("keeps public routes unprotected when Clerk is configured", async () => {
-    process.env.CLERK_JWKS_URL = "https://clerk.example/jwks";
+    vi.stubEnv("CLERK_JWKS_URL", "https://clerk.example/jwks");
 
     const protect = vi.fn();
-    const middleware = (await import("@/middleware")).default as (
-      auth: { protect: () => Promise<void> },
-      request: { nextUrl: { pathname: string } },
-    ) => Promise<void>;
+    const middleware = (await import("@/middleware")).default as unknown as MiddlewareHandler;
 
     await middleware({ protect }, { nextUrl: { pathname: "/api/orders" } });
 
@@ -69,14 +66,11 @@ describe("web auth bypass middleware", () => {
   });
 
   it("ignores the bypass flag in production mode", async () => {
-    process.env.RADON_BYPASS_WEB_AUTH = "1";
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("RADON_BYPASS_WEB_AUTH", "1");
+    vi.stubEnv("NODE_ENV", "production");
 
     const protect = vi.fn();
-    const middleware = (await import("@/middleware")).default as (
-      auth: { protect: () => Promise<void> },
-      request: { nextUrl: { pathname: string } },
-    ) => Promise<void>;
+    const middleware = (await import("@/middleware")).default as unknown as MiddlewareHandler;
 
     await middleware({ protect }, { nextUrl: { pathname: "/kit" } });
 

--- a/web/tests/local-web-auth-bypass.test.ts
+++ b/web/tests/local-web-auth-bypass.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const clerkMiddlewareMock = vi.fn((handler: unknown) => handler);
+const createRouteMatcherMock = vi.fn((patterns: string[]) => {
+  const prefixes = patterns.map((pattern) => pattern.replace("(.*)", ""));
+  return (request: { nextUrl: { pathname: string } }) =>
+    prefixes.some((prefix) => request.nextUrl.pathname.startsWith(prefix));
+});
+
+vi.mock("@clerk/nextjs/server", () => ({
+  clerkMiddleware: clerkMiddlewareMock,
+  createRouteMatcher: createRouteMatcherMock,
+}));
+
+describe("web auth bypass middleware", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    delete process.env.CLERK_JWKS_URL;
+    delete process.env.RADON_BYPASS_WEB_AUTH;
+    delete process.env.NODE_ENV;
+
+    clerkMiddlewareMock.mockImplementation((handler: unknown) => handler);
+    createRouteMatcherMock.mockImplementation((patterns: string[]) => {
+      const prefixes = patterns.map((pattern) => pattern.replace("(.*)", ""));
+      return (request: { nextUrl: { pathname: string } }) =>
+        prefixes.some((prefix) => request.nextUrl.pathname.startsWith(prefix));
+    });
+  });
+
+  it("protects local app routes by default when bypass is not explicitly enabled", async () => {
+    const protect = vi.fn();
+    const middleware = (await import("@/middleware")).default as (
+      auth: { protect: () => Promise<void> },
+      request: { nextUrl: { pathname: string } },
+    ) => Promise<void>;
+
+    await middleware({ protect }, { nextUrl: { pathname: "/kit" } });
+
+    expect(protect).toHaveBeenCalledOnce();
+  });
+
+  it("does not protect local app routes when bypass is explicitly enabled", async () => {
+    process.env.RADON_BYPASS_WEB_AUTH = "1";
+
+    const protect = vi.fn();
+    const middleware = (await import("@/middleware")).default as (
+      auth: { protect: () => Promise<void> },
+      request: { nextUrl: { pathname: string } },
+    ) => Promise<void>;
+
+    await middleware({ protect }, { nextUrl: { pathname: "/kit" } });
+
+    expect(protect).not.toHaveBeenCalled();
+  });
+
+  it("keeps public routes unprotected when Clerk is configured", async () => {
+    process.env.CLERK_JWKS_URL = "https://clerk.example/jwks";
+
+    const protect = vi.fn();
+    const middleware = (await import("@/middleware")).default as (
+      auth: { protect: () => Promise<void> },
+      request: { nextUrl: { pathname: string } },
+    ) => Promise<void>;
+
+    await middleware({ protect }, { nextUrl: { pathname: "/api/orders" } });
+
+    expect(protect).not.toHaveBeenCalled();
+  });
+
+  it("ignores the bypass flag in production mode", async () => {
+    process.env.RADON_BYPASS_WEB_AUTH = "1";
+    process.env.NODE_ENV = "production";
+
+    const protect = vi.fn();
+    const middleware = (await import("@/middleware")).default as (
+      auth: { protect: () => Promise<void> },
+      request: { nextUrl: { pathname: string } },
+    ) => Promise<void>;
+
+    await middleware({ protect }, { nextUrl: { pathname: "/kit" } });
+
+    expect(protect).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary
- require `RADON_BYPASS_WEB_AUTH=1` for local Next.js auth bypass instead of bypassing implicitly when Clerk config is absent
- ignore the bypass in production mode and redirect `/sign-in` and `/sign-up` back to `/` when local bypass is active
- document the local-only workflow and add unit and Playwright regression coverage

## Testing
- `npx vitest run --config vitest.config.ts web/tests/local-web-auth-bypass.test.ts`
- `cd web && npx playwright test --config playwright.no-server.config.ts e2e/local-auth-bypass.spec.ts`
