### PR TITLE
feat(flow): 20-session dark pool history with progressive chart

### DIFF
--- a/scripts/api/server.py
+++ b/scripts/api/server.py
@@ -1903,7 +1903,13 @@ async def run_flow_report(ticker: str):
                 pass
         return demo_disabled_payload(f"Live flow analysis for {upper}")
 
-    result = await run_script("flow_report.py", [upper], timeout=120)
+    # 20 trading-day dark-pool history (flow_report DEFAULT_LOOKBACK_DAYS).
+    # Cold liquid names paginate UW heavily; allow longer than the old 120s.
+    result = await run_script(
+        "flow_report.py",
+        [upper, "--days", "20"],
+        timeout=300,
+    )
     if not result.ok:
         raise HTTPException(status_code=502, detail=result.error)
     if not result.data:

--- a/scripts/flow_report.py
+++ b/scripts/flow_report.py
@@ -22,6 +22,10 @@ from scanner import analyze_signal
 _BULLISH_OPTION_BIAS = {"BULLISH", "STRONGLY_BULLISH"}
 _BEARISH_OPTION_BIAS = {"BEARISH", "STRONGLY_BEARISH"}
 
+# Daily Dark Pool History window for the per-ticker flow report UI.
+# Scanner / batch paths keep their own shorter defaults for rate budget.
+DEFAULT_LOOKBACK_DAYS = 20
+
 
 def _classify_direction(flow: Dict[str, Any], analysis: Dict[str, Any]) -> Dict[str, Any]:
     """Pick BULLISH / NEUTRAL / BEARISH and a confidence score.
@@ -74,7 +78,7 @@ def _classify_direction(flow: Dict[str, Any], analysis: Dict[str, Any]) -> Dict[
     }
 
 
-def build_report(ticker: str, lookback_days: int = 5) -> Dict[str, Any]:
+def build_report(ticker: str, lookback_days: int = DEFAULT_LOOKBACK_DAYS) -> Dict[str, Any]:
     """Run the flow fetch + analysis pipeline for a single ticker."""
     ticker = ticker.upper()
     flow = fetch_flow(ticker, lookback_days=lookback_days)
@@ -99,7 +103,12 @@ def build_report(ticker: str, lookback_days: int = 5) -> Dict[str, Any]:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run flow report for a single ticker")
     parser.add_argument("ticker", help="Stock ticker symbol")
-    parser.add_argument("--days", type=int, default=5, help="Lookback trading days (default 5)")
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=DEFAULT_LOOKBACK_DAYS,
+        help=f"Lookback trading days (default {DEFAULT_LOOKBACK_DAYS})",
+    )
     args = parser.parse_args()
 
     try:

--- a/scripts/tests/test_flow_report_lookback.py
+++ b/scripts/tests/test_flow_report_lookback.py
@@ -1,0 +1,24 @@
+"""flow_report defaults to a 20-session dark-pool history window."""
+
+from unittest.mock import patch
+
+
+def test_build_report_default_lookback_is_20():
+    import flow_report
+
+    assert flow_report.DEFAULT_LOOKBACK_DAYS == 20
+
+    fake_flow = {
+        "dark_pool": {"aggregate": {}, "daily": []},
+        "options_flow": {"bias": "NO_DATA"},
+        "combined_signal": "NO_SIGNAL",
+        "market_status": "closed",
+        "trading_day_progress": 1.0,
+        "trading_days_checked": [],
+    }
+    with patch.object(flow_report, "fetch_flow", return_value=fake_flow) as mock_fetch, \
+         patch.object(flow_report, "analyze_signal", return_value={"direction": "NEUTRAL", "strength": 0}):
+        report = flow_report.build_report("GLD")
+
+    mock_fetch.assert_called_once_with("GLD", lookback_days=20)
+    assert report["lookback_days"] == 20

--- a/scripts/utils/darkpool_cache.py
+++ b/scripts/utils/darkpool_cache.py
@@ -45,9 +45,9 @@ CACHE_DIR = Path(__file__).resolve().parent.parent.parent / "data" / "darkpool_c
 # Bump when on-disk payload semantics change (forces re-fetch of stale rows).
 CACHE_SCHEMA = 2
 
-# Entries older than this are never read again (lookback windows are <= ~5 days),
-# so they are pruned to keep the directory bounded.
-MAX_AGE_DAYS = 15
+# Entries older than this are never read again. Flow reports use a 20-trading-day
+# window (~28 calendar days); keep a buffer for weekends/holidays.
+MAX_AGE_DAYS = 45
 _PRUNE_EVERY = 50  # run a prune sweep roughly every N writes
 _write_count = 0
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,23 @@
+# Task: 20-session Daily Dark Pool History + progressive disclosure (2026-08-07)
+
+## Summary
+
+Per-ticker flow report lookback 5 → 20 trading days. UI shows 5 sessions
+by default; expand reveals full table + buy-% chart.
+
+## Checklist
+
+- [x] flow_report DEFAULT_LOOKBACK_DAYS=20 + API timeout 300s
+- [x] darkpool_cache MAX_AGE_DAYS=45
+- [x] DailyDarkPoolHistory progressive disclosure + chart
+- [x] Tests (pytest + vitest)
+
+## Review
+
+Pending browser/prod verify after deploy.
+
+---
+
 # Task: Dark pool multi-page pagination (2026-08-07)
 
 ## Summary

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -16826,6 +16826,114 @@ body[data-mobile="true"] td.right {
   border-bottom: none;
 }
 
+.ticker-flow-history-disclosure {
+  display: flex;
+  justify-content: flex-start;
+  margin-top: 12px;
+}
+
+.ticker-flow-history-toggle {
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--border-dim);
+  border-radius: 4px;
+  color: var(--text-secondary, var(--text-muted));
+  cursor: pointer;
+  font-family: var(--font-ui, inherit);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  padding: 6px 10px;
+  text-transform: uppercase;
+}
+
+.ticker-flow-history-toggle:hover {
+  border-color: var(--signal-core, #05AD98);
+  color: var(--text-primary);
+}
+
+.ticker-flow-history-toggle:focus-visible {
+  outline: 1px solid var(--signal-core, #05AD98);
+  outline-offset: 2px;
+}
+
+.ticker-flow-history-chart {
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border-dim);
+}
+
+.ticker-flow-history-chart-title {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 8px;
+}
+
+.ticker-flow-history-chart-svg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.ticker-flow-history-chart-grid {
+  stroke: var(--line-grid, var(--border-dim));
+  stroke-width: 1;
+  stroke-dasharray: 2 3;
+}
+
+.ticker-flow-history-chart-mid {
+  stroke: var(--text-muted);
+  stroke-width: 1;
+  stroke-dasharray: 4 3;
+  opacity: 0.55;
+}
+
+.ticker-flow-history-chart-line {
+  stroke: var(--signal-core, #05AD98);
+  stroke-width: 1.75;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+}
+
+.ticker-flow-history-chart-dot {
+  fill: var(--text-muted);
+  stroke: var(--panel, #0f1519);
+  stroke-width: 1;
+}
+
+.ticker-flow-history-chart-dot.accum {
+  fill: var(--signal-core, #05AD98);
+}
+
+.ticker-flow-history-chart-dot.distrib {
+  fill: var(--negative, #e35d6a);
+}
+
+.ticker-flow-history-chart-axis {
+  fill: var(--text-muted);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 10px;
+}
+
+.ticker-flow-history-chart-empty {
+  margin-top: 12px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.ticker-flow-history-compact .section-header {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.ticker-flow-history-compact .section-body {
+  padding-left: 0;
+  padding-right: 0;
+}
+
 @media (max-width: 640px) {
   .ticker-flow-hero {
     padding: 12px;

--- a/web/components/flow-analysis/DailyDarkPoolHistory.tsx
+++ b/web/components/flow-analysis/DailyDarkPoolHistory.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { useId, useMemo, useState } from "react";
+
+export type DailyDarkPoolRow = {
+  date?: string;
+  flow_direction?: string;
+  flow_strength?: number;
+  dp_buy_ratio?: number | null;
+  num_prints?: number;
+};
+
+type Props = {
+  daily: DailyDarkPoolRow[];
+  /** Rows shown before progressive disclosure. */
+  previewCount?: number;
+  compact?: boolean;
+};
+
+const PREVIEW_DEFAULT = 5;
+
+function buyPct(row: DailyDarkPoolRow): number | null {
+  return typeof row.dp_buy_ratio === "number" ? Math.round(row.dp_buy_ratio * 100) : null;
+}
+
+function directionClass(direction?: string): string {
+  if (direction === "ACCUMULATION") return "accum";
+  if (direction === "DISTRIBUTION") return "distrib";
+  return "neutral";
+}
+
+function DailyTable({ rows }: { rows: DailyDarkPoolRow[] }) {
+  return (
+    <table className="ticker-flow-daily">
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>Direction</th>
+          <th>Strength</th>
+          <th>Buy %</th>
+          <th>Prints</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((d) => {
+          const pct = buyPct(d);
+          return (
+            <tr key={d.date ?? JSON.stringify(d)}>
+              <td className="mono">{d.date ?? "--"}</td>
+              <td>
+                <span className={`pill ${directionClass(d.flow_direction)}`}>
+                  {(d.flow_direction ?? "NEUTRAL").replace("_", " ")}
+                </span>
+              </td>
+              <td className="mono">{d.flow_strength ?? "--"}</td>
+              <td className="mono">{pct == null ? "--" : `${pct}%`}</td>
+              <td className="mono">{d.num_prints ?? "--"}</td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}
+
+/** Chronological buy-% chart for the disclosed history window. */
+function DailyBuyRatioChart({ rows }: { rows: DailyDarkPoolRow[] }) {
+  const uid = useId().replace(/:/g, "");
+  // Chart left→right = oldest→newest (opposite of the newest-first table).
+  const points = useMemo(() => {
+    return rows
+      .slice()
+      .sort((a, b) => (a.date ?? "").localeCompare(b.date ?? ""))
+      .map((row) => ({
+        date: row.date ?? "",
+        buy: buyPct(row),
+        strength: typeof row.flow_strength === "number" ? row.flow_strength : null,
+        direction: row.flow_direction ?? "NEUTRAL",
+      }))
+      .filter((p) => p.date && p.buy != null) as Array<{
+      date: string;
+      buy: number;
+      strength: number | null;
+      direction: string;
+    }>;
+  }, [rows]);
+
+  if (points.length === 0) {
+    return (
+      <div className="ticker-flow-history-chart-empty" data-testid="daily-dp-history-chart-empty">
+        No buy-ratio series for chart (missing session ratios).
+      </div>
+    );
+  }
+
+  const W = 640;
+  const H = 160;
+  const pad = { top: 12, right: 12, bottom: 28, left: 36 };
+  const innerW = W - pad.left - pad.right;
+  const innerH = H - pad.top - pad.bottom;
+  const n = points.length;
+  const xAt = (i: number) => pad.left + (n === 1 ? innerW / 2 : (i / (n - 1)) * innerW);
+  const yAt = (buy: number) => pad.top + ((100 - buy) / 100) * innerH;
+
+  const linePath = points
+    .map((p, i) => `${i === 0 ? "M" : "L"} ${xAt(i).toFixed(1)} ${yAt(p.buy).toFixed(1)}`)
+    .join(" ");
+
+  const tickIdx =
+    n <= 5
+      ? points.map((_, i) => i)
+      : [0, Math.floor((n - 1) / 2), n - 1];
+
+  const yTicks = [0, 25, 50, 75, 100];
+
+  return (
+    <div className="ticker-flow-history-chart" data-testid="daily-dp-history-chart">
+      <div className="ticker-flow-history-chart-title">Buy % by session</div>
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        role="img"
+        aria-label="Daily dark pool buy percentage over sessions"
+        className="ticker-flow-history-chart-svg"
+      >
+        <defs>
+          <linearGradient id={`dp-buy-fill-${uid}`} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="var(--signal-core, #05AD98)" stopOpacity="0.28" />
+            <stop offset="100%" stopColor="var(--signal-core, #05AD98)" stopOpacity="0.02" />
+          </linearGradient>
+        </defs>
+
+        {/* Grid + accumulation band (55–100) */}
+        <rect
+          x={pad.left}
+          y={yAt(100)}
+          width={innerW}
+          height={Math.max(0, yAt(55) - yAt(100))}
+          fill="var(--signal-core, #05AD98)"
+          opacity={0.06}
+        />
+        <rect
+          x={pad.left}
+          y={yAt(45)}
+          width={innerW}
+          height={Math.max(0, yAt(0) - yAt(45))}
+          fill="var(--negative, #e35d6a)"
+          opacity={0.06}
+        />
+
+        {yTicks.map((t) => (
+          <g key={t}>
+            <line
+              x1={pad.left}
+              x2={pad.left + innerW}
+              y1={yAt(t)}
+              y2={yAt(t)}
+              className="ticker-flow-history-chart-grid"
+            />
+            <text x={pad.left - 6} y={yAt(t) + 3} textAnchor="end" className="ticker-flow-history-chart-axis">
+              {t}
+            </text>
+          </g>
+        ))}
+
+        {/* 50% mid reference */}
+        <line
+          x1={pad.left}
+          x2={pad.left + innerW}
+          y1={yAt(50)}
+          y2={yAt(50)}
+          className="ticker-flow-history-chart-mid"
+        />
+
+        {/* Area under buy% line */}
+        <path
+          d={`${linePath} L ${xAt(n - 1).toFixed(1)} ${yAt(0).toFixed(1)} L ${xAt(0).toFixed(1)} ${yAt(0).toFixed(1)} Z`}
+          fill={`url(#dp-buy-fill-${uid})`}
+        />
+        <path d={linePath} className="ticker-flow-history-chart-line" fill="none" />
+
+        {points.map((p, i) => (
+          <circle
+            key={p.date}
+            cx={xAt(i)}
+            cy={yAt(p.buy)}
+            r={3}
+            className={
+              p.direction === "ACCUMULATION"
+                ? "ticker-flow-history-chart-dot accum"
+                : p.direction === "DISTRIBUTION"
+                  ? "ticker-flow-history-chart-dot distrib"
+                  : "ticker-flow-history-chart-dot neutral"
+            }
+          >
+            <title>
+              {p.date}: buy {p.buy}%
+              {p.strength != null ? `, strength ${p.strength}` : ""} ({p.direction})
+            </title>
+          </circle>
+        ))}
+
+        {tickIdx.map((i) => (
+          <text
+            key={points[i].date}
+            x={xAt(i)}
+            y={H - 8}
+            textAnchor="middle"
+            className="ticker-flow-history-chart-axis"
+          >
+            {points[i].date.slice(5)}
+          </text>
+        ))}
+      </svg>
+    </div>
+  );
+}
+
+/**
+ * Daily dark-pool session table with progressive disclosure.
+ * Preview shows the most recent N sessions; expand reveals the full
+ * lookback window plus a buy-% chart of the same rows.
+ */
+export default function DailyDarkPoolHistory({
+  daily,
+  previewCount = PREVIEW_DEFAULT,
+  compact = false,
+}: Props) {
+  const [expanded, setExpanded] = useState(false);
+
+  const sortedNewestFirst = useMemo(
+    () => daily.slice().sort((a, b) => (b.date ?? "").localeCompare(a.date ?? "")),
+    [daily],
+  );
+
+  if (sortedNewestFirst.length === 0) return null;
+
+  const canExpand = sortedNewestFirst.length > previewCount;
+  const visible = expanded || !canExpand
+    ? sortedNewestFirst
+    : sortedNewestFirst.slice(0, previewCount);
+  const hiddenCount = Math.max(0, sortedNewestFirst.length - previewCount);
+
+  return (
+    <section className={`section${compact ? " ticker-flow-history-compact" : ""}`} data-testid="daily-dp-history">
+      <div className="section-header">
+        <div className="section-title">Daily Dark Pool History</div>
+        <span className="pill neutral">{sortedNewestFirst.length} SESSIONS</span>
+      </div>
+      <div className="section-body">
+        <DailyTable rows={visible} />
+
+        {canExpand && (
+          <div className="ticker-flow-history-disclosure">
+            <button
+              type="button"
+              className="ticker-flow-history-toggle"
+              data-testid="daily-dp-history-toggle"
+              aria-expanded={expanded}
+              onClick={() => setExpanded((v) => !v)}
+            >
+              {expanded
+                ? "Show recent sessions only"
+                : `Show full ${sortedNewestFirst.length}-session history (+${hiddenCount})`}
+            </button>
+          </div>
+        )}
+
+        {expanded && canExpand && (
+          <DailyBuyRatioChart rows={sortedNewestFirst} />
+        )}
+
+        {/* When the full set already fits the preview, still chart if >1 session */}
+        {!canExpand && sortedNewestFirst.length > 1 && (
+          <DailyBuyRatioChart rows={sortedNewestFirst} />
+        )}
+      </div>
+    </section>
+  );
+}

--- a/web/components/flow-analysis/TickerFlowReport.tsx
+++ b/web/components/flow-analysis/TickerFlowReport.tsx
@@ -7,6 +7,7 @@ import { classifyFlowSignal, type FlowDirection } from "@/lib/flowSignal";
 import { resolvePutCallRatio } from "@/lib/flowRatio";
 import SignalCard from "@/components/mobile/SignalCard";
 import { useViewport } from "@/lib/useViewport";
+import DailyDarkPoolHistory from "@/components/flow-analysis/DailyDarkPoolHistory";
 
 type Props = {
   ticker: string;
@@ -329,71 +330,13 @@ function MobileTickerFlowReport({
         )}
 
         {section === "history" && (
-          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-            {daily.length === 0 ? (
-              <div className="alert-item" style={{ textAlign: "center", padding: "24px 0" }}>
-                No history available
-              </div>
-            ) : (
-              daily.map((d) => {
-                const pct = typeof d.dp_buy_ratio === "number" ? Math.round(d.dp_buy_ratio * 100) : null;
-                const dirTone =
-                  d.flow_direction === "ACCUMULATION" ? "pos" as const
-                    : d.flow_direction === "DISTRIBUTION" ? "neg" as const
-                      : "mut" as const;
-                return (
-                  <div
-                    key={d.date}
-                    style={{
-                      display: "grid",
-                      gridTemplateColumns: "80px 1fr auto auto",
-                      gap: 8,
-                      alignItems: "center",
-                      padding: "8px 0",
-                      borderBottom: "1px solid var(--line-grid)",
-                    }}
-                  >
-                    <span
-                      style={{
-                        fontFamily: "var(--font-mono)",
-                        fontSize: 11,
-                        fontVariantNumeric: "tabular-nums",
-                        color: "var(--text-muted)",
-                      }}
-                    >
-                      {d.date}
-                    </span>
-                    <span
-                      className={`m-pill m-pill--${dirTone}`}
-                      style={{ minHeight: 24, fontSize: 10, padding: "2px 8px" }}
-                    >
-                      {(d.flow_direction ?? "NEUTRAL").replace("_", " ")}
-                    </span>
-                    <span
-                      style={{
-                        fontFamily: "var(--font-mono)",
-                        fontSize: 11,
-                        fontVariantNumeric: "tabular-nums",
-                        color: "var(--text-muted)",
-                      }}
-                    >
-                      {d.flow_strength ?? "--"}
-                    </span>
-                    <span
-                      style={{
-                        fontFamily: "var(--font-mono)",
-                        fontSize: 11,
-                        fontVariantNumeric: "tabular-nums",
-                        color: "var(--text-primary)",
-                      }}
-                    >
-                      {pct != null ? `${pct}%` : "--"}
-                    </span>
-                  </div>
-                );
-              })
-            )}
-          </div>
+          daily.length === 0 ? (
+            <div className="alert-item" style={{ textAlign: "center", padding: "24px 0" }}>
+              No history available
+            </div>
+          ) : (
+            <DailyDarkPoolHistory daily={daily} compact />
+          )
         )}
       </div>
 
@@ -619,56 +562,12 @@ function ReportSections({
         </div>
       </section>
 
-      {daily.length > 0 && (
-        <section className="section">
-          <div className="section-header">
-            <div className="section-title">Daily Dark Pool History</div>
-            <span className="pill neutral">{daily.length} SESSIONS</span>
-          </div>
-          <div className="section-body">
-            <table className="ticker-flow-daily">
-              <thead>
-                <tr>
-                  <th>Date</th>
-                  <th>Direction</th>
-                  <th>Strength</th>
-                  <th>Buy %</th>
-                  <th>Prints</th>
-                </tr>
-              </thead>
-              <tbody>
-                {daily.map((d) => {
-                  const pct = typeof d.dp_buy_ratio === "number" ? Math.round(d.dp_buy_ratio * 100) : null;
-                  const dirClass =
-                    d.flow_direction === "ACCUMULATION"
-                      ? "accum"
-                      : d.flow_direction === "DISTRIBUTION"
-                        ? "distrib"
-                        : "neutral";
-                  return (
-                    <tr key={d.date}>
-                      <td className="mono">{d.date}</td>
-                      <td>
-                        <span className={`pill ${dirClass}`}>
-                          {(d.flow_direction ?? "NEUTRAL").replace("_", " ")}
-                        </span>
-                      </td>
-                      <td className="mono">{d.flow_strength ?? "--"}</td>
-                      <td className="mono">{pct == null ? "--" : `${pct}%`}</td>
-                      <td className="mono">{d.num_prints ?? "--"}</td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        </section>
-      )}
+      {daily.length > 0 && <DailyDarkPoolHistory daily={daily} />}
 
       <section className="section">
         <div className="report-meta">
           {data.fetched_at
-            ? `Report Generated: ${new Date(data.fetched_at).toLocaleString()} - Source: UW API - Dark Pool Lookback: ${data.lookback_days ?? 5} Trading Days`
+            ? `Report Generated: ${new Date(data.fetched_at).toLocaleString()} - Source: UW API - Dark Pool Lookback: ${data.lookback_days ?? 20} Trading Days`
             : "No report timestamp available"}
           {isAnalyzing ? " - Refreshing in background..." : ""}
         </div>

--- a/web/e2e/flow-analysis-ticker.spec.ts
+++ b/web/e2e/flow-analysis-ticker.spec.ts
@@ -37,7 +37,7 @@ function bullishReport(ticker: string, fetchedAt: string) {
   return {
     ticker,
     fetched_at: fetchedAt,
-    lookback_days: 5,
+    lookback_days: 20,
     verdict: { direction: "BULLISH", confidence: 78 },
     analysis: { signal: "STRONG", direction: "ACCUMULATION", strength: 78 },
     dark_pool: {

--- a/web/tests/daily-dark-pool-history.test.tsx
+++ b/web/tests/daily-dark-pool-history.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen, fireEvent } from "@testing-library/react";
+import DailyDarkPoolHistory, {
+  type DailyDarkPoolRow,
+} from "@/components/flow-analysis/DailyDarkPoolHistory";
+
+afterEach(() => cleanup());
+
+function makeSessions(n: number): DailyDarkPoolRow[] {
+  const rows: DailyDarkPoolRow[] = [];
+  for (let i = 0; i < n; i += 1) {
+    const day = String(20 - i).padStart(2, "0");
+    rows.push({
+      date: `2026-07-${day}`,
+      flow_direction: i % 3 === 0 ? "ACCUMULATION" : i % 3 === 1 ? "DISTRIBUTION" : "NEUTRAL",
+      flow_strength: 20 + i,
+      dp_buy_ratio: 0.4 + (i % 5) * 0.05,
+      num_prints: 100 + i * 10,
+    });
+  }
+  return rows;
+}
+
+describe("DailyDarkPoolHistory", () => {
+  it("previews five sessions and discloses the rest with a chart", () => {
+    render(<DailyDarkPoolHistory daily={makeSessions(20)} />);
+
+    expect(screen.getByTestId("daily-dp-history")).toBeTruthy();
+    expect(screen.getByText("20 SESSIONS")).toBeTruthy();
+
+    // Newest five dates visible; oldest session hidden until expand.
+    expect(screen.getByText("2026-07-20")).toBeTruthy();
+    expect(screen.queryByText("2026-07-01")).toBeNull();
+    expect(screen.queryByTestId("daily-dp-history-chart")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("daily-dp-history-toggle"));
+
+    expect(screen.getByText("2026-07-01")).toBeTruthy();
+    expect(screen.getByTestId("daily-dp-history-chart")).toBeTruthy();
+    expect(screen.getByLabelText(/buy percentage over sessions/i)).toBeTruthy();
+  });
+
+  it("renders chart immediately when history fits the preview", () => {
+    render(<DailyDarkPoolHistory daily={makeSessions(3)} />);
+    expect(screen.queryByTestId("daily-dp-history-toggle")).toBeNull();
+    expect(screen.getByTestId("daily-dp-history-chart")).toBeTruthy();
+  });
+
+  it("renders nothing for empty daily", () => {
+    const { container } = render(<DailyDarkPoolHistory daily={[]} />);
+    expect(container.innerHTML).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
- Per-ticker flow reports now fetch **20 trading days** of dark-pool sessions (was 5).
- Daily Dark Pool History previews 5 rows; expand shows the full window plus a buy-% chart.
- API timeout raised to 300s for cold multi-page UW walks; disk cache age to 45 days.

## Test plan
- [x] pytest `test_flow_report_lookback`
- [x] vitest `daily-dark-pool-history`
- [ ] After deploy: refresh GLD, expand history, confirm 20 sessions + chart