### PR TITLE
ci(deploy): bind the VPS deploy job to a gated GitHub Environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,22 @@ jobs:
     needs: [secret-scan, web-tests, py-tests, perimeter-smoke]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
+    # Bind the deploy to a GitHub Environment so a REQUIRED REVIEWER can gate it.
+    # `git push origin main` runs `deploy.sh` over SSH as `radon` on the box that
+    # owns the live IB Gateway (:4001) — i.e. push-to-main == code execution on
+    # the trading host (security posture audit M3, threat T3). An Environment
+    # with a required reviewer turns that into a human-gated release.
+    #
+    # ACTIVATION (one-time, GitHub UI — this YAML alone is a no-op until then):
+    #   Settings > Environments > New environment "production" >
+    #   Required reviewers: add the operator. Optionally restrict deployment
+    #   branches to `main`. Until a protection rule is added, the environment
+    #   auto-creates with NO gate, so merging this changes nothing operationally.
+    # Pair with branch protection on `main` (see the audit's verify-on-host list:
+    #   gh api repos/:owner/:repo/branches/main/protection).
+    environment:
+      name: production
+      url: https://app.radon.run
     steps:
       - name: Deploy via SSH
         # Pinned to the v1.2.5 commit SHA (was the mutable `@v1` tag). This step


### PR DESCRIPTION
## What

Binds the `deploy` job to a GitHub Environment (`production`) so a **required reviewer** can gate deploys to the live-trading host.

## Why (audit finding M3 / threat T3)

`git push origin main` → CI → SSH into Hetzner → `deploy.sh` as `radon` on the box that owns the live IB Gateway (`:4001`). **Push-to-main is code execution on the trading host.** A compromised maintainer credential, a self-approved PR, or a direct push to an unprotected `main` becomes RCE that can read the Turso token, reach `:4001`, and place live orders. The SSH step is already SHA-pinned and gated to `push`+`main` — the missing layer is a human in the loop.

## Safety — merging this is a no-op until you opt in

Referencing an environment with **no protection rule** auto-creates it with no gate, so **merging changes nothing operationally.** It only takes effect once you configure the gate:

**Activation (one-time, GitHub UI):**
1. **Settings → Environments → New environment** → `production`
2. **Required reviewers** → add yourself. (Optionally restrict deployment branches to `main`.)

**Companion (branch protection on `main`, from the audit's verify-on-host list):**
```bash
gh api repos/:owner/:repo/branches/main/protection
```
Enforce ≥1 PR review + required status checks (`secret-scan`, `web-tests`, `py-tests`, `perimeter-smoke`, `strict=true`) + `enforce_admins` + block force-push.

## Verification

- `yaml.safe_load` → `deploy.environment = {name: production, url: https://app.radon.run}`; `needs` + job graph intact.
- gitleaks clean.

From the 2026-07-02 VPS security posture audit. `docs/security-posture-audit-2026-07-02.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)