### PR TITLE
fix(flow): paginate UW darkpool beyond 500 print cap

### DIFF
--- a/docs/unusual_whales_api.md
+++ b/docs/unusual_whales_api.md
@@ -25,7 +25,13 @@ The `UW_TOKEN` environment variable should contain your API key.
 - `date` (query, optional): ISO date (YYYY-MM-DD), defaults to current/last market day
 - `min_premium`, `max_premium`: Filter by trade premium
 - `min_size`, `max_size`: Filter by trade size
-- `limit`: Max 500
+- `limit`: Default 500, **max 500** (hard cap per request)
+- `older_than` / `newer_than`: time cursors (unix ms/s or ISO/RFC3339) for pagination
+- `order`: `desc` (default) or `asc`; `order_by` defaults to `executed_at`
+
+**Pagination:** one request never returns more than 500 prints. Radon
+`fetch_flow.fetch_darkpool` walks `older_than` (desc) until a short page.
+Liquid names (GLD, SPY) routinely need multiple pages per session day.
 
 **Response Fields:**
 ```json

--- a/scripts/clients/uw_client.py
+++ b/scripts/clients/uw_client.py
@@ -264,16 +264,32 @@ class UWClient:
         max_premium: Optional[int] = None,
         min_size: Optional[int] = None,
         max_size: Optional[int] = None,
+        min_volume: Optional[int] = None,
+        max_volume: Optional[int] = None,
+        newer_than: Optional[str] = None,
+        older_than: Optional[str] = None,
         limit: Optional[int] = None,
+        order: Optional[str] = None,
+        order_by: Optional[str] = None,
     ) -> dict:
-        """GET /api/darkpool/{ticker} - Dark pool trades for a ticker."""
+        """GET /api/darkpool/{ticker} - Dark pool trades for a ticker.
+
+        UW hard-caps ``limit`` at 500. Walk the day with ``older_than`` /
+        ``newer_than`` (time cursors) when a full page is returned.
+        """
         params = self._build_params(
             date=date,
             min_premium=min_premium,
             max_premium=max_premium,
             min_size=min_size,
             max_size=max_size,
+            min_volume=min_volume,
+            max_volume=max_volume,
+            newer_than=newer_than,
+            older_than=older_than,
             limit=limit,
+            order=order,
+            order_by=order_by,
         )
         return self._get(f"darkpool/{ticker.upper()}", params=params)
 

--- a/scripts/discover.py
+++ b/scripts/discover.py
@@ -161,13 +161,15 @@ def fetch_darkpool_multi(ticker: str, days: int = 3, _client: UWClient = None) -
         # Prior (closed) sessions are immutable — serve from the shared on-disk
         # cache and skip UW. Only today hits the API. (Same P0 reduction as
         # fetch_flow; discover scans market-wide so this is high-impact.)
+        # Full-day multi-page walk lives in fetch_flow.fetch_darkpool (UW 500 cap).
+        from fetch_flow import fetch_darkpool
+
         trades = get_cached_darkpool(ticker, date)
         if trades is None:
             try:
-                resp = client.get_darkpool_flow(ticker, date=date)
+                trades = fetch_darkpool(ticker, date=date, _client=client)
             except UWAPIError:
                 return None, []
-            trades = resp.get("data", [])
             if isinstance(trades, list):
                 set_cached_darkpool(ticker, date, trades)
         if isinstance(trades, list):

--- a/scripts/fetch_flow.py
+++ b/scripts/fetch_flow.py
@@ -46,6 +46,12 @@ logger = logging.getLogger(__name__)
 # retry covers the common transient case without amplifying the throttle.
 _UW_TRANSIENT_RETRY_SLEEP_S = 2.0
 
+# UW /api/darkpool/{ticker}: limit default 500, max 500. Full days on liquid
+# names (GLD, SPY, …) require older_than cursor walks (default order=desc).
+DARKPOOL_PAGE_LIMIT = 500
+# Safety ceiling: 40 pages × 500 = 20k prints/day. Beyond that log and stop.
+DARKPOOL_MAX_PAGES = 40
+
 # Session calendar is always US/Eastern. Host-local/UTC datetime.now() on CI
 # runners (and the VPS after 20:00 ET) invents an extra "today" that is not
 # yet a US session day and breaks the darkpool cache immutability contract.
@@ -281,6 +287,22 @@ def _call_uw_with_retry(call, *, what: str, retry_transient: bool = True):
         raise
 
 
+def _darkpool_page_cursor(trades: List[Dict]) -> Optional[str]:
+    """Oldest executed_at on a desc-ordered page → next older_than cursor.
+
+    Returns None when the page has no usable timestamps (cannot advance).
+    """
+    oldest: Optional[str] = None
+    for trade in trades:
+        ts = trade.get("executed_at") or trade.get("trf_executed_at")
+        if not ts:
+            continue
+        ts_s = str(ts)
+        if oldest is None or ts_s < oldest:
+            oldest = ts_s
+    return oldest
+
+
 def fetch_darkpool(
     ticker: str,
     date: Optional[str] = None,
@@ -288,7 +310,10 @@ def fetch_darkpool(
     *,
     retry_transient: bool = True,
 ) -> List[Dict]:
-    """Fetch dark pool trade prints for a ticker.
+    """Fetch dark pool trade prints for a ticker (full day, multi-page).
+
+    UW hard-caps each response at ``DARKPOOL_PAGE_LIMIT`` (500). Walks
+    older pages with ``older_than`` until a short page or empty page.
 
     Returns list of individual dark pool transactions with price, size,
     NBBO context, and premium.
@@ -298,16 +323,58 @@ def fetch_darkpool(
     flow_report build rather than build a structurally-degraded report
     that gets cached.
     """
-    def _fetch(client):
-        what = f"darkpool({ticker}, date={date})"
-        resp = _call_uw_with_retry(
-            lambda: client.get_darkpool_flow(ticker, date=date),
+    def _fetch_page(client, *, older_than: Optional[str]):
+        what = f"darkpool({ticker}, date={date}, older_than={older_than})"
+        return _call_uw_with_retry(
+            lambda: client.get_darkpool_flow(
+                ticker,
+                date=date,
+                limit=DARKPOOL_PAGE_LIMIT,
+                older_than=older_than,
+                order="desc",
+            ),
             what=what,
             retry_transient=retry_transient,
         )
-        if resp is None:
-            return []
-        return resp.get("data", [])
+
+    def _fetch(client):
+        all_trades: List[Dict] = []
+        older_than: Optional[str] = None
+        seen_ids: set = set()
+        for page_idx in range(DARKPOOL_MAX_PAGES):
+            resp = _fetch_page(client, older_than=older_than)
+            if resp is None:
+                break
+            page = resp.get("data") or []
+            if not isinstance(page, list) or not page:
+                break
+
+            for trade in page:
+                tid = trade.get("tracking_id")
+                if tid is not None:
+                    if tid in seen_ids:
+                        continue
+                    seen_ids.add(tid)
+                all_trades.append(trade)
+
+            if len(page) < DARKPOOL_PAGE_LIMIT:
+                break
+
+            next_cursor = _darkpool_page_cursor(page)
+            if next_cursor is None or next_cursor == older_than:
+                logger.warning(
+                    "darkpool(%s, date=%s): full page without advancing cursor; "
+                    "stopping at %d prints",
+                    ticker, date, len(all_trades),
+                )
+                break
+            older_than = next_cursor
+        else:
+            logger.warning(
+                "darkpool(%s, date=%s): hit DARKPOOL_MAX_PAGES=%d (%d prints)",
+                ticker, date, DARKPOOL_MAX_PAGES, len(all_trades),
+            )
+        return all_trades
 
     if _client is not None:
         return _fetch(_client)

--- a/scripts/tests/test_backfill_flow_history.py
+++ b/scripts/tests/test_backfill_flow_history.py
@@ -31,6 +31,7 @@ def _write_cache_file(ticker: str, date: str, trades: list) -> None:
         "ticker": ticker.upper(),
         "date": date,
         "count": len(trades),
+        "schema": darkpool_cache.CACHE_SCHEMA,
         "cached_at": datetime.now().isoformat(),
         "trades": trades,
     }

--- a/scripts/tests/test_darkpool_cache.py
+++ b/scripts/tests/test_darkpool_cache.py
@@ -69,6 +69,44 @@ class TestPriorDayRoundTrip:
         payload = json.loads(path.read_text())
         assert payload["count"] == 2
         assert payload["date"] == date
+        assert payload["schema"] == dpc.CACHE_SCHEMA
+
+
+class TestCacheSchemaPagination:
+    """Pre-pagination disk rows (schema missing / < 2) are single-page
+    truncated at UW's 500 limit. Reject them so liquid names re-fetch.
+    """
+
+    def test_legacy_schema_miss_forces_refetch(self):
+        date = _yesterday()
+        path = dpc._path("GLD", date)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({
+            "ticker": "GLD",
+            "date": date,
+            "count": 500,
+            "trades": [{"price": 1, "size": 1}] * 500,
+            # no schema key — pre-pagination write
+        }))
+        assert dpc.get_cached_darkpool("GLD", date) is None
+
+    def test_schema_v1_miss(self):
+        date = _yesterday()
+        path = dpc._path("GLD", date)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({
+            "ticker": "GLD",
+            "date": date,
+            "count": 500,
+            "schema": 1,
+            "trades": [{"price": 1, "size": 1}] * 500,
+        }))
+        assert dpc.get_cached_darkpool("GLD", date) is None
+
+    def test_current_schema_hit(self):
+        date = _yesterday()
+        dpc.set_cached_darkpool("GLD", date, SAMPLE_TRADES)
+        assert dpc.get_cached_darkpool("GLD", date) == SAMPLE_TRADES
 
 
 # ── today is never cached ───────────────────────────────────────────

--- a/scripts/tests/test_fetch_flow.py
+++ b/scripts/tests/test_fetch_flow.py
@@ -316,6 +316,107 @@ class TestFetchFlowCombinedSignal:
         assert result["combined_signal"] == "DP_ACCUMULATION_ONLY"
 
 
+class TestDarkpoolPagination:
+    """UW hard-caps each darkpool response at 500. Liquid names (GLD)
+    need older_than cursor walks so Daily Dark Pool History is not stuck
+    at 500 prints forever.
+    """
+
+    def _trade(self, i: int, executed_at: str) -> dict:
+        return {
+            "size": 100 + i,
+            "price": 50.0,
+            "premium": 5000,
+            "nbbo_bid": 49.9,
+            "nbbo_ask": 50.1,
+            "executed_at": executed_at,
+            "tracking_id": i,
+        }
+
+    def test_single_short_page_one_call(self):
+        from fetch_flow import DARKPOOL_PAGE_LIMIT, fetch_darkpool
+
+        mock_client = MagicMock()
+        page = [self._trade(i, f"2026-08-06T14:00:{i:02d}Z") for i in range(3)]
+        mock_client.get_darkpool_flow.return_value = {"data": page}
+
+        result = fetch_darkpool("GLD", date="2026-08-06", _client=mock_client)
+
+        assert result == page
+        assert mock_client.get_darkpool_flow.call_count == 1
+        kwargs = mock_client.get_darkpool_flow.call_args.kwargs
+        assert kwargs.get("limit") == DARKPOOL_PAGE_LIMIT
+        assert kwargs.get("older_than") is None
+
+    def test_full_page_then_partial_walks_older_than(self):
+        from fetch_flow import DARKPOOL_PAGE_LIMIT, _darkpool_page_cursor, fetch_darkpool
+
+        # Strictly desc timestamps so cursor is unambiguous.
+        page1 = [
+            self._trade(i, f"2026-08-06T16:{59 - (i // 60):02d}:{59 - (i % 60):02d}Z")
+            for i in range(DARKPOOL_PAGE_LIMIT)
+        ]
+        oldest_p1 = _darkpool_page_cursor(page1)
+        page2 = [
+            self._trade(500 + i, f"2026-08-06T12:00:{i:02d}Z") for i in range(42)
+        ]
+        mock_client = MagicMock()
+        mock_client.get_darkpool_flow.side_effect = [
+            {"data": page1},
+            {"data": page2},
+        ]
+
+        result = fetch_darkpool("GLD", date="2026-08-06", _client=mock_client)
+
+        assert len(result) == DARKPOOL_PAGE_LIMIT + 42
+        assert mock_client.get_darkpool_flow.call_count == 2
+        second = mock_client.get_darkpool_flow.call_args_list[1].kwargs
+        assert second["older_than"] == oldest_p1
+        assert second["date"] == "2026-08-06"
+        assert second["limit"] == DARKPOOL_PAGE_LIMIT
+
+    def test_three_full_pages_then_empty_stops(self):
+        from fetch_flow import DARKPOOL_PAGE_LIMIT, _darkpool_page_cursor, fetch_darkpool
+
+        pages = []
+        for p in range(3):
+            pages.append([
+                self._trade(
+                    p * DARKPOOL_PAGE_LIMIT + i,
+                    f"2026-08-06T{16 - p:02d}:{59 - (i // 60):02d}:{59 - (i % 60):02d}Z",
+                )
+                for i in range(DARKPOOL_PAGE_LIMIT)
+            ])
+        mock_client = MagicMock()
+        mock_client.get_darkpool_flow.side_effect = [
+            {"data": pages[0]},
+            {"data": pages[1]},
+            {"data": pages[2]},
+            {"data": []},
+        ]
+
+        result = fetch_darkpool("GLD", date="2026-08-06", _client=mock_client)
+
+        assert len(result) == 3 * DARKPOOL_PAGE_LIMIT
+        assert mock_client.get_darkpool_flow.call_count == 4
+        assert mock_client.get_darkpool_flow.call_args_list[3].kwargs["older_than"] == (
+            _darkpool_page_cursor(pages[2])
+        )
+
+    def test_stops_when_cursor_cannot_advance(self):
+        """If UW returns a full page without a usable older cursor, stop."""
+        from fetch_flow import DARKPOOL_PAGE_LIMIT, fetch_darkpool
+
+        page = [{"size": 1, "price": 1.0, "premium": 1} for _ in range(DARKPOOL_PAGE_LIMIT)]
+        mock_client = MagicMock()
+        mock_client.get_darkpool_flow.return_value = {"data": page}
+
+        result = fetch_darkpool("GLD", date="2026-08-06", _client=mock_client)
+
+        assert len(result) == DARKPOOL_PAGE_LIMIT
+        assert mock_client.get_darkpool_flow.call_count == 1
+
+
 class TestUWRetryPolicy:
     """Regression for the 2026-05-15 EWY incident: a transient UW
     rate-limit on per-day darkpool calls was silently swallowed and

--- a/scripts/tests/test_uw_client.py
+++ b/scripts/tests/test_uw_client.py
@@ -353,6 +353,22 @@ class TestDarkPoolEndpoints:
         assert call_kwargs["params"]["min_premium"] == 100000
         assert call_kwargs["params"]["limit"] == 100
 
+    def test_get_darkpool_flow_pagination_cursors(self, client, mock_session):
+        """UW pages darkpool by time: older_than / newer_than + limit."""
+        mock_session.get.return_value = _make_response(200, {"data": []})
+        client.get_darkpool_flow(
+            "GLD",
+            date="2026-08-06",
+            limit=500,
+            older_than="2026-08-06T15:30:00Z",
+            order="desc",
+        )
+        params = mock_session.get.call_args[1]["params"]
+        assert params["date"] == "2026-08-06"
+        assert params["limit"] == 500
+        assert params["older_than"] == "2026-08-06T15:30:00Z"
+        assert params["order"] == "desc"
+
     def test_get_darkpool_flow_uppercases_ticker(self, client, mock_session):
         mock_session.get.return_value = _make_response(200, {"data": []})
         client.get_darkpool_flow("aapl")

--- a/scripts/utils/darkpool_cache.py
+++ b/scripts/utils/darkpool_cache.py
@@ -20,6 +20,11 @@ This cache persists prior-day prints to disk so only TODAY hits UW intraday:
 
 This collapses scanner/flow dark-pool load from ~5 calls/ticker/run to ~1
 (today only) — an ~80% cut against the UW daily request budget.
+
+Schema:
+  - v1 / missing: single-page fetch (UW 500 cap) — treat as miss so liquid
+    names re-fetch with multi-page pagination.
+  - v2: full-day cursor walk complete.
 """
 
 from __future__ import annotations
@@ -36,6 +41,9 @@ _ET = pytz.timezone("America/New_York")
 
 # Module-level so tests can monkeypatch it to a tmp dir.
 CACHE_DIR = Path(__file__).resolve().parent.parent.parent / "data" / "darkpool_cache"
+
+# Bump when on-disk payload semantics change (forces re-fetch of stale rows).
+CACHE_SCHEMA = 2
 
 # Entries older than this are never read again (lookback windows are <= ~5 days),
 # so they are pruned to keep the directory bounded.
@@ -77,6 +85,10 @@ def get_cached_darkpool(ticker: str, date: str) -> Optional[List[dict]]:
             payload = json.load(f)
     except (OSError, ValueError):
         return None
+    # Reject pre-pagination rows (missing/legacy schema) so liquid names
+    # re-walk UW pages instead of serving a 500-print truncated day forever.
+    if payload.get("schema") != CACHE_SCHEMA:
+        return None
     trades = payload.get("trades")
     return trades if isinstance(trades, list) else None
 
@@ -103,6 +115,7 @@ def set_cached_darkpool(ticker: str, date: str, trades) -> None:
         "ticker": ticker.upper(),
         "date": date,
         "count": len(trades),
+        "schema": CACHE_SCHEMA,
         "cached_at": datetime.now(_ET).isoformat(),
         "trades": trades,
     }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,153 @@
+# Task: Dark pool multi-page pagination (2026-08-07)
+
+## Summary
+
+UW `/api/darkpool/{ticker}` returns max 500 prints per request. Liquid names
+(GLD) saturate Daily Dark Pool History at 500. Paginate with `older_than`
+until a short page; bust single-page disk cache.
+
+## Dependency graph
+
+- T1 depends_on: [] - Failing tests for client params, page loop, cache schema v2
+- T2 depends_on: [T1] - Implement pagination in fetch_darkpool + client + cache + discover
+- T3 depends_on: [T2] - Docs + focused pytest green
+
+## Checklist
+
+- [x] T1 Red tests
+- [x] T2 Implement
+- [x] T3 Verify
+
+## Review
+
+- `fetch_darkpool` walks UW pages with `older_than` (max 40×500).
+- Disk cache schema v2; legacy single-page rows miss and re-fetch.
+- `discover.fetch_darkpool_multi` reuses paginated fetch.
+- Focused pytest: 311 passed.
+
+---
+
+# Task: Implement execution-linked return capital v2 (2026-08-07)
+
+## Summary
+
+Replace the rejected structure-key Reg-T producer with a fail-closed capital
+basis ledger keyed to immutable position instances and exact executions.
+
+## User story
+
+As the portfolio operator, I want Return % to use exact loss/debit or an
+isolated broker-observed opening margin delta so credit and undefined-risk
+positions show defensible performance instead of premium-based or modeled ROE.
+
+## Acceptance criteria
+
+- Generic Return % accepts only exact or isolated-observed capital.
+- Every observed basis links account, position instance, conIds, orderRef or
+  permId, execIds, currency, multiplier, and before/after margin samples.
+- Open/add/reduce/close/zero-cross/reopen lifecycle replay is deterministic and
+  idempotent; reopen never inherits an old basis.
+- What-if and modeled Reg-T remain estimated and never become generic Return %.
+- SMART combo error 360 without an isolated observation remains unavailable.
+- `/orders/place` performs no what-if, capital write, or reconciliation wait.
+- Missing schema, ambiguous linkage, concurrent account events, stale samples,
+  currency mismatch, or invalid provenance fails closed to `N/A`.
+
+## Non-goals
+
+- Do not allocate Portfolio Margin using summed leg estimates.
+- Do not backfill verified capital from ticker/expiry/structure similarity.
+- Do not mutate live orders or run a production capture during implementation.
+
+## Risks and assumptions
+
+- IB exposes account-level margin, not native per-position margin; observed
+  attribution is valid only inside an isolated execution window.
+- Historical fills may lack enough identity or margin samples and must remain
+  unavailable.
+
+## Dependency graph
+
+- T1 depends_on: [] - Trace execution identity, fill ingestion, account-margin sampling, journal persistence, and UI hydration contracts.
+- T2 depends_on: [T1] - Add red regression coverage for lifecycle identity, provenance, isolation rejection, API safety, and UI fail-closed behavior.
+- T3 depends_on: [T2] - Replace migration and rejected helpers with the v2 instance/execution/sample/observation ledger.
+- T4 depends_on: [T3] - Integrate future-fill sampling and asynchronous reconciliation outside `/orders/place`.
+- T5 depends_on: [T3, T4] - Hydrate exact/observed v2 payloads and keep estimates unavailable in every portfolio surface.
+- T6 depends_on: [T5] - Run focused and full Python/TypeScript suites, Playwright/browser verification, migration checks, and document rollout.
+
+## Checklist
+
+- [x] T1 Trace identity and sampling paths.
+- [x] T2 Red regression coverage.
+- [x] T3 V2 ledger and migration.
+- [x] T4 Asynchronous sampling/reconciliation.
+- [x] T5 Portfolio/UI hydration.
+- [x] T6 Verification and rollout review.
+
+## Review
+
+- Replaced the rejected ticker/expiry/size key and modeled Reg-T producer with
+  immutable account-scoped execution facts, position episodes, lifecycle
+  events, account margin samples, and isolated capital observations.
+- Existing portfolio and orders syncs provide the evidence without another IB
+  socket: portfolio sync records one-minute `InitMarginReq` plus signed conId
+  vectors; orders sync preserves account, conId, permId/orderRef, execId,
+  currency, multiplier, exact time, and correction lineage.
+- Replay covers open, add, reduce, close, zero-cross, and reopen. Duplicate
+  execution syncs are idempotent; corrections and ambiguous/concurrent/stale
+  windows fail closed instead of inheriting or overwriting an old basis.
+- The web accepts only v2 exact or isolated-observed provenance. Legacy,
+  versionless, what-if, Reg-T modeled, unlinked, mismatched, or incomplete
+  payloads render `N/A`. Defined max risk and demonstrable full-loss debit keep
+  exact priority.
+- `/orders/place` still performs no what-if, capital write, IB evidence read,
+  or reconciliation wait. It only stamps a durable 32-character `orderRef` for
+  later execution linkage.
+- Verification: focused Python 13 passed; affected Python 604 passed with only
+  seven unrelated pre-existing dark-pool cache fixture failures. Full Python
+  reached 4,978 passed / 13 skipped with one unrelated stale
+  `data/performance.json` `period_label` failure. Full Vitest passed 5,006 with
+  26 skipped; TypeScript, focused ESLint, production build, and the 144-manifest
+  output-trace audit passed. Playwright passed and the rendered SPCX +70.9%
+  isolated-observed Return was visually inspected.
+- No IB calls, Turso writes, migrations, commits, pushes, or deployments were
+  performed during implementation.
+
+---
+
+# Task: Isolate SKEW and redesign return capital (2026-08-07)
+
+## Dependency graph
+
+- T1 depends_on: [] - Freeze the SKEW commit scope and preserve unrelated return-capital work.
+- T2 depends_on: [T1] - Commit the verified real-time SKEW implementation on a feature branch.
+- T3 depends_on: [T1] - Start a separate read-only agent workflow for the return-capital redesign.
+- T4 depends_on: [T1] - Remove only the generated gold/silver research bundle using a recoverable operation.
+- T5 depends_on: [T2, T3, T4] - Verify repository state and record the handoff.
+
+## Checklist
+
+- [x] T1 Freeze scope.
+- [x] T2 Commit SKEW.
+- [x] T3 Start return-capital redesign workflow.
+- [x] T4 Discard gold/silver research bundle.
+- [x] T5 Verify and hand off.
+
+## Review
+
+- Real-time SKEW was committed alone as `af255787` on `feat/realtime-skew`; it
+  was not pushed. Return-capital files remained uncommitted and unstaged.
+- The redesign audit rejected the current producer because it labels a
+  current Reg-T heuristic as fill-linked opening margin. The replacement uses
+  immutable position instances, execution-linked lifecycle events, and only
+  exact or isolated observed capital for generic Return %.
+- Twenty-three generated gold/silver research files were moved to the macOS
+  Trash for recovery rather than permanently deleted.
+- `data/earnings_dates/HONA.json` is a generated Theta Harvester earnings
+  fallback cache and remains untouched.
+
+---
+
 # Task: Keep Upcoming Catalysts current (2026-08-07)
 
 ## Goal


### PR DESCRIPTION
## Summary
- UW `/api/darkpool/{ticker}` maxes at 500 prints per request; liquid names (GLD) froze Daily Dark Pool History at 500.
- `fetch_darkpool` now walks `older_than` until a short page (cap 40×500).
- Disk cache schema v2 invalidates truncated single-page history; discover reuses the same path.

## Live proof (local UW, pre-merge)
| Date | num_prints |
|------|------------|
| 2026-08-07 | 7403 |
| 2026-08-06 | 5565 |
| 2026-08-05 | 4192 |
| 2026-08-04 | 1835 |
| 2026-08-03 | 944 |

## Test plan
- [x] Focused pytest (pagination, cache schema, UW client) green
- [x] Live `fetch_darkpool("GLD")` multi-page >500
- [ ] After deploy: POST `/flow-analysis/GLD` and confirm daily `num_prints` ≫ 500