### PR TITLE
fix(portfolio): apply the same-day entry baseline to equity Today P&L

### DIFF
--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -91,6 +91,8 @@ Per-leg: `sign × (last - close) × contracts × 100`. Impl: `getOptionDailyChg(
 
 **Same-day exception:** `entry_date == today (ET)` → yesterday's close meaningless. Day Chg + Today P&L use entry-cost baseline → Today P&L = Total P&L = `MV − EC`. `ib_daily_pnl` ignored same-day.
 
+**The exception covers STOCKS as well as options** (2026-08-11). It shipped options-only, so equities opened today kept the close baseline and reported a Today P&L that contradicted their own P&L (QQQ 666 sh @ $717.83, last $718.46: P&L +$421, Today P&L −$1,605). Impls: `getStockDailyChg()` + the stock branch of `getTodayPnlDollars()`, and the `isSameDay` branch in `computeDayMoveBreakdown` (which feeds the Day P&L card — a stock-only carve-out there makes the card disagree with the column it summarises). IB's own `reqPnLSingle` daily P&L for a same-day equity equals `MV − EC` to the cent, so the broker is the tiebreaker. Never reintroduce a stock-only inline copy of Today P&L in `PositionTable` / `MobilePositionList`; both must call `getTodayPnlDollars`. Tests: `same-day-stock-pnl.test.ts`, `e2e/portfolio-same-day-equity-pnl.spec.ts`.
+
 ### Entry-Date Resolution (`ib_sync.py`)
 
 Strict ordered fallback, MOST → LEAST specific:

--- a/web/components/PositionTable.tsx
+++ b/web/components/PositionTable.tsx
@@ -27,6 +27,7 @@ import {
   getLastPriceIsCalculated,
   legPriceKey,
   getOptionDailyChg,
+  getStockDailyChg,
   getTodayPnlDollars,
   resolveRealtimePrice,
 } from "@/lib/positionUtils";
@@ -65,13 +66,6 @@ function useDensity(tableId: string): [DensityMode, () => void] {
 }
 
 /* ─── Helpers ──────────────────────────────────────────── */
-
-function getDailyChange(realtimePrice?: PriceData | null): number | null {
-  if (!realtimePrice) return null;
-  const { last, close } = realtimePrice;
-  if (last == null || last <= 0 || close == null || close <= 0) return null;
-  return ((last - close) / close) * 100;
-}
 
 function getLegMultiplier(leg: { type: string }): number {
   return leg.type === "Stock" ? 1 : 100;
@@ -194,7 +188,7 @@ function makePositionExtract(prices?: Record<string, PriceData>, riskFreeRate = 
         if (isStock || !prices) return null;
         return computePositionImpliedValue(pos, prices, { riskFreeRate }).netNotional;
       }
-      case "daily_chg": return isStock ? getDailyChange(prices?.[pos.ticker]) : getOptionDailyChg(pos, prices);
+      case "daily_chg": return isStock ? getStockDailyChg(pos, prices) : getOptionDailyChg(pos, prices);
       case "today_pnl": return getTodayPnlDollars(pos, prices);
       // Initial Value follows the Avg Entry sign convention: combo net sign,
       // single-leg short option is a CREDIT (negative), stock/long-option are
@@ -386,7 +380,7 @@ function PositionRow({ pos, showExpiry = true, showUnderlying = false, showImpli
   // Same-day positions opened today: yesterday's close is meaningless.
   // Use entry-cost-based P&L instead (Today's P&L = Total P&L).
   const dailyChg = isStock
-    ? getDailyChange(realtimePrice)
+    ? getStockDailyChg(pos, prices)
     : getOptionDailyChg(pos, prices);
 
   // Black-Scholes implied per-share, signed-summed across legs. null for stocks
@@ -403,13 +397,10 @@ function PositionRow({ pos, showExpiry = true, showUnderlying = false, showImpli
     return computePositionImpliedValue(pos, prices, { riskFreeRate }).netNotional;
   }, [isStock, pos, prices, riskFreeRate]);
 
-  // Today's P&L in dollars
-  const todayPnl = isStock
-    ? (realtimePrice?.last != null && realtimePrice.last > 0 && realtimePrice?.close != null && realtimePrice.close > 0
-        // Sign-aware: a SHORT loses on an up day; pos.contracts is a magnitude.
-        ? positionDirectionSign(pos) * (realtimePrice.last - realtimePrice.close) * Math.abs(pos.contracts)
-        : null)
-    : getTodayPnlDollars(pos, prices);
+  // Today's P&L in dollars. Stocks and options share one implementation so the
+  // same-day entry baseline can't drift between them (a stock-only inline copy
+  // is exactly how same-day equities kept reporting a close-based figure).
+  const todayPnl = getTodayPnlDollars(pos, prices);
 
   // Structure already includes strike from ib_sync format_structure_description()
   const structureDisplay = pos.structure;

--- a/web/e2e/portfolio-same-day-equity-pnl.spec.ts
+++ b/web/e2e/portfolio-same-day-equity-pnl.spec.ts
@@ -1,0 +1,241 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Same-day EQUITY Today P&L. Sibling of portfolio-same-day-combo-pnl.spec.ts —
+ * the entry-cost baseline shipped for options only, so three ETF positions
+ * opened the same morning reported a Today P&L that contradicted their own P&L:
+ *
+ *   QQQ 666 sh @ $717.83 → P&L +$608 but Today P&L −$1,418 (yesterday's close)
+ *
+ * Position payload is the real 2026-08-11 Turso snapshot; IB's own
+ * reqPnLSingle daily P&L for these rows equals MV − EC to the cent, which is
+ * what the entry-baselined figure computes.
+ */
+
+const TODAY = "2026-08-11";
+
+const PORTFOLIO_MOCK = {
+  bankroll: 1_000_000,
+  peak_value: 1_000_000,
+  last_sync: `${TODAY}T17:57:05Z`,
+  total_deployed_pct: 1.41,
+  total_deployed_dollars: 1_412_056.63,
+  remaining_capacity_pct: 0,
+  position_count: 3,
+  defined_risk_count: 3,
+  undefined_risk_count: 0,
+  avg_kelly_optimal: null,
+  exposure: {},
+  violations: [],
+  account_summary: {
+    net_liquidation: 1_000_000,
+    daily_pnl: 1035.21,
+    unrealized_pnl: 1035.21,
+    realized_pnl: 0,
+    settled_cash: 100_000,
+    maintenance_margin: 0,
+    excess_liquidity: 100_000,
+    buying_power: 400_000,
+    dividends: 0,
+  },
+  positions: [
+    stock({ id: 8, ticker: "IWM", shares: 800, entryCost: 240_801.68, marketValue: 240_808.0, avgCost: 301.00210, marketPrice: 301.01, ibDaily: 6.32 }),
+    stock({ id: 9, ticker: "QQQ", shares: 666, entryCost: 478_073.05, marketValue: 478_680.84, avgCost: 717.827402, marketPrice: 718.74, ibDaily: 607.78 }),
+    stock({ id: 10, ticker: "SPY", shares: 900, entryCost: 693_181.90, marketValue: 693_603.0, avgCost: 770.202111, marketPrice: 770.67, ibDaily: 421.09 }),
+  ],
+};
+
+function stock(o: {
+  id: number; ticker: string; shares: number; entryCost: number;
+  marketValue: number; avgCost: number; marketPrice: number; ibDaily: number;
+}) {
+  return {
+    id: o.id,
+    ticker: o.ticker,
+    structure: `Stock (${o.shares}.0 shares)`,
+    structure_type: "Stock",
+    risk_profile: "equity",
+    expiry: "N/A",
+    contracts: o.shares,
+    direction: "LONG",
+    entry_cost: o.entryCost,
+    max_risk: null,
+    market_value: o.marketValue,
+    market_price_is_calculated: false,
+    ib_daily_pnl: o.ibDaily,
+    entry_date: TODAY,
+    kelly_optimal: null,
+    target: null,
+    stop: null,
+    legs: [{
+      direction: "LONG",
+      contracts: o.shares,
+      type: "Stock",
+      strike: 0.0,
+      entry_cost: o.entryCost,
+      avg_cost: o.avgCost,
+      market_price: o.marketPrice,
+      market_value: o.marketValue,
+      market_price_is_calculated: false,
+    }],
+  };
+}
+
+/** Live quotes: `last` is the synced mark, `close` is the prior session — the
+ *  baseline that produced the wrong figures before the fix. */
+const QUOTES: Record<string, { last: number; close: number }> = {
+  IWM: { last: 301.01, close: 299.98 },
+  QQQ: { last: 718.74, close: 720.87 },
+  SPY: { last: 770.67, close: 773.03 },
+};
+
+const ORDERS_EMPTY = {
+  last_sync: `${TODAY}T17:57:05Z`,
+  open_orders: [],
+  executed_orders: [],
+  open_count: 0,
+  executed_count: 0,
+};
+
+async function freezeToTradingDay(page: import("@playwright/test").Page) {
+  await page.addInitScript((iso) => {
+    const fixedNow = new Date(iso).valueOf();
+    const RealDate = Date;
+    class MockDate extends RealDate {
+      constructor(...args: ConstructorParameters<typeof Date>) {
+        if (args.length === 0) {
+          super(fixedNow);
+          return;
+        }
+        super(...args);
+      }
+      static now() {
+        return fixedNow;
+      }
+    }
+    Object.defineProperty(window, "Date", { value: MockDate, configurable: true, writable: true });
+  }, `${TODAY}T17:57:05Z`);
+}
+
+async function installMockWebSocket(
+  page: import("@playwright/test").Page,
+  quotes: Record<string, { last: number; close: number }>,
+) {
+  await page.addInitScript((quoteMap: Record<string, { last: number; close: number }>) => {
+    class MockWebSocket {
+      public static OPEN = 1;
+      public url: string;
+      public readyState = 0;
+      public onopen: ((event: Event) => void) | null = null;
+      public onmessage: ((event: MessageEvent<string>) => void) | null = null;
+      public onclose: ((event: Event) => void) | null = null;
+      public onerror: ((event: Event) => void) | null = null;
+
+      constructor(url: string) {
+        this.url = url;
+        window.setTimeout(() => {
+          this.readyState = MockWebSocket.OPEN;
+          this.onopen?.(new Event("open"));
+        }, 0);
+        window.setTimeout(() => {
+          this.onmessage?.({
+            data: JSON.stringify({
+              type: "status",
+              ib_connected: true,
+              ib_issue: null,
+              ib_status_message: null,
+              subscriptions: [],
+            }),
+          } as MessageEvent<string>);
+        }, 10);
+        // Prior-session `close` alongside `last` is what made the bug
+        // reproducible: without it the stock branch simply returned null.
+        window.setTimeout(() => {
+          const updates: Record<string, unknown> = {};
+          for (const [symbol, q] of Object.entries(quoteMap)) {
+            updates[symbol] = {
+              symbol, last: q.last, lastIsCalculated: false,
+              bid: q.last - 0.01, ask: q.last + 0.01, bidSize: 10, askSize: 10,
+              volume: 1_000_000, high: q.last, low: q.last, open: q.close, close: q.close,
+              week52High: null, week52Low: null, avgVolume: null,
+              delta: null, gamma: null, theta: null, vega: null, impliedVol: null, undPrice: null,
+              timestamp: new Date().toISOString(),
+            };
+          }
+          this.onmessage?.({ data: JSON.stringify({ type: "batch", updates }) } as MessageEvent<string>);
+        }, 20);
+      }
+
+      send(_message: string) {}
+
+      close() {
+        this.readyState = 3;
+        this.onclose?.(new Event("close"));
+      }
+    }
+
+    // Relay socket only — replacing window.WebSocket wholesale hijacks the dev
+    // server's HMR socket and stalls hydration. See
+    // feedback_e2e_ws_mock_relay_only_and_44px_button_floor.
+    const NativeWebSocket = window.WebSocket;
+    const RelayAwareWebSocket = function (url: string | URL, protocols?: string | string[]) {
+      return String(url).includes("localhost:8765")
+        ? (new MockWebSocket(String(url)) as unknown as WebSocket)
+        : new NativeWebSocket(url, protocols);
+    } as unknown as typeof WebSocket;
+    Object.assign(RelayAwareWebSocket, { CONNECTING: 0, OPEN: 1, CLOSING: 2, CLOSED: 3 });
+    Object.defineProperty(window, "WebSocket", {
+      configurable: true, writable: true, value: RelayAwareWebSocket,
+    });
+  }, quotes);
+}
+
+async function setupMocks(page: import("@playwright/test").Page) {
+  await page.unrouteAll({ behavior: "ignoreErrors" });
+  await freezeToTradingDay(page);
+  await installMockWebSocket(page, QUOTES);
+
+  const json = (body: unknown) => ({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+
+  await page.route("**/api/portfolio", (route) => route.fulfill(json(PORTFOLIO_MOCK)));
+  await page.route("**/api/orders", (route) => route.fulfill(json(ORDERS_EMPTY)));
+  await page.route("**/api/flex-token", (route) => route.fulfill(json({ ok: true, days_until_expiry: 14 })));
+  await page.route("**/api/ib-status", (route) => route.fulfill(json({ connected: true })));
+  await page.route("**/api/blotter", (route) =>
+    route.fulfill(json({ as_of: `${TODAY}T17:57:05Z`, summary: { realized_pnl: 0 }, closed_trades: [], open_trades: [] })),
+  );
+  await page.route("**/api/prices**", (route) => route.abort());
+}
+
+test.describe("/portfolio same-day equity today pnl", () => {
+  test("equities opened today use the entry-cost baseline, not yesterday's close", async ({ page }) => {
+    await setupMocks(page);
+    await page.goto("/portfolio");
+
+    const qqq = page.locator("tr", { hasText: "QQQ" }).first();
+    await expect(qqq).toBeVisible();
+
+    // Today P&L = Total P&L = MV − EC = 478,680.84 − 478,073.05 = +$607.79
+    // → fmtUsd rounds to "+$608". Matches IB's reqPnLSingle daily (+607.78).
+    await expect(qqq).toContainText("+$608");
+    // Close-based figure the column used to show: (718.74 − 720.87) × 666.
+    await expect(qqq).not.toContainText("-$1,419");
+    // Day Chg %: 607.79 / 478,073.05 × 100 = +0.13% (was −0.30% off the close).
+    await expect(qqq).toContainText("+0.13%");
+    await expect(qqq).not.toContainText("-0.30%");
+
+    const spy = page.locator("tr", { hasText: "SPY" }).first();
+    // 693,603.00 − 693,181.90 = +$421.10 (IB daily: +421.09).
+    await expect(spy).toContainText("+$421");
+    await expect(spy).not.toContainText("-$2,124");
+
+    const iwm = page.locator("tr", { hasText: "IWM" }).first();
+    // 240,808.00 − 240,801.68 = +$6.32 (IB daily: +6.32).
+    await expect(iwm).toContainText("+$6");
+    await expect(iwm).not.toContainText("+$824");
+  });
+});

--- a/web/lib/dayMoveBreakdown.ts
+++ b/web/lib/dayMoveBreakdown.ts
@@ -97,9 +97,10 @@ function quoteLabelsForPosition(
  * Precedence (must match operator expectation vs TWS):
  *   1. `pos.ib_daily_pnl` — IB reqPnLSingle, no quotes required. Handles
  *      same-day opens and intraday adds correctly.
- *   2. Same-day options — entry-cost baseline via getTodayPnlDollars (prior
- *      close is meaningless when the position did not exist yesterday).
- *   3. Stock close-based with SHORT sign awareness + last/mid.
+ *   2. Same-day positions (stocks AND options) — entry-cost baseline via
+ *      getTodayPnlDollars (prior close is meaningless when the position did
+ *      not exist yesterday).
+ *   3. Overnight stock — close-based with SHORT sign awareness + last/mid.
  *   4. Overnight options — last/mid vs prior close.
  */
 export function computeDayMoveBreakdown(
@@ -128,8 +129,11 @@ export function computeDayMoveBreakdown(
       continue;
     }
 
-    // 2. Same-day options: entry baseline (shared with position-table Today P&L).
-    if (pos.structure_type !== "Stock" && isSameDay(pos)) {
+    // 2. Same-day positions: entry baseline (shared with position-table Today
+    //    P&L). Equities included — a stock opened today has no prior close of
+    //    its own either, and a stock-only exception here made the Day P&L card
+    //    disagree with the Today P&L column it summarises.
+    if (isSameDay(pos)) {
       const todayPnl = getTodayPnlDollars(pos, prices);
       if (todayPnl == null) continue;
       total += todayPnl;

--- a/web/lib/positionUtils.ts
+++ b/web/lib/positionUtils.ts
@@ -469,6 +469,15 @@ export function isSameDay(pos: PortfolioPosition): boolean {
   return entryDate != null && entryDate === todayInET();
 }
 
+/** Compute real-time market value from WS prices for a stock position.
+ *  Sign-aware: `pos.contracts` is a positive magnitude, so a SHORT's market
+ *  value must read negative for `mv − entry_cost` to be a signed P&L. */
+function computeStockRtMv(pos: PortfolioPosition, prices?: Record<string, PriceData>): number | null {
+  const last = prices?.[pos.ticker]?.last;
+  if (last == null || last <= 0) return null;
+  return positionDirectionSign(pos) * last * Math.abs(pos.contracts);
+}
+
 /** Compute real-time market value from WS prices for option positions. */
 function computeRtMv(pos: PortfolioPosition, prices?: Record<string, PriceData>): number | null {
   if (pos.structure_type === "Stock" || !prices) return null;
@@ -526,6 +535,32 @@ export function getOptionDailyChg(pos: PortfolioPosition, prices?: Record<string
   return (effectivePnl / Math.abs(closeValue)) * 100;
 }
 
+/* ─── Stock daily change ──────────────────────────────────── */
+
+/**
+ * Day Chg % for an equity position.
+ *
+ * Overnight: the instrument's own move off yesterday's close.
+ * Same-day: yesterday's close is meaningless (the position didn't exist), so
+ * the entry cost is the baseline and the reading becomes the position's return
+ * since entry — matching the same-day rule already applied to options.
+ */
+export function getStockDailyChg(pos: PortfolioPosition, prices?: Record<string, PriceData>): number | null {
+  if (pos.structure_type !== "Stock") return null;
+
+  if (isSameDay(pos)) {
+    const entryCost = resolveEntryCost(pos);
+    if (entryCost === 0) return null;
+    const todayPnl = getTodayPnlDollars(pos, prices);
+    if (todayPnl == null) return null;
+    return (todayPnl / Math.abs(entryCost)) * 100;
+  }
+
+  const p = prices?.[pos.ticker];
+  if (!p || p.last == null || p.last <= 0 || p.close == null || p.close <= 0) return null;
+  return ((p.last - p.close) / p.close) * 100;
+}
+
 /** Direction sign for a position: +1 long, -1 short. A stock's direction lives
  *  on the position/leg, NOT in `pos.contracts` (which is a positive magnitude),
  *  so any `price × contracts` value MUST be multiplied by this to be
@@ -541,6 +576,12 @@ export function positionDirectionSign(pos: PortfolioPosition): number {
 
 export function getTodayPnlDollars(pos: PortfolioPosition, prices?: Record<string, PriceData>): number | null {
   if (pos.structure_type === "Stock") {
+    // Same-day position: Today's P&L = Total P&L (the shares didn't exist
+    // yesterday, so the pre-entry move belongs to the market, not the operator).
+    if (isSameDay(pos)) {
+      const mv = computeStockRtMv(pos, prices) ?? resolveMarketValue(pos);
+      return getPnlDollars(pos, mv);
+    }
     const p = prices?.[pos.ticker];
     if (!p || p.last == null || p.last <= 0 || p.close == null || p.close <= 0) return null;
     // Sign-aware: a SHORT loses when price rises. `pos.contracts` is a positive

--- a/web/tests/same-day-stock-pnl.test.ts
+++ b/web/tests/same-day-stock-pnl.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Regression: equity positions opened TODAY must report Today P&L = Total P&L.
+ *
+ * The same-day entry-cost baseline (web/CLAUDE.md "Daily Change % → Same-day
+ * exception") was only wired for OPTIONS. Stocks returned before the
+ * `isSameDay` check and always used yesterday's close, so three ETF positions
+ * opened the same morning showed a Today P&L that contradicted their own P&L:
+ *
+ *   QQQ 666 sh @ $717.83, last $718.46 → P&L +$421 but Today P&L −$1,605
+ *   SPY 900 sh @ $770.20, last $770.45 → P&L +$223 but Today P&L −$2,322
+ *   IWM 800 sh @ $301.00, last $300.94 → P&L −$50   but Today P&L +$768
+ *
+ * Yesterday's close is meaningless for a position that did not exist
+ * yesterday: the pre-entry move belongs to the market, not to the operator.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { computeDayMoveBreakdown } from "../lib/dayMoveBreakdown";
+import { getStockDailyChg, getTodayPnlDollars } from "../lib/positionUtils";
+import type { PriceData } from "../lib/pricesProtocol";
+import type { PortfolioData, PortfolioPosition } from "../lib/types";
+
+function makePriceData(overrides: Partial<PriceData> = {}): PriceData {
+  return {
+    symbol: "TEST", last: null, lastIsCalculated: false,
+    bid: null, ask: null, bidSize: null, askSize: null,
+    volume: null, high: null, low: null, open: null, close: null,
+    week52High: null, week52Low: null, avgVolume: null,
+    delta: null, gamma: null, theta: null, vega: null, impliedVol: null, undPrice: null,
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function todayET(): string {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: "America/New_York",
+    year: "numeric", month: "2-digit", day: "2-digit",
+  }).formatToParts(new Date());
+  const get = (type: string) => parts.find((p) => p.type === type)!.value;
+  return `${get("year")}-${get("month")}-${get("day")}`;
+}
+
+function makeStock(over: {
+  ticker: string;
+  shares: number;
+  avgEntry: number;
+  direction?: "LONG" | "SHORT";
+  entryDate?: string;
+}): PortfolioPosition {
+  const direction = over.direction ?? "LONG";
+  // Production convention (`scripts/ib_sync.py`): `contracts` is a positive
+  // magnitude and a SHORT's `entry_cost` carries the credit sign, so
+  // `mv - entry_cost` is the signed P&L for both directions.
+  const notional = over.shares * over.avgEntry;
+  const entryCost = direction === "LONG" ? notional : -notional;
+  return {
+    id: 1,
+    ticker: over.ticker,
+    structure: `Stock (${over.shares}.0 shares)`,
+    structure_type: "Stock",
+    risk_profile: "equity",
+    expiry: "N/A",
+    contracts: over.shares,
+    direction,
+    entry_cost: entryCost,
+    max_risk: direction === "LONG" ? notional : null,
+    market_value: null,
+    ib_daily_pnl: null,
+    kelly_optimal: null,
+    target: null,
+    stop: null,
+    entry_date: over.entryDate ?? todayET(),
+    legs: [{
+      direction,
+      contracts: over.shares,
+      type: "Stock",
+      strike: null,
+      entry_cost: entryCost,
+      avg_cost: over.avgEntry,
+      market_price: null,
+      market_value: null,
+    }],
+  } as PortfolioPosition;
+}
+
+/* ─── Production repro ─────────────────────────────────────── */
+
+const QQQ = makeStock({ ticker: "QQQ", shares: 666, avgEntry: 717.83 });
+const QQQ_PRICES = { QQQ: makePriceData({ symbol: "QQQ", last: 718.46, close: 720.87 }) };
+
+const SPY = makeStock({ ticker: "SPY", shares: 900, avgEntry: 770.20 });
+const SPY_PRICES = { SPY: makePriceData({ symbol: "SPY", last: 770.45, close: 773.03 }) };
+
+const IWM = makeStock({ ticker: "IWM", shares: 800, avgEntry: 301.00 });
+const IWM_PRICES = { IWM: makePriceData({ symbol: "IWM", last: 300.94, close: 299.98 }) };
+
+describe("same-day equity Today P&L", () => {
+  it("QQQ opened today reports +$420, not the −$1,605 close-based figure", () => {
+    expect(getTodayPnlDollars(QQQ, QQQ_PRICES)).toBeCloseTo(419.58, 2);
+  });
+
+  it("SPY opened today reports +$225, not −$2,322", () => {
+    expect(getTodayPnlDollars(SPY, SPY_PRICES)).toBeCloseTo(225, 2);
+  });
+
+  it("IWM opened today reports the −$48 loss, not a +$768 phantom gain", () => {
+    expect(getTodayPnlDollars(IWM, IWM_PRICES)).toBeCloseTo(-48, 2);
+  });
+
+  it("a same-day SHORT stock is sign-correct: price below entry is a gain", () => {
+    // SHORT 1,000 @ $100 (credit −$100,000), last $98 → +$2,000.
+    // Close-based math would have read +$7,000 off a $105 prior close.
+    const short = makeStock({ ticker: "MU", shares: 1000, avgEntry: 100, direction: "SHORT" });
+    const prices = { MU: makePriceData({ symbol: "MU", last: 98, close: 105 }) };
+    expect(getTodayPnlDollars(short, prices)).toBeCloseTo(2000, 2);
+  });
+
+  it("an OVERNIGHT stock still uses yesterday's close (control)", () => {
+    const overnight = makeStock({
+      ticker: "QQQ", shares: 666, avgEntry: 717.83, entryDate: "2026-08-04",
+    });
+    expect(getTodayPnlDollars(overnight, QQQ_PRICES)).toBeCloseTo(-1605.06, 2);
+  });
+
+  it("returns null when no live last price is available", () => {
+    expect(getTodayPnlDollars(QQQ, { QQQ: makePriceData({ close: 720.87 }) })).toBeNull();
+  });
+});
+
+describe("same-day equity Day Chg %", () => {
+  it("QQQ opened today measures against entry, not yesterday's close", () => {
+    // (718.46 − 717.83) / 717.83 × 100 = +0.0878%
+    expect(getStockDailyChg(QQQ, QQQ_PRICES)).toBeCloseTo(0.0878, 3);
+  });
+
+  it("an OVERNIGHT stock still measures against yesterday's close (control)", () => {
+    const overnight = makeStock({
+      ticker: "QQQ", shares: 666, avgEntry: 717.83, entryDate: "2026-08-04",
+    });
+    expect(getStockDailyChg(overnight, QQQ_PRICES)).toBeCloseTo(-0.3343, 3);
+  });
+
+  it("a same-day SHORT stock reads positive when the price falls", () => {
+    const short = makeStock({ ticker: "MU", shares: 1000, avgEntry: 100, direction: "SHORT" });
+    const prices = { MU: makePriceData({ symbol: "MU", last: 98, close: 105 }) };
+    expect(getStockDailyChg(short, prices)).toBeCloseTo(2, 3);
+  });
+});
+
+/* ─── Account Day P&L aggregate must agree with the table ──── */
+
+function portfolioOf(positions: PortfolioPosition[]): PortfolioData {
+  return {
+    bankroll: 1_000_000,
+    peak_value: 1_000_000,
+    last_sync: new Date().toISOString(),
+    total_deployed_pct: 0,
+    total_deployed_dollars: 0,
+    remaining_capacity_pct: 100,
+    position_count: positions.length,
+    defined_risk_count: positions.length,
+    undefined_risk_count: 0,
+    avg_kelly_optimal: null,
+    positions,
+  } as unknown as PortfolioData;
+}
+
+describe("computeDayMoveBreakdown — same-day equities", () => {
+  it("totals the entry-baselined P&L so the Day P&L card matches the table", () => {
+    const { total, rows } = computeDayMoveBreakdown(
+      portfolioOf([QQQ, SPY, IWM]),
+      { ...QQQ_PRICES, ...SPY_PRICES, ...IWM_PRICES },
+    );
+    // 419.58 + 225 − 48 = 596.58 (the buggy close-based total was −3,159)
+    expect(total).toBeCloseTo(596.58, 2);
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.col2)).toEqual(["same-day", "same-day", "same-day"]);
+  });
+
+  it("an overnight equity keeps the close-based row (control)", () => {
+    const overnight = makeStock({
+      ticker: "QQQ", shares: 666, avgEntry: 717.83, entryDate: "2026-08-04",
+    });
+    const { total, rows } = computeDayMoveBreakdown(portfolioOf([overnight]), QQQ_PRICES);
+    expect(total).toBeCloseTo(-1605.06, 2);
+    expect(rows[0].col1).toBe("$720.87");
+  });
+});


### PR DESCRIPTION
## Bug

Equity positions opened today reported a **Today P&L that contradicted their own P&L**:

| | qty | avg entry | last | P&L | Today P&L (before) |
|---|---|---|---|---|---|
| QQQ | 666 | $717.83 | $718.46 | **+$421** | −$1,605 |
| SPY | 900 | $770.20 | $770.45 | **+$223** | −$2,322 |
| IWM | 800 | $301.00 | $300.94 | **−$50** | +$768 |

## Root cause

A position opened today has no prior close of its own, so Today P&L collapses to Total P&L (`MV − EC`). That exception was wired for **options only** — the stock branch of `getTodayPnlDollars` returned before the `isSameDay` check and always measured against yesterday's close. `web/CLAUDE.md` already documented the rule generally; stocks were never covered.

## Broker cross-check

IB's own `reqPnLSingle` daily P&L for these rows equals `MV − EC` to the cent, against the live Turso snapshot:

```
TKR   QTY  entry_date    entry_cost    mkt_value      MV-EC   ib_daily
IWM   800  2026-08-11    240,801.68   240,808.00       6.32       6.32
QQQ   666  2026-08-11    478,073.05   478,680.84     607.79     607.78
SPY   900  2026-08-11    693,181.90   693,603.00     421.10     421.09
```

## Changes

- `getTodayPnlDollars` — same-day stock branch, sign-aware, falls back to the synced MV when no tick is live.
- `getStockDailyChg` — new shared helper so Day Chg follows the same rule; overnight equities keep the instrument's close-based move.
- `PositionTable` — dropped the stock-only inline copies of both columns; that duplication is how the paths drifted apart.
- `computeDayMoveBreakdown` — same-day branch now covers stocks, so the Day P&L card cannot disagree with the column it summarises.

## Verification

- 11 new unit tests (red first, reproducing the exact production numbers), full suite **5,274 pass / 0 fail**.
- New Playwright spec **fails without the fix**, passes with it.
- Live browser render — Today P&L now equals P&L on every same-day row:

```
QQQ  $717.83  $718.74  +0.13%  +$608  $478,681  +$608  +0.1%
SPY  $770.20  $770.67  +0.06%  +$421  $693,603  +$421  +0.1%
IWM  $301.00  $301.01  +0.00%    +$6  $240,808    +$6  +0.0%
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)