### PR TITLE
fix: use shared IB status for sidebar state

### DIFF
--- a/web/components/WorkspaceShell.tsx
+++ b/web/components/WorkspaceShell.tsx
@@ -28,6 +28,7 @@ const WorkspaceSections = dynamic(() => import("@/components/WorkspaceSections")
 import ConnectionBanner from "@/components/ConnectionBanner";
 import FlexTokenBanner from "@/components/FlexTokenBanner";
 import { useTickerDetail } from "@/lib/TickerDetailContext";
+import { useIBStatus } from "@/lib/useIBStatus";
 
 type WorkspaceShellProps = {
   section?: WorkspaceSection;
@@ -168,6 +169,10 @@ export default function WorkspaceShell({ section, tickerParam }: WorkspaceShellP
     contracts: allContracts,
     indexes: regimeIndexes,
   });
+  const {
+    wsConnected: statusWsConnected,
+    ibConnected: statusIbConnected,
+  } = useIBStatus();
 
   // Debounce ibConnected: disconnections must persist >2s before surfacing to UI.
   // IB farm connectivity checks fire brief disconnected→connected sequences that
@@ -311,10 +316,11 @@ export default function WorkspaceShell({ section, tickerParam }: WorkspaceShellP
     : error
       ? `Sync error`
       : "No sync yet";
+  const sidebarIbConnected = statusWsConnected && statusIbConnected;
 
   return (
     <div className="app-shell" suppressHydrationWarning>
-      <Sidebar activeSection={activeSection} actionTone={actionTone} ibConnected={ibConnected} lastSync={lastSync} />
+      <Sidebar activeSection={activeSection} actionTone={actionTone} ibConnected={sidebarIbConnected} lastSync={lastSync} />
 
       <main className="main">
         <Header

--- a/web/e2e/ws-connection-stability.spec.ts
+++ b/web/e2e/ws-connection-stability.spec.ts
@@ -52,6 +52,14 @@ const PORTFOLIO_MOCK = {
   violations: [],
 };
 
+const PORTFOLIO_EMPTY = {
+  bankroll: 100_000,
+  positions: [],
+  account_summary: {},
+  exposure: {},
+  violations: [],
+};
+
 const ORDERS_MOCK = {
   last_sync: new Date().toISOString(),
   open_orders: [],
@@ -366,6 +374,25 @@ test.describe("WebSocket connection stability on ticker detail page", () => {
 
     // Verify it never showed OFFLINE at any point —
     // the debounced ibConnected starts truthy from mock, so there should be no flicker
+    const statusText = await statusDot.textContent();
+    expect(statusText).not.toContain("OFFLINE");
+  });
+
+  test("empty orders page still shows CONNECTED when the shared IB status socket is healthy", async ({ page }) => {
+    await page.route("**/api/portfolio", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(PORTFOLIO_EMPTY) }),
+    );
+    await page.route("**/api/orders", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(ORDERS_MOCK) }),
+    );
+
+    await page.goto("http://127.0.0.1:3000/orders");
+
+    const statusDot = page.locator(".sidebar-footer .status-dot-wrap");
+    await expect(statusDot).toBeVisible({ timeout: 10_000 });
+    await page.waitForTimeout(300);
+
+    await expect(statusDot).toContainText("CONNECTED");
     const statusText = await statusDot.textContent();
     expect(statusText).not.toContain("OFFLINE");
   });

--- a/web/e2e/ws-connection-stability.spec.ts
+++ b/web/e2e/ws-connection-stability.spec.ts
@@ -161,11 +161,11 @@ async function setupApiMocks(page: import("@playwright/test").Page) {
 async function injectMockWebSocket(page: import("@playwright/test").Page) {
   await page.addInitScript(() => {
     // Tracking counters for assertions
-    (window as Record<string, unknown>).__wsConstructorCount = 0;
-    (window as Record<string, unknown>).__wsMaxConcurrent = 0;
-    (window as Record<string, unknown>).__wsActiveCount = 0;
-    (window as Record<string, unknown>).__wsSubscribeCount = 0;
-    (window as Record<string, unknown>).__wsSubscribeInstanceIds = new Set<number>();
+    (window as unknown as Record<string, unknown>).__wsConstructorCount = 0;
+    (window as unknown as Record<string, unknown>).__wsMaxConcurrent = 0;
+    (window as unknown as Record<string, unknown>).__wsActiveCount = 0;
+    (window as unknown as Record<string, unknown>).__wsSubscribeCount = 0;
+    (window as unknown as Record<string, unknown>).__wsSubscribeInstanceIds = new Set<number>();
 
     class MockWebSocket {
       public static CONNECTING = 0;
@@ -183,7 +183,7 @@ async function injectMockWebSocket(page: import("@playwright/test").Page) {
 
       constructor(url: string) {
         this.url = url;
-        const w = window as Record<string, unknown>;
+        const w = window as unknown as Record<string, unknown>;
         w.__wsConstructorCount = (w.__wsConstructorCount as number) + 1;
         this._instanceId = w.__wsConstructorCount as number;
         w.__wsActiveCount = (w.__wsActiveCount as number) + 1;
@@ -312,7 +312,7 @@ async function injectMockWebSocket(page: import("@playwright/test").Page) {
           const msg = JSON.parse(_message);
           if (msg.action === "subscribe") {
             // Track which WS instances receive subscribe actions (usePrices pattern)
-            const w = window as Record<string, unknown>;
+            const w = window as unknown as Record<string, unknown>;
             const ids = w.__wsSubscribeInstanceIds as Set<number>;
             if (!ids.has(this._instanceId)) {
               ids.add(this._instanceId);
@@ -333,7 +333,7 @@ async function injectMockWebSocket(page: import("@playwright/test").Page) {
 
       close() {
         this.readyState = MockWebSocket.CLOSED;
-        const w = window as Record<string, unknown>;
+        const w = window as unknown as Record<string, unknown>;
         w.__wsActiveCount = Math.max(0, (w.__wsActiveCount as number) - 1);
         this.onclose?.(new Event("close"));
       }
@@ -447,14 +447,14 @@ test.describe("WebSocket connection stability on ticker detail page", () => {
     //
     // Count WS instances that received a "subscribe" action (the usePrices pattern).
     // useIBStatus sends "status" pings, TickerSearch sends "search", getSnapshot sends "snapshot".
-    const subscribeWsCount = await page.evaluate(() => (window as Record<string, unknown>).__wsSubscribeCount ?? 0);
+    const subscribeWsCount = await page.evaluate(() => (window as unknown as Record<string, unknown>).__wsSubscribeCount ?? 0);
 
     // usePrices should create exactly 1 WS that receives subscribe messages.
     // Before the fix, this would be 3+ (one per subscription change: portfolio → orders → chain).
     expect(subscribeWsCount).toBeLessThanOrEqual(1);
 
     // Verify max concurrent is bounded (usePrices + useIBStatus + possible getSnapshot/TickerSearch)
-    const maxConcurrent = await page.evaluate(() => (window as Record<string, unknown>).__wsMaxConcurrent);
+    const maxConcurrent = await page.evaluate(() => (window as unknown as Record<string, unknown>).__wsMaxConcurrent);
     expect(maxConcurrent).toBeLessThanOrEqual(4);
   });
 

--- a/web/tests/workspace-shell-sidebar-status.test.tsx
+++ b/web/tests/workspace-shell-sidebar-status.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import WorkspaceShell from "../components/WorkspaceShell";
+
+const sidebarSpy = vi.fn();
+
+vi.mock("next/dynamic", () => ({
+  default: () => () => null,
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/orders",
+}));
+
+vi.mock("../lib/usePortfolio", () => ({
+  usePortfolio: () => ({
+    data: { bankroll: 100_000, positions: [], account_summary: {}, exposure: {}, violations: [] },
+    syncing: false,
+    error: null,
+    lastSync: null,
+    syncNow: vi.fn(),
+  }),
+}));
+
+vi.mock("../lib/useOrders", () => ({
+  useOrders: () => ({
+    data: {
+      last_sync: "2026-04-05T10:36:31Z",
+      open_orders: [],
+      executed_orders: [],
+      open_count: 0,
+      executed_count: 0,
+    },
+    syncing: false,
+    error: null,
+    lastSync: "2026-04-05T10:36:31Z",
+    syncNow: vi.fn(),
+    updateData: vi.fn(),
+  }),
+}));
+
+vi.mock("../lib/useMarketHours", () => ({
+  MarketState: { CLOSED: "CLOSED" },
+  useMarketHours: () => "CLOSED",
+}));
+
+vi.mock("../lib/useToast", () => ({
+  useToast: () => ({
+    toasts: [],
+    addToast: vi.fn(),
+    removeToast: vi.fn(),
+  }),
+}));
+
+vi.mock("../lib/OrderActionsContext", () => ({
+  useOrderActions: () => ({
+    drainNotifications: () => [],
+    setOrdersUpdater: vi.fn(),
+  }),
+}));
+
+vi.mock("../lib/usePrices", () => ({
+  usePrices: () => ({
+    prices: {},
+    fundamentals: {},
+    connected: false,
+    ibConnected: false,
+    ibIssue: null,
+    ibStatusMessage: null,
+  }),
+}));
+
+vi.mock("../lib/useIBStatus", () => ({
+  useIBStatus: () => ({
+    wsConnected: true,
+    ibConnected: true,
+    disconnectedSince: null,
+    connectionState: "connected",
+  }),
+}));
+
+vi.mock("../lib/usePreviousClose", () => ({
+  usePreviousClose: (prices: unknown) => prices,
+}));
+
+vi.mock("../lib/TickerDetailContext", () => ({
+  useTickerDetail: () => ({
+    chainContracts: [],
+    setActiveTicker: vi.fn(),
+    setPrices: vi.fn(),
+    setFundamentals: vi.fn(),
+    setPortfolio: vi.fn(),
+    setOrders: vi.fn(),
+  }),
+}));
+
+vi.mock("../components/Sidebar", () => ({
+  default: (props: { ibConnected?: boolean }) => {
+    sidebarSpy(props);
+    return <div data-testid="sidebar-status">{props.ibConnected ? "CONNECTED" : "OFFLINE"}</div>;
+  },
+}));
+
+vi.mock("../components/Header", () => ({
+  default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../components/ChatPanel", () => ({
+  default: () => null,
+}));
+
+vi.mock("../components/MetricCards", () => ({
+  default: () => null,
+}));
+
+vi.mock("../components/ConnectionBanner", () => ({
+  default: () => null,
+}));
+
+vi.mock("../components/FlexTokenBanner", () => ({
+  default: () => null,
+}));
+
+vi.mock("../components/Toast", () => ({
+  default: () => null,
+}));
+
+describe("WorkspaceShell sidebar IB status", () => {
+  beforeEach(() => {
+    sidebarSpy.mockClear();
+    cleanup();
+    localStorage.clear();
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockReturnValue({
+        matches: true,
+        media: "(prefers-color-scheme: dark)",
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }),
+    });
+  });
+
+  it("keeps the sidebar connected on an empty orders page when the shared IB status socket is healthy", () => {
+    render(<WorkspaceShell section="orders" />);
+
+    expect(screen.getByTestId("sidebar-status").textContent).toContain("CONNECTED");
+    expect(sidebarSpy).toHaveBeenCalled();
+    expect(sidebarSpy.mock.calls.at(-1)?.[0]).toEqual(
+      expect.objectContaining({ ibConnected: true }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- use the shared IB status socket for the sidebar footer badge instead of the price-subscription socket
- keep the Orders footer connected even when the page has no quote subscriptions
- add unit and Playwright regression coverage for the empty Orders-page case

## Validation
- npx vitest run --config ../vitest.config.ts web/tests/workspace-shell-sidebar-status.test.tsx
- npx playwright test --config playwright.no-server.config.ts e2e/ws-connection-stability.spec.ts --grep "empty orders page still shows CONNECTED"