### PR TITLE
fix(auth): opt-in prod interlock so an empty operator allowlist fails closed

### DIFF
--- a/scripts/api/auth.py
+++ b/scripts/api/auth.py
@@ -116,6 +116,19 @@ def _get_allowed_users() -> set[str]:
     return {uid.strip() for uid in raw.split(",") if uid.strip()}
 
 
+def _require_operator_allowlist() -> bool:
+    """Whether an EMPTY ALLOWED_USER_IDS should fail CLOSED (deny) rather than
+    open.
+
+    Set ``RADON_REQUIRE_OPERATOR_ALLOWLIST=1`` on production (the app.radon.run
+    radon-api env) so a blanked/typo'd allowlist cannot silently admit a
+    non-operator JWT caller through the public Caddy ``/api/ib/*`` mount. Unset
+    everywhere else (dev, CI, demo VM), so behavior there is unchanged. Mirrors
+    the Next.js ``isAuthorizedUser`` interlock in ``web/middleware.ts``.
+    """
+    return os.environ.get("RADON_REQUIRE_OPERATOR_ALLOWLIST") == "1"
+
+
 def _get_issuer() -> str:
     """Get Clerk issuer URL from env."""
     return os.environ.get("CLERK_ISSUER", "")
@@ -172,7 +185,21 @@ async def verify_clerk_jwt(request: Request) -> dict:
         raise HTTPException(status_code=401, detail="Invalid token")
 
     allowed = _get_allowed_users()
-    if allowed and payload.get("sub") not in allowed:
+    if not allowed:
+        # No operator allowlist configured. Default (dev, CI, demo VM): don't
+        # enforce. Production sets RADON_REQUIRE_OPERATOR_ALLOWLIST=1 so a
+        # blanked/typo'd ALLOWED_USER_IDS fails CLOSED — this untrusted JWT
+        # caller (public via Caddy /api/ib/*) is denied rather than admitted to
+        # the operator surface. Mirrors web/middleware.ts:isAuthorizedUser.
+        if _require_operator_allowlist():
+            logger.error(
+                "RADON_REQUIRE_OPERATOR_ALLOWLIST=1 but ALLOWED_USER_IDS is empty "
+                "— denying user %s (fail-closed operator interlock)",
+                payload.get("sub"),
+            )
+            raise HTTPException(status_code=403, detail="Not authorized")
+        return payload
+    if payload.get("sub") not in allowed:
         logger.warning("Access denied for user %s", payload.get("sub"))
         raise HTTPException(status_code=403, detail="Not authorized")
 

--- a/scripts/api/tests/test_auth.py
+++ b/scripts/api/tests/test_auth.py
@@ -348,6 +348,39 @@ class TestVerifyClerkJwt:
         assert payload["sub"] == "anyone"
 
     @pytest.mark.asyncio
+    async def test_empty_allowlist_denies_when_prod_interlock_on(self):
+        # RADON_REQUIRE_OPERATOR_ALLOWLIST=1 + empty ALLOWED_USER_IDS must fail
+        # CLOSED: a valid JWT that would otherwise sail through the fail-open
+        # branch is denied 403 (the production misconfiguration guard).
+        req = _FakeRequest(host="8.8.8.8", auth_header="Bearer " + _make_token(sub="anyone"))
+        env = {
+            "CLERK_ISSUER": _ISSUER,
+            "ALLOWED_USER_IDS": "",
+            "RADON_REQUIRE_OPERATOR_ALLOWLIST": "1",
+        }
+        with self._patch_jwks(), patch.dict(os.environ, env):
+            with pytest.raises(HTTPException) as exc:
+                await verify_clerk_jwt(req)
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_populated_allowlist_unaffected_by_prod_interlock(self):
+        # Interlock ON but the allowlist IS set: the operator still passes and a
+        # non-operator is still denied — the flag only changes the EMPTY case.
+        env = {
+            "CLERK_ISSUER": _ISSUER,
+            "ALLOWED_USER_IDS": "user_ok",
+            "RADON_REQUIRE_OPERATOR_ALLOWLIST": "1",
+        }
+        ok = _FakeRequest(host="8.8.8.8", auth_header="Bearer " + _make_token(sub="user_ok"))
+        intruder = _FakeRequest(host="8.8.8.8", auth_header="Bearer " + _make_token(sub="intruder"))
+        with self._patch_jwks(), patch.dict(os.environ, env):
+            assert (await verify_clerk_jwt(ok))["sub"] == "user_ok"
+            with pytest.raises(HTTPException) as exc:
+                await verify_clerk_jwt(intruder)
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
     async def test_missing_bearer_401(self):
         req = _FakeRequest(host="8.8.8.8")  # no Authorization header
         with self._patch_jwks(), self._env():

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -203,12 +203,32 @@ export function parseAllowedUserIds(
   );
 }
 
+// Production interlock. When RADON_REQUIRE_OPERATOR_ALLOWLIST=1 (set ONLY in the
+// Hetzner radon-nextjs env), an EMPTY allowlist fails CLOSED instead of open —
+// see isAuthorizedUser. Absent everywhere else (dev, CI, and demo.radon.run's
+// Vercel env), so it changes nothing until the operator opts in on prod.
+export function requiresOperatorAllowlist(
+  flag: string | undefined = process.env.RADON_REQUIRE_OPERATOR_ALLOWLIST,
+): boolean {
+  return flag === "1";
+}
+
 export function isAuthorizedUser(
   userId: string,
   raw: string | undefined = process.env.ALLOWED_USER_IDS,
+  requireAllowlist: boolean = requiresOperatorAllowlist(),
 ): boolean {
   const allow = parseAllowedUserIds(raw);
-  if (allow.size === 0) return true; // no allowlist configured -> don't enforce
+  if (allow.size === 0) {
+    // No allowlist configured. Default (dev, CI, demo.radon.run): fail OPEN —
+    // the demo gate governs the demo deployment and local dev must not wall
+    // itself off. Production sets RADON_REQUIRE_OPERATOR_ALLOWLIST=1 so a
+    // blanked/typo'd ALLOWED_USER_IDS fails CLOSED (deny EVERY authenticated
+    // user, operator included) rather than silently re-opening the operator app
+    // to any signed-in demo user on the shared Clerk instance (the 2026-06-27
+    // incident class). Better locked-out-and-loud than world-open-and-silent.
+    return !requireAllowlist;
+  }
   return allow.has(userId);
 }
 

--- a/web/tests/middleware-allowlist.test.ts
+++ b/web/tests/middleware-allowlist.test.ts
@@ -17,7 +17,11 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { isAuthorizedUser, parseAllowedUserIds } from "../middleware";
+import {
+  isAuthorizedUser,
+  parseAllowedUserIds,
+  requiresOperatorAllowlist,
+} from "../middleware";
 
 describe("operator allowlist — authorization layer", () => {
   it("fails open when ALLOWED_USER_IDS is unset/empty (dev, CI, demo)", () => {
@@ -47,5 +51,37 @@ describe("operator allowlist — authorization layer", () => {
     expect(parseAllowedUserIds("a, b ,c,")).toEqual(new Set(["a", "b", "c"]));
     expect(parseAllowedUserIds(" ")).toEqual(new Set());
     expect(parseAllowedUserIds(undefined).size).toBe(0);
+  });
+});
+
+// The production fail-closed interlock. Default behavior (interlock OFF) is the
+// existing fail-open; production sets RADON_REQUIRE_OPERATOR_ALLOWLIST=1 so a
+// blanked ALLOWED_USER_IDS denies everyone instead of re-opening the app.
+describe("operator allowlist — production fail-closed interlock", () => {
+  it("requiresOperatorAllowlist is true only for the literal '1'", () => {
+    expect(requiresOperatorAllowlist("1")).toBe(true);
+    expect(requiresOperatorAllowlist("0")).toBe(false);
+    expect(requiresOperatorAllowlist("true")).toBe(false);
+    expect(requiresOperatorAllowlist(undefined)).toBe(false);
+    expect(requiresOperatorAllowlist("")).toBe(false);
+  });
+
+  it("interlock OFF (default) keeps failing OPEN on an empty allowlist", () => {
+    expect(isAuthorizedUser("user_anything", "", false)).toBe(true);
+    expect(isAuthorizedUser("user_anything", undefined, false)).toBe(true);
+    expect(isAuthorizedUser("user_anything", "  ", false)).toBe(true);
+  });
+
+  it("interlock ON fails CLOSED on an empty allowlist — denies EVERY user incl. the operator", () => {
+    expect(isAuthorizedUser("user_operator", "", true)).toBe(false);
+    expect(isAuthorizedUser("user_operator", undefined, true)).toBe(false);
+    expect(isAuthorizedUser("user_operator", "   ", true)).toBe(false);
+  });
+
+  it("interlock ON is a no-op once the allowlist IS populated (operator passes, intruder denied)", () => {
+    const raw = "user_operator1, user_operator2";
+    expect(isAuthorizedUser("user_operator1", raw, true)).toBe(true);
+    expect(isAuthorizedUser("user_operator2", raw, true)).toBe(true);
+    expect(isAuthorizedUser("user_intruder", raw, true)).toBe(false);
   });
 });


### PR DESCRIPTION
## What

Adds an **opt-in** production interlock so a blanked/typo'd `ALLOWED_USER_IDS` fails **closed** instead of open.

Both perimeter layers currently fail **open** on an empty allowlist (intentional, so dev/CI/demo work):
- `web/middleware.ts` — `isAuthorizedUser` returns `true` when the allowlist is empty
- `scripts/api/auth.py` — `verify_clerk_jwt` skips the allowlist check when it's empty

On the shared `pk_live` Clerk instance (frictionless demo signups), one env slip on prod would re-open the operator app — real portfolio + live-order routes — to **any** signed-in demo user. Global data tables + the trusted-local Next→FastAPI bypass mean there's no second line of defense. This is the 2026-06-27 incident class; the env var is the only thing standing.

## Change

New flag `RADON_REQUIRE_OPERATOR_ALLOWLIST=1`:
- **Set** (production only): empty allowlist ⇒ **deny every authenticated user** (operator included). Better locked-out-and-loud than world-open-and-silent.
- **Unset** (dev, CI, demo.radon.run Vercel): unchanged fail-open.

A **populated** allowlist is unaffected either way — the flag only changes the empty case.

## Safety / rollout

- Purely additive and **off by default** — merging this changes nothing at runtime.
- Cannot break the Vercel demo (flag never set there) and cannot surprise-lock the operator (only bites when the flag is on **and** the allowlist is empty — exactly the misconfiguration we want refused).
- **To activate after merge:** add `RADON_REQUIRE_OPERATOR_ALLOWLIST=1` to `/home/radon/radon-cloud/.env` (covers both radon-nextjs + radon-api via their shared `EnvironmentFile`), then `radon restart`.

## Tests

- `web/tests/middleware-allowlist.test.ts` +4 (interlock on/off, populated-allowlist no-op) — 9 passed
- `scripts/api/tests/test_auth.py` +2 (empty-allowlist deny under flag; populated unaffected) — 57 passed
- Regression: `test_auth_fail_closed.py` + `test_route_authz_matrix.py` — 76 passed
- tsc + eslint clean

From the 2026-07-02 VPS security posture audit (finding L1). `docs/security-posture-audit-2026-07-02.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)