### PR TITLE
Mobile order builder UX analysis and phased proposal

### DIFF
--- a/docs/demo-environment.md
+++ b/docs/demo-environment.md
@@ -65,6 +65,8 @@ The demo reads the vars below. They live in **two places**: `web/.env` (local de
 
 **Topology revised from the original plan (2026-06-27):** the **frontend runs on Vercel** (`demo.radon.run`, project `radon-demo`, root `web/`) behind **Vercel WAF + rate-limiting** (100 req/min/IP challenge, 1000 req/min/IP deny) — replacing the Cloudflare layer described above. Only **FastAPI + the relay** run on the Hetzner VM; the Vercel frontend calls the VM backend over the public internet via `RADON_API_URL`, so the backend authenticates the Clerk JWT (no localhost-trust bypass). The managed OWASP WAF ruleset is Enterprise-only and not enabled on Pro.
 
+**Ignored Build Step:** `web/vercel.json` → `scripts/vercel-ignore-build.mjs` skips the `radon-demo` build unless `web/` or `lib/tools` changed (the `@tools` webpack alias). Docs/tasks/site-only pushes cancel with "Canceled by Ignored Build Step", matching the marketing `site/` project. Defaults to continuing the build if the diff cannot be determined.
+
 ## Build phases
 
 **Operator-provisioned infra (you; I provide configs/checklists):**

--- a/tasks/mobile-order-builder-ux-proposal.md
+++ b/tasks/mobile-order-builder-ux-proposal.md
@@ -1,0 +1,203 @@
+# Mobile Order Builder UX Proposal
+
+Analysis of the mobile chain → ticket flow (`MobileChainLadder` + `MobileOrderTicket`) against desktop `OrderBuilder` and industry mobile trading patterns (Robinhood Options, tastytrade, Thinkorswim mobile, IBKR mobile, Webull).
+
+Scope: `/{TICKER}?tab=chain` at ≤640px. Not a redesign of desktop.
+
+---
+
+## Current flow (as shipped)
+
+```
+Chain ladder cell tap
+  → Contract detail BottomSheet (Greeks + Last/BidAsk)
+    → BUY or SELL
+      → Pending strip ("N LEGS · Mid $x · Build order →")
+        → Order ticket BottomSheet
+          → Legs / qty / limit / TIF / risk / submit
+```
+
+Desktop is one-tap: bid/ask cell click adds a leg and the sticky `OrderBuilder` updates in place.
+
+---
+
+## What already works
+
+- Bottom sheet + sticky footer thumb zone; 44–56px targets; 18px limit input (no iOS zoom).
+- Credit/debit colored submit (`m-submit--credit` / `--debit`).
+- Live Bid/Mid/Ask strip + ComboSkewPanel.
+- Risk routed through `<OrderRiskGate surface="mobile-ticket">`.
+- Combo payload preserves per-leg actions; envelope stays BUY.
+- ATM auto-center; CALLS/PUTS/ALL + strikes window deep-linked.
+
+---
+
+## Pain points (severity-ranked)
+
+### P0 — Safety / correctness gaps
+
+| ID | Issue | Why it matters | Evidence |
+|---|---|---|---|
+| S1 | **No confirm step** | Desktop requires Place → Confirm. Mobile submits on first tap. Fat-finger risk on a live broker. | `MobileOrderTicket.handleSubmit` vs desktop `confirmStep` |
+| S2 | **Submit ignores `okToSubmit`** | Gate can show pending / unbounded / Gate-1 fail while submit stays enabled (only checks price + legs). CLAUDE.md: parent MUST disable when `okToSubmit !== true`. | Submit `disabled={!isValidPrice \|\| submitting \|\| legs.length === 0}`; no `onState` |
+| S3 | **Always labels "BUY/SELL TO OPEN"** | Closing a held long/short still reads as opening. Misleading direction is a classic mobile trading failure mode. | Hardcoded `directionLabel`; no `closeOut` / position detection |
+| S4 | **Raw IB errors** | Desktop runs `formatOrderError`. Mobile dumps `json.error`. `<br>` and long margin text are unreadable on 393px. | `setError(json.error \|\| ...)` |
+
+### P1 — Friction vs industry norms
+
+| ID | Issue | Industry pattern | Current |
+|---|---|---|---|
+| F1 | **3 taps to add a leg** | Robinhood / tasty / TOS: tap bid or ask (or long-press) adds side immediately | Cell → sheet → BUY/SELL |
+| F2 | **Pending strip is opaque** | Ticket preview shows structure name, debit/credit, notional | Count + mid only; no structure, no Clear |
+| F3 | **No BID / MID / ASK quick-set** | Every major options app: one-tap fill from quote | ±$0.05 steppers only |
+| F4 | **Cannot flip leg side in ticket** | Desktop toggles BUY↔SELL on the leg | Must remove + re-add via chain |
+| F5 | **No Clear / discard** | Always offer abandon without removing legs one-by-one | Only per-leg X |
+| F6 | **Risk always expanded in footer** | Confirm-step or collapsible "Review risk" keeps CTA visible | Risk + submit compete in ~82vh sheet; E2E already needs `tapJs` because footer can sit off-viewport |
+| F7 | **No notional / total cost** | "You'll pay/receive $X" before submit | Desktop shows `$… notional`; mobile does not |
+| F8 | **Missing desktop safety copy** | Coverage chip + bearish-RR routing warning | Absent on mobile |
+
+### P2 — Polish
+
+| ID | Issue |
+|---|---|
+| P1 | Leg row duplicates expiry/right (`BuySellRow` label + sub) |
+| P2 | Fixed $0.05 tick; underlyings with $0.01 / $0.10 ticks feel wrong |
+| P3 | No haptic / press feedback on add-leg |
+| P4 | Success auto-closes in 800ms; easy to miss order id |
+| P5 | No "legs selected" highlight on ladder rows |
+| P6 | Qty only ±1; no quick 5/10 or "Max" for closes |
+
+---
+
+## Design principles (apply to Radon mobile ticket)
+
+1. **Progressive disclosure** — Build on chain; review risk only when committing.
+2. **Thumb-first** — Primary CTA and price controls in lower third; never bury submit under a tall risk block.
+3. **One decision per screen** — Add legs vs size/price vs confirm.
+4. **Quote → price in one gesture** — Bid/Mid/Ask are actions, not decoration.
+5. **Direction honesty** — Open vs close, debit vs credit, must match portfolio.
+6. **Parity of safety, not of chrome** — Mobile can look different; it cannot skip confirm, risk gating, or error hygiene.
+7. **Stay in brand** — Tokens, ≤4px radius, mono numerics, no glass/pills-as-decoration.
+
+---
+
+## Proposed UX (target flow)
+
+### A. Faster leg building (chain)
+
+**Default (recommended): long-press / swipe affordance + keep detail sheet**
+
+1. **Tap** cell → detail sheet (Greeks) with BUY | SELL (unchanged for discovery).
+2. **Long-press** cell → haptic + add as BUY (call left / put right convention) **or** show a 2-button popover anchored to the cell: BUY / SELL, no full sheet.
+3. **Optional power mode** (settings or "Quick add"): tap bid half → SELL, ask half → BUY (mirrors desktop bid/ask click semantics). Split the cell visually with a hairline so the affordance is learnable.
+
+Also:
+
+- Highlight selected strikes on the ladder (BUY tint / SELL tint border).
+- Pending strip becomes a **mini ticket preview**:
+  - Structure name (`detectStructure`)
+  - `N legs · Net debit/credit Mid $x · ~$notional`
+  - Secondary **Clear** (destructive slot) + primary **Review**
+
+### B. Ticket as review + size (sheet)
+
+Reorder body:
+
+1. **Header**: `AAPL · Bull Call Spread` + Clear
+2. **Legs** (editable): side toggle, qty stepper, remove; collapse duplicate subcopy
+3. **Price**: Bid | Mid | Ask as **tappable chips** that set limit; ± tick beside input; show **notional** under input
+4. **TIF**: DAY / GTC
+5. **Warnings** (compact): coverage chip, bearish-RR note when applicable
+6. **Footer**: primary button = `Review order` (not place yet)
+
+Risk summary moves **out of the always-on footer** into the confirm step (or a single-line "Max loss $X · Max gain $Y" teaser that expands on Review).
+
+### C. Confirm step (mandatory)
+
+Second state in the same sheet (or a stacked sheet):
+
+- Full `<OrderRiskGate>` summary
+- Direction label from portfolio: `BUY TO OPEN` / `SELL TO CLOSE` / etc.
+- Net debit/credit + notional + TIF
+- **Back** | **Confirm & send**
+- Confirm disabled unless `riskState.okToSubmit === true`
+- Errors via `formatOrderError` + `.order-error-detail`
+
+### D. Post-submit
+
+- Keep success visible until user dismisses **or** 2.5s with order id / "View in Orders"
+- Do not clear legs until success is acknowledged if placement failed partially
+
+---
+
+## Mapping to components
+
+| Change | Primary files |
+|---|---|
+| Confirm + `okToSubmit` + close labeling | `MobileOrderTicket.tsx` |
+| Bid/Mid/Ask chips, notional, Clear, side flip | `MobileOrderTicket.tsx` + `globals.css` |
+| Error formatting | reuse `formatOrderError` / `OrderErrorBanner` |
+| Pending strip preview + Clear | `MobileChainLadder.tsx` |
+| Quick-add / long-press | `MobileChainLadder.tsx` `SideCell` |
+| Coverage + RR warning | port copy from desktop `OrderBuilder` |
+| Close-out risk input | mirror `OrderTab` / `positionTrade` close detection when held qty covers |
+| Tests | extend `e2e/mobile-order-ticket.spec.ts`; unit for submit gating |
+
+---
+
+## Phased delivery
+
+### Phase 1 — Safety parity (ship first)
+
+- Confirm step
+- Wire `OrderRiskGate onState` → disable submit when `!okToSubmit`
+- `formatOrderError` on failures
+- Honest open/close labels + `closeOut` when applicable
+- Notional line + Clear all
+
+**Success:** cannot place unbounded / pending-coverage order; closing a long never says TO OPEN; IB errors readable.
+
+### Phase 2 — Speed parity
+
+- Bid/Mid/Ask quick-set chips
+- Leg side toggle in ticket
+- Pending strip shows structure + debit/credit + Clear
+- Ladder selection chrome for active legs
+
+**Success:** quote → limit in one tap; strip answers "what am I building?" without opening the sheet.
+
+### Phase 3 — Build-speed
+
+- Long-press or split-cell quick add
+- Optional Quick-add mode
+- Adaptive tick size
+- Qty presets / max close
+
+**Success:** experienced operator adds a 2-leg vertical in ≤3 gestures end-to-end (vs ~6 today).
+
+---
+
+## Explicit non-goals
+
+- Do not port the full desktop sticky builder into the ladder (vertical space is the constraint).
+- Do not remove the detail sheet for first-time / discovery taps.
+- Do not weaken Gate-1 / risk chokepoint for "simpler" mobile.
+- Do not add structure wizards (Iron Condor templates, etc.) until the core ticket is safe and fast.
+
+---
+
+## Open decisions (need operator call before Phase 3)
+
+1. **Quick-add default:** long-press popover vs split bid/ask cell vs settings toggle?
+2. **Confirm UI:** in-sheet step (recommended, matches desktop) vs second full-height sheet?
+3. **Risk teaser on Review screen:** one-line max loss/gain always visible, or only after Review?
+
+Recommendation if unblocked: (1) long-press popover, (2) in-sheet confirm, (3) one-line teaser + full gate on confirm.
+
+---
+
+## Acceptance checks (when implementing)
+
+- Vitest: submit disabled when `okToSubmit` false; close label when held long; error formatter used.
+- Playwright mobile 393×852: confirm step required; Bid chip sets limit; pending strip shows structure; no click on live place in verification (far limit / cancel if unavoidable).
+- Visual: brand tokens only; footer CTA remains in thumb zone with risk on confirm.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -13,6 +13,9 @@ Proposal: `tasks/mobile-order-builder-ux-proposal.md`
 - Current mobile path is discovery-heavy (3 taps/leg) and skips desktop safety (confirm, `okToSubmit`, open/close honesty, error formatting).
 - Recommended ship order: safety parity first, then quote chips + strip preview, then long-press quick-add.
 
+## Follow-up (this branch)
+- [x] Add `web/vercel.json` Ignored Build Step for `radon-demo` (watch `web/` + `lib/tools`) so docs-only PRs do not deploy demo.radon.run.
+
 ---
 
 # Task: Margin Debt Acceleration Indicator (FINRA)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,20 @@
+# Task: Mobile Order Builder UX (analysis)
+
+Proposal: `tasks/mobile-order-builder-ux-proposal.md`
+
+## Dependency graph
+- T1 Analyze mobile chain + ticket vs desktop OrderBuilder — done
+- T2 Map gaps to industry mobile options UX — done
+- T3 Write prioritized proposal (P0 safety → P1 speed → P2 polish) — done
+- T4 Operator decisions on quick-add / confirm chrome — blocked on review
+- T5 Implement Phase 1 safety parity — depends_on: [T4] (or proceed on defaults in proposal)
+
+## Review
+- Current mobile path is discovery-heavy (3 taps/leg) and skips desktop safety (confirm, `okToSubmit`, open/close honesty, error formatting).
+- Recommended ship order: safety parity first, then quote chips + strip preview, then long-press quick-add.
+
+---
+
 # Task: Margin Debt Acceleration Indicator (FINRA)
 
 Decisions (2026-07-03): splice legacy NYSE history back to ~1959 · lives as a new

--- a/web/scripts/vercel-ignore-build.mjs
+++ b/web/scripts/vercel-ignore-build.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+
+/**
+ * Vercel Ignored Build Step for the radon-demo project (demo.radon.run).
+ *
+ * Vercel Root Directory is `web/`. Skip the build when the commit touches
+ * neither the Next app nor the `@tools` alias target (`lib/tools`), which
+ * next.config.mjs resolves into the webpack graph.
+ *
+ * Exit codes (Vercel convention):
+ *   0 → skip build
+ *   1 → continue build
+ *
+ * Defaults to CONTINUE when the diff cannot be determined (safer than
+ * silently skipping a real app change).
+ */
+
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+/** Paths relative to the repo root that can change the demo frontend build. */
+export const DEMO_WATCH_REL_PATHS = ["web", path.join("lib", "tools")];
+
+export function git(args, opts = {}) {
+  return execFileSync("git", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    ...opts,
+  }).trim();
+}
+
+export function safeRevParse(ref) {
+  try {
+    return git(["rev-parse", ref]);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Map watch dirs to pathspecs relative to `cwd` (Vercel runs ignoreCommand
+ * from the project Root Directory, usually `web/`).
+ */
+export function resolveWatchDiffPaths({
+  repoRoot,
+  cwd,
+  watchRelPaths = DEMO_WATCH_REL_PATHS,
+}) {
+  return watchRelPaths.map((rel) => {
+    const abs = path.join(repoRoot, rel);
+    if (path.resolve(cwd) === path.resolve(abs)) return ".";
+    return path.relative(cwd, abs) || ".";
+  });
+}
+
+/**
+ * Interpret `git diff --quiet` status for the Vercel ignoreCommand.
+ * Returns the process exit code to use.
+ */
+export function ignoreExitFromDiffStatus(status) {
+  if (status === 0) return 0; // no changes → skip
+  if (status === 1) return 1; // changes → build
+  return 1; // unknown → build
+}
+
+export function defaultResolveRepoRoot() {
+  return git(["rev-parse", "--show-toplevel"]);
+}
+
+export function defaultResolveShas(env) {
+  return {
+    headSha: env.VERCEL_GIT_COMMIT_SHA?.trim() || safeRevParse("HEAD"),
+    baseSha: env.VERCEL_GIT_PREVIOUS_SHA?.trim() || safeRevParse("HEAD^"),
+  };
+}
+
+export function defaultExecDiffQuiet(base, head, paths) {
+  try {
+    execFileSync("git", ["diff", "--quiet", base, head, "--", ...paths], {
+      stdio: "ignore",
+    });
+    return 0;
+  } catch (error) {
+    if (error && typeof error === "object" && "status" in error) {
+      return Number(error.status);
+    }
+    return 128;
+  }
+}
+
+export function main({
+  env = process.env,
+  cwd = process.cwd(),
+  resolveRepoRoot = defaultResolveRepoRoot,
+  resolveShas = defaultResolveShas,
+  execDiffQuiet = defaultExecDiffQuiet,
+  log = console.log,
+} = {}) {
+  let repoRoot;
+  try {
+    repoRoot = resolveRepoRoot();
+  } catch {
+    log("Not running inside a git checkout. Continuing build.");
+    return 1;
+  }
+
+  const { headSha, baseSha } = resolveShas(env);
+
+  if (!headSha || !baseSha) {
+    log("No previous commit available. Continuing build.");
+    return 1;
+  }
+
+  const diffPaths = resolveWatchDiffPaths({ repoRoot, cwd });
+  const logPaths = DEMO_WATCH_REL_PATHS.map((p) => `${p}/`).join(" + ");
+
+  const status = execDiffQuiet(baseSha, headSha, diffPaths);
+  const exitCode = ignoreExitFromDiffStatus(status);
+  if (exitCode === 0) {
+    log(`No changes detected under ${logPaths}. Skipping Vercel build.`);
+  } else if (status === 1) {
+    log(`Changes detected under ${logPaths}. Continuing Vercel build.`);
+  } else {
+    log("Unable to determine changed files. Continuing build.");
+  }
+  return exitCode;
+}
+
+const isCli =
+  typeof process.argv[1] === "string" &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+
+if (isCli) {
+  process.exit(main());
+}

--- a/web/tests/vercel-ignore-build.test.ts
+++ b/web/tests/vercel-ignore-build.test.ts
@@ -1,0 +1,130 @@
+/**
+ * radon-demo Vercel Ignored Build Step — skip when neither web/ nor
+ * lib/tools changed (mirrors site/scripts/vercel-ignore-build.mjs).
+ */
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEMO_WATCH_REL_PATHS,
+  ignoreExitFromDiffStatus,
+  main,
+  resolveWatchDiffPaths,
+} from "../scripts/vercel-ignore-build.mjs";
+
+const REPO = "/repo";
+
+describe("resolveWatchDiffPaths", () => {
+  it("maps watch dirs relative to web/ Root Directory cwd", () => {
+    expect(
+      resolveWatchDiffPaths({
+        repoRoot: REPO,
+        cwd: path.join(REPO, "web"),
+      }),
+    ).toEqual([".", path.join("..", "lib", "tools")]);
+  });
+
+  it("maps watch dirs relative to repo-root cwd", () => {
+    expect(
+      resolveWatchDiffPaths({
+        repoRoot: REPO,
+        cwd: REPO,
+      }),
+    ).toEqual(["web", path.join("lib", "tools")]);
+  });
+
+  it("exports the demo watch set used by radon-demo", () => {
+    expect(DEMO_WATCH_REL_PATHS).toEqual(["web", path.join("lib", "tools")]);
+  });
+});
+
+describe("ignoreExitFromDiffStatus", () => {
+  it("skips (0) when git diff --quiet reports no changes", () => {
+    expect(ignoreExitFromDiffStatus(0)).toBe(0);
+  });
+
+  it("continues (1) when git diff --quiet reports changes", () => {
+    expect(ignoreExitFromDiffStatus(1)).toBe(1);
+  });
+
+  it("continues (1) on unknown status (fail open to build)", () => {
+    expect(ignoreExitFromDiffStatus(128)).toBe(1);
+  });
+});
+
+describe("main", () => {
+  const shas = {
+    headSha: "head",
+    baseSha: "base",
+  };
+
+  it("skips when the watched paths are unchanged", () => {
+    const log = vi.fn();
+    const execDiffQuiet = vi.fn(() => 0);
+    const code = main({
+      env: {},
+      cwd: path.join(REPO, "web"),
+      resolveRepoRoot: () => REPO,
+      resolveShas: () => shas,
+      execDiffQuiet,
+      log,
+    });
+    expect(code).toBe(0);
+    expect(execDiffQuiet).toHaveBeenCalledWith("base", "head", [
+      ".",
+      path.join("..", "lib", "tools"),
+    ]);
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining("Skipping Vercel build"),
+    );
+  });
+
+  it("continues when watched paths changed", () => {
+    const log = vi.fn();
+    const code = main({
+      env: {},
+      cwd: path.join(REPO, "web"),
+      resolveRepoRoot: () => REPO,
+      resolveShas: () => shas,
+      execDiffQuiet: () => 1,
+      log,
+    });
+    expect(code).toBe(1);
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining("Continuing Vercel build"),
+    );
+  });
+
+  it("continues when commit SHAs are missing", () => {
+    const log = vi.fn();
+    const code = main({
+      env: {},
+      cwd: path.join(REPO, "web"),
+      resolveRepoRoot: () => REPO,
+      resolveShas: () => ({ headSha: null, baseSha: null }),
+      execDiffQuiet: () => 0,
+      log,
+    });
+    expect(code).toBe(1);
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining("No previous commit available"),
+    );
+  });
+
+  it("continues when not in a git checkout", () => {
+    const log = vi.fn();
+    const code = main({
+      env: {},
+      cwd: path.join(REPO, "web"),
+      resolveRepoRoot: () => {
+        throw new Error("not a git repo");
+      },
+      resolveShas: () => shas,
+      execDiffQuiet: () => 0,
+      log,
+    });
+    expect(code).toBe(1);
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining("Not running inside a git checkout"),
+    );
+  });
+});

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,0 +1,3 @@
+{
+  "ignoreCommand": "node scripts/vercel-ignore-build.mjs"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

1. Mobile order builder UX analysis (`tasks/mobile-order-builder-ux-proposal.md`).
2. **Vercel Ignored Build Step for `radon-demo`** so docs/tasks-only PRs no longer deploy `demo.radon.run`.

## Why radon-demo was deploying

CI `Deploy to VPS` was skipped on this PR. The `Vercel – radon-demo` check came from the GitHub-linked Vercel project (root `web/`), which had no ignore filter. The marketing `radon` project already skipped via `site/scripts/vercel-ignore-build.mjs`.

## Change

- `web/vercel.json` → `ignoreCommand: node scripts/vercel-ignore-build.mjs`
- Watches `web/` + `lib/tools` (the `@tools` webpack alias)
- Exit 0 = skip, 1 = build; fail-open to build if the diff is unknown
- Vitest: `web/tests/vercel-ignore-build.test.ts` (10 passing)
- Docs note in `docs/demo-environment.md`

This commit itself touches `web/`, so the next Vercel check on this PR will still **build** (correct). Subsequent docs-only pushes will cancel with "Canceled by Ignored Build Step".
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f43d8-85c1-7ea2-8df9-6b70216ee0fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f43d8-85c1-7ea2-8df9-6b70216ee0fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

