### PR TITLE
fix(flow): paginate UW flow-alerts and OI; portfolio_report uses fetch_darkpool

### DIFF
--- a/docs/unusual_whales_api.md
+++ b/docs/unusual_whales_api.md
@@ -71,7 +71,12 @@ Liquid names (GLD, SPY) routinely need multiple pages per session day.
 - `is_otm`: Boolean - OTM contracts only
 - `rule_name[]`: Filter by alert type (RepeatedHits, FloorTradeLargeCap, etc.)
 - `issue_types[]`: Common Stock, ETF, Index
-- `limit`: Max 200
+- `limit`: Default 100, **max 200**
+- `older_than` / `newer_than`: time cursors for multi-page walks
+
+**Pagination:** one request never returns more than 200 alerts. Radon
+`fetch_flow.fetch_flow_alerts` walks `older_than` until a short page
+(market-wide or per-ticker). Discover and `fetch_options` reuse that helper.
 
 **Response Fields:**
 ```json

--- a/scripts/clients/uw_client.py
+++ b/scripts/clients/uw_client.py
@@ -679,9 +679,19 @@ class UWClient:
         """GET /api/market/total-options-volume - Total market options volume."""
         return self._get("market/total-options-volume")
 
-    def get_oi_change(self) -> dict:
-        """GET /api/market/oi-change - Biggest OI changes."""
-        return self._get("market/oi-change")
+    def get_oi_change(
+        self,
+        *,
+        date: Optional[str] = None,
+        limit: Optional[int] = None,
+        order: Optional[str] = None,
+    ) -> dict:
+        """GET /api/market/oi-change - Biggest OI changes.
+
+        UW max ``limit`` is 200; no page cursor on this route.
+        """
+        params = self._build_params(date=date, limit=limit, order=order)
+        return self._get("market/oi-change", params=params)
 
     def get_economic_calendar(self) -> dict:
         """GET /api/market/economic-calendar - Economic events."""

--- a/scripts/discover.py
+++ b/scripts/discover.py
@@ -84,19 +84,23 @@ def get_existing_tickers() -> set:
     return {t for t in tickers if t}
 
 
-def fetch_options_flow(min_premium: int = 500000, limit: int = 100, _client: UWClient = None) -> list:
-    """Fetch market-wide options flow alerts."""
-    def _fetch(client):
-        try:
-            resp = client.get_flow_alerts(min_premium=min_premium, limit=limit)
-            return resp.get("data", [])
-        except UWAPIError:
-            return []
+def fetch_options_flow(min_premium: int = 500000, limit: int = 200, _client: UWClient = None) -> list:
+    """Fetch market-wide options flow alerts (full multi-page walk).
 
-    if _client is not None:
-        return _fetch(_client)
-    with UWClient() as client:
-        return _fetch(client)
+    Delegates to ``fetch_flow.fetch_flow_alerts`` so market-wide discovery
+    is not stuck at a single UW page (max 200).
+    """
+    from fetch_flow import fetch_flow_alerts
+
+    try:
+        return fetch_flow_alerts(
+            ticker=None,
+            min_premium=min_premium,
+            _client=_client,
+            limit=limit,
+        )
+    except UWAPIError:
+        return []
 
 
 def analyze_darkpool_day(trades: list) -> dict:
@@ -443,9 +447,14 @@ def discover_targeted(tickers: list, dp_days: int = 3,
 
     with UWClient() as client:
         def _process_targeted(ticker):
+            from fetch_flow import fetch_flow_alerts
+
             try:
-                resp = client.get_flow_alerts(ticker=ticker, min_premium=min_premium, limit=50)
-                alerts = resp.get("data", [])
+                alerts = fetch_flow_alerts(
+                    ticker=ticker,
+                    min_premium=min_premium,
+                    _client=client,
+                )
             except UWAPIError:
                 alerts = []
 

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -483,7 +483,8 @@ def _run_parallel_milestones(
         return ("M3", fetch_options(ticker, source="uw"))
 
     def _m3b():
-        return ("M3B", fetch_ticker_oi_changes(ticker))
+        # Full OI book (paginated); no arbitrary top-50 slice for M3B.
+        return ("M3B", fetch_ticker_oi_changes(ticker, limit=None))
 
     def _m1d():
         return ("M1D", fetch_news(ticker, days=7, limit=20))

--- a/scripts/fetch_flow.py
+++ b/scripts/fetch_flow.py
@@ -52,6 +52,10 @@ DARKPOOL_PAGE_LIMIT = 500
 # Safety ceiling: 40 pages × 500 = 20k prints/day. Beyond that log and stop.
 DARKPOOL_MAX_PAGES = 40
 
+# UW /api/option-trades/flow-alerts: default 100, max 200. Walk older_than.
+FLOW_ALERTS_PAGE_LIMIT = 200
+FLOW_ALERTS_MAX_PAGES = 25
+
 # Session calendar is always US/Eastern. Host-local/UTC datetime.now() on CI
 # runners (and the VPS after 20:00 ET) invents an extra "today" that is not
 # yet a US session day and breaks the darkpool cache immutability contract.
@@ -383,29 +387,100 @@ def fetch_darkpool(
         return _fetch(client)
 
 
+def _flow_alerts_page_cursor(alerts: List[Dict]) -> Optional[str]:
+    """Oldest created_at on a desc-ordered page → next older_than cursor."""
+    oldest: Optional[str] = None
+    for alert in alerts:
+        ts = alert.get("created_at") or alert.get("executed_at") or alert.get("timestamp")
+        if not ts:
+            continue
+        ts_s = str(ts)
+        if oldest is None or ts_s < oldest:
+            oldest = ts_s
+    return oldest
+
+
+def _flow_alert_dedupe_key(alert: Dict) -> Optional[str]:
+    """Stable identity for multi-page alert de-duplication."""
+    chain = alert.get("option_chain") or alert.get("option_symbol")
+    created = alert.get("created_at") or alert.get("executed_at") or ""
+    prem = alert.get("total_premium") or alert.get("premium") or ""
+    size = alert.get("total_size") or alert.get("size") or ""
+    if chain or created:
+        return f"{chain}|{created}|{prem}|{size}"
+    return None
+
+
 def fetch_flow_alerts(
-    ticker: str,
+    ticker: Optional[str] = None,
     min_premium: int = 50000,
     _client: Optional[UWClient] = None,
     *,
     retry_transient: bool = True,
+    limit: int = FLOW_ALERTS_PAGE_LIMIT,
 ) -> List[Dict]:
-    """Fetch options flow alerts for a ticker.
+    """Fetch options flow alerts (full multi-page walk).
 
-    Filters for larger trades (default $50k+ premium) that are more likely
-    to represent institutional activity. Same retry / raise semantics as
+    UW hard-caps each response at ``FLOW_ALERTS_PAGE_LIMIT`` (200). Walks
+    older pages with ``older_than`` until a short page.
+
+    ``ticker`` may be None for market-wide alerts (discover). Filters for
+    larger trades (default $50k+ premium). Same retry / raise semantics as
     `fetch_darkpool`.
     """
-    def _fetch(client):
-        what = f"flow_alerts({ticker}, min_premium={min_premium})"
-        resp = _call_uw_with_retry(
-            lambda: client.get_flow_alerts(ticker=ticker, min_premium=min_premium, limit=100),
+    page_limit = max(1, min(int(limit or FLOW_ALERTS_PAGE_LIMIT), FLOW_ALERTS_PAGE_LIMIT))
+
+    def _fetch_page(client, *, older_than: Optional[str]):
+        label = ticker or "MARKET"
+        what = f"flow_alerts({label}, min_premium={min_premium}, older_than={older_than})"
+        return _call_uw_with_retry(
+            lambda: client.get_flow_alerts(
+                ticker=ticker,
+                min_premium=min_premium,
+                limit=page_limit,
+                older_than=older_than,
+            ),
             what=what,
             retry_transient=retry_transient,
         )
-        if resp is None:
-            return []
-        return resp.get("data", [])
+
+    def _fetch(client):
+        all_alerts: List[Dict] = []
+        older_than: Optional[str] = None
+        seen: set = set()
+        for _page_idx in range(FLOW_ALERTS_MAX_PAGES):
+            resp = _fetch_page(client, older_than=older_than)
+            if resp is None:
+                break
+            page = resp.get("data") or []
+            if not isinstance(page, list) or not page:
+                break
+
+            for alert in page:
+                key = _flow_alert_dedupe_key(alert)
+                if key is not None:
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                all_alerts.append(alert)
+
+            if len(page) < page_limit:
+                break
+
+            next_cursor = _flow_alerts_page_cursor(page)
+            if next_cursor is None or next_cursor == older_than:
+                logger.warning(
+                    "flow_alerts(%s): full page without advancing cursor; stopping at %d",
+                    ticker or "MARKET", len(all_alerts),
+                )
+                break
+            older_than = next_cursor
+        else:
+            logger.warning(
+                "flow_alerts(%s): hit FLOW_ALERTS_MAX_PAGES=%d (%d alerts)",
+                ticker or "MARKET", FLOW_ALERTS_MAX_PAGES, len(all_alerts),
+            )
+        return all_alerts
 
     if _client is not None:
         return _fetch(_client)

--- a/scripts/fetch_oi_changes.py
+++ b/scripts/fetch_oi_changes.py
@@ -34,50 +34,91 @@ except Exception:  # pragma: no cover — DB layer optional
     def mirror_scan_snapshot(*args, **kwargs):  # type: ignore
         return None
 
+# UW /api/stock/{ticker}/oi-change supports limit + page (page from 0).
+# Walk until a short page so M3B is not stuck on the first page.
+_OI_PAGE_LIMIT = 500
+_OI_MAX_PAGES = 40
+# Market-wide /api/market/oi-change: max 200, no page cursor.
+_MARKET_OI_LIMIT = 200
+
+
+def _passes_filters(item: dict, min_oi_change: int, min_premium: float) -> bool:
+    oi_diff = item.get("oi_diff_plain", 0) or 0
+    premium = float(item.get("prev_total_premium", 0) or 0)
+    return abs(oi_diff) >= min_oi_change and premium >= min_premium
+
+
+def _sort_oi_significance(rows: list) -> list:
+    """Largest absolute OI move, then premium — not API response order."""
+    return sorted(
+        rows,
+        key=lambda item: (
+            abs(item.get("oi_diff_plain", 0) or 0),
+            float(item.get("prev_total_premium", 0) or 0),
+        ),
+        reverse=True,
+    )
+
+
+def _apply_limit(rows: list, limit: Optional[int]) -> list:
+    if limit is None or limit <= 0:
+        return rows
+    return rows[:limit]
+
 
 def fetch_ticker_oi_changes(
     ticker: str,
     min_oi_change: int = 0,
     min_premium: float = 0,
-    limit: int = 50,
+    limit: Optional[int] = None,
 ) -> list:
-    """Fetch OI changes for a specific ticker."""
+    """Fetch OI changes for a specific ticker (full multi-page walk).
+
+    ``limit`` caps results *after* paging + filter + significance sort.
+    Pass ``None`` (default) for the complete filtered set — used by eval M3B.
+    """
     with UWClient() as client:
-        result = client.get_stock_oi_change(ticker)
-        data = result.get('data', [])
-        
-        # Filter
-        filtered = []
-        for item in data:
-            oi_diff = item.get('oi_diff_plain', 0) or 0
-            premium = float(item.get('prev_total_premium', 0) or 0)
-            
-            if abs(oi_diff) >= min_oi_change and premium >= min_premium:
-                filtered.append(item)
-        
-        return filtered[:limit]
+        all_rows: list = []
+        for page in range(_OI_MAX_PAGES):
+            result = client.get_stock_oi_change(
+                ticker, limit=_OI_PAGE_LIMIT, page=page,
+            )
+            page_rows = result.get("data") or []
+            if not isinstance(page_rows, list) or not page_rows:
+                break
+            all_rows.extend(page_rows)
+            if len(page_rows) < _OI_PAGE_LIMIT:
+                break
+
+        filtered = [
+            item for item in all_rows
+            if _passes_filters(item, min_oi_change, min_premium)
+        ]
+        return _apply_limit(_sort_oi_significance(filtered), limit)
 
 
 def fetch_market_oi_changes(
     min_oi_change: int = 0,
     min_premium: float = 0,
-    limit: int = 50,
+    limit: Optional[int] = None,
 ) -> list:
-    """Fetch market-wide biggest OI changes."""
+    """Fetch market-wide biggest OI changes.
+
+    UW market endpoint has no page cursor (max 200). Request the max, then
+    filter/sort; ``limit`` only truncates the final ranked list.
+    """
     with UWClient() as client:
-        result = client.get_oi_change()
-        data = result.get('data', [])
-        
-        # Filter
-        filtered = []
-        for item in data:
-            oi_diff = item.get('oi_diff_plain', 0) or 0
-            premium = float(item.get('prev_total_premium', 0) or 0)
-            
-            if abs(oi_diff) >= min_oi_change and premium >= min_premium:
-                filtered.append(item)
-        
-        return filtered[:limit]
+        result = client.get_oi_change(limit=_MARKET_OI_LIMIT)
+        data = result.get("data") or []
+        if not isinstance(data, list):
+            data = []
+
+        filtered = [
+            item for item in data
+            if _passes_filters(item, min_oi_change, min_premium)
+        ]
+        ranked = _sort_oi_significance(filtered)
+        return _apply_limit(ranked, limit)
 
 
 def categorize_signal(item: dict) -> dict:
@@ -202,20 +243,25 @@ Examples:
     parser.add_argument('--market', '-m', action='store_true', help='Market-wide OI changes')
     parser.add_argument('--min-oi-change', type=int, default=0, help='Minimum OI change (contracts)')
     parser.add_argument('--min-premium', type=float, default=0, help='Minimum premium ($)')
-    parser.add_argument('--limit', type=int, default=50, help='Max results')
+    parser.add_argument(
+        '--limit', type=int, default=50,
+        help='Max results after full fetch+rank (default 50; 0 = no cap)',
+    )
     parser.add_argument('--json', action='store_true', help='Output as JSON')
     
     args = parser.parse_args()
     
     if not args.ticker and not args.market:
         parser.error('Either provide a ticker or use --market for market-wide scan')
+
+    result_limit = None if args.limit == 0 else args.limit
     
     try:
         if args.market:
             data = fetch_market_oi_changes(
                 min_oi_change=args.min_oi_change,
                 min_premium=args.min_premium,
-                limit=args.limit,
+                limit=result_limit,
             )
             ticker = None
         else:
@@ -223,7 +269,7 @@ Examples:
                 args.ticker.upper(),
                 min_oi_change=args.min_oi_change,
                 min_premium=args.min_premium,
-                limit=args.limit,
+                limit=result_limit,
             )
             ticker = args.ticker.upper()
         

--- a/scripts/fetch_options.py
+++ b/scripts/fetch_options.py
@@ -229,23 +229,19 @@ def fetch_uw_chain(ticker: str, _client: UWClient = None) -> Optional[Dict]:
 
 
 def fetch_uw_flow(ticker: str, days: int = 7, _client: UWClient = None) -> Optional[Dict]:
-    """Fetch options flow alerts from Unusual Whales."""
+    """Fetch options flow alerts from Unusual Whales (full multi-page walk)."""
     if not UW_TOKEN:
         return None
 
     try:
-        def _fetch(client):
-            # Use same params as fetch_flow.py for cache hits
-            return client.get_flow_alerts(ticker=ticker, min_premium=50000, limit=100)
+        from fetch_flow import fetch_flow_alerts
 
-        if _client is not None:
-            raw = _fetch(_client)
-        else:
-            with UWClient() as client:
-                raw = _fetch(client)
+        data = fetch_flow_alerts(
+            ticker=ticker,
+            min_premium=50000,
+            _client=_client,
+        )
 
-        data = raw.get("data", [])
-        
         if not data:
             return {"total_alerts": 0, "bias": "NO_DATA"}
         

--- a/scripts/portfolio_report.py
+++ b/scripts/portfolio_report.py
@@ -136,15 +136,19 @@ def fetch_ib_data(ib) -> Tuple[List[Dict], Dict[str, str]]:
 def fetch_dark_pool_flow(tickers: List[str], days: int = 5) -> Dict[str, Dict]:
     """Fetch dark pool flow for multiple tickers in parallel.
 
+    Uses ``fetch_flow.fetch_darkpool`` (multi-page UW walk + disk cache) so
+    liquid names are not silently capped at 500 prints/day.
+
     Returns per-ticker aggregate + daily breakdown. The daily data is ordered
     oldest-first so sparkline builders can iterate left→right, with the
     *last* element being today.
     """
-    import requests as _req
-
     token = os.environ.get('UW_TOKEN', '')
     if not token:
         return {t: _no_flow('NO_TOKEN') for t in tickers}
+
+    from fetch_flow import fetch_darkpool
+    from utils.darkpool_cache import get_cached_darkpool, set_cached_darkpool
 
     # Last N business days (most recent first → we reverse later)
     date_list = []
@@ -154,29 +158,36 @@ def fetch_dark_pool_flow(tickers: List[str], days: int = 5) -> Dict[str, Dict]:
             date_list.append(d.strftime('%Y-%m-%d'))
         d -= timedelta(days=1)
 
+    def _day_trades(ticker: str, dt: str) -> List[dict]:
+        trades = get_cached_darkpool(ticker, dt)
+        if trades is not None:
+            return trades if isinstance(trades, list) else []
+        try:
+            trades = fetch_darkpool(ticker, date=dt)
+        except Exception:
+            return []
+        if isinstance(trades, list):
+            set_cached_darkpool(ticker, dt, trades)
+            return trades
+        return []
+
     def _fetch_one(ticker: str) -> Tuple[str, Dict]:
         try:
             daily = defaultdict(lambda: {'buy_vol': 0, 'sell_vol': 0})
-            headers = {'Authorization': f'Bearer {token}'}
 
             for dt in date_list:
-                try:
-                    url = f"https://api.unusualwhales.com/api/darkpool/{ticker}?date={dt}"
-                    resp = _req.get(url, headers=headers, timeout=10)
-                    if resp.status_code != 200:
+                for trade in _day_trades(ticker, dt):
+                    if trade.get('canceled'):
                         continue
-                    for trade in resp.json().get('data', []):
-                        price = float(trade.get('price', 0) or 0)
-                        bid = float(trade.get('nbbo_bid', 0) or 0)
-                        ask = float(trade.get('nbbo_ask', 0) or 0)
-                        size = int(trade.get('size', 0) or 0)
-                        mid = (bid + ask) / 2 if bid > 0 and ask > 0 else price
-                        if price >= mid:
-                            daily[dt]['buy_vol'] += size
-                        else:
-                            daily[dt]['sell_vol'] += size
-                except Exception:
-                    continue
+                    price = float(trade.get('price', 0) or 0)
+                    bid = float(trade.get('nbbo_bid', 0) or 0)
+                    ask = float(trade.get('nbbo_ask', 0) or 0)
+                    size = int(trade.get('size', 0) or 0)
+                    mid = (bid + ask) / 2 if bid > 0 and ask > 0 else price
+                    if price >= mid:
+                        daily[dt]['buy_vol'] += size
+                    else:
+                        daily[dt]['sell_vol'] += size
 
             if not daily:
                 return ticker, _no_flow('NO_DATA')

--- a/scripts/tests/test_fetch_flow.py
+++ b/scripts/tests/test_fetch_flow.py
@@ -530,11 +530,83 @@ class TestUWRetryPolicy:
         mock_client = MagicMock()
         mock_client.get_flow_alerts.side_effect = [
             UWRateLimitError("429", status_code=429),
-            {"data": [{"ticker": "AAPL"}]},
+            {"data": [{"ticker": "AAPL", "created_at": "2026-08-07T15:00:00Z"}]},
         ]
 
         with patch("fetch_flow.time_module.sleep"):
             result = fetch_flow_alerts("AAPL", _client=mock_client)
 
-        assert result == [{"ticker": "AAPL"}]
+        assert result == [{"ticker": "AAPL", "created_at": "2026-08-07T15:00:00Z"}]
         assert mock_client.get_flow_alerts.call_count == 2
+
+
+class TestFlowAlertsPagination:
+    def test_single_short_page(self):
+        from fetch_flow import FLOW_ALERTS_PAGE_LIMIT, fetch_flow_alerts
+
+        page = [
+            {
+                "ticker": "AAPL",
+                "option_chain": f"AAPL{i}",
+                "created_at": f"2026-08-07T15:00:{i:02d}Z",
+                "total_premium": "100000",
+            }
+            for i in range(3)
+        ]
+        mock_client = MagicMock()
+        mock_client.get_flow_alerts.return_value = {"data": page}
+
+        result = fetch_flow_alerts("AAPL", _client=mock_client)
+
+        assert len(result) == 3
+        assert mock_client.get_flow_alerts.call_count == 1
+        kwargs = mock_client.get_flow_alerts.call_args.kwargs
+        assert kwargs.get("limit") == FLOW_ALERTS_PAGE_LIMIT
+        assert kwargs.get("older_than") is None
+
+    def test_full_page_then_partial_walks_older_than(self):
+        from fetch_flow import FLOW_ALERTS_PAGE_LIMIT, _flow_alerts_page_cursor, fetch_flow_alerts
+
+        page1 = [
+            {
+                "ticker": "GLD",
+                "option_chain": f"GLD{i}",
+                "created_at": f"2026-08-07T18:{59 - (i // 60):02d}:{59 - (i % 60):02d}Z",
+                "total_premium": str(100000 + i),
+            }
+            for i in range(FLOW_ALERTS_PAGE_LIMIT)
+        ]
+        oldest = _flow_alerts_page_cursor(page1)
+        page2 = [
+            {
+                "ticker": "GLD",
+                "option_chain": f"GLDx{i}",
+                "created_at": f"2026-08-07T12:00:{i:02d}Z",
+                "total_premium": "50000",
+            }
+            for i in range(12)
+        ]
+        mock_client = MagicMock()
+        mock_client.get_flow_alerts.side_effect = [
+            {"data": page1},
+            {"data": page2},
+        ]
+
+        result = fetch_flow_alerts("GLD", min_premium=50000, _client=mock_client)
+
+        assert len(result) == FLOW_ALERTS_PAGE_LIMIT + 12
+        assert mock_client.get_flow_alerts.call_count == 2
+        second = mock_client.get_flow_alerts.call_args_list[1].kwargs
+        assert second["older_than"] == oldest
+        assert second["limit"] == FLOW_ALERTS_PAGE_LIMIT
+
+    def test_market_wide_allows_none_ticker(self):
+        from fetch_flow import fetch_flow_alerts
+
+        mock_client = MagicMock()
+        mock_client.get_flow_alerts.return_value = {
+            "data": [{"ticker": "X", "created_at": "2026-08-07T10:00:00Z", "option_chain": "X1"}],
+        }
+        result = fetch_flow_alerts(ticker=None, min_premium=500000, _client=mock_client)
+        assert len(result) == 1
+        assert mock_client.get_flow_alerts.call_args.kwargs.get("ticker") is None

--- a/scripts/tests/test_fetch_oi_changes.py
+++ b/scripts/tests/test_fetch_oi_changes.py
@@ -1,0 +1,73 @@
+"""OI change fetch must page the full ticker book before any result cap."""
+
+from unittest.mock import MagicMock, patch
+
+
+def test_ticker_oi_pages_until_short():
+    from fetch_oi_changes import _OI_PAGE_LIMIT, fetch_ticker_oi_changes
+
+    page0 = [
+        {"option_symbol": f"A{i}", "oi_diff_plain": 1000 + i, "prev_total_premium": 1_000_000}
+        for i in range(_OI_PAGE_LIMIT)
+    ]
+    page1 = [
+        {"option_symbol": "TAIL", "oi_diff_plain": 50_000, "prev_total_premium": 20_000_000},
+    ]
+    mock_client = MagicMock()
+    mock_client.get_stock_oi_change.side_effect = [
+        {"data": page0},
+        {"data": page1},
+    ]
+    mock_cm = MagicMock()
+    mock_cm.__enter__.return_value = mock_client
+    mock_cm.__exit__.return_value = False
+
+    with patch("fetch_oi_changes.UWClient", return_value=mock_cm):
+        rows = fetch_ticker_oi_changes("MSFT", limit=None)
+
+    assert mock_client.get_stock_oi_change.call_count == 2
+    assert mock_client.get_stock_oi_change.call_args_list[0].kwargs["page"] == 0
+    assert mock_client.get_stock_oi_change.call_args_list[1].kwargs["page"] == 1
+    assert len(rows) == _OI_PAGE_LIMIT + 1
+    # Significance sort: largest abs OI first
+    assert rows[0]["option_symbol"] == "TAIL"
+
+
+def test_ticker_oi_limit_applies_after_sort():
+    from fetch_oi_changes import fetch_ticker_oi_changes
+
+    data = [
+        {"option_symbol": "SMALL", "oi_diff_plain": 10, "prev_total_premium": 100},
+        {"option_symbol": "BIG", "oi_diff_plain": 9_999, "prev_total_premium": 5_000_000},
+        {"option_symbol": "MID", "oi_diff_plain": 100, "prev_total_premium": 50_000},
+    ]
+    mock_client = MagicMock()
+    mock_client.get_stock_oi_change.return_value = {"data": data}
+    mock_cm = MagicMock()
+    mock_cm.__enter__.return_value = mock_client
+    mock_cm.__exit__.return_value = False
+
+    with patch("fetch_oi_changes.UWClient", return_value=mock_cm):
+        rows = fetch_ticker_oi_changes("MSFT", limit=2)
+
+    assert [r["option_symbol"] for r in rows] == ["BIG", "MID"]
+
+
+def test_market_oi_requests_max_limit():
+    from fetch_oi_changes import _MARKET_OI_LIMIT, fetch_market_oi_changes
+
+    mock_client = MagicMock()
+    mock_client.get_oi_change.return_value = {
+        "data": [
+            {"option_symbol": "X", "oi_diff_plain": 1, "prev_total_premium": 1},
+        ],
+    }
+    mock_cm = MagicMock()
+    mock_cm.__enter__.return_value = mock_client
+    mock_cm.__exit__.return_value = False
+
+    with patch("fetch_oi_changes.UWClient", return_value=mock_cm):
+        rows = fetch_market_oi_changes(limit=1)
+
+    assert mock_client.get_oi_change.call_args.kwargs["limit"] == _MARKET_OI_LIMIT
+    assert len(rows) == 1

--- a/scripts/tests/test_portfolio_report_darkpool.py
+++ b/scripts/tests/test_portfolio_report_darkpool.py
@@ -1,0 +1,40 @@
+"""portfolio_report dark-pool path must use multi-page fetch_darkpool."""
+
+from datetime import date
+from unittest.mock import patch
+
+
+def test_fetch_dark_pool_flow_uses_paginated_fetch_darkpool():
+    import portfolio_report as pr
+
+    trades = [
+        {"price": "101", "nbbo_bid": "100", "nbbo_ask": "102", "size": 1000},
+        {"price": "99", "nbbo_bid": "100", "nbbo_ask": "102", "size": 500},
+    ]
+
+    pr.TODAY = date(2026, 8, 7)
+    pr.TODAY_STR = "2026-08-07"
+
+    with patch.dict("os.environ", {"UW_TOKEN": "test-token"}), \
+         patch("fetch_flow.fetch_darkpool", return_value=trades) as mock_dp, \
+         patch("utils.darkpool_cache.get_cached_darkpool", return_value=None), \
+         patch("utils.darkpool_cache.set_cached_darkpool") as mock_set:
+        out = pr.fetch_dark_pool_flow(["GLD"], days=1)
+
+    assert mock_dp.call_count >= 1
+    assert mock_set.called
+    assert out["GLD"]["direction"] in ("ACCUMULATION", "DISTRIBUTION", "NEUTRAL")
+    assert out["GLD"]["buy_ratio"] > 0
+    # No raw requests module path — fetch_darkpool is the only UW entry.
+    call = mock_dp.call_args
+    assert call.args[0] == "GLD" or call.kwargs.get("ticker") == "GLD" or call.args[0] == "GLD"
+
+
+def test_fetch_dark_pool_flow_no_token_short_circuits():
+    import portfolio_report as pr
+
+    with patch.dict("os.environ", {"UW_TOKEN": ""}):
+        out = pr.fetch_dark_pool_flow(["AAPL"], days=1)
+    assert out["AAPL"]["direction"] == "NO_TOKEN" or out["AAPL"].get("status") == "NO_TOKEN" or (
+        "NO_TOKEN" in str(out["AAPL"])
+    ) or out["AAPL"].get("direction") == "NO_TOKEN"

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,18 @@
+# Task: UW P0+P1 truncation fixes (2026-08-07)
+
+## Summary
+
+- P0: `portfolio_report` uses paginated `fetch_darkpool` + disk cache.
+- P1: `fetch_flow_alerts` multi-page walk (max 200); discover + fetch_options reuse it.
+- P1: `fetch_oi_changes` pages ticker OI; market requests limit=200; eval M3B unlimited after rank.
+
+## Checklist
+
+- [x] Implement
+- [x] Tests green
+
+---
+
 # Task: 20-session Daily Dark Pool History + progressive disclosure (2026-08-07)
 
 ## Summary


### PR DESCRIPTION
## Summary
- **P0** `portfolio_report` → paginated `fetch_darkpool` + disk cache (no raw 500-cap URL).
- **P1** `fetch_flow_alerts` multi-page (`limit=200` + `older_than`); discover + `fetch_options` reuse.
- **P1** ticker OI `page` walk; market OI `limit=200`; eval M3B unlimited after significance sort.

## Test plan
- [x] 212 focused pytest green (fetch_flow, oi, portfolio_report, options, discover, uw_client)