### PR TITLE
fix(ib-gateway): remove willfarrell/autoheal sidecar + docker.sock mount

### DIFF
--- a/docker/ib-gateway/docker-compose.yml
+++ b/docker/ib-gateway/docker-compose.yml
@@ -2,8 +2,6 @@ services:
   ib-gateway:
     image: ghcr.io/gnzsnz/ib-gateway@sha256:22d5bf5e6699b3c28cb806c21e2cc46c6337df3599f758d9ae685ad3aa9eb0d5
     restart: unless-stopped
-    labels:
-      - "autoheal=true"
     environment:
       TWS_USERID: ${TWS_USERID}
       TWS_PASSWORD_FILE: /run/secrets/ib_password
@@ -19,9 +17,9 @@ services:
       # only one 2FA push is ever in flight at a time. Letting IBC
       # ALSO relogin on its own would bypass the lock.
       # `exit` makes IBC quit on 2FA timeout; the container's
-      # `restart: unless-stopped` + our autoheal label still recover,
-      # but go through a fresh container boot rather than an IBC
-      # in-container restart that the radon stack can't see.
+      # `restart: unless-stopped` recovers via a fresh container boot
+      # rather than an IBC in-container restart the radon stack can't
+      # see. (No autoheal sidecar — see the note below the healthcheck.)
       TWOFA_TIMEOUT_ACTION: exit
       RELOGIN_AFTER_TWOFA_TIMEOUT: "no"
       EXISTING_SESSION_DETECTED_ACTION: primary
@@ -54,19 +52,16 @@ services:
       retries: 5
       start_period: 120s
 
-  # Auto-restart unhealthy containers.
-  # Docker's restart: unless-stopped only restarts on exit, not on
-  # unhealthy status. Autoheal watches healthcheck and restarts
-  # containers labeled autoheal=true when they go unhealthy.
-  autoheal:
-    image: willfarrell/autoheal
-    restart: unless-stopped
-    environment:
-      AUTOHEAL_CONTAINER_LABEL: "autoheal"
-      AUTOHEAL_INTERVAL: 30
-      AUTOHEAL_START_PERIOD: 180
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+  # NOTE: no autoheal sidecar. A blind `docker restart` on an unhealthy gateway
+  # bypasses the cross-process 2FA push lock (scripts/utils/ib_2fa_lock.py) and
+  # stacks IBKR Mobile pushes — IBKR's backend then rejects EVERY approval the
+  # operator taps, locking them out of the live brokerage session. The unhealthy
+  # case (API listener wedged while the process stays alive) is handled instead
+  # by scripts/ib_watchdog.py, which acquires the push lock before restarting.
+  # Autoheal also required a read-write /var/run/docker.sock mount = host-root on
+  # the live-trading box, from an unpinned willfarrell/autoheal image. Removed
+  # 2026-07-02 (security posture audit M1). See feedback_watchdog_works_dont_
+  # deploy_autoheal + docs/ib-gateway-recovery.md (RELOGIN must stay "no").
 
 secrets:
   ib_password:

--- a/docs/ib-gateway-docker.md
+++ b/docs/ib-gateway-docker.md
@@ -103,7 +103,7 @@ Docker's built-in healthcheck runs every 30s:
 bash -c 'echo > /dev/tcp/localhost/4001'
 ```
 
-**Important:** Uses bash `/dev/tcp` builtin, NOT `nc`/`netcat` — the `gnzsnz/ib-gateway` image doesn't include netcat. Using `nc` causes the healthcheck to always fail, making the container permanently unhealthy and triggering autoheal restart loops.
+**Important:** Uses bash `/dev/tcp` builtin, NOT `nc`/`netcat` — the `gnzsnz/ib-gateway` image doesn't include netcat. Using `nc` causes the healthcheck to always fail, making the container permanently unhealthy.
 
 - **healthy**: IB Gateway API is accepting connections
 - **unhealthy**: API not responding (2FA pending, login failed, or Gateway crashed)
@@ -111,23 +111,16 @@ bash -c 'echo > /dev/tcp/localhost/4001'
 
 Check via: `scripts/docker_ib_gateway.sh status` or `curl localhost:8321/health`
 
-## Autoheal (Automatic Unhealthy Restart)
+## Unhealthy-container recovery (NO autoheal sidecar)
 
-Docker's `restart: unless-stopped` only restarts containers that **exit**. When IB Gateway's API becomes unresponsive (session drop, 2FA expiry), the Java process stays alive but the healthcheck fails — the container goes `unhealthy` but never exits.
+Docker's `restart: unless-stopped` only restarts containers that **exit**. When IB Gateway's API becomes unresponsive (session drop, 2FA expiry) the Java process stays alive but the healthcheck fails — the container goes `unhealthy` but never exits.
 
-The `autoheal` sidecar container watches for this and restarts unhealthy containers automatically:
+**This is NOT handled by an autoheal sidecar.** The `willfarrell/autoheal` container was removed 2026-07-02 (security posture audit M1) for two reasons:
 
-- Checks every 30s for containers labeled `autoheal=true`
-- 180s grace period after container start (allows for IB's slow startup + 2FA)
-- When unhealthy detected: `docker restart` the container
-- IB Gateway re-authenticates on restart (`RELOGIN_AFTER_TWOFA_TIMEOUT: yes`)
+1. **It bypasses the 2FA push lock.** A blind `docker restart` on an unhealthy gateway fires a fresh IBKR Mobile 2FA push without acquiring `scripts/utils/ib_2fa_lock.py`. Stacked pushes make IBKR reject every approval the operator taps (see `feedback_watchdog_works_dont_deploy_autoheal` + `docs/ib-gateway-recovery.md` — `RELOGIN_AFTER_TWOFA_TIMEOUT` MUST stay `"no"`).
+2. **It required a root-equivalent `docker.sock` mount** on the live-trading host, from an unpinned image — a supply-chain path to host takeover + live-order capability.
 
-This eliminates the infinite 502 loop where the API keeps trying to connect to an unresponsive Gateway.
-
-**Autoheal logs:**
-```bash
-docker logs ib-gateway-autoheal-1
-```
+The unhealthy/API-wedge case is handled instead by **`scripts/ib_watchdog.py`** (`is_api_hang()` / `is_stuck_awaiting_2fa()`): it detects the wedge, **acquires the push lock**, and restarts `radon-ib-gateway.service` lock-respectfully after a debounce. See `docs/ib-gateway-recovery.md` and `scripts/api/CLAUDE.md` (2FA-Aware Restart).
 
 ## Credential Security
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -60,7 +60,7 @@ Three deployment modes selected by `IB_GATEWAY_MODE`:
 
 | Mode | Description |
 |------|-------------|
-| `docker` (default; Hetzner production) | `ghcr.io/gnzsnz/ib-gateway` via Docker Compose, `restart: unless-stopped`, healthcheck, autoheal sidecar. |
+| `docker` (default; Hetzner production) | `ghcr.io/gnzsnz/ib-gateway` via Docker Compose, `restart: unless-stopped`, healthcheck. Unhealthy/API-wedge recovery is handled by `scripts/ib_watchdog.py` (lock-respectful restart), NOT an autoheal sidecar — removed 2026-07-02, it bypassed the 2FA push lock and required a root `docker.sock` mount. |
 | `cloud` (laptop dev) | Gateway on the Hetzner VM at `ib-gateway:4001` over Tailscale MagicDNS. Health check is a TCP port probe; local restart returns 503. |
 | `launchd` (legacy) | IBC under macOS launchd. |
 


### PR DESCRIPTION
## What

Removes the `willfarrell/autoheal` sidecar (and its `/var/run/docker.sock` mount + `autoheal=true` label) from the in-tree IB Gateway compose, and fixes the stale docs that documented it.

## Why (audit finding M1)

The autoheal sidecar was the single most dangerous thing in the compose:

1. **`docker.sock` mounted read-write = host root** on the live-trading box, from an **unpinned** `willfarrell/autoheal` image — while `ib-gateway` itself is `sha256`-pinned. A supply-chain compromise of `:latest` on a re-pull → host takeover, the IB password secret, the Turso token, and live-order capability.
2. **It bypasses the 2FA push lock.** Autoheal recovers an unhealthy gateway with a blind `docker restart`, which fires a fresh IBKR Mobile 2FA push **without** acquiring `scripts/utils/ib_2fa_lock.py`. Stacked pushes make IBKR reject **every** approval the operator taps — locking them out of the live brokerage. This is exactly what `feedback_watchdog_works_dont_deploy_autoheal` already warned against.

The unhealthy / API-wedge case is **already** handled lock-respectfully by `scripts/ib_watchdog.py` (`is_api_hang` / `is_stuck_awaiting_2fa` acquire the push lock before restarting `radon-ib-gateway.service`), so autoheal is redundant as well as hazardous.

## Also fixes a doc contradiction

`docs/ib-gateway-docker.md` documented autoheal as live with `RELOGIN_AFTER_TWOFA_TIMEOUT: yes` — which directly contradicts the compose (`"no"`) and `docs/ib-gateway-recovery.md`, which **forbids** re-enabling relogin (same 2FA-stacking hazard). Rewrote that section and the `operations.md` mode table to describe the watchdog path.

## Scope / caveat

- Touches the **in-tree** compose (laptop local-docker mode + disaster-recovery rebuild). Production runs the **separate** `radon-cloud` compose — the audit's host checklist includes `grep autoheal ~/radon-cloud/docker-compose.yml` + `docker ps` to confirm prod matches (I did not SSH in to verify).
- Keeps the compose-native healthcheck (still useful for `docker ps` + the watchdog's external checks).

## Verification

- `python -c "import yaml; yaml.safe_load(...)"` → valid; `services: [ib-gateway]`, no `docker.sock`, no `autoheal`.
- gitleaks clean.

From the 2026-07-02 VPS security posture audit. `docs/security-posture-audit-2026-07-02.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)