### PR TITLE
fix(scripts): resolve the project venv in run_*.sh wrappers

### DIFF
--- a/scripts/lib/python_bin.sh
+++ b/scripts/lib/python_bin.sh
@@ -1,0 +1,88 @@
+# shellcheck shell=bash
+#
+# Shared interpreter resolution for the scripts/run_*.sh scheduler wrappers.
+#
+# Each wrapper used to carry its own copy of resolve_python(). The copies had
+# drifted into three behaviours — a real dependency probe, a stdlib-only
+# `import sys` probe that every interpreter on earth passes, and no probe at
+# all — but they shared one defect: none of them listed the project
+# virtualenv. With RADON_PYTHON_BIN unset (its state in every deployed .env)
+# the first match on the VPS was /usr/bin/python3.13, which carries none of
+# the project dependencies. So the "FastAPI unreachable, invoke the scanner
+# directly" fallback died on ModuleNotFoundError at precisely the moment it
+# existed to help. See scripts/tests/test_wrapper_python_resolution.py.
+#
+# Usage:
+#   . "$(dirname "$0")/lib/python_bin.sh"
+#   PYTHON_BIN=$(radon_resolve_python ib_insync libsql_experimental) || exit 1
+#
+# Modules are optional; with none given the probe only checks that the
+# interpreter runs. Set RADON_PYTHON_MIN_VERSION (e.g. "3.13") to add a
+# version floor.
+
+# Repo root derived from this file's own location so resolution does not
+# depend on the caller's cwd.
+radon_repo_root() {
+    local lib_dir
+    lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    dirname "$(dirname "$lib_dir")"
+}
+
+radon_python_candidates() {
+    local root
+    root="$(radon_repo_root)"
+    # Order matters: an operator override wins, then the project virtualenv,
+    # then progressively less specific interpreters on PATH.
+    printf '%s\n' \
+        "${RADON_PYTHON_BIN:-}" \
+        "$root/.venv/bin/python3.13" \
+        "$root/.venv/bin/python" \
+        /opt/homebrew/bin/python3.13 \
+        /usr/local/bin/python3.13 \
+        /usr/bin/python3.13 \
+        python3.13 \
+        python3.11 \
+        python3.9 \
+        /usr/bin/python3 \
+        python3
+}
+
+radon_python_satisfies() {
+    local interpreter="$1"
+    shift
+    RADON_PYTHON_MIN_VERSION="${RADON_PYTHON_MIN_VERSION:-}" \
+        "$interpreter" - "$@" <<'PY' >/dev/null 2>&1
+import importlib.util
+import os
+import sys
+
+floor = os.environ.get("RADON_PYTHON_MIN_VERSION", "").strip()
+if floor:
+    required = tuple(int(part) for part in floor.split("."))
+    if sys.version_info[: len(required)] < required:
+        raise SystemExit(1)
+
+missing = [name for name in sys.argv[1:] if importlib.util.find_spec(name) is None]
+raise SystemExit(1 if missing else 0)
+PY
+}
+
+# Echo the first interpreter satisfying every requested module; return 1 when
+# none qualifies so callers can fail loudly instead of limping into an
+# ImportError further downstream.
+radon_resolve_python() {
+    local candidate resolved
+    while IFS= read -r candidate; do
+        [ -n "$candidate" ] || continue
+        if [ "${candidate#*/}" != "$candidate" ]; then
+            [ -x "$candidate" ] || continue
+            resolved="$candidate"
+        else
+            resolved=$(command -v "$candidate" 2>/dev/null) || continue
+        fi
+        radon_python_satisfies "$resolved" "$@" || continue
+        printf '%s\n' "$resolved"
+        return 0
+    done < <(radon_python_candidates)
+    return 1
+}

--- a/scripts/run_breadth_scan.sh
+++ b/scripts/run_breadth_scan.sh
@@ -64,19 +64,9 @@ _load_env() {
 _load_env "web/.env"
 _load_env ".env"
 
-resolve_python() {
-    local candidate
-    for candidate in "${RADON_PYTHON_BIN:-}" python3.13 python3.9 /usr/bin/python3 python3; do
-        [ -n "$candidate" ] || continue
-        command -v "$candidate" >/dev/null 2>&1 || continue
-        "$candidate" -c "import sys" >/dev/null 2>&1 || continue
-        echo "$candidate"
-        return 0
-    done
-    return 1
-}
+. scripts/lib/python_bin.sh
 
-PYTHON_BIN=$(resolve_python)
+PYTHON_BIN=$(radon_resolve_python dotenv)
 if [ -z "$PYTHON_BIN" ]; then
     echo "$(date): No Python interpreter available for breadth scan" >&2
     exit 1

--- a/scripts/run_catalysts.sh
+++ b/scripts/run_catalysts.sh
@@ -9,18 +9,9 @@
 
 cd "$(dirname "$0")/.."
 
-resolve_python() {
-    local candidate
-    for candidate in "${RADON_PYTHON_BIN:-}" python3.13 python3.11 python3.9 /usr/bin/python3 python3; do
-        [ -n "$candidate" ] || continue
-        command -v "$candidate" >/dev/null 2>&1 || continue
-        echo "$candidate"
-        return 0
-    done
-    return 1
-}
+. scripts/lib/python_bin.sh
 
-PYTHON_BIN=$(resolve_python)
+PYTHON_BIN=$(radon_resolve_python dotenv)
 if [ -z "$PYTHON_BIN" ]; then
     echo "$(date): No Python interpreter available for catalyst fetch"
     exit 1

--- a/scripts/run_cri_scan.sh
+++ b/scripts/run_cri_scan.sh
@@ -8,25 +8,9 @@
 
 cd "$(dirname "$0")/.."
 
-resolve_python() {
-    local candidate
-    for candidate in "${RADON_PYTHON_BIN:-}" python3.13 python3.9 /usr/bin/python3 python3; do
-        [ -n "$candidate" ] || continue
-        command -v "$candidate" >/dev/null 2>&1 || continue
-        "$candidate" - <<'PY' >/dev/null 2>&1
-import importlib.util
-required = ("ib_insync",)
-raise SystemExit(0 if all(importlib.util.find_spec(name) for name in required) else 1)
-PY
-        if [ $? -eq 0 ]; then
-            echo "$candidate"
-            return 0
-        fi
-    done
-    return 1
-}
+. scripts/lib/python_bin.sh
 
-PYTHON_BIN=$(resolve_python)
+PYTHON_BIN=$(radon_resolve_python ib_insync)
 if [ -z "$PYTHON_BIN" ]; then
     echo "$(date): No Python interpreter with ib_insync available for CRI scan"
     exit 1

--- a/scripts/run_cta_sync.sh
+++ b/scripts/run_cta_sync.sh
@@ -45,24 +45,9 @@ _load_env ".env"
 
 mkdir -p data/menthorq_cache logs
 
-resolve_python() {
-    local candidate
-    for candidate in "${RADON_PYTHON_BIN:-}" python3.13 python3.9 /usr/bin/python3 python3; do
-        [ -n "$candidate" ] || continue
-        command -v "$candidate" >/dev/null 2>&1 || continue
-        "$candidate" - <<'PY' >/dev/null 2>&1
-import importlib.util
-raise SystemExit(0 if importlib.util.find_spec("playwright") else 1)
-PY
-        if [ $? -eq 0 ]; then
-            echo "$candidate"
-            return 0
-        fi
-    done
-    return 1
-}
+. scripts/lib/python_bin.sh
 
-PYTHON_BIN=$(resolve_python)
+PYTHON_BIN=$(radon_resolve_python playwright)
 if [ -z "$PYTHON_BIN" ]; then
     echo "$(date): No Python interpreter with Playwright available for CTA sync"
     exit 1

--- a/scripts/run_data_refresh.sh
+++ b/scripts/run_data_refresh.sh
@@ -47,39 +47,10 @@ _load_env() {
 _load_env "web/.env"
 _load_env ".env"
 
-resolve_python() {
-    local candidate resolved
-    for candidate in \
-        "${RADON_PYTHON_BIN:-}" \
-        /opt/homebrew/bin/python3.13 \
-        /usr/local/bin/python3.13 \
-        /usr/bin/python3.13 \
-        python3.13; do
-        [ -n "$candidate" ] || continue
-        if [[ "$candidate" == */* ]]; then
-            [ -x "$candidate" ] || continue
-            resolved="$candidate"
-        else
-            resolved=$(command -v "$candidate" 2>/dev/null) || continue
-        fi
-        "$resolved" - <<'PY' >/dev/null 2>&1
-import importlib.util
-import sys
+. scripts/lib/python_bin.sh
 
-required = ("ib_insync", "libsql_experimental")
-version_ok = sys.version_info >= (3, 13)
-dependencies_ok = all(importlib.util.find_spec(name) for name in required)
-raise SystemExit(0 if version_ok and dependencies_ok else 1)
-PY
-        if [ $? -eq 0 ]; then
-            echo "$resolved"
-            return 0
-        fi
-    done
-    return 1
-}
-
-PYTHON_BIN=$(resolve_python)
+RADON_PYTHON_MIN_VERSION="3.13"
+PYTHON_BIN=$(radon_resolve_python ib_insync libsql_experimental)
 if [ -z "$PYTHON_BIN" ]; then
     echo "$(date): No Python 3.13 interpreter with ib_insync and libsql_experimental available for data refresh"
     exit 1

--- a/scripts/run_event_odds.sh
+++ b/scripts/run_event_odds.sh
@@ -14,18 +14,9 @@ cd "$(dirname "$0")/.."
 
 EVENT_ODDS_TICKERS="${RADON_EVENT_ODDS_TICKERS:-SPX NDX RUT VIX}"
 
-resolve_python() {
-    local candidate
-    for candidate in "${RADON_PYTHON_BIN:-}" python3.13 python3.11 python3.9 /usr/bin/python3 python3; do
-        [ -n "$candidate" ] || continue
-        command -v "$candidate" >/dev/null 2>&1 || continue
-        echo "$candidate"
-        return 0
-    done
-    return 1
-}
+. scripts/lib/python_bin.sh
 
-PYTHON_BIN=$(resolve_python)
+PYTHON_BIN=$(radon_resolve_python dotenv)
 if [ -z "$PYTHON_BIN" ]; then
     echo "$(date): No Python interpreter available for event-odds fetch"
     exit 1

--- a/scripts/run_garch_refresh.sh
+++ b/scripts/run_garch_refresh.sh
@@ -57,19 +57,9 @@ _load_env() {
 _load_env "web/.env"
 _load_env ".env"
 
-resolve_python() {
-    local candidate
-    for candidate in "${RADON_PYTHON_BIN:-}" python3.13 python3.9 /usr/bin/python3 python3; do
-        [ -n "$candidate" ] || continue
-        command -v "$candidate" >/dev/null 2>&1 || continue
-        "$candidate" -c "import sys" >/dev/null 2>&1 || continue
-        echo "$candidate"
-        return 0
-    done
-    return 1
-}
+. scripts/lib/python_bin.sh
 
-PYTHON_BIN=$(resolve_python)
+PYTHON_BIN=$(radon_resolve_python numpy dotenv)
 if [ -z "$PYTHON_BIN" ]; then
     echo "$(date): No Python interpreter available for GARCH refresh" >&2
     exit 1

--- a/scripts/run_informed_flow.sh
+++ b/scripts/run_informed_flow.sh
@@ -10,18 +10,9 @@
 
 cd "$(dirname "$0")/.."
 
-resolve_python() {
-    local candidate
-    for candidate in "${RADON_PYTHON_BIN:-}" python3.13 python3.11 python3.9 /usr/bin/python3 python3; do
-        [ -n "$candidate" ] || continue
-        command -v "$candidate" >/dev/null 2>&1 || continue
-        echo "$candidate"
-        return 0
-    done
-    return 1
-}
+. scripts/lib/python_bin.sh
 
-PYTHON_BIN=$(resolve_python)
+PYTHON_BIN=$(radon_resolve_python dotenv)
 if [ -z "$PYTHON_BIN" ]; then
     echo "$(date): No Python interpreter available for informed-flow sweep"
     exit 1

--- a/scripts/run_leap_refresh.sh
+++ b/scripts/run_leap_refresh.sh
@@ -60,19 +60,9 @@ _load_env() {
 _load_env "web/.env"
 _load_env ".env"
 
-resolve_python() {
-    local candidate
-    for candidate in "${RADON_PYTHON_BIN:-}" python3.13 python3.9 /usr/bin/python3 python3; do
-        [ -n "$candidate" ] || continue
-        command -v "$candidate" >/dev/null 2>&1 || continue
-        "$candidate" -c "import sys" >/dev/null 2>&1 || continue
-        echo "$candidate"
-        return 0
-    done
-    return 1
-}
+. scripts/lib/python_bin.sh
 
-PYTHON_BIN=$(resolve_python)
+PYTHON_BIN=$(radon_resolve_python dotenv)
 if [ -z "$PYTHON_BIN" ]; then
     echo "$(date): No Python interpreter available for LEAP refresh" >&2
     exit 1

--- a/scripts/run_margin_debt_refresh.sh
+++ b/scripts/run_margin_debt_refresh.sh
@@ -11,18 +11,9 @@
 
 cd "$(dirname "$0")/.."
 
-resolve_python() {
-    local candidate
-    for candidate in "${RADON_PYTHON_BIN:-}" python3.13 python3.11 python3.9 /usr/bin/python3 python3; do
-        [ -n "$candidate" ] || continue
-        command -v "$candidate" >/dev/null 2>&1 || continue
-        echo "$candidate"
-        return 0
-    done
-    return 1
-}
+. scripts/lib/python_bin.sh
 
-PYTHON_BIN=$(resolve_python)
+PYTHON_BIN=$(radon_resolve_python dotenv)
 if [ -z "$PYTHON_BIN" ]; then
     echo "$(date): No Python interpreter available for margin debt refresh"
     exit 1

--- a/scripts/run_oi_changes_refresh.sh
+++ b/scripts/run_oi_changes_refresh.sh
@@ -58,19 +58,9 @@ _load_env() {
 _load_env "web/.env"
 _load_env ".env"
 
-resolve_python() {
-    local candidate
-    for candidate in "${RADON_PYTHON_BIN:-}" python3.13 python3.11 python3.9 /usr/bin/python3 python3; do
-        [ -n "$candidate" ] || continue
-        command -v "$candidate" >/dev/null 2>&1 || continue
-        "$candidate" -c "import sys" >/dev/null 2>&1 || continue
-        echo "$candidate"
-        return 0
-    done
-    return 1
-}
+. scripts/lib/python_bin.sh
 
-PYTHON_BIN=$(resolve_python)
+PYTHON_BIN=$(radon_resolve_python dotenv)
 if [ -z "$PYTHON_BIN" ]; then
     echo "$(date): No Python interpreter available for OI-changes refresh" >&2
     exit 1

--- a/scripts/run_portfolio_refresh.sh
+++ b/scripts/run_portfolio_refresh.sh
@@ -67,19 +67,9 @@ _load_env() {
 _load_env "web/.env"
 _load_env ".env"
 
-resolve_python() {
-    local candidate
-    for candidate in "${RADON_PYTHON_BIN:-}" python3.13 python3.9 /usr/bin/python3 python3; do
-        [ -n "$candidate" ] || continue
-        command -v "$candidate" >/dev/null 2>&1 || continue
-        "$candidate" -c "import sys" >/dev/null 2>&1 || continue
-        echo "$candidate"
-        return 0
-    done
-    return 1
-}
+. scripts/lib/python_bin.sh
 
-PYTHON_BIN=$(resolve_python)
+PYTHON_BIN=$(radon_resolve_python dotenv)
 if [ -z "$PYTHON_BIN" ]; then
     echo "$(date): No Python interpreter available for portfolio refresh" >&2
     exit 1

--- a/scripts/run_vcg_refresh.sh
+++ b/scripts/run_vcg_refresh.sh
@@ -69,19 +69,9 @@ _load_env() {
 _load_env "web/.env"
 _load_env ".env"
 
-resolve_python() {
-    local candidate
-    for candidate in "${RADON_PYTHON_BIN:-}" python3.13 python3.9 /usr/bin/python3 python3; do
-        [ -n "$candidate" ] || continue
-        command -v "$candidate" >/dev/null 2>&1 || continue
-        "$candidate" -c "import sys" >/dev/null 2>&1 || continue
-        echo "$candidate"
-        return 0
-    done
-    return 1
-}
+. scripts/lib/python_bin.sh
 
-PYTHON_BIN=$(resolve_python)
+PYTHON_BIN=$(radon_resolve_python numpy dotenv)
 if [ -z "$PYTHON_BIN" ]; then
     echo "$(date): No Python interpreter available for vcg refresh" >&2
     exit 1

--- a/scripts/tests/test_local_scheduler_reliability.py
+++ b/scripts/tests/test_local_scheduler_reliability.py
@@ -252,6 +252,9 @@ def _refresh_project(tmp_path: Path) -> tuple[Path, Path, Path]:
     scripts = project / "scripts"
     scripts.mkdir(parents=True)
     shutil.copy2(SCRIPTS_DIR / "run_data_refresh.sh", scripts)
+    # The wrapper sources interpreter resolution from scripts/lib/python_bin.sh.
+    (scripts / "lib").mkdir(parents=True, exist_ok=True)
+    shutil.copy2(SCRIPTS_DIR / "lib" / "python_bin.sh", scripts / "lib" / "python_bin.sh")
 
     data = project / "data"
     data.mkdir()
@@ -404,12 +407,19 @@ def test_post_close_cri_repair_recovers_failed_scan(tmp_path: Path) -> None:
 
 
 def test_data_refresh_resolver_requires_python313_and_runtime_dependencies() -> None:
+    """Interpreter resolution moved to scripts/lib/python_bin.sh, but
+    run_data_refresh.sh must still declare the same two guarantees: a 3.13
+    floor and the runtime dependencies it cannot run without.
+
+    The shared candidate list does include older interpreters, so the
+    "never run this on 3.9" guarantee is now enforced by the version floor
+    rather than by omission. That enforcement is covered behaviourally in
+    scripts/tests/test_wrapper_python_resolution.py.
+    """
     text = (SCRIPTS_DIR / "run_data_refresh.sh").read_text()
 
-    assert "sys.version_info >= (3, 13)" in text
-    assert 'required = ("ib_insync", "libsql_experimental")' in text
-    assert "python3.9" not in text
-    assert "/usr/bin/python3 " not in text
+    assert 'RADON_PYTHON_MIN_VERSION="3.13"' in text
+    assert "radon_resolve_python ib_insync libsql_experimental" in text
 
 
 def test_data_refresh_setup_generator_preserves_explicit_path(tmp_path: Path) -> None:

--- a/scripts/tests/test_run_cta_sync_wrapper.py
+++ b/scripts/tests/test_run_cta_sync_wrapper.py
@@ -30,6 +30,12 @@ def test_run_cta_sync_preserves_literal_env_values(tmp_path: Path) -> None:
 
     wrapper_src = Path(__file__).resolve().parents[1] / "run_cta_sync.sh"
     shutil.copy2(wrapper_src, scripts_dir / "run_cta_sync.sh")
+    # The wrapper sources interpreter resolution from scripts/lib/python_bin.sh.
+    (scripts_dir / "lib").mkdir(parents=True, exist_ok=True)
+    shutil.copy2(
+        Path(__file__).resolve().parents[1] / "lib" / "python_bin.sh",
+        scripts_dir / "lib" / "python_bin.sh",
+    )
     (scripts_dir / "run_cta_sync.sh").chmod((scripts_dir / "run_cta_sync.sh").stat().st_mode | stat.S_IXUSR)
 
     literal_user = "cta-user@example.com"

--- a/scripts/tests/test_run_vcg_refresh_wrapper.py
+++ b/scripts/tests/test_run_vcg_refresh_wrapper.py
@@ -52,7 +52,18 @@ def _stage_wrapper(repo_dir: Path) -> Path:
     dst = scripts_dir / "run_vcg_refresh.sh"
     shutil.copy2(src, dst)
     dst.chmod(dst.stat().st_mode | stat.S_IXUSR)
+    _stage_python_bin_lib(scripts_dir)
     return dst
+
+
+def _stage_python_bin_lib(scripts_dir: Path) -> None:
+    """Wrappers source interpreter resolution from scripts/lib/python_bin.sh."""
+    lib_dir = scripts_dir / "lib"
+    lib_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(
+        Path(__file__).resolve().parents[1] / "lib" / "python_bin.sh",
+        lib_dir / "python_bin.sh",
+    )
 
 
 def _stage_python_with_market_open(bin_dir: Path) -> Path:

--- a/scripts/tests/test_wrapper_python_resolution.py
+++ b/scripts/tests/test_wrapper_python_resolution.py
@@ -1,0 +1,232 @@
+"""Every ``scripts/run_*.sh`` wrapper must resolve the project virtualenv.
+
+Each wrapper is a two-tier scheduler entry point: POST to the local FastAPI
+endpoint first, then fall back to invoking the Python scanner directly when
+FastAPI is unreachable. The fallback exists for exactly one situation — the
+API is down — and on the VPS that is precisely when it was broken.
+
+``resolve_python()`` never listed the project virtualenv among its
+candidates, and ``RADON_PYTHON_BIN`` is unset in every deployed ``.env``.
+So the first match was a bare ``python3.13`` on PATH (``/usr/bin/python3.13``
+on the VPS), which carries none of the project dependencies. The fallback
+died instantly on ``ModuleNotFoundError`` — ``dotenv`` for breadth, ``numpy``
+for vcg — and the next timer tick five minutes later masked it as a flake.
+
+The pre-existing wrapper tests all pinned ``RADON_PYTHON_BIN`` explicitly,
+which short-circuits resolution at the first candidate and is why none of
+them caught this. These tests deliberately leave it unset so the candidate
+*ordering* is what is under test.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+
+# Every wrapper that resolves an interpreter for a direct-invocation fallback.
+WRAPPERS = [
+    "run_breadth_scan.sh",
+    "run_catalysts.sh",
+    "run_cri_scan.sh",
+    "run_cta_sync.sh",
+    "run_data_refresh.sh",
+    "run_event_odds.sh",
+    "run_garch_refresh.sh",
+    "run_informed_flow.sh",
+    "run_leap_refresh.sh",
+    "run_margin_debt_refresh.sh",
+    "run_oi_changes_refresh.sh",
+    "run_portfolio_refresh.sh",
+    "run_vcg_refresh.sh",
+]
+
+
+def _executable(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _stub(identity: str, log: Path, *, has_project_deps: bool) -> str:
+    """A fake interpreter that records that it was chosen.
+
+    ``has_project_deps`` models the real split on the VPS: the virtualenv
+    satisfies every ``importlib.util.find_spec`` probe, the system
+    interpreter satisfies none of them — but still answers a bare
+    ``-c "import sys"`` successfully, which is the whole reason the weak
+    probe selected it.
+    """
+    dep_exit = "0" if has_project_deps else "1"
+    return textwrap.dedent(
+        f"""\
+        #!/bin/bash
+        echo "{identity}" >> "{log}"
+        if [ "$1" = "-c" ]; then
+            # A stdlib-only probe (`import sys`) succeeds on ANY interpreter.
+            # A project-dependency probe must reflect this stub's identity.
+            case "$2" in
+                *"import sys"*) exit 0 ;;
+                *) exit {dep_exit} ;;
+            esac
+        fi
+        if [ "$1" = "-" ]; then
+            # Heredoc mode serves two callers: the trading-day gate (reads
+            # stdout) and find_spec dependency probes (read exit status).
+            cat >/dev/null
+            echo "yes"
+            exit {dep_exit}
+        fi
+        exit {dep_exit}
+        """
+    )
+
+
+def _stage(tmp_path: Path, wrapper: str) -> tuple[Path, Path, dict[str, str]]:
+    repo = tmp_path / "repo"
+    (repo / "scripts").mkdir(parents=True)
+    shutil.copy2(SCRIPTS_DIR / wrapper, repo / "scripts" / wrapper)
+    # The wrappers source their interpreter resolution from a shared helper.
+    (repo / "scripts" / "lib").mkdir()
+    shutil.copy2(SCRIPTS_DIR / "lib" / "python_bin.sh",
+                 repo / "scripts" / "lib" / "python_bin.sh")
+
+    log = tmp_path / "which-python.log"
+
+    # The project virtualenv: has every dependency.
+    _executable(repo / ".venv" / "bin" / "python3.13",
+                _stub("venv", log, has_project_deps=True))
+    _executable(repo / ".venv" / "bin" / "python",
+                _stub("venv", log, has_project_deps=True))
+
+    # A bare system interpreter earlier on PATH: no project dependencies.
+    # This is /usr/bin/python3.13 on the VPS.
+    fake_bin = tmp_path / "fakebin"
+    for name in ("python3.13", "python3.11", "python3.9", "python3"):
+        _executable(fake_bin / name, _stub("system", log, has_project_deps=False))
+
+    env = {
+        "PATH": f"{fake_bin}:/usr/bin:/bin",
+        "HOME": str(tmp_path),
+        # Deliberately NOT setting RADON_PYTHON_BIN — that is the deployed
+        # reality and the condition under which resolution actually matters.
+    }
+    return repo, log, env
+
+
+@pytest.mark.parametrize("wrapper", WRAPPERS)
+def test_wrapper_prefers_venv_over_bare_path_python(tmp_path: Path, wrapper: str) -> None:
+    """The virtualenv must win over a dependency-less PATH interpreter."""
+    repo, log, env = _stage(tmp_path, wrapper)
+
+    subprocess.run(
+        ["bash", str(repo / "scripts" / wrapper)],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
+    )
+
+    assert log.exists(), (
+        f"{wrapper} resolved no interpreter at all — it should have found "
+        f"the virtualenv at .venv/bin/python3.13"
+    )
+    chosen = log.read_text(encoding="utf-8").split()
+    assert chosen[0] == "venv", (
+        f"{wrapper} chose the bare system interpreter over the project "
+        f"virtualenv. On the VPS that interpreter has no project "
+        f"dependencies, so the direct-invocation fallback dies on "
+        f"ModuleNotFoundError. Resolution order was: {chosen}"
+    )
+
+
+def _resolve(tmp_path: Path, args: str, extra_env: dict[str, str] | None = None):
+    """Source the shared helper and call radon_resolve_python directly."""
+    script = tmp_path / "probe.sh"
+    script.write_text(
+        f'. "{SCRIPTS_DIR / "lib" / "python_bin.sh"}"\n'
+        f"radon_resolve_python {args}\n",
+        encoding="utf-8",
+    )
+    return subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
+        env={**os.environ, **(extra_env or {})},
+    )
+
+
+def test_version_floor_rejects_every_interpreter_below_it(tmp_path: Path) -> None:
+    """RADON_PYTHON_MIN_VERSION is what keeps run_data_refresh.sh off 3.9.
+
+    The shared candidate list includes older interpreters, so the floor —
+    not omission from the list — is the mechanism. An unsatisfiable floor
+    must reject everything rather than quietly returning something older.
+    """
+    result = _resolve(tmp_path, "", {"RADON_PYTHON_MIN_VERSION": "99.0"})
+
+    assert result.returncode != 0, (
+        f"an unsatisfiable version floor still resolved {result.stdout.strip()!r}"
+    )
+    assert result.stdout.strip() == ""
+
+
+def test_missing_dependency_is_rejected_rather_than_deferred(tmp_path: Path) -> None:
+    """Resolution must fail loudly, not hand back a broken interpreter.
+
+    Returning one anyway is the original bug: the caller proceeds and dies
+    on ModuleNotFoundError deep inside the scanner, five minutes before the
+    next timer tick papers over it.
+    """
+    result = _resolve(tmp_path, "a_module_that_does_not_exist_anywhere")
+
+    assert result.returncode != 0, (
+        f"resolution returned {result.stdout.strip()!r} despite the required "
+        f"module being absent"
+    )
+    assert result.stdout.strip() == ""
+
+
+def test_resolves_a_real_interpreter_for_a_stdlib_module(tmp_path: Path) -> None:
+    """Sanity check that the probe is not simply rejecting everything."""
+    result = _resolve(tmp_path, "json")
+
+    assert result.returncode == 0, result.stderr
+    assert Path(result.stdout.strip()).exists()
+
+
+@pytest.mark.parametrize("wrapper", WRAPPERS)
+def test_explicit_python_bin_still_wins(tmp_path: Path, wrapper: str) -> None:
+    """An operator-pinned RADON_PYTHON_BIN keeps priority over the venv."""
+    repo, log, env = _stage(tmp_path, wrapper)
+
+    pinned = tmp_path / "pinned" / "python3.13"
+    _executable(pinned, _stub("pinned", log, has_project_deps=True))
+    env["RADON_PYTHON_BIN"] = str(pinned)
+
+    subprocess.run(
+        ["bash", str(repo / "scripts" / wrapper)],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
+    )
+
+    assert log.exists(), f"{wrapper} resolved no interpreter at all"
+    chosen = log.read_text(encoding="utf-8").split()
+    assert chosen[0] == "pinned", (
+        f"{wrapper} ignored an explicitly pinned RADON_PYTHON_BIN. "
+        f"Resolution order was: {chosen}"
+    )


### PR DESCRIPTION
## Problem

Every `scripts/run_*.sh` wrapper is two-tier: POST to local FastAPI first, then **fall back to invoking the Python scanner directly** when FastAPI is unreachable. On the VPS that fallback could never succeed.

`resolve_python()` accepted the first candidate passing `-c "import sys"` — a probe *every* interpreter passes — and never listed the project virtualenv. With `RADON_PYTHON_BIN` unset in all three deployed `.env` files, the winner was `/usr/bin/python3.13`, which carries none of the project dependencies:

```
/tmp/breadth-scan.err  ->  ModuleNotFoundError: No module named 'dotenv'
/tmp/vcg-scan.err      ->  ModuleNotFoundError: No module named 'numpy'
```

The fallback died at exactly the moment it existed to help, and the next timer tick 5 minutes later masked it as a flake.

### How it surfaced

Investigating "why does breadth keep failing". It doesn't — **991 runs, 987 OK over 13 days (99.6%)**. All 4 failures coincided with a deploy. Two were a harmless SIGTERM race (`stop-clean` killing an oneshot the timer started ~1s earlier); the other two took this fallback and hit the bug above.

## Change

The 13 private copies had drifted into three behaviours — a real dependency probe, the stdlib-only probe, and **no probe at all**. Replaced with one shared `scripts/lib/python_bin.sh`:

- operator-pinned `RADON_PYTHON_BIN` first, then the **venv**, then PATH interpreters
- candidates filtered by the modules each wrapper actually needs
- optional `RADON_PYTHON_MIN_VERSION` floor
- fails loudly instead of returning a broken interpreter

Net **-129 lines**.

### Behaviour preserved

`run_data_refresh.sh` keeps its `>=3.13` floor via `RADON_PYTHON_MIN_VERSION`. Its old "never run on 3.9" guarantee came from *omitting* 3.9 from a private candidate list; the shared list includes it, so the floor now enforces that. Swapped the string assertion for behavioural coverage.

## Verification

Live on the VPS, against the real interpreters:

```
dotenv           -> .venv/bin/python3.13
numpy            -> .venv/bin/python3.13
ib_insync+libsql -> .venv/bin/python3.13
playwright       -> .venv/bin/python3.13
--- old code picked ---
command -v python3.13 = /usr/bin/python3.13
--- floor enforcement ---
floor rejects everything as expected
```

New test `scripts/tests/test_wrapper_python_resolution.py` was **red for all 13 wrappers** before the fix. Every pre-existing wrapper test pinned `RADON_PYTHON_BIN`, which short-circuits resolution — that is why none of them caught this. These leave it unset so candidate *ordering* is under test.

| Suite | Result |
|---|---|
| pytest | 4651 passed, 14 skipped |
| cloud/tests | 700 passed, 2 skipped |
| vitest | 4470 passed, 0 failed |
| `bash -n` | 13 wrappers + lib OK |

Deploy safety: `/home/radon/radon` is a git checkout (654 tracked files under `scripts/`, nested subdirs included), so the new `scripts/lib/python_bin.sh` ships automatically — no rsync allowlist to update.

## Not addressed

The deploy/timer SIGTERM race that latches `Result=signal` on in-flight oneshots. Cosmetic, self-heals next tick, but the watchdog error bucket alerts on it — worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)