### PR TITLE
feat(preferences): operator-tunable runtime limits behind /preferences

### DIFF
--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -111,6 +111,45 @@ FastAPI timeouts now match the script deadlines: `/orders/place` is 25s subproce
 
 ---
 
+## Operator Preferences Contract (`app_preferences.py`)
+
+The `/preferences` page makes the order-limit caps and scanner worker counts
+tunable at runtime. `order_limits.py` keeps its public functions but delegates
+every lookup here. Rules that must not be relaxed:
+
+1. **A stored value can never widen a cap.** Resolution is DB row > env var >
+   code default, with one asymmetry that is the whole point: an env value
+   outside the registry band is CLAMPED into it, a DB value outside the band is
+   **DISCARDED** (falls through to env/default, `db_rejected: true`). The check
+   lives on the READ path, not just the write path, so editing the Turso row
+   directly cannot raise `RADON_MAX_ORDER_NOTIONAL` past its declared ceiling.
+   Verified live 2026-08-11: a hand-written `99000000.0` row resolved to the
+   250,000 default.
+2. **The order path never does inline I/O.** `resolve()` / `get_*()` read a
+   process-local snapshot and never block, never raise. A dead Turso resolves to
+   env/default. The one blocking read is `refresh_snapshot()`.
+3. **Background refresh is opt-in** (`enable_background_refresh(True)`, set only
+   in the radon-api lifespan). `ib_place_order.py` is a fresh interpreter per
+   order: it must resolve from the inherited environment overlay, never open a
+   Turso socket it abandons at exit.
+4. **`bootstrap()` runs in the FastAPI lifespan** and exports stored values into
+   `os.environ`, which is what makes subprocesses inherit the operator's caps.
+   Without it a restart silently reverts the placement funnel to env/defaults.
+5. **Every mutation is audited before it is applied.** `set_value`/`clear_value`
+   write `app_preference_events` FIRST; a failed audit write refuses the change.
+   The actor is derived server-side from the authenticated principal in
+   `routes/preferences.py:_actor`, never from the request body.
+6. **Adding a key means proving something reads it.** The five keys dropped
+   during review were consumed only by standalone systemd units with their own
+   `EnvironmentFile`, which never inherit radon-api's environment — a control
+   surface whose described effect is false is worse than no control.
+   `test_app_preferences.py::TestRegistryIsHonest` pins this.
+
+Migration `0046_app_preferences.sql`. Hard bands live in the registry and are
+deliberately a small multiple of each default; widening one is a code change.
+
+---
+
 ## Position Cache Refresh Contract (`ib_sync.py`)
 
 `ib_insync.positions()` returns an in-memory cache. TWS push updates `pos.position` immediately but `pos.avgCost` lags while TWS recomputes VWAP server-side. `IBClient.get_positions()` calls `reqPositions()` + `sleep(1)` BEFORE reading, draining pending updates so size and avgCost are consistent. Opt out via `get_positions(refresh=False)` for tight read loops. Try/except so gateway hiccups fall back to cache. Tests: `test_ib_client.py::TestPortfolioOperations`. Added 2026-05-20 (commit 5d10def).

--- a/scripts/api/routes/preferences.py
+++ b/scripts/api/routes/preferences.py
@@ -1,0 +1,142 @@
+"""Operator-tunable runtime preferences behind the /preferences page.
+
+Auth: no per-route dependency. The global auth middleware in
+scripts/api/server.py gates these paths (they are deliberately absent from
+AUTH_EXEMPT_PATHS), and in production verify_clerk_jwt additionally pins the
+caller to ALLOWED_USER_IDS, so every verb here is operator-only.
+
+Event-loop discipline: uvicorn runs a single loop, so every app_preferences call
+that can touch Turso goes through asyncio.to_thread. This module never imports
+db.client / db.writer / libsql.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+
+try:
+    import app_preferences
+except ImportError:  # pragma: no cover - depends on which root is on sys.path
+    from scripts import app_preferences
+
+logger = logging.getLogger("radon.preferences")
+
+router = APIRouter()
+
+UPDATED_BY_MAX_LEN = 64
+
+
+def _generated_at() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _actor(request: Request) -> str | None:
+    """Who the audit log records, derived server-side from the authenticated
+    principal.
+
+    Never read from the request body: a self-asserted actor is worthless on an
+    audit trail for live risk caps. The trusted-local bypass in server.py
+    returns before setting request.state.user, so an unattributed local caller
+    is labelled rather than silently recorded as NULL.
+    """
+    payload = getattr(request.state, "user", None)
+    if isinstance(payload, dict):
+        subject = payload.get("sub")
+        if isinstance(subject, str) and subject:
+            return subject[:UPDATED_BY_MAX_LEN]
+    return "trusted-local"
+
+
+def _bad_request() -> HTTPException:
+    return HTTPException(
+        status_code=400,
+        detail={
+            "code": "BAD_REQUEST",
+            "message": "body must be a JSON object with a 'value' field",
+        },
+    )
+
+
+def _store_unavailable() -> HTTPException:
+    return HTTPException(
+        status_code=503,
+        detail={
+            "code": "PREFERENCE_STORE_UNAVAILABLE",
+            "message": "preferences store temporarily unavailable",
+        },
+    )
+
+
+def _validation_error(exc) -> HTTPException:
+    """404 for an unknown key, 422 for a value the registry refuses."""
+    detail: dict[str, Any] = {"code": exc.code, "message": exc.message}
+    if exc.code == "UNKNOWN_PREFERENCE":
+        return HTTPException(status_code=404, detail=detail)
+    if exc.code == "OUT_OF_RANGE":
+        detail["allowed_min"] = exc.allowed_min
+        detail["allowed_max"] = exc.allowed_max
+    return HTTPException(status_code=422, detail=detail)
+
+
+async def _mutate(operation, key: str, *args) -> dict:
+    """Run a blocking app_preferences write off-loop and shape the response."""
+    try:
+        resolved = await asyncio.to_thread(operation, key, *args)
+    except app_preferences.PreferenceValidationError as exc:
+        raise _validation_error(exc) from exc
+    except app_preferences.PreferenceStoreError as exc:
+        logger.warning("preferences store write failed for %s: %s", key, exc)
+        raise _store_unavailable() from exc
+
+    store = await asyncio.to_thread(app_preferences.store_status)
+    return {"preference": resolved.to_dict(), "store": store}
+
+
+async def _json_object(request: Request) -> dict:
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise _bad_request() from exc
+    if not isinstance(body, dict):
+        raise _bad_request()
+    return body
+
+
+@router.get("/preferences")
+async def list_preferences(request: Request):
+    """Every registry entry with its effective value, source and provenance.
+
+    A store outage is reported in `store`, never as a 5xx: the entries still
+    resolve from environment and code defaults.
+    """
+    await asyncio.to_thread(app_preferences.refresh_snapshot)
+    resolved = await asyncio.to_thread(app_preferences.resolve_all)
+    store = await asyncio.to_thread(app_preferences.store_status)
+
+    return {
+        "preferences": [entry.to_dict() for entry in resolved],
+        "groups": list(app_preferences.GROUP_ORDER),
+        "store": store,
+        "generated_at": _generated_at(),
+    }
+
+
+@router.put("/preferences/{key}")
+async def put_preference(key: str, request: Request):
+    """Store an operator override and return the value that now applies."""
+    body = await _json_object(request)
+    if "value" not in body:
+        raise _bad_request()
+
+    return await _mutate(app_preferences.set_value, key, body["value"], _actor(request))
+
+
+@router.delete("/preferences/{key}")
+async def reset_preference(key: str, request: Request):
+    """Drop the stored override and return the value the system falls back to."""
+    return await _mutate(app_preferences.clear_value, key, _actor(request))

--- a/scripts/api/server.py
+++ b/scripts/api/server.py
@@ -63,6 +63,9 @@ from api.order_audit import record_order_event
 from api.auth import verify_clerk_jwt, verify_api_key, is_trusted_local_request
 from api.ws_ticket import create_ticket, validate_ticket
 from api.routes.historical import router as historical_router
+from api.routes.preferences import router as preferences_router
+
+import app_preferences
 from clients.menthorq_dashboard_client import (
     MenthorQDashboardAuthError,
     MenthorQDashboardClient,
@@ -468,6 +471,19 @@ async def lifespan(app: FastAPI):
     """Start IB pool and UW client on startup, tear down on shutdown."""
     global ib_pool, uw_available
 
+    # Operator preferences BEFORE anything can place an order. bootstrap()
+    # publishes stored values into os.environ so every subprocess we spawn
+    # (ib_place_order.py above all) inherits the caps the operator set; without
+    # it a restart silently reverts the placement funnel to env/defaults.
+    # Only this long-lived process opts into background refreshes — short-lived
+    # subprocesses read the inherited overlay instead of opening their own
+    # Turso socket per invocation.
+    app_preferences.enable_background_refresh(True)
+    if await asyncio.to_thread(app_preferences.bootstrap):
+        logger.info("Operator preferences loaded from Turso")
+    else:
+        logger.warning("Operator preferences unavailable; env and code defaults in force")
+
     if test_mode:
         logger.info("Radon API starting in test mode; IB Gateway and pool startup are disabled")
         uw_available = bool(os.environ.get("UW_TOKEN"))
@@ -536,6 +552,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Radon API", version="1.0.0", lifespan=lifespan)
 app.include_router(historical_router)
+app.include_router(preferences_router)
 
 # Explicit origin allowlist (was a `https://.*\.radon\.run` wildcard regex). The
 # wildcard matched ANY *.radon.run subdomain, so a subdomain takeover of a stale

--- a/scripts/api/tests/test_preferences_routes.py
+++ b/scripts/api/tests/test_preferences_routes.py
@@ -1,0 +1,401 @@
+"""Route tests for the operator preferences surface (GET/PUT/DELETE /preferences).
+
+Every `app_preferences` call is monkeypatched on the module object the route
+module itself holds, so no Turso connection is ever opened here. The registry is
+NOT mocked: it is a pure constant with no I/O, and pinning the response against
+it is what proves the route exposes the whole operator surface.
+
+Offload discipline: uvicorn runs one event loop, so every blocking
+app_preferences call must go through asyncio.to_thread. Each stub records
+whether a running event loop was visible from its own thread; a stub that sees
+one was called inline on the loop.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+ENTRY_KEYS = (
+    "key",
+    "label",
+    "group",
+    "value_type",
+    "value",
+    "default",
+    "hard_min",
+    "hard_max",
+    "unit",
+    "description",
+    "applies_immediately",
+    "source",
+    "db_rejected",
+    "updated_at",
+    "updated_by",
+)
+
+STORE_OK = {"available": True, "error": None, "checked_at": "2026-08-11T17:02:11Z"}
+STORE_DOWN = {
+    "available": False,
+    "error": "HranaHttpError: connection refused",
+    "checked_at": None,
+}
+
+
+def _ran_on_event_loop() -> bool:
+    """True when the caller is executing on a thread that owns a running loop."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return False
+    return True
+
+
+class _Recorder:
+    """Callable stub that records call args and its execution thread context."""
+
+    def __init__(self, result=None, raises: BaseException | None = None):
+        self.result = result
+        self.raises = raises
+        self.calls: list[tuple] = []
+        self.idents: list[int] = []
+        self.on_loop: list[bool] = []
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        self.idents.append(threading.get_ident())
+        self.on_loop.append(_ran_on_event_loop())
+        if self.raises is not None:
+            raise self.raises
+        return self.result
+
+
+class _FakeResolved:
+    """Stand-in for ResolvedPreference: the route only ever calls to_dict()."""
+
+    def __init__(self, entry: dict):
+        self._entry = entry
+
+    def to_dict(self) -> dict:
+        return dict(self._entry)
+
+
+def _entry_for(pref, *, value=None, source="default", updated_at=None, updated_by=None) -> dict:
+    return {
+        "key": pref.key,
+        "label": pref.label,
+        "group": pref.group,
+        "value_type": pref.value_type,
+        "value": pref.default if value is None else value,
+        "default": pref.default,
+        "hard_min": pref.hard_min,
+        "hard_max": pref.hard_max,
+        "unit": pref.unit,
+        "description": pref.description,
+        "applies_immediately": pref.applies_immediately,
+        "source": source,
+        "db_rejected": False,
+        "updated_at": updated_at,
+        "updated_by": updated_by,
+    }
+
+
+@pytest.fixture(autouse=True)
+def localhost_bypass(monkeypatch):
+    from scripts.api import auth, server
+
+    monkeypatch.setattr(auth, "is_trusted_local_request", lambda request: True)
+    monkeypatch.setattr(server, "is_trusted_local_request", lambda request: True)
+
+
+@pytest.fixture
+def client():
+    from scripts.api.server import app
+
+    return TestClient(app)
+
+
+@pytest.fixture
+def prefs():
+    """The app_preferences module object the route module resolved at import."""
+    from scripts.api.routes import preferences as preferences_module
+
+    return preferences_module.app_preferences
+
+
+@pytest.fixture
+def registry(prefs):
+    return list(prefs.registry())
+
+
+@pytest.fixture
+def store(monkeypatch, prefs, registry):
+    """Patch every blocking app_preferences call with a recorder."""
+
+    stubs = {
+        "refresh_snapshot": _Recorder(result=True),
+        "apply_env_overlay": _Recorder(result={}),
+        "resolve_all": _Recorder(
+            result=[_FakeResolved(_entry_for(pref)) for pref in registry]
+        ),
+        "store_status": _Recorder(result=dict(STORE_OK)),
+        "set_value": _Recorder(),
+        "clear_value": _Recorder(),
+    }
+    for name, stub in stubs.items():
+        monkeypatch.setattr(prefs, name, stub)
+    return stubs
+
+
+class TestGetPreferences:
+    def test_get_returns_every_registry_entry(self, client, store, prefs, registry):
+        response = client.get("/preferences")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body["preferences"]) == len(registry)
+        assert body["groups"] == list(prefs.GROUP_ORDER)
+        assert body["store"] == STORE_OK
+        assert isinstance(body["generated_at"], str) and body["generated_at"]
+
+    def test_get_entry_shape(self, client, store):
+        """The handler passes ResolvedPreference.to_dict() through verbatim."""
+        body = client.get("/preferences").json()
+
+        assert tuple(body["preferences"][0].keys()) == ENTRY_KEYS
+
+    def test_get_returns_200_when_store_unavailable(self, client, store, registry):
+        store["refresh_snapshot"].result = False
+        store["store_status"].result = dict(STORE_DOWN)
+
+        response = client.get("/preferences")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["store"]["available"] is False
+        assert body["store"]["error"]
+        assert len(body["preferences"]) == len(registry)
+
+    def test_get_does_not_mutate_the_process_environment(self, client, store):
+        """A read verb must have no global side effect. The overlay belongs to
+        lifespan startup and the write paths, so the effective cap in a
+        subprocess never depends on whether anyone loaded the page."""
+        assert client.get("/preferences").status_code == 200
+
+        assert store["apply_env_overlay"].calls == []
+        assert len(store["refresh_snapshot"].calls) == 1
+
+    def test_get_never_blocks_the_event_loop(self, client, store):
+        assert client.get("/preferences").status_code == 200
+
+        for name in ("refresh_snapshot", "resolve_all", "store_status"):
+            assert store[name].on_loop == [False], f"{name} ran on the event loop"
+
+
+class TestPutPreference:
+    def test_put_valid_calls_set_value_and_echoes_entry(self, client, store, registry):
+        pref = registry[0]
+        entry = _entry_for(pref, value=400, source="db", updated_by="user_2abc")
+        store["set_value"].result = _FakeResolved(entry)
+
+        response = client.put(f"/preferences/{pref.key}", json={"value": 400})
+
+        assert response.status_code == 200
+        assert response.json() == {"preference": entry, "store": STORE_OK}
+        args, _ = store["set_value"].calls[0]
+        assert args == (pref.key, 400, "trusted-local")
+
+    def test_the_actor_is_never_taken_from_the_request_body(self, client, store, registry):
+        """A self-asserted actor is worthless on an audit trail for risk caps."""
+        pref = registry[0]
+        store["set_value"].result = _FakeResolved(_entry_for(pref, value=400, source="db"))
+
+        response = client.put(
+            f"/preferences/{pref.key}",
+            json={"value": 400, "updated_by": "someone-else"},
+        )
+
+        assert response.status_code == 200
+        args, _ = store["set_value"].calls[0]
+        assert "someone-else" not in args
+
+    def test_put_unknown_key_returns_404_with_code(self, client, store, prefs):
+        store["set_value"].raises = prefs.PreferenceValidationError(
+            "UNKNOWN_PREFERENCE", "unknown preference key 'FOO'", key="FOO"
+        )
+
+        response = client.put("/preferences/FOO", json={"value": 1})
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == {
+            "code": "UNKNOWN_PREFERENCE",
+            "message": "unknown preference key 'FOO'",
+        }
+
+    def test_put_wrong_type_returns_422(self, client, store, prefs):
+        store["set_value"].raises = prefs.PreferenceValidationError(
+            "WRONG_TYPE",
+            "RADON_MAX_ORDER_QTY expects an integer value",
+            key="RADON_MAX_ORDER_QTY",
+        )
+
+        response = client.put("/preferences/RADON_MAX_ORDER_QTY", json={"value": 400.5})
+
+        assert response.status_code == 422
+        assert response.json()["detail"] == {
+            "code": "WRONG_TYPE",
+            "message": "RADON_MAX_ORDER_QTY expects an integer value",
+        }
+
+    def test_put_out_of_range_returns_422_with_allowed_range(self, client, store, prefs):
+        store["set_value"].raises = prefs.PreferenceValidationError(
+            "OUT_OF_RANGE",
+            "RADON_MAX_ORDER_QTY must be between 1 and 5000 (got 9000)",
+            key="RADON_MAX_ORDER_QTY",
+            allowed_min=1,
+            allowed_max=5000,
+        )
+
+        response = client.put("/preferences/RADON_MAX_ORDER_QTY", json={"value": 9000})
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        assert detail["code"] == "OUT_OF_RANGE"
+        assert "1" in detail["message"] and "5000" in detail["message"]
+        assert detail["allowed_min"] == 1
+        assert detail["allowed_max"] == 5000
+
+    def test_put_missing_value_returns_400(self, client, store, registry):
+        response = client.put(f"/preferences/{registry[0].key}", json={"updated_by": "u"})
+
+        assert response.status_code == 400
+        assert response.json()["detail"]["code"] == "BAD_REQUEST"
+        assert store["set_value"].calls == []
+
+    def test_put_non_object_body_returns_400(self, client, store, registry):
+        response = client.put(f"/preferences/{registry[0].key}", json=[1, 2, 3])
+
+        assert response.status_code == 400
+        assert response.json()["detail"]["code"] == "BAD_REQUEST"
+        assert store["set_value"].calls == []
+
+    def test_put_unparseable_body_returns_400(self, client, store, registry):
+        response = client.put(
+            f"/preferences/{registry[0].key}",
+            content=b"not json",
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"]["code"] == "BAD_REQUEST"
+        assert store["set_value"].calls == []
+
+    def test_put_store_failure_returns_503_not_500(self, client, store, prefs, registry):
+        store["set_value"].raises = prefs.PreferenceStoreError("turso unreachable")
+
+        response = client.put(f"/preferences/{registry[0].key}", json={"value": 400})
+
+        assert response.status_code == 503
+        assert response.json()["detail"] == {
+            "code": "PREFERENCE_STORE_UNAVAILABLE",
+            "message": "preferences store temporarily unavailable",
+        }
+
+    def test_db_work_is_offloaded_from_the_event_loop(self, client, store, registry):
+        """A stub that can see a running loop was called inline on the loop.
+
+        The handler is async, so an un-offloaded set_value would execute on the
+        uvicorn loop thread and observe its running loop; asyncio.to_thread runs
+        it on a worker thread where get_running_loop() raises.
+        """
+        pref = registry[0]
+        store["set_value"].result = _FakeResolved(_entry_for(pref, value=400, source="db"))
+
+        assert client.put(f"/preferences/{pref.key}", json={"value": 400}).status_code == 200
+
+        assert store["set_value"].on_loop == [False]
+        assert store["store_status"].on_loop == [False]
+
+
+class TestDeletePreference:
+    def test_delete_calls_clear_value_and_returns_fallback_entry(
+        self, client, store, registry
+    ):
+        pref = registry[0]
+        entry = _entry_for(pref, source="default")
+        store["clear_value"].result = _FakeResolved(entry)
+
+        response = client.delete(f"/preferences/{pref.key}?updated_by=someone-else")
+
+        assert response.status_code == 200
+        assert response.json() == {"preference": entry, "store": STORE_OK}
+        args, _ = store["clear_value"].calls[0]
+        assert args == (pref.key, "trusted-local"), "the actor must be server-derived"
+
+    def test_delete_is_idempotent_when_no_row_exists(self, client, store, registry):
+        """Resetting a key with no stored override is a success, not an error."""
+        pref = registry[0]
+        store["clear_value"].result = _FakeResolved(_entry_for(pref, source="default"))
+
+        response = client.delete(f"/preferences/{pref.key}")
+
+        assert response.status_code == 200
+        assert response.json()["preference"]["source"] == "default"
+        args, _ = store["clear_value"].calls[0]
+        assert args == (pref.key, "trusted-local")
+
+    def test_delete_unknown_key_returns_404(self, client, store, prefs):
+        store["clear_value"].raises = prefs.PreferenceValidationError(
+            "UNKNOWN_PREFERENCE", "unknown preference key 'FOO'", key="FOO"
+        )
+
+        response = client.delete("/preferences/FOO")
+
+        assert response.status_code == 404
+        assert response.json()["detail"]["code"] == "UNKNOWN_PREFERENCE"
+
+    def test_delete_store_failure_returns_503(self, client, store, prefs, registry):
+        store["clear_value"].raises = prefs.PreferenceStoreError("turso unreachable")
+
+        response = client.delete(f"/preferences/{registry[0].key}")
+
+        assert response.status_code == 503
+        assert response.json()["detail"]["code"] == "PREFERENCE_STORE_UNAVAILABLE"
+
+    def test_delete_is_offloaded_from_the_event_loop(self, client, store, registry):
+        pref = registry[0]
+        store["clear_value"].result = _FakeResolved(_entry_for(pref, source="default"))
+
+        assert client.delete(f"/preferences/{pref.key}").status_code == 200
+
+        assert store["clear_value"].on_loop == [False]
+
+
+class TestPreferencesPerimeter:
+    def test_preferences_paths_are_not_auth_exempt(self):
+        """These routes are operator-only; the global middleware must gate them."""
+        from scripts.api.server import AUTH_EXEMPT_PATHS
+
+        assert "/preferences" not in AUTH_EXEMPT_PATHS
+        assert "/preferences/{key}" not in AUTH_EXEMPT_PATHS
+
+    def test_routes_are_registered_on_the_app(self):
+        from scripts.api.server import app
+
+        paths = {
+            (route.path, verb)
+            for route in app.routes
+            for verb in getattr(route, "methods", set()) or set()
+        }
+        assert ("/preferences", "GET") in paths
+        assert ("/preferences/{key}", "PUT") in paths
+        assert ("/preferences/{key}", "DELETE") in paths

--- a/scripts/app_preferences.py
+++ b/scripts/app_preferences.py
@@ -1,0 +1,732 @@
+#!/usr/bin/env python3
+"""Operator-tunable runtime preferences (the /preferences page store).
+
+One registry of declared keys, each with a code default and a HARD band.
+Resolution order per key is DB row > environment variable > code default,
+with one asymmetry that is the whole point of the module:
+
+  * an environment value outside the band is CLAMPED into it,
+  * a DB value outside the band is DISCARDED, never clamped.
+
+A corrupt or hostile ``app_preferences`` row therefore cannot widen a
+safety cap such as ``RADON_MAX_ORDER_NOTIONAL``; the worst it can do is
+fall back to the deployed environment.
+
+Reads are stale-while-revalidate: ``resolve``/``get_*`` never perform I/O
+on the calling thread, so the order placement funnel
+(``order_limits.check_order_limits``) stays pure in-process computation on
+the uvicorn event loop. The single blocking read is
+:func:`refresh_snapshot`, and it runs over the bounded stdlib hrana
+transport (``db.hrana_http``) rather than sync libsql, which holds the GIL
+and would freeze the API process.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+logger = logging.getLogger(__name__)
+
+PrefValue = Union[int, float, bool]
+
+CACHE_TTL_SECONDS: float = 5.0
+DB_READ_TIMEOUT_S: float = 2.0
+DB_WRITE_TIMEOUT_S: float = 4.0
+GROUP_ORDER: Tuple[str, ...] = ("Order Limits", "Scanning")
+
+_WARN_INTERVAL_S = 60.0
+_UPDATED_BY_MAX_LEN = 64
+_STORE_ERROR_MAX_LEN = 200
+
+_SELECT_SQL = "SELECT key, value, updated_at, updated_by FROM app_preferences"
+_EVENT_SQL = (
+    "INSERT INTO app_preference_events (key, action, old_value, new_value, actor, at) "
+    "VALUES (?, ?, ?, ?, ?, ?)"
+)
+_UPSERT_SQL = (
+    "INSERT INTO app_preferences (key, value, updated_at, updated_by) "
+    "VALUES (?, ?, ?, ?) ON CONFLICT(key) DO UPDATE SET "
+    "value = excluded.value, updated_at = excluded.updated_at, "
+    "updated_by = excluded.updated_by"
+)
+_DELETE_SQL = "DELETE FROM app_preferences WHERE key = ?"
+
+
+class PreferenceValidationError(ValueError):
+    """Raised by coerce_value / set_value. Never raised by resolve/get_*."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        key: str = "",
+        allowed_min: Optional[PrefValue] = None,
+        allowed_max: Optional[PrefValue] = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.key = key
+        self.allowed_min = allowed_min
+        self.allowed_max = allowed_max
+
+
+class PreferenceStoreError(RuntimeError):
+    """Raised ONLY by set_value / clear_value when the Turso write fails."""
+
+
+@dataclass(frozen=True)
+class Preference:
+    key: str
+    label: str
+    group: str
+    value_type: str
+    default: PrefValue
+    hard_min: PrefValue
+    hard_max: PrefValue
+    unit: str
+    description: str
+    applies_immediately: bool
+
+
+@dataclass(frozen=True)
+class ResolvedPreference:
+    preference: Preference
+    value: PrefValue
+    source: str
+    db_rejected: bool
+    updated_at: Optional[str]
+    updated_by: Optional[str]
+
+    def to_dict(self) -> Dict[str, Any]:
+        pref = self.preference
+        return {
+            "key": pref.key,
+            "label": pref.label,
+            "group": pref.group,
+            "value_type": pref.value_type,
+            "value": self.value,
+            "default": pref.default,
+            "hard_min": pref.hard_min,
+            "hard_max": pref.hard_max,
+            "unit": pref.unit,
+            "description": pref.description,
+            "applies_immediately": pref.applies_immediately,
+            "source": self.source,
+            "db_rejected": self.db_rejected,
+            "updated_at": self.updated_at,
+            "updated_by": self.updated_by,
+        }
+
+
+REGISTRY: Tuple[Preference, ...] = (
+    Preference(
+        key="RADON_MAX_ORDER_QTY",
+        label="Max contracts per order",
+        group="Order Limits",
+        value_type="int",
+        default=500,
+        hard_min=1,
+        hard_max=2500,
+        unit="contracts",
+        description=(
+            "Hard ceiling on contracts per options or combo order. The order is "
+            "refused at the placement funnel before any IB call."
+        ),
+        applies_immediately=True,
+    ),
+    Preference(
+        key="RADON_MAX_STOCK_ORDER_QTY",
+        label="Max shares per stock order",
+        group="Order Limits",
+        value_type="int",
+        default=10000,
+        hard_min=1,
+        hard_max=50000,
+        unit="shares",
+        description=(
+            "Hard ceiling on shares per stock order. Shares run larger than "
+            "contracts, so this is separate from the contract cap."
+        ),
+        applies_immediately=True,
+    ),
+    Preference(
+        key="RADON_MAX_ORDER_NOTIONAL",
+        label="Max order notional",
+        group="Order Limits",
+        value_type="float",
+        default=250000.0,
+        hard_min=1000.0,
+        hard_max=1000000.0,
+        unit="USD",
+        description=(
+            "Hard ceiling on dollar notional per order, computed as quantity "
+            "times limit price times multiplier. The primary fat finger stop."
+        ),
+        applies_immediately=True,
+    ),
+    Preference(
+        key="RADON_MAX_ORDERS_PER_MIN",
+        label="Max orders per minute",
+        group="Order Limits",
+        value_type="int",
+        default=10,
+        hard_min=1,
+        hard_max=60,
+        unit="orders per minute",
+        description=(
+            "Accepted order placements allowed per rolling minute. The brake on "
+            "a runaway automation loop."
+        ),
+        applies_immediately=True,
+    ),
+    Preference(
+        key="RADON_WORKFLOW_MAX_ORDERS",
+        label="Max orders per workflow run",
+        group="Order Limits",
+        value_type="int",
+        default=3,
+        hard_min=1,
+        hard_max=18,
+        unit="orders",
+        description=(
+            "Orders a single automated workflow run may place before it is cut "
+            "off. The refusal is atomic, so no partial batch is sent."
+        ),
+        applies_immediately=True,
+    ),
+    Preference(
+        key="RADON_SCANNER_WORKERS",
+        label="Watchlist scanner workers",
+        group="Scanning",
+        value_type="int",
+        default=24,
+        hard_min=1,
+        hard_max=64,
+        unit="threads",
+        description=(
+            "Concurrent worker threads for the watchlist scanner. Higher is "
+            "faster but pushes harder on Unusual Whales rate limits."
+        ),
+        applies_immediately=True,
+    ),
+    Preference(
+        key="RADON_THETA_SCANNER_WORKERS",
+        label="Theta harvester workers",
+        group="Scanning",
+        value_type="int",
+        default=24,
+        hard_min=1,
+        hard_max=64,
+        unit="threads",
+        description="Concurrent worker threads for the theta harvester scanner.",
+        applies_immediately=True,
+    ),
+    Preference(
+        key="RADON_STRENGTH_SCANNER_WORKERS",
+        label="Strength confirmation workers",
+        group="Scanning",
+        value_type="int",
+        default=24,
+        hard_min=1,
+        hard_max=64,
+        unit="threads",
+        description="Concurrent worker threads for the strength confirmation scanner.",
+        applies_immediately=True,
+    ),
+)
+
+REGISTRY_BY_KEY: Dict[str, Preference] = {pref.key: pref for pref in REGISTRY}
+
+_LOCK = threading.Lock()
+_SNAPSHOT: Dict[str, Tuple[str, Optional[str], Optional[str]]] = {}
+_SNAPSHOT_AT: float = 0.0
+_REFRESHING: bool = False
+_BACKGROUND_REFRESH: bool = False
+_WRITE_GENERATION: int = 0
+_STORE_ERROR: Optional[str] = None
+_STORE_CHECKED_AT: Optional[str] = None
+_LAST_WARN_AT: Dict[str, float] = {}
+_OVERLAY_WRITTEN: Dict[str, str] = {}
+_OVERLAY_ORIGINAL: Dict[str, Optional[str]] = {}
+
+
+def registry() -> Tuple[Preference, ...]:
+    return REGISTRY
+
+
+def get_preference(key: str) -> Optional[Preference]:
+    return REGISTRY_BY_KEY.get(key)
+
+
+# ── parsing / encoding ────────────────────────────────────────────────
+
+
+def _parse_bool(text: str) -> Optional[bool]:
+    token = str(text).strip().lower()
+    if token in {"1", "true", "yes", "on"}:
+        return True
+    if token in {"0", "false", "no", "off"}:
+        return False
+    return None
+
+
+def _parse_text(value_type: str, text: str) -> Optional[PrefValue]:
+    if value_type == "bool":
+        return _parse_bool(text)
+    try:
+        number = float(str(text).strip())
+    except (TypeError, ValueError):
+        return None
+    if number != number or number in (float("inf"), float("-inf")):
+        return None
+    return int(number) if value_type == "int" else number
+
+
+def _encode(pref: Preference, value: PrefValue) -> str:
+    if pref.value_type == "bool":
+        return "true" if bool(value) else "false"
+    if pref.value_type == "int":
+        return str(int(value))
+    return repr(float(value))
+
+
+def _in_band(pref: Preference, value: PrefValue) -> bool:
+    if pref.value_type == "bool":
+        return True
+    return pref.hard_min <= value <= pref.hard_max
+
+
+def _clamp(pref: Preference, value: PrefValue) -> PrefValue:
+    if pref.value_type == "bool":
+        return bool(value)
+    return min(max(value, pref.hard_min), pref.hard_max)
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _warn_once(bucket: str, message: str, *args: Any) -> None:
+    now = time.monotonic()
+    last = _LAST_WARN_AT.get(bucket, 0.0)
+    if now - last < _WARN_INTERVAL_S:
+        return
+    _LAST_WARN_AT[bucket] = now
+    logger.warning(message, *args)
+
+
+# ── transport (lazily imported so the API import graph stays libsql-free) ──
+
+
+def _hrana_query(sql: str, args: Any = (), timeout: float = DB_READ_TIMEOUT_S) -> List[tuple]:
+    try:  # scripts/ on sys.path
+        from db.hrana_http import hrana_query
+    except ImportError:  # imported as scripts.app_preferences from the repo root
+        from scripts.db.hrana_http import hrana_query
+    return hrana_query(sql, args, timeout)
+
+
+def _hrana_execute(sql: str, args: Any = (), timeout: float = DB_WRITE_TIMEOUT_S) -> None:
+    try:
+        from db.hrana_http import hrana_execute
+    except ImportError:
+        from scripts.db.hrana_http import hrana_execute
+    hrana_execute(sql, args, timeout)
+
+
+def _db_enabled() -> bool:
+    """Under pytest the store is inert: env/default plus whatever
+    seed_snapshot_for_tests injected. No threads, no sockets."""
+    return not (
+        os.environ.get("PYTEST_CURRENT_TEST")
+        and os.environ.get("RADON_DB_TEST_WRITE_OK") != "1"
+    )
+
+
+# ── snapshot / refresh ────────────────────────────────────────────────
+
+
+def refresh_snapshot(timeout: float = DB_READ_TIMEOUT_S) -> bool:
+    """The ONLY blocking read. Never raises; returns whether it succeeded.
+
+    A failure keeps the previous snapshot (last known good) and still
+    stamps the load time so the next attempt backs off a full TTL.
+    """
+    global _SNAPSHOT, _SNAPSHOT_AT, _STORE_ERROR, _STORE_CHECKED_AT
+    with _LOCK:
+        generation_at_start = _WRITE_GENERATION
+    try:
+        rows = _hrana_query(_SELECT_SQL, (), timeout)
+        loaded: Dict[str, Tuple[str, Optional[str], Optional[str]]] = {}
+        for row in rows:
+            key = str(row[0])
+            value = "" if row[1] is None else str(row[1])
+            updated_at = None if len(row) < 3 or row[2] is None else str(row[2])
+            updated_by = None if len(row) < 4 or row[3] is None else str(row[3])
+            loaded[key] = (value, updated_at, updated_by)
+    except Exception as exc:  # noqa: BLE001 - the store is best effort by contract
+        with _LOCK:
+            _SNAPSHOT_AT = time.monotonic()
+            _STORE_ERROR = f"{type(exc).__name__}: {exc}"[:_STORE_ERROR_MAX_LEN]
+            _STORE_CHECKED_AT = _utcnow_iso()
+        _warn_once("refresh", "app_preferences: preference store read failed (%s)", exc)
+        return False
+    with _LOCK:
+        _SNAPSHOT_AT = time.monotonic()
+        _STORE_ERROR = None
+        _STORE_CHECKED_AT = _utcnow_iso()
+        # A save that landed mid-read already holds the newer truth. Adopting
+        # this load would silently roll the operator's change back.
+        if _WRITE_GENERATION == generation_at_start:
+            _SNAPSHOT = loaded
+    return True
+
+
+def _refresh_worker() -> None:
+    global _SNAPSHOT_AT, _REFRESHING
+    try:
+        if refresh_snapshot(DB_READ_TIMEOUT_S):
+            apply_env_overlay()
+    finally:
+        with _LOCK:
+            _SNAPSHOT_AT = time.monotonic()
+            _REFRESHING = False
+
+
+def enable_background_refresh(enabled: bool = True) -> None:
+    """Opt a LONG-LIVED process into stale-while-revalidate refreshes.
+
+    Off by default. A short-lived process (``ib_place_order.py`` is a fresh
+    interpreter per order) would otherwise open a Turso socket per
+    invocation and abandon it at exit, which is the documented per-IP
+    socket exhaustion failure mode. Those processes resolve from the
+    environment overlay ``bootstrap`` published in radon-api instead.
+    """
+    global _BACKGROUND_REFRESH
+    _BACKGROUND_REFRESH = bool(enabled)
+
+
+def _maybe_refresh_async() -> None:
+    global _REFRESHING
+    if not _BACKGROUND_REFRESH or not _db_enabled():
+        return
+    with _LOCK:
+        if _REFRESHING or time.monotonic() - _SNAPSHOT_AT <= CACHE_TTL_SECONDS:
+            return
+        _REFRESHING = True
+    try:
+        threading.Thread(target=_refresh_worker, daemon=True, name="app-prefs-refresh").start()
+    except Exception as exc:  # noqa: BLE001 - resolve() never raises, by contract
+        with _LOCK:
+            _REFRESHING = False
+        _warn_once("spawn", "app_preferences: refresh thread spawn failed (%s)", exc)
+
+
+def bootstrap(timeout: float = DB_READ_TIMEOUT_S) -> bool:
+    """Load the store once and publish it into ``os.environ``.
+
+    Called from the radon-api lifespan so that (a) stored caps are in
+    effect before the first request and (b) every subprocess the API
+    spawns, including the ``ib_place_order.py`` placement funnel, inherits
+    them. Never raises; a dead store leaves env/default in force.
+    """
+    loaded = refresh_snapshot(timeout)
+    apply_env_overlay()
+    return loaded
+
+
+def store_status() -> Dict[str, Any]:
+    with _LOCK:
+        return {
+            "available": _STORE_ERROR is None and _SNAPSHOT_AT > 0.0,
+            "error": _STORE_ERROR,
+            "checked_at": _STORE_CHECKED_AT,
+        }
+
+
+def seed_snapshot_for_tests(
+    rows: Dict[str, str],
+    *,
+    updated_at: str = "2026-01-01T00:00:00Z",
+    updated_by: str = "test",
+) -> None:
+    global _SNAPSHOT, _SNAPSHOT_AT, _STORE_ERROR, _STORE_CHECKED_AT
+    with _LOCK:
+        _SNAPSHOT = {key: (str(value), updated_at, updated_by) for key, value in rows.items()}
+        _SNAPSHOT_AT = time.monotonic()
+        _STORE_ERROR = None
+        _STORE_CHECKED_AT = updated_at
+
+
+def clear_snapshot_for_tests() -> None:
+    global _SNAPSHOT, _SNAPSHOT_AT, _STORE_ERROR, _STORE_CHECKED_AT
+    with _LOCK:
+        _SNAPSHOT = {}
+        _SNAPSHOT_AT = 0.0
+        _STORE_ERROR = None
+        _STORE_CHECKED_AT = None
+    _LAST_WARN_AT.clear()
+    apply_env_overlay()
+
+
+# ── resolution ────────────────────────────────────────────────────────
+
+
+def _resolve_from(
+    pref: Preference, row: Optional[Tuple[str, Optional[str], Optional[str]]]
+) -> ResolvedPreference:
+    db_rejected = False
+    if row is not None:
+        parsed = _parse_text(pref.value_type, row[0])
+        if parsed is not None and _in_band(pref, parsed):
+            return ResolvedPreference(
+                preference=pref,
+                value=parsed,
+                source="db",
+                db_rejected=False,
+                updated_at=row[1],
+                updated_by=row[2],
+            )
+        db_rejected = True
+        _warn_once(
+            pref.key,
+            "app_preferences: ignoring out-of-band DB value for %s",
+            pref.key,
+        )
+
+    raw_env = os.environ.get(pref.key)
+    if raw_env is not None and _OVERLAY_WRITTEN.get(pref.key) == raw_env:
+        # Our own export from a previous DB value, not a deployment setting.
+        # Reading it back would report source="env" for a row that is gone or
+        # has since been rejected, and would pin the discarded value.
+        raw_env = None
+    if raw_env is not None and str(raw_env).strip():
+        parsed_env = _parse_text(pref.value_type, raw_env)
+        if parsed_env is not None:
+            return ResolvedPreference(
+                preference=pref,
+                value=_clamp(pref, parsed_env),
+                source="env",
+                db_rejected=db_rejected,
+                updated_at=None,
+                updated_by=None,
+            )
+
+    return ResolvedPreference(
+        preference=pref,
+        value=pref.default,
+        source="default",
+        db_rejected=db_rejected,
+        updated_at=None,
+        updated_by=None,
+    )
+
+
+def resolve(key: str) -> ResolvedPreference:
+    pref = REGISTRY_BY_KEY[key]
+    with _LOCK:
+        row = _SNAPSHOT.get(key)
+    _maybe_refresh_async()
+    return _resolve_from(pref, row)
+
+
+def resolve_all() -> List[ResolvedPreference]:
+    with _LOCK:
+        snapshot = dict(_SNAPSHOT)
+    _maybe_refresh_async()
+    return [_resolve_from(pref, snapshot.get(pref.key)) for pref in REGISTRY]
+
+
+def get_int(key: str) -> int:
+    return int(resolve(key).value)
+
+
+def get_float(key: str) -> float:
+    return float(resolve(key).value)
+
+
+def get_bool(key: str) -> bool:
+    return bool(resolve(key).value)
+
+
+# ── validation ────────────────────────────────────────────────────────
+
+
+def _coerce_bool(pref: Preference, raw: Any) -> bool:
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, str):
+        parsed = _parse_bool(raw)
+        if parsed is not None:
+            return parsed
+    raise PreferenceValidationError(
+        "WRONG_TYPE", f"{pref.key} expects a boolean value", pref.key
+    )
+
+
+def _coerce_number(pref: Preference, raw: Any) -> PrefValue:
+    wants_int = pref.value_type == "int"
+    noun = "an integer" if wants_int else "a numeric"
+    if isinstance(raw, bool):
+        raise PreferenceValidationError(
+            "WRONG_TYPE", f"{pref.key} expects {noun} value", pref.key
+        )
+    if isinstance(raw, (int, float)):
+        number = float(raw)
+    elif isinstance(raw, str) and raw.strip():
+        try:
+            number = float(raw.strip())
+        except ValueError:
+            raise PreferenceValidationError(
+                "WRONG_TYPE", f"{pref.key} expects {noun} value", pref.key
+            ) from None
+    else:
+        raise PreferenceValidationError(
+            "WRONG_TYPE", f"{pref.key} expects {noun} value", pref.key
+        )
+    if wants_int:
+        if number != int(number):
+            raise PreferenceValidationError(
+                "WRONG_TYPE", f"{pref.key} expects an integer value", pref.key
+            )
+        return int(number)
+    return number
+
+
+def coerce_value(key: str, raw: Any) -> PrefValue:
+    pref = REGISTRY_BY_KEY.get(key)
+    if pref is None:
+        raise PreferenceValidationError(
+            "UNKNOWN_PREFERENCE", f"unknown preference key '{key}'", key
+        )
+    if pref.value_type == "bool":
+        return _coerce_bool(pref, raw)
+    value = _coerce_number(pref, raw)
+    if not _in_band(pref, value):
+        raise PreferenceValidationError(
+            "OUT_OF_RANGE",
+            f"{pref.key} must be between {pref.hard_min} and {pref.hard_max} (got {value})",
+            pref.key,
+            allowed_min=pref.hard_min,
+            allowed_max=pref.hard_max,
+        )
+    return value
+
+
+# ── writes ────────────────────────────────────────────────────────────
+
+
+def _normalized_operator(updated_by: Optional[str]) -> Optional[str]:
+    if not isinstance(updated_by, str) or not updated_by:
+        return None
+    return updated_by[:_UPDATED_BY_MAX_LEN]
+
+
+def _stored_value(key: str) -> Optional[str]:
+    with _LOCK:
+        row = _SNAPSHOT.get(key)
+    return None if row is None else row[0]
+
+
+def _record_event(
+    key: str, action: str, old_value: Optional[str], new_value: Optional[str], actor: Optional[str]
+) -> None:
+    """Append the intended change to the immutable event log BEFORE applying it.
+
+    Ordering is deliberate: a failed audit write refuses the mutation, so a
+    live risk cap can never move without a record of who moved it. The cost
+    is that a mutation failing after its event lands leaves an attempt on
+    the log, which is the safe direction to be wrong in.
+    """
+    try:
+        _hrana_execute(
+            _EVENT_SQL, (key, action, old_value, new_value, actor, _utcnow_iso()), DB_WRITE_TIMEOUT_S
+        )
+    except Exception as exc:  # noqa: BLE001 - surfaced as a 503 by the route layer
+        raise PreferenceStoreError(f"audit write failed: {type(exc).__name__}: {exc}") from exc
+
+
+def _mark_store_reachable() -> None:
+    global _STORE_ERROR, _STORE_CHECKED_AT, _WRITE_GENERATION
+    _STORE_ERROR = None
+    _STORE_CHECKED_AT = _utcnow_iso()
+    _WRITE_GENERATION += 1
+
+
+def set_value(key: str, value: Any, updated_by: Optional[str] = None) -> ResolvedPreference:
+    """Persist an override. BLOCKING write; raises PreferenceStoreError on failure."""
+    coerced = coerce_value(key, value)
+    pref = REGISTRY_BY_KEY[key]
+    encoded = _encode(pref, coerced)
+    updated_at = _utcnow_iso()
+    operator = _normalized_operator(updated_by)
+    _record_event(key, "set", _stored_value(key), encoded, operator)
+    try:
+        _hrana_execute(_UPSERT_SQL, (key, encoded, updated_at, operator), DB_WRITE_TIMEOUT_S)
+    except Exception as exc:  # noqa: BLE001 - surfaced as a 503 by the route layer
+        raise PreferenceStoreError(f"{type(exc).__name__}: {exc}") from exc
+    with _LOCK:
+        _SNAPSHOT[key] = (encoded, updated_at, operator)
+        _mark_store_reachable()
+    apply_env_overlay()
+    return resolve(key)
+
+
+def clear_value(key: str, updated_by: Optional[str] = None) -> ResolvedPreference:
+    """Drop the override. Idempotent: deleting a missing row succeeds."""
+    if key not in REGISTRY_BY_KEY:
+        raise PreferenceValidationError(
+            "UNKNOWN_PREFERENCE", f"unknown preference key '{key}'", key
+        )
+    operator = _normalized_operator(updated_by)
+    _record_event(key, "reset", _stored_value(key), None, operator)
+    try:
+        _hrana_execute(_DELETE_SQL, (key,), DB_WRITE_TIMEOUT_S)
+    except Exception as exc:  # noqa: BLE001
+        raise PreferenceStoreError(f"{type(exc).__name__}: {exc}") from exc
+    with _LOCK:
+        _SNAPSHOT.pop(key, None)
+        _mark_store_reachable()
+    apply_env_overlay()
+    return resolve(key)
+
+
+def apply_env_overlay() -> Dict[str, str]:
+    """Export DB-sourced values into os.environ, and unwind stale exports.
+
+    This is what makes the scanner worker counts effective without a
+    restart: radon-api reads those names from os.environ at call time and
+    subprocess scanners inherit the environment. Only registry keys are
+    ever touched.
+    """
+    global _OVERLAY_WRITTEN
+    written: Dict[str, str] = {}
+    for pref in REGISTRY:
+        with _LOCK:
+            row = _SNAPSHOT.get(pref.key)
+        resolved = _resolve_from(pref, row)
+        if resolved.source != "db":
+            continue
+        encoded = _encode(pref, resolved.value)
+        if pref.key not in _OVERLAY_ORIGINAL:
+            _OVERLAY_ORIGINAL[pref.key] = os.environ.get(pref.key)
+        os.environ[pref.key] = encoded
+        written[pref.key] = encoded
+
+    for key in list(_OVERLAY_WRITTEN):
+        if key in written:
+            continue
+        original = _OVERLAY_ORIGINAL.pop(key, None)
+        if original is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = original
+    _OVERLAY_WRITTEN = written
+    return dict(written)

--- a/scripts/db/migrations/0046_app_preferences.sql
+++ b/scripts/db/migrations/0046_app_preferences.sql
@@ -1,0 +1,43 @@
+-- 0046_app_preferences.sql
+-- Operator-tunable runtime preferences backing the /preferences page.
+-- One row per registry key declared in scripts/app_preferences.py. A row is an
+-- OVERRIDE only: resolution is DB row > environment variable > code default,
+-- and a value outside the registry's [hard_min, hard_max] band is IGNORED at
+-- read time (falling through to env/default), so a bad row can never widen a
+-- safety cap such as RADON_MAX_ORDER_NOTIONAL.
+-- value holds the canonical text encoding produced by app_preferences:
+-- integers as "500", floats as "250000.0", booleans as "true" / "false".
+-- updated_by is the Clerk user id of the operator who wrote the row, derived
+-- server-side from the authenticated principal, never from the request body.
+-- Version 46 is the next free number: Turso is at 45 and the in-flight
+-- equibles-integration worktree holds 0041 through 0045.
+
+CREATE TABLE IF NOT EXISTS app_preferences (
+  key        TEXT PRIMARY KEY,
+  value      TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  updated_by TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_app_preferences_updated_at ON app_preferences (updated_at);
+
+-- Append-only audit of every change to a live risk cap. app_preferences holds
+-- one mutable row per key, so without this a cap could be raised, exploited and
+-- reset with no trace. The event is written BEFORE the mutation and a failed
+-- audit write refuses the change, so a value can never move unrecorded.
+-- action is 'set' or 'reset'; new_value is NULL on a reset.
+CREATE TABLE IF NOT EXISTS app_preference_events (
+  id        INTEGER PRIMARY KEY AUTOINCREMENT,
+  key       TEXT NOT NULL,
+  action    TEXT NOT NULL,
+  old_value TEXT,
+  new_value TEXT,
+  actor     TEXT,
+  at        TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_app_preference_events_at ON app_preference_events (at);
+CREATE INDEX IF NOT EXISTS idx_app_preference_events_key ON app_preference_events (key, at);
+
+INSERT OR IGNORE INTO schema_migrations (version, applied_at)
+VALUES (46, datetime('now'));

--- a/scripts/order_limits.py
+++ b/scripts/order_limits.py
@@ -7,7 +7,9 @@ caps enforced at the placement funnel (``ib_place_order.place_order``)
 and mirrored at the FastAPI routes for fast refusal; the client-side
 risk UI remains a display, never the enforcement.
 
-Env-tunable (read at call time so operators can adjust without restart):
+Operator-tunable (read at call time so operators can adjust without restart)
+through ``app_preferences``, which resolves DB row > env var > code default
+and discards any stored value outside the declared hard band:
   RADON_MAX_ORDER_QTY        max contracts/shares per order   (default 500)
   RADON_MAX_ORDER_NOTIONAL   max $ per order (qty×price×mult) (default 250_000)
   RADON_MAX_ORDERS_PER_MIN   max accepted placements per min  (default 10)
@@ -21,40 +23,37 @@ Kelly policy (that stays in the evaluation pipeline).
 
 from __future__ import annotations
 
-import os
 from typing import Any, Optional
+
+try:  # scripts/ on sys.path (subprocess scripts, pytest)
+    import app_preferences
+except ImportError:  # imported as scripts.order_limits from the repo root
+    from scripts import app_preferences
 
 _OPTION_MULTIPLIER = 100
 
 
-def _env_num(name: str, default: float) -> float:
-    try:
-        return float(os.environ.get(name, "") or default)
-    except (TypeError, ValueError):
-        return default
-
-
 def max_order_qty() -> int:
     """Contract cap for options/combos (shares use max_stock_order_qty)."""
-    return int(_env_num("RADON_MAX_ORDER_QTY", 500))
+    return app_preferences.get_int("RADON_MAX_ORDER_QTY")
 
 
 def max_stock_order_qty() -> int:
     """Share cap for stock orders — shares run larger than contracts, and
     the notional cap is the binding constraint anyway."""
-    return int(_env_num("RADON_MAX_STOCK_ORDER_QTY", 10_000))
+    return app_preferences.get_int("RADON_MAX_STOCK_ORDER_QTY")
 
 
 def max_order_notional() -> float:
-    return _env_num("RADON_MAX_ORDER_NOTIONAL", 250_000)
+    return app_preferences.get_float("RADON_MAX_ORDER_NOTIONAL")
 
 
 def max_orders_per_min() -> int:
-    return int(_env_num("RADON_MAX_ORDERS_PER_MIN", 10))
+    return app_preferences.get_int("RADON_MAX_ORDERS_PER_MIN")
 
 
 def workflow_max_orders() -> int:
-    return int(_env_num("RADON_WORKFLOW_MAX_ORDERS", 3))
+    return app_preferences.get_int("RADON_WORKFLOW_MAX_ORDERS")
 
 
 def order_notional(params: dict) -> Optional[float]:

--- a/scripts/tests/test_app_preferences.py
+++ b/scripts/tests/test_app_preferences.py
@@ -1,0 +1,628 @@
+#!/usr/bin/env python3
+"""Operator preference store — registry, precedence, caching and writes.
+
+The safety-critical property under test: a stored (DB) value can NEVER
+widen a hard cap. A row outside the registry band is discarded, not
+clamped, so a corrupt ``app_preferences`` row cannot raise
+``RADON_MAX_ORDER_NOTIONAL`` past its declared ceiling. The order path
+(``order_limits.check_order_limits``) must also stay pure in-process
+computation: a dead Turso resolves to env/default without raising and
+without blocking the caller.
+"""
+
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import app_preferences  # noqa: E402
+import order_limits  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _clean_preferences(monkeypatch):
+    app_preferences.clear_snapshot_for_tests()
+    app_preferences.enable_background_refresh(False)
+    for pref in app_preferences.REGISTRY:
+        monkeypatch.delenv(pref.key, raising=False)
+    yield
+    app_preferences.clear_snapshot_for_tests()
+    app_preferences.enable_background_refresh(False)
+
+
+class TestRegistryIntegrity:
+    def test_registry_keys_are_unique_and_nonempty(self):
+        keys = [pref.key for pref in app_preferences.registry()]
+        assert keys, "registry must not be empty"
+        assert all(key.strip() for key in keys)
+        assert len(set(keys)) == len(keys)
+
+    def test_every_entry_is_well_formed(self):
+        for pref in app_preferences.registry():
+            assert pref.value_type in {"int", "float", "bool"}
+            assert pref.label.strip()
+            assert pref.description.strip()
+            assert pref.group in app_preferences.GROUP_ORDER
+            assert isinstance(pref.unit, str)
+            assert isinstance(pref.applies_immediately, bool)
+            if pref.value_type in {"int", "float"}:
+                assert pref.hard_min <= pref.default <= pref.hard_max
+
+    def test_registry_contains_all_five_order_limit_keys(self):
+        keys = {pref.key for pref in app_preferences.registry()}
+        assert {
+            "RADON_MAX_ORDER_QTY",
+            "RADON_MAX_STOCK_ORDER_QTY",
+            "RADON_MAX_ORDER_NOTIONAL",
+            "RADON_MAX_ORDERS_PER_MIN",
+            "RADON_WORKFLOW_MAX_ORDERS",
+        } <= keys
+
+    def test_no_em_dash_in_labels_or_descriptions(self):
+        for pref in app_preferences.registry():
+            assert "—" not in pref.label
+            assert "—" not in pref.description
+
+    def test_to_dict_shape_is_the_documented_contract(self):
+        entry = app_preferences.resolve("RADON_MAX_ORDER_QTY").to_dict()
+        assert list(entry.keys()) == [
+            "key",
+            "label",
+            "group",
+            "value_type",
+            "value",
+            "default",
+            "hard_min",
+            "hard_max",
+            "unit",
+            "description",
+            "applies_immediately",
+            "source",
+            "db_rejected",
+            "updated_at",
+            "updated_by",
+        ]
+        assert entry["value"] == 500
+        assert entry["applies_immediately"] is True
+        assert entry["db_rejected"] is False
+        assert entry["updated_at"] is None
+
+
+class TestPrecedence:
+    def test_default_when_no_env_and_no_db(self):
+        resolved = app_preferences.resolve("RADON_MAX_ORDER_QTY")
+        assert resolved.value == 500
+        assert resolved.source == "default"
+
+    def test_env_overrides_default(self, monkeypatch):
+        monkeypatch.setenv("RADON_MAX_ORDER_QTY", "250")
+        resolved = app_preferences.resolve("RADON_MAX_ORDER_QTY")
+        assert resolved.value == 250
+        assert resolved.source == "env"
+
+    def test_env_above_hard_max_is_clamped(self, monkeypatch):
+        monkeypatch.setenv("RADON_MAX_ORDER_QTY", "999999")
+        resolved = app_preferences.resolve("RADON_MAX_ORDER_QTY")
+        assert resolved.value == 2500
+        assert resolved.source == "env"
+
+    def test_env_below_hard_min_is_clamped(self, monkeypatch):
+        monkeypatch.setenv("RADON_MAX_ORDER_QTY", "0")
+        assert app_preferences.resolve("RADON_MAX_ORDER_QTY").value == 1
+
+    def test_unparseable_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("RADON_MAX_ORDER_QTY", "abc")
+        resolved = app_preferences.resolve("RADON_MAX_ORDER_QTY")
+        assert resolved.value == 500
+        assert resolved.source == "default"
+
+    def test_db_row_beats_env(self, monkeypatch):
+        monkeypatch.setenv("RADON_MAX_ORDER_QTY", "300")
+        app_preferences.seed_snapshot_for_tests({"RADON_MAX_ORDER_QTY": "250"})
+        resolved = app_preferences.resolve("RADON_MAX_ORDER_QTY")
+        assert resolved.value == 250
+        assert resolved.source == "db"
+        assert resolved.updated_at == "2026-01-01T00:00:00Z"
+        assert resolved.updated_by == "test"
+
+    def test_db_row_out_of_band_is_ignored_not_clamped(self, monkeypatch):
+        monkeypatch.setenv("RADON_MAX_ORDER_QTY", "300")
+        app_preferences.seed_snapshot_for_tests({"RADON_MAX_ORDER_QTY": "999999"})
+        resolved = app_preferences.resolve("RADON_MAX_ORDER_QTY")
+        assert resolved.value != 2500, "a DB row must never be clamped up to the cap"
+        assert resolved.value == 300
+        assert resolved.source == "env"
+        assert resolved.db_rejected is True
+
+    def test_db_row_below_hard_min_is_ignored(self, monkeypatch):
+        monkeypatch.setenv("RADON_MAX_ORDER_QTY", "300")
+        app_preferences.seed_snapshot_for_tests({"RADON_MAX_ORDER_QTY": "0"})
+        resolved = app_preferences.resolve("RADON_MAX_ORDER_QTY")
+        assert resolved.value == 300
+        assert resolved.source == "env"
+        assert resolved.db_rejected is True
+
+    def test_db_row_out_of_band_with_no_env_uses_default(self):
+        app_preferences.seed_snapshot_for_tests({"RADON_MAX_ORDER_NOTIONAL": "99000000.0"})
+        resolved = app_preferences.resolve("RADON_MAX_ORDER_NOTIONAL")
+        assert resolved.value == 250000.0
+        assert resolved.source == "default"
+        assert resolved.db_rejected is True
+
+    def test_db_row_unparseable_is_ignored(self):
+        app_preferences.seed_snapshot_for_tests({"RADON_MAX_ORDER_QTY": "abc"})
+        resolved = app_preferences.resolve("RADON_MAX_ORDER_QTY")
+        assert resolved.value == 500
+        assert resolved.source == "default"
+        assert resolved.db_rejected is True
+
+    def test_bool_parsing_accepts_common_forms(self):
+        """No bool key ships today, so the parser is covered directly rather
+        than through a registry entry nothing reads."""
+        for raw in ("true", "1", "yes", "on", "TRUE", " On "):
+            assert app_preferences._parse_text("bool", raw) is True
+        for raw in ("false", "0", "no", "off", "OFF"):
+            assert app_preferences._parse_text("bool", raw) is False
+        assert app_preferences._parse_text("bool", "maybe") is None
+
+    def test_int_preference_accepts_integral_float_text(self):
+        app_preferences.seed_snapshot_for_tests({"RADON_MAX_ORDER_QTY": "250.0"})
+        assert app_preferences.get_int("RADON_MAX_ORDER_QTY") == 250
+
+    def test_float_preference_resolves_as_float(self):
+        resolved = app_preferences.resolve("RADON_MAX_ORDER_NOTIONAL")
+        assert resolved.value == 250000.0
+        assert isinstance(app_preferences.get_float("RADON_MAX_ORDER_NOTIONAL"), float)
+
+    def test_resolve_unknown_key_raises_key_error(self):
+        with pytest.raises(KeyError):
+            app_preferences.resolve("RADON_NOT_A_PREFERENCE")
+
+
+class TestFailureIsolation:
+    def test_resolve_never_raises_when_store_unavailable(self, monkeypatch):
+        def _boom(sql, args=(), timeout=None):
+            raise RuntimeError("turso is down")
+
+        monkeypatch.setattr(app_preferences, "_hrana_query", _boom)
+        assert app_preferences.refresh_snapshot() is False
+        resolved = app_preferences.resolve_all()
+        assert len(resolved) == len(app_preferences.REGISTRY)
+        assert all(item.source in {"env", "default"} for item in resolved)
+        status = app_preferences.store_status()
+        assert status["available"] is False
+        assert status["error"]
+
+    def test_order_path_survives_a_dead_store(self, monkeypatch):
+        def _boom(sql, args=(), timeout=None):
+            raise RuntimeError("turso is down")
+
+        monkeypatch.setattr(app_preferences, "_hrana_query", _boom)
+        monkeypatch.setenv("RADON_MAX_ORDER_QTY", "100")
+        app_preferences.refresh_snapshot()
+        violation = order_limits.check_order_limits({
+            "type": "option", "symbol": "GOOG", "action": "BUY",
+            "quantity": 101, "limitPrice": 1.0,
+        })
+        assert violation is not None
+        assert violation["code"] == "ORDER_QTY_LIMIT"
+        assert order_limits.check_order_limits({
+            "type": "option", "symbol": "GOOG", "action": "BUY",
+            "quantity": 44, "limitPrice": 1.0,
+        }) is None
+
+    def test_hot_path_does_no_inline_io(self, monkeypatch):
+        idents = []
+
+        def _slow_refresh(timeout=app_preferences.DB_READ_TIMEOUT_S):
+            idents.append(threading.get_ident())
+            time.sleep(3)
+            return False
+
+        monkeypatch.setattr(app_preferences, "refresh_snapshot", _slow_refresh)
+        started = time.monotonic()
+        app_preferences.get_int("RADON_MAX_ORDER_QTY")
+        app_preferences.get_int("RADON_MAX_ORDER_QTY")
+        elapsed = time.monotonic() - started
+        assert elapsed < 0.1
+        assert threading.get_ident() not in idents
+
+    def test_cache_ttl_bounds_refresh_count(self, monkeypatch):
+        monkeypatch.setattr(app_preferences, "_db_enabled", lambda: True)
+        app_preferences.enable_background_refresh(True)
+        calls = []
+
+        def _counting_refresh(timeout=app_preferences.DB_READ_TIMEOUT_S):
+            calls.append(1)
+            return True
+
+        monkeypatch.setattr(app_preferences, "refresh_snapshot", _counting_refresh)
+        for _ in range(20):
+            app_preferences.resolve("RADON_MAX_ORDER_QTY")
+            time.sleep(0.005)
+        time.sleep(0.1)
+        assert len(calls) == 1
+
+    def test_failed_refresh_keeps_last_known_good(self, monkeypatch):
+        app_preferences.seed_snapshot_for_tests({"RADON_MAX_ORDER_QTY": "250"})
+
+        def _boom(sql, args=(), timeout=None):
+            raise RuntimeError("turso is down")
+
+        monkeypatch.setattr(app_preferences, "_hrana_query", _boom)
+        assert app_preferences.refresh_snapshot() is False
+        resolved = app_preferences.resolve("RADON_MAX_ORDER_QTY")
+        assert resolved.value == 250
+        assert resolved.source == "db"
+
+    def test_refresh_snapshot_loads_rows(self, monkeypatch):
+        monkeypatch.setattr(
+            app_preferences,
+            "_hrana_query",
+            lambda sql, args=(), timeout=None: [
+                ("RADON_MAX_ORDER_QTY", "250", "2026-08-11T00:00:00Z", "user_a"),
+            ],
+        )
+        assert app_preferences.refresh_snapshot() is True
+        resolved = app_preferences.resolve("RADON_MAX_ORDER_QTY")
+        assert resolved.value == 250
+        assert resolved.source == "db"
+        assert resolved.updated_by == "user_a"
+        assert app_preferences.store_status()["available"] is True
+
+
+class TestValidation:
+    def test_coerce_value_unknown_key_raises_unknown_preference(self):
+        with pytest.raises(app_preferences.PreferenceValidationError) as exc:
+            app_preferences.coerce_value("RADON_NOPE", 1)
+        assert exc.value.code == "UNKNOWN_PREFERENCE"
+        assert "RADON_NOPE" in exc.value.message
+
+    def test_coerce_value_wrong_type_raises_wrong_type(self):
+        with pytest.raises(app_preferences.PreferenceValidationError) as exc:
+            app_preferences.coerce_value("RADON_MAX_ORDER_QTY", 400.5)
+        assert exc.value.code == "WRONG_TYPE"
+        assert "integer" in exc.value.message
+        with pytest.raises(app_preferences.PreferenceValidationError) as exc:
+            app_preferences.coerce_value("RADON_MAX_ORDER_NOTIONAL", "banana")
+        assert exc.value.code == "WRONG_TYPE"
+        with pytest.raises(app_preferences.PreferenceValidationError) as exc:
+            app_preferences.coerce_value("RADON_MAX_ORDER_QTY", True)
+        assert exc.value.code == "WRONG_TYPE"
+
+    def test_coerce_value_accepts_valid_forms(self):
+        assert app_preferences.coerce_value("RADON_MAX_ORDER_QTY", "400") == 400
+        assert app_preferences.coerce_value("RADON_MAX_ORDER_QTY", 400.0) == 400
+        assert app_preferences.coerce_value("RADON_MAX_ORDER_NOTIONAL", 300000) == 300000.0
+
+    def test_coerce_value_out_of_range_raises_with_allowed_bounds(self):
+        with pytest.raises(app_preferences.PreferenceValidationError) as exc:
+            app_preferences.coerce_value("RADON_MAX_ORDER_QTY", 9000)
+        assert exc.value.code == "OUT_OF_RANGE"
+        assert exc.value.allowed_min == 1
+        assert exc.value.allowed_max == 2500
+        assert "1" in exc.value.message and "2500" in exc.value.message
+        assert "9000" in exc.value.message
+
+
+class TestWrites:
+    def test_set_value_writes_canonical_text(self, monkeypatch):
+        recorded = []
+        monkeypatch.setattr(
+            app_preferences,
+            "_hrana_execute",
+            lambda sql, args=(), timeout=None: recorded.append((sql, tuple(args), timeout)),
+        )
+        app_preferences.set_value("RADON_MAX_ORDER_NOTIONAL", 300000)
+        assert recorded[-1][1][0] == "RADON_MAX_ORDER_NOTIONAL"
+        assert recorded[-1][1][1] == "300000.0"
+        assert recorded[-1][2] == app_preferences.DB_WRITE_TIMEOUT_S
+
+        app_preferences.set_value("RADON_MAX_ORDERS_PER_MIN", 20, updated_by="user_2abc")
+        assert recorded[-1][1][1] == "20"
+        assert recorded[-1][1][3] == "user_2abc"
+
+        app_preferences.set_value("RADON_MAX_ORDER_QTY", 400, updated_by="u" * 200)
+        assert recorded[-1][1][1] == "400"
+        assert recorded[-1][1][3] == "u" * 64
+
+    def test_set_value_updates_snapshot_immediately(self, monkeypatch):
+        monkeypatch.setattr(
+            app_preferences, "_hrana_execute", lambda sql, args=(), timeout=None: None
+        )
+        resolved = app_preferences.set_value("RADON_MAX_ORDER_QTY", 400, updated_by="user_x")
+        assert resolved.value == 400
+        assert resolved.source == "db"
+        assert resolved.updated_by == "user_x"
+        assert app_preferences.get_int("RADON_MAX_ORDER_QTY") == 400
+
+    def test_set_value_rejects_out_of_range_before_writing(self, monkeypatch):
+        recorded = []
+        monkeypatch.setattr(
+            app_preferences,
+            "_hrana_execute",
+            lambda sql, args=(), timeout=None: recorded.append(args),
+        )
+        with pytest.raises(app_preferences.PreferenceValidationError):
+            app_preferences.set_value("RADON_MAX_ORDER_QTY", 9000)
+        assert recorded == []
+
+    def test_set_value_store_failure_raises_and_leaves_snapshot_unchanged(self, monkeypatch):
+        app_preferences.seed_snapshot_for_tests({"RADON_MAX_ORDER_QTY": "250"})
+
+        def _boom(sql, args=(), timeout=None):
+            raise RuntimeError("write failed")
+
+        monkeypatch.setattr(app_preferences, "_hrana_execute", _boom)
+        with pytest.raises(app_preferences.PreferenceStoreError):
+            app_preferences.set_value("RADON_MAX_ORDER_QTY", 400)
+        assert app_preferences.get_int("RADON_MAX_ORDER_QTY") == 250
+
+    def test_clear_value_deletes_row_and_falls_back_to_env_then_default(self, monkeypatch):
+        statements = []
+        monkeypatch.setattr(
+            app_preferences,
+            "_hrana_execute",
+            lambda sql, args=(), timeout=None: statements.append((sql, tuple(args))),
+        )
+        app_preferences.seed_snapshot_for_tests({"RADON_MAX_ORDER_QTY": "250"})
+        monkeypatch.setenv("RADON_MAX_ORDER_QTY", "300")
+        resolved = app_preferences.clear_value("RADON_MAX_ORDER_QTY", updated_by="user_x")
+        assert "DELETE" in statements[-1][0].upper()
+        assert statements[-1][1] == ("RADON_MAX_ORDER_QTY",)
+        assert resolved.value == 300
+        assert resolved.source == "env"
+
+        monkeypatch.delenv("RADON_MAX_ORDER_QTY", raising=False)
+        assert app_preferences.resolve("RADON_MAX_ORDER_QTY").source == "default"
+
+    def test_clear_value_unknown_key_raises(self):
+        with pytest.raises(app_preferences.PreferenceValidationError) as exc:
+            app_preferences.clear_value("RADON_NOPE")
+        assert exc.value.code == "UNKNOWN_PREFERENCE"
+
+    def test_apply_env_overlay_only_touches_registry_keys(self, monkeypatch):
+        monkeypatch.setattr(
+            app_preferences, "_hrana_execute", lambda sql, args=(), timeout=None: None
+        )
+        monkeypatch.setenv("RADON_NOT_A_PREFERENCE", "untouched")
+        app_preferences.set_value("RADON_SCANNER_WORKERS", 8)
+        import os
+
+        assert os.environ["RADON_SCANNER_WORKERS"] == "8"
+        assert os.environ["RADON_NOT_A_PREFERENCE"] == "untouched"
+
+        app_preferences.clear_value("RADON_SCANNER_WORKERS")
+        assert os.environ.get("RADON_SCANNER_WORKERS") is None
+
+    def test_apply_env_overlay_restores_the_prior_environment_value(self, monkeypatch):
+        monkeypatch.setattr(
+            app_preferences, "_hrana_execute", lambda sql, args=(), timeout=None: None
+        )
+        monkeypatch.setenv("RADON_SCANNER_WORKERS", "12")
+        app_preferences.set_value("RADON_SCANNER_WORKERS", 8)
+        import os
+
+        assert os.environ["RADON_SCANNER_WORKERS"] == "8"
+        app_preferences.clear_value("RADON_SCANNER_WORKERS")
+        assert os.environ["RADON_SCANNER_WORKERS"] == "12"
+
+
+class TestOrderLimitsDelegation:
+    def test_max_order_qty_reads_the_store(self):
+        app_preferences.seed_snapshot_for_tests({"RADON_MAX_ORDER_QTY": "250"})
+        assert order_limits.max_order_qty() == 250
+
+    def test_every_accessor_delegates_to_the_store(self):
+        app_preferences.seed_snapshot_for_tests({
+            "RADON_MAX_STOCK_ORDER_QTY": "2000",
+            "RADON_MAX_ORDER_NOTIONAL": "50000.0",
+            "RADON_MAX_ORDERS_PER_MIN": "4",
+            "RADON_WORKFLOW_MAX_ORDERS": "2",
+        })
+        assert order_limits.max_stock_order_qty() == 2000
+        assert order_limits.max_order_notional() == 50000.0
+        assert order_limits.max_orders_per_min() == 4
+        assert order_limits.workflow_max_orders() == 2
+
+    def test_check_order_limits_uses_stored_cap(self):
+        app_preferences.seed_snapshot_for_tests({"RADON_MAX_ORDER_QTY": "100"})
+        violation = order_limits.check_order_limits({
+            "type": "option", "symbol": "GOOG", "action": "BUY",
+            "quantity": 101, "limitPrice": 1.0,
+        })
+        assert violation is not None
+        assert violation["code"] == "ORDER_QTY_LIMIT"
+        assert "RADON_MAX_ORDER_QTY" in violation["message"]
+
+    def test_stored_cap_cannot_widen_past_the_hard_max(self):
+        app_preferences.seed_snapshot_for_tests({"RADON_MAX_ORDER_NOTIONAL": "99000000.0"})
+        violation = order_limits.check_order_limits({
+            "type": "option", "symbol": "CRCL", "action": "BUY",
+            "quantity": 250, "limitPrice": 40.0,
+        })
+        assert violation is not None
+        assert violation["code"] == "ORDER_NOTIONAL_LIMIT"
+
+    def test_check_quantity_limit_still_applies_the_contract_cap(self):
+        app_preferences.seed_snapshot_for_tests({"RADON_MAX_ORDER_QTY": "100"})
+        assert order_limits.check_quantity_limit(101)["code"] == "ORDER_QTY_LIMIT"
+        assert order_limits.check_quantity_limit(50) is None
+
+
+class TestRegistryIsHonest:
+    """Every declared key must be reachable by the process that reads it.
+
+    A control surface whose described effect is false is worse than no
+    control at all, so the registry carries only keys that radon-api (or a
+    subprocess inheriting its environment) reads at call time.
+    """
+
+    def test_every_entry_applies_immediately(self):
+        inert = [p.key for p in app_preferences.registry() if not p.applies_immediately]
+        assert inert == [], f"registry declares keys nothing live reads: {inert}"
+
+    def test_order_limit_bands_stay_within_a_small_multiple_of_the_default(self):
+        for pref in app_preferences.registry():
+            if pref.group != "Order Limits":
+                continue
+            assert pref.hard_max <= pref.default * 6, (
+                f"{pref.key} band lets one click widen the cap "
+                f"{pref.hard_max / pref.default:.0f}x past the default"
+            )
+
+
+class TestRefreshSpawnFailureIsContained:
+    def test_thread_spawn_failure_never_reaches_the_order_path(self, monkeypatch):
+        monkeypatch.setattr(app_preferences, "_db_enabled", lambda: True)
+        app_preferences.enable_background_refresh(True)
+
+        def _explode(self, *a, **k):
+            raise RuntimeError("can't start new thread")
+
+        monkeypatch.setattr(threading.Thread, "start", _explode)
+        assert order_limits.max_order_qty() == 500
+        assert order_limits.check_order_limits({
+            "type": "option", "quantity": 1, "limitPrice": 1.0,
+        }) is None
+
+    def test_thread_spawn_failure_does_not_latch_the_refreshing_flag(self, monkeypatch):
+        monkeypatch.setattr(app_preferences, "_db_enabled", lambda: True)
+        app_preferences.enable_background_refresh(True)
+        calls = []
+
+        def _explode(self, *a, **k):
+            calls.append(1)
+            raise RuntimeError("can't start new thread")
+
+        monkeypatch.setattr(threading.Thread, "start", _explode)
+        app_preferences.resolve("RADON_MAX_ORDER_QTY")
+        app_preferences.resolve("RADON_MAX_ORDER_QTY")
+        assert len(calls) == 2, "refresh latched after a spawn failure"
+
+
+class TestShortLivedProcessesDoNotTouchTheStore:
+    """ib_place_order.py is a fresh process per order. It must resolve from
+    the inherited environment overlay, never open a Turso socket it will
+    abandon at exit (feedback_turso_per_ip_socket_exhaustion_bounded_pool)."""
+
+    def test_background_refresh_is_off_unless_explicitly_enabled(self, monkeypatch):
+        app_preferences.enable_background_refresh(False)
+        spawned = []
+        monkeypatch.setattr(
+            threading.Thread, "start", lambda self, *a, **k: spawned.append(1)
+        )
+        app_preferences.resolve("RADON_MAX_ORDER_QTY")
+        app_preferences.resolve("RADON_MAX_ORDER_NOTIONAL")
+        assert spawned == [], "a short-lived process spawned a store refresh"
+
+    def test_bootstrap_publishes_stored_values_into_the_environment(self, monkeypatch):
+        monkeypatch.setattr(
+            app_preferences,
+            "_hrana_query",
+            lambda *a, **k: [("RADON_MAX_ORDER_QTY", "50", "2026-08-11T00:00:00Z", "op")],
+        )
+        assert app_preferences.bootstrap() is True
+        assert os.environ["RADON_MAX_ORDER_QTY"] == "50"
+        assert order_limits.max_order_qty() == 50
+
+    def test_bootstrap_survives_a_dead_store(self, monkeypatch):
+        def _boom(*a, **k):
+            raise RuntimeError("turso down")
+
+        monkeypatch.setattr(app_preferences, "_hrana_query", _boom)
+        assert app_preferences.bootstrap() is False
+        assert order_limits.max_order_qty() == 500
+
+
+class TestAuditTrail:
+    def test_set_value_records_an_append_only_event_before_mutating(self, monkeypatch):
+        statements = []
+        monkeypatch.setattr(
+            app_preferences,
+            "_hrana_execute",
+            lambda sql, args=(), timeout=0: statements.append((sql, tuple(args))),
+        )
+        app_preferences.set_value("RADON_MAX_ORDER_NOTIONAL", 400000.0, updated_by="user_abc")
+        assert len(statements) == 2
+        assert "app_preference_events" in statements[0][0], "audit event must be written first"
+        assert "INSERT INTO app_preferences" in statements[1][0]
+        event_args = statements[0][1]
+        assert "RADON_MAX_ORDER_NOTIONAL" in event_args
+        assert "user_abc" in event_args
+        assert "set" in event_args
+
+    def test_clear_value_records_the_actor_and_the_superseded_value(self, monkeypatch):
+        app_preferences.seed_snapshot_for_tests({"RADON_MAX_ORDER_QTY": "50"})
+        statements = []
+        monkeypatch.setattr(
+            app_preferences,
+            "_hrana_execute",
+            lambda sql, args=(), timeout=0: statements.append((sql, tuple(args))),
+        )
+        app_preferences.clear_value("RADON_MAX_ORDER_QTY", updated_by="user_abc")
+        assert "app_preference_events" in statements[0][0]
+        assert "user_abc" in statements[0][1]
+        assert "reset" in statements[0][1]
+        assert "50" in statements[0][1], "the superseded value must be recorded"
+
+    def test_a_failed_audit_write_refuses_the_mutation(self, monkeypatch):
+        def _boom(sql, args=(), timeout=0):
+            raise RuntimeError("audit table unreachable")
+
+        monkeypatch.setattr(app_preferences, "_hrana_execute", _boom)
+        with pytest.raises(app_preferences.PreferenceStoreError):
+            app_preferences.set_value("RADON_MAX_ORDER_QTY", 50, updated_by="op")
+        assert order_limits.max_order_qty() == 500
+
+
+class TestConcurrentWriteAndRefresh:
+    def test_an_in_flight_refresh_cannot_roll_back_a_newer_write(self, monkeypatch):
+        """The refresh SELECT is issued before the save lands, so its result
+        is stale by the time it returns and must not clobber the new value."""
+        released = threading.Event()
+        monkeypatch.setattr(app_preferences, "_hrana_execute", lambda *a, **k: None)
+
+        def _slow_query(*a, **k):
+            released.wait(2.0)
+            return [("RADON_MAX_ORDER_QTY", "500", "2026-08-11T00:00:00Z", "old")]
+
+        monkeypatch.setattr(app_preferences, "_hrana_query", _slow_query)
+        worker = threading.Thread(target=app_preferences.refresh_snapshot, daemon=True)
+        worker.start()
+        time.sleep(0.05)
+        app_preferences.set_value("RADON_MAX_ORDER_QTY", 50, updated_by="op")
+        released.set()
+        worker.join(3.0)
+        assert order_limits.max_order_qty() == 50
+
+
+class TestStoreStatus:
+    def test_a_successful_write_clears_a_stale_read_error(self, monkeypatch):
+        def _boom(*a, **k):
+            raise RuntimeError("turso read down")
+
+        monkeypatch.setattr(app_preferences, "_hrana_query", _boom)
+        app_preferences.refresh_snapshot()
+        assert app_preferences.store_status()["available"] is False
+
+        monkeypatch.setattr(app_preferences, "_hrana_execute", lambda *a, **k: None)
+        app_preferences.set_value("RADON_MAX_ORDER_QTY", 50, updated_by="op")
+        assert app_preferences.store_status()["available"] is True
+
+
+class TestOverlayDoesNotMasqueradeAsEnv:
+    def test_a_removed_row_falls_back_to_the_code_default(self, monkeypatch):
+        monkeypatch.setattr(app_preferences, "_hrana_execute", lambda *a, **k: None)
+        app_preferences.set_value("RADON_MAX_ORDER_QTY", 50, updated_by="op")
+        assert os.environ["RADON_MAX_ORDER_QTY"] == "50"
+
+        app_preferences.clear_value("RADON_MAX_ORDER_QTY", updated_by="op")
+        resolved = app_preferences.resolve("RADON_MAX_ORDER_QTY")
+        assert resolved.value == 500
+        assert resolved.source == "default"

--- a/web/app/api/preferences/route.ts
+++ b/web/app/api/preferences/route.ts
@@ -1,0 +1,155 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { radonFetch, RadonApiError } from "@/lib/radonApi";
+import {
+  getRequestId,
+  jsonApiError,
+  setNoStoreResponseHeaders,
+} from "@/lib/apiContracts";
+import { requireDemoAdmin } from "@/lib/demo/adminAuth";
+
+/**
+ * Operator preferences proxy in front of FastAPI `/preferences`.
+ *
+ * GET is readable by any signed-in user (the page is operator-gated in the
+ * perimeter, and the payload carries no secrets). PUT and DELETE mutate live
+ * safety caps, so they fail CLOSED behind the operator allowlist — parity with
+ * the sibling admin routes, which do not lean on the middleware perimeter
+ * alone.
+ *
+ * Upstream status is preserved verbatim: a 422 validation refusal must reach
+ * the operator as 422 with the allowed range, never as a blanket 500.
+ */
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const UPSTREAM_TIMEOUT_MS = 15_000;
+
+function upstreamFailure(error: unknown, requestId: string): NextResponse {
+  const status = error instanceof RadonApiError ? error.status : 502;
+  const detail =
+    error instanceof RadonApiError
+      ? error.detail
+      : error instanceof Error
+        ? error.message
+        : "preferences request failed";
+  return setNoStoreResponseHeaders(
+    jsonApiError({
+      message: detail,
+      status,
+      code: status === 503 ? "DB_UNAVAILABLE" : "UPSTREAM_ERROR",
+      requestId,
+    }),
+    requestId,
+  );
+}
+
+function validationFailure(
+  message: string,
+  requestId: string,
+  code: "BAD_REQUEST" | "VALIDATION_ERROR" = "VALIDATION_ERROR",
+): NextResponse {
+  return setNoStoreResponseHeaders(
+    jsonApiError({ message, status: 400, code, requestId }),
+    requestId,
+  );
+}
+
+function operatorRejected(requestId: string): NextResponse {
+  return setNoStoreResponseHeaders(
+    jsonApiError({
+      message: "Operator authorization required",
+      status: 403,
+      code: "FORBIDDEN",
+      requestId,
+    }),
+    requestId,
+  );
+}
+
+export async function GET(): Promise<Response> {
+  const requestId = getRequestId();
+  const { userId } = await auth();
+  if (!userId) {
+    return setNoStoreResponseHeaders(
+      jsonApiError({
+        message: "Sign in required",
+        status: 401,
+        code: "UNAUTHORIZED",
+        requestId,
+      }),
+      requestId,
+    );
+  }
+  try {
+    const data = await radonFetch("/preferences", {
+      method: "GET",
+      timeout: UPSTREAM_TIMEOUT_MS,
+    });
+    return setNoStoreResponseHeaders(NextResponse.json(data), requestId);
+  } catch (error) {
+    return upstreamFailure(error, requestId);
+  }
+}
+
+export async function PUT(request: Request): Promise<Response> {
+  const requestId = getRequestId();
+  const operatorId = await requireDemoAdmin();
+  if (!operatorId) {
+    return operatorRejected(requestId);
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return validationFailure("Invalid JSON body", requestId, "BAD_REQUEST");
+  }
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return validationFailure("Invalid JSON body", requestId, "BAD_REQUEST");
+  }
+  const payload = body as Record<string, unknown>;
+  const key = payload.key;
+  if (typeof key !== "string" || !key.trim()) {
+    return validationFailure("key is required", requestId);
+  }
+  if (!("value" in payload)) {
+    return validationFailure("value is required", requestId);
+  }
+
+  try {
+    const data = await radonFetch(`/preferences/${encodeURIComponent(key)}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ value: payload.value, updated_by: operatorId }),
+      timeout: UPSTREAM_TIMEOUT_MS,
+    });
+    return setNoStoreResponseHeaders(NextResponse.json(data), requestId);
+  } catch (error) {
+    return upstreamFailure(error, requestId);
+  }
+}
+
+export async function DELETE(request: Request): Promise<Response> {
+  const requestId = getRequestId();
+  const operatorId = await requireDemoAdmin();
+  if (!operatorId) {
+    return operatorRejected(requestId);
+  }
+
+  const key = new URL(request.url).searchParams.get("key");
+  if (!key || !key.trim()) {
+    return validationFailure("key is required", requestId);
+  }
+
+  try {
+    const data = await radonFetch(
+      `/preferences/${encodeURIComponent(key)}?updated_by=${encodeURIComponent(operatorId)}`,
+      { method: "DELETE", timeout: UPSTREAM_TIMEOUT_MS },
+    );
+    return setNoStoreResponseHeaders(NextResponse.json(data), requestId);
+  } catch (error) {
+    return upstreamFailure(error, requestId);
+  }
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -19246,3 +19246,168 @@ body[data-mobile="true"] .alerts-rule__fired {
 body[data-mobile="true"] .alerts-rule__channel {
   display: none;
 }
+
+/* ── Preferences page ── */
+.preferences-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.preferences-store-banner {
+  border-left-color: var(--negative);
+}
+
+.preferences-group {
+  gap: 0;
+}
+
+.preferences-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, max-content);
+  grid-template-areas:
+    "head control"
+    "description control"
+    "metaline actions"
+    "error error";
+  gap: 8px;
+  padding: 12px 0;
+  border-top: 1px solid var(--border-dim);
+  align-items: start;
+}
+
+.preferences-group .preferences-row:first-of-type {
+  border-top: 0;
+}
+
+.preferences-row__head {
+  grid-area: head;
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.preferences-row__label {
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.preferences-row__key {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.preferences-row__description {
+  grid-area: description;
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.45;
+}
+
+.preferences-row__metaline {
+  grid-area: metaline;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.preferences-row__meta {
+  font-size: 11px;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+}
+
+.preferences-row__control {
+  grid-area: control;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.preferences-row__input {
+  width: 120px;
+  text-align: right;
+  font-family: var(--font-mono);
+}
+
+.preferences-row__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.preferences-row .admin-actions-row {
+  grid-area: actions;
+  justify-content: flex-end;
+}
+
+.preferences-row .admin-card-error {
+  grid-area: error;
+  margin: 0;
+}
+
+.preferences-badge {
+  font-size: 11px;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 1px 6px;
+  border-radius: 4px;
+  border: 1px solid var(--border-dim);
+}
+
+.preferences-badge--db {
+  background: color-mix(in srgb, var(--signal-core) 14%, transparent);
+  color: var(--signal-core);
+}
+
+.preferences-badge--env {
+  background: var(--bg-panel-raised);
+  color: var(--text-secondary);
+}
+
+.preferences-badge--default {
+  background: transparent;
+  color: var(--text-muted);
+}
+
+.preferences-badge--restart {
+  background: color-mix(in srgb, var(--neutral) 12%, transparent);
+  color: var(--text-secondary);
+}
+
+.preferences-badge--rejected {
+  color: var(--negative);
+  border-color: color-mix(in srgb, var(--negative) 40%, transparent);
+}
+
+@media (max-width: 640px) {
+  .preferences-row {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "head"
+      "description"
+      "metaline"
+      "control"
+      "actions"
+      "error";
+  }
+
+  .preferences-row__control,
+  .preferences-row .admin-actions-row {
+    justify-content: flex-start;
+  }
+
+  .preferences-row__input {
+    width: 100%;
+    text-align: left;
+  }
+}

--- a/web/app/preferences/page.tsx
+++ b/web/app/preferences/page.tsx
@@ -1,0 +1,7 @@
+import WorkspaceShell from "@/components/WorkspaceShell";
+
+export const dynamic = "force-dynamic";
+
+export default function PreferencesPage() {
+  return <WorkspaceShell section="preferences" />;
+}

--- a/web/components/PreferencesSection.tsx
+++ b/web/components/PreferencesSection.tsx
@@ -1,0 +1,401 @@
+"use client";
+
+/**
+ * Operator preferences surface for /preferences.
+ *
+ * Renders one card per registry group and one row per preference, each showing
+ * the effective value, where it came from (db / env / default), the code
+ * default and the allowed band. Nothing is optimistic: a row only ever renders
+ * the server's value, so a rejected save leaves the displayed value untouched.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import ConfirmDialog from "@/components/admin/ConfirmDialog";
+import {
+  fetchPreferences,
+  formatPreferenceValue,
+  groupPreferences,
+  parsePreferenceInput,
+  resetPreference,
+  savePreference,
+} from "@/lib/preferences";
+import type { PreferenceEntry, PreferenceMutationResult, PreferencesPayload } from "@/lib/preferences";
+
+/** The group whose values bound how much money one order can move. */
+const RISK_GROUP = "Order Limits";
+
+function groupSlug(group: string): string {
+  return group.toLowerCase().replace(/\s+/g, "-");
+}
+
+/**
+ * Loosening a fat-finger stop is the only edit here that can cost money, and an
+ * extra typed zero is exactly the mistake these caps exist to catch. Raising
+ * one takes the same type-to-confirm gate as the gateway Stop control.
+ * Tightening a cap, or changing anything outside Order Limits, saves directly.
+ */
+function isWidening(entry: PreferenceEntry, next: number | boolean): boolean {
+  if (entry.group !== RISK_GROUP) return false;
+  if (typeof next !== "number" || typeof entry.value !== "number") return false;
+  return next > entry.value;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error && error.message ? error.message : "preferences request failed";
+}
+
+function rangeLabel(entry: PreferenceEntry): string {
+  if (entry.value_type === "bool") {
+    return "Allowed On or Off";
+  }
+  return `Allowed ${entry.hard_min} to ${entry.hard_max}`;
+}
+
+export default function PreferencesSection() {
+  const [payload, setPayload] = useState<PreferencesPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [pageError, setPageError] = useState<string | null>(null);
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const [boolDrafts, setBoolDrafts] = useState<Record<string, boolean>>({});
+  const [rowBusy, setRowBusy] = useState<Record<string, boolean>>({});
+  const [rowError, setRowError] = useState<Record<string, string>>({});
+  const [pendingWiden, setPendingWiden] = useState<
+    { entry: PreferenceEntry; value: number | boolean } | null
+  >(null);
+
+  useEffect(() => {
+    let active = true;
+    fetchPreferences()
+      .then((next) => {
+        if (!active) return;
+        setPayload(next);
+        setPageError(null);
+      })
+      .catch((error: unknown) => {
+        if (!active) return;
+        setPageError(errorMessage(error));
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const applyMutation = useCallback((key: string, result: PreferenceMutationResult) => {
+    setPayload((current) => {
+      if (!current) return current;
+      return {
+        ...current,
+        preferences: current.preferences.map((entry) => (entry.key === key ? result.preference : entry)),
+        store: result.store,
+      };
+    });
+    setDrafts((current) => {
+      const next = { ...current };
+      delete next[key];
+      return next;
+    });
+    setBoolDrafts((current) => {
+      const next = { ...current };
+      delete next[key];
+      return next;
+    });
+    setRowError((current) => {
+      const next = { ...current };
+      delete next[key];
+      return next;
+    });
+  }, []);
+
+  const setBusy = useCallback((key: string, busy: boolean) => {
+    setRowBusy((current) => ({ ...current, [key]: busy }));
+  }, []);
+
+  const draftFor = (entry: PreferenceEntry): string => drafts[entry.key] ?? String(entry.value);
+  const boolDraftFor = (entry: PreferenceEntry): boolean => boolDrafts[entry.key] ?? Boolean(entry.value);
+
+  const inputErrorFor = (entry: PreferenceEntry): string | null => {
+    if (entry.value_type === "bool") return null;
+    const draft = drafts[entry.key];
+    if (draft === undefined) return null;
+    const parsed = parsePreferenceInput(entry, draft);
+    return "error" in parsed ? parsed.error : null;
+  };
+
+  const isDirty = (entry: PreferenceEntry): boolean => (
+    entry.value_type === "bool"
+      ? boolDraftFor(entry) !== entry.value
+      : draftFor(entry) !== String(entry.value)
+  );
+
+  const draftValueFor = useCallback((entry: PreferenceEntry): number | boolean | null => {
+    if (entry.value_type === "bool") {
+      return boolDrafts[entry.key] ?? Boolean(entry.value);
+    }
+    const parsed = parsePreferenceInput(entry, drafts[entry.key] ?? String(entry.value));
+    if ("error" in parsed) {
+      setRowError((current) => ({ ...current, [entry.key]: parsed.error }));
+      return null;
+    }
+    return parsed.value;
+  }, [boolDrafts, drafts]);
+
+  const commitSave = useCallback(async (
+    entry: PreferenceEntry,
+    value: number | boolean,
+  ): Promise<boolean> => {
+    setBusy(entry.key, true);
+    setRowError((current) => {
+      const next = { ...current };
+      delete next[entry.key];
+      return next;
+    });
+    try {
+      const result = await savePreference(entry.key, value);
+      applyMutation(entry.key, result);
+      return true;
+    } catch (error: unknown) {
+      setRowError((current) => ({ ...current, [entry.key]: errorMessage(error) }));
+      return false;
+    } finally {
+      setBusy(entry.key, false);
+    }
+  }, [applyMutation, setBusy]);
+
+  const saveRow = useCallback(async (entry: PreferenceEntry): Promise<boolean> => {
+    const value = draftValueFor(entry);
+    if (value === null) return false;
+    if (isWidening(entry, value)) {
+      setPendingWiden({ entry, value });
+      return false;
+    }
+    return commitSave(entry, value);
+  }, [commitSave, draftValueFor]);
+
+  const resetRow = useCallback(async (entry: PreferenceEntry) => {
+    setBusy(entry.key, true);
+    setRowError((current) => {
+      const next = { ...current };
+      delete next[entry.key];
+      return next;
+    });
+    try {
+      const result = await resetPreference(entry.key);
+      applyMutation(entry.key, result);
+    } catch (error: unknown) {
+      setRowError((current) => ({ ...current, [entry.key]: errorMessage(error) }));
+    } finally {
+      setBusy(entry.key, false);
+    }
+  }, [applyMutation, setBusy]);
+
+  const saveGroup = useCallback(async (entries: PreferenceEntry[]) => {
+    for (const entry of entries.filter(isDirty)) {
+      const ok = await saveRow(entry);
+      if (!ok) return;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [saveRow, drafts, boolDrafts, payload]);
+
+  if (loading) {
+    return (
+      <div className="preferences-shell" data-testid="preferences-section">
+        <p data-testid="preferences-loading">Loading preferences</p>
+      </div>
+    );
+  }
+
+  if (pageError || !payload) {
+    return (
+      <div className="preferences-shell" data-testid="preferences-section">
+        <p className="admin-card-note admin-card-error" role="alert" data-testid="preferences-error">
+          {pageError ?? "preferences request failed"}
+        </p>
+      </div>
+    );
+  }
+
+  const storeUnavailable = payload.store.available === false;
+  const groups = groupPreferences(payload.preferences, payload.groups);
+
+  return (
+    <div className="preferences-shell" data-testid="preferences-section">
+      {storeUnavailable ? (
+        <p className="admin-card-note preferences-store-banner" role="status" data-testid="preferences-store-banner">
+          Preferences store unavailable. Showing environment and code defaults. Saving is disabled.
+        </p>
+      ) : null}
+
+      {groups.map(({ group, entries }) => {
+        const slug = groupSlug(group);
+        const groupDirty = entries.some(isDirty);
+        return (
+          <section className="admin-card preferences-group" data-testid={`preferences-group-${slug}`} key={group}>
+            <header className="admin-card-header">
+              <span className="admin-card-title">{group}</span>
+              <div className="admin-actions-row">
+                <button
+                  type="button"
+                  className="admin-btn admin-btn-primary"
+                  data-testid={`preference-group-save-${slug}`}
+                  disabled={!groupDirty || storeUnavailable}
+                  onClick={() => { void saveGroup(entries); }}
+                >
+                  Save group
+                </button>
+              </div>
+            </header>
+
+            {entries.map((entry) => {
+              const busy = Boolean(rowBusy[entry.key]);
+              const inputError = inputErrorFor(entry);
+              const message = rowError[entry.key] ?? inputError;
+              const dirty = isDirty(entry);
+              return (
+                <div className="preferences-row" data-testid={`preference-row-${entry.key}`} key={entry.key}>
+                  <div className="preferences-row__head">
+                    <span className="preferences-row__label">{entry.label}</span>
+                    <code className="preferences-row__key">{entry.key}</code>
+                  </div>
+
+                  <p className="preferences-row__description">{entry.description}</p>
+
+                  <div className="preferences-row__metaline">
+                    <span
+                      className={`preferences-badge preferences-badge--${entry.source}`}
+                      data-testid={`preference-source-${entry.key}`}
+                    >
+                      {entry.source.toUpperCase()}
+                    </span>
+                    <span className="preferences-row__meta" data-testid={`preference-default-${entry.key}`}>
+                      Default {formatPreferenceValue(entry, entry.default)}
+                    </span>
+                    <span className="preferences-row__meta" data-testid={`preference-range-${entry.key}`}>
+                      {rangeLabel(entry)}
+                    </span>
+                    {entry.applies_immediately ? null : (
+                      <span
+                        className="preferences-badge preferences-badge--restart"
+                        data-testid={`preference-restart-badge-${entry.key}`}
+                        title="Stored now. The consuming process reads this when it next starts."
+                      >
+                        RESTART REQUIRED
+                      </span>
+                    )}
+                    {entry.db_rejected ? (
+                      <>
+                        <span
+                          className="preferences-badge preferences-badge--rejected"
+                          data-testid={`preference-rejected-${entry.key}`}
+                        >
+                          STORED VALUE IGNORED
+                        </span>
+                        <span className="preferences-row__meta">
+                          A stored value was outside the allowed range and was ignored.
+                        </span>
+                      </>
+                    ) : null}
+                  </div>
+
+                  <div className="preferences-row__control">
+                    {entry.value_type === "bool" ? (
+                      <label className="preferences-row__toggle">
+                        <input
+                          type="checkbox"
+                          checked={boolDraftFor(entry)}
+                          onChange={(e) => setBoolDrafts((current) => ({ ...current, [entry.key]: e.target.checked }))}
+                          data-testid={`preference-input-${entry.key}`}
+                          aria-label={entry.label}
+                        />
+                        <span>{boolDraftFor(entry) ? "On" : "Off"}</span>
+                      </label>
+                    ) : (
+                      <input
+                        type="number"
+                        step={entry.value_type === "int" ? "1" : "any"}
+                        min={Number(entry.hard_min)}
+                        max={Number(entry.hard_max)}
+                        inputMode={entry.value_type === "int" ? "numeric" : "decimal"}
+                        className="order-input preferences-row__input"
+                        value={draftFor(entry)}
+                        onChange={(e) => {
+                          const raw = e.target.value;
+                          setDrafts((current) => ({ ...current, [entry.key]: raw }));
+                          setRowError((current) => {
+                            const next = { ...current };
+                            delete next[entry.key];
+                            return next;
+                          });
+                        }}
+                        data-testid={`preference-input-${entry.key}`}
+                        aria-label={entry.label}
+                      />
+                    )}
+                  </div>
+
+                  <div className="admin-actions-row">
+                    <button
+                      type="button"
+                      className="admin-btn admin-btn-primary"
+                      data-testid={`preference-save-${entry.key}`}
+                      disabled={!dirty || busy || storeUnavailable || Boolean(inputError)}
+                      onClick={() => { void saveRow(entry); }}
+                    >
+                      Save
+                    </button>
+                    <button
+                      type="button"
+                      className="admin-btn admin-btn-ghost"
+                      data-testid={`preference-reset-${entry.key}`}
+                      disabled={busy || storeUnavailable || entry.source !== "db"}
+                      title={entry.source !== "db" ? "No stored override to reset" : undefined}
+                      onClick={() => { void resetRow(entry); }}
+                    >
+                      Reset to default
+                    </button>
+                  </div>
+
+                  {message ? (
+                    <p
+                      className="admin-card-note admin-card-error"
+                      role="alert"
+                      data-testid={`preference-error-${entry.key}`}
+                    >
+                      {message}
+                    </p>
+                  ) : null}
+                </div>
+              );
+            })}
+          </section>
+        );
+      })}
+
+      {pendingWiden ? (
+        <div data-testid="preference-widen-confirm">
+          <ConfirmDialog
+            open
+            destructive
+            title="Widen a risk cap"
+            body={
+              `${pendingWiden.entry.label} (${pendingWiden.entry.key}) goes from ` +
+              `${formatPreferenceValue(pendingWiden.entry, pendingWiden.entry.value)} to ` +
+              `${formatPreferenceValue(pendingWiden.entry, pendingWiden.value)}. ` +
+              "This loosens a fat finger stop on live order placement and is recorded in the audit log."
+            }
+            confirmLabel="Widen cap"
+            requireTyped={pendingWiden.entry.key}
+            onConfirm={() => {
+              const { entry, value } = pendingWiden;
+              setPendingWiden(null);
+              void commitSave(entry, value);
+            }}
+            onCancel={() => setPendingWiden(null)}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/components/WorkspaceSections.tsx
+++ b/web/components/WorkspaceSections.tsx
@@ -116,6 +116,7 @@ import type { ModifyOrderRequest } from "@/lib/orderModify";
 import RegimePanel from "./RegimePanel";
 import CtaPage from "./CtaPage";
 import AdminWorkspace from "./admin/AdminWorkspace";
+import PreferencesSection from "./PreferencesSection";
 import ProfileContent from "./profile/ProfileContent";
 import WatchlistContent from "./watchlist/WatchlistContent";
 import PerformancePanel from "./PerformancePanel";
@@ -4111,6 +4112,8 @@ function WorkspaceSections({ section, portfolio, portfolioLastSync, orders, pric
       return <WorkflowComposer />;
     case "admin":
       return <AdminWorkspace />;
+    case "preferences":
+      return <PreferencesSection />;
     case "profile":
       return <ProfileContent prices={prices} />;
     case "watchlist":

--- a/web/components/WorkspaceShell.tsx
+++ b/web/components/WorkspaceShell.tsx
@@ -552,7 +552,7 @@ export default function WorkspaceShell({ section, tickerParam }: WorkspaceShellP
             />
           ) : null}
 
-          {activeSection !== "dashboard" && activeSection !== "ticker-detail" && activeSection !== "watchlist" && activeSection !== "admin" && activeSection !== "profile" && activeSection !== "alerts" && activeSection !== "workflow" && !isOptionsWorkspace ? <div className={isStale ? "metric-cards--stale" : undefined}><MetricCards portfolio={portfolio} prices={prices} realizedPnl={todayRealizedPnl} executedOrders={executedOrders} section={activeSection} /></div> : null}
+          {activeSection !== "dashboard" && activeSection !== "ticker-detail" && activeSection !== "watchlist" && activeSection !== "admin" && activeSection !== "preferences" && activeSection !== "profile" && activeSection !== "alerts" && activeSection !== "workflow" && !isOptionsWorkspace ? <div className={isStale ? "metric-cards--stale" : undefined}><MetricCards portfolio={portfolio} prices={prices} realizedPnl={todayRealizedPnl} executedOrders={executedOrders} section={activeSection} /></div> : null}
 
           {activeSection !== "dashboard" ? (
             <WorkspaceSections

--- a/web/components/icons/RadonGlyphs.tsx
+++ b/web/components/icons/RadonGlyphs.tsx
@@ -221,6 +221,21 @@ export function ProfileGlyph(p: GlyphProps) {
   );
 }
 
+/* Preferences — three calibration slider tracks, each with a handle at a
+   different detent. Reads as a tuning bench rather than a generic gear. */
+export function PreferencesGlyph(p: GlyphProps) {
+  return (
+    <Glyph {...p}>
+      <path d="M3 6 L21 6" />
+      <path d="M3 12 L21 12" />
+      <path d="M3 18 L21 18" />
+      <rect x="6" y="4" width="3" height="4" />
+      <rect x="14" y="10" width="3" height="4" />
+      <rect x="9" y="16" width="3" height="4" />
+    </Glyph>
+  );
+}
+
 /* Performance — spectral bars stacked vertically. Kept available for
    when the Performance route is unhidden in lib/data.ts. */
 export function PerformanceGlyph(p: GlyphProps) {

--- a/web/lib/chat.ts
+++ b/web/lib/chat.ts
@@ -375,6 +375,10 @@ export function resolveSectionFromPath(pathname: string | null, fallback: Worksp
     return "admin";
   }
 
+  if (pathname.startsWith("/preferences")) {
+    return "preferences";
+  }
+
   if (pathname.startsWith("/profile")) {
     return "profile";
   }

--- a/web/lib/data.ts
+++ b/web/lib/data.ts
@@ -9,6 +9,7 @@ import {
   OrdersGlyph,
   PerformanceGlyph,
   PortfolioGlyph,
+  PreferencesGlyph,
   RegimeGlyph,
   ScannerGlyph,
   WatchlistGlyph,
@@ -54,6 +55,7 @@ export const navItems: WorkspaceNavItem[] = [
   { label: "Alerts", route: "alerts", href: "/alerts", icon: ScannerGlyph, group: "operations" },
   { label: "Workflow", route: "workflow", href: "/workflow", icon: OperatorGlyph, group: "operations" },
   { label: "Operator", route: "admin", href: "/admin", icon: OperatorGlyph, group: "operations" },
+  { label: "Preferences", route: "preferences", href: "/preferences", icon: PreferencesGlyph, group: "operations" },
   // Profile is reached via the dedicated user card above the sidebar footer,
   // not the main nav list — hidden keeps it out of the primary loop while
   // still exposing the route/label/icon to consumers that resolve by route.
@@ -76,6 +78,7 @@ export const quickPromptsBySection: Record<WorkspaceSection, string[]> = {
   alerts: ["scan --top 12", "portfolio", "help"],
   workflow: ["scan --top 12", "portfolio", "help"],
   admin: ["help"],
+  preferences: ["help"],
   profile: ["portfolio", "scan --top 12", "help"],
   "ticker-detail": ["portfolio", "scan --top 12", "help"],
 };
@@ -96,6 +99,7 @@ export const sectionDescription: Record<WorkspaceSection, string> = {
   alerts: "Signal alert rules evaluated against incoming scan rows.",
   workflow: "Visual flow-pipeline composer for chaining scans and signals.",
   admin: "Operator controls for IB Gateway 2FA and Radon services.",
+  preferences: "Operator tunable runtime limits, scanner concurrency and feature flags.",
   profile: "Your account, saved articles and symbol watchlist.",
   "ticker-detail": "Instrument research surface — company, book, chain, position, orders, news, ratings, seasonality.",
 };

--- a/web/lib/preferences.ts
+++ b/web/lib/preferences.ts
@@ -1,0 +1,167 @@
+/**
+ * Operator preferences client contract.
+ *
+ * Wire types mirror `ResolvedPreference.to_dict()` in `scripts/app_preferences.py`
+ * exactly, and the browser helpers talk only to `/api/preferences` (the Next.js
+ * proxy), never to FastAPI directly.
+ */
+
+export type PreferenceValueType = "int" | "float" | "bool";
+export type PreferenceSource = "db" | "env" | "default";
+
+export type PreferenceEntry = {
+  key: string;
+  label: string;
+  group: string;
+  value_type: PreferenceValueType;
+  value: number | boolean;
+  default: number | boolean;
+  hard_min: number | boolean;
+  hard_max: number | boolean;
+  unit: string;
+  description: string;
+  applies_immediately: boolean;
+  source: PreferenceSource;
+  db_rejected: boolean;
+  updated_at: string | null;
+  updated_by: string | null;
+};
+
+export type PreferenceStoreStatus = {
+  available: boolean;
+  error: string | null;
+  checked_at: string | null;
+};
+
+export type PreferencesPayload = {
+  preferences: PreferenceEntry[];
+  groups: string[];
+  store: PreferenceStoreStatus;
+  generated_at: string;
+};
+
+export type PreferenceMutationResult = {
+  preference: PreferenceEntry;
+  store: PreferenceStoreStatus;
+};
+
+export class PreferencesRequestError extends Error {
+  readonly status: number;
+  readonly code: string;
+
+  constructor(status: number, code: string, message: string) {
+    super(message);
+    this.name = "PreferencesRequestError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+const PREFERENCES_ENDPOINT = "/api/preferences";
+
+function errorFromBody(status: number, body: unknown): PreferencesRequestError {
+  const payload = (body ?? {}) as Record<string, unknown>;
+  const code = typeof payload.code === "string" ? payload.code : "UPSTREAM_ERROR";
+  const message =
+    typeof payload.error === "string"
+      ? payload.error
+      : typeof payload.detail === "string"
+        ? payload.detail
+        : `HTTP ${status}`;
+  return new PreferencesRequestError(status, code, message);
+}
+
+async function readJson(res: Response): Promise<unknown> {
+  try {
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+async function requestJson<T>(input: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(input, { cache: "no-store", ...init });
+  const body = await readJson(res);
+  if (!res.ok) {
+    throw errorFromBody(res.status, body);
+  }
+  return body as T;
+}
+
+export async function fetchPreferences(): Promise<PreferencesPayload> {
+  return requestJson<PreferencesPayload>(PREFERENCES_ENDPOINT, { method: "GET" });
+}
+
+export async function savePreference(
+  key: string,
+  value: number | boolean,
+): Promise<PreferenceMutationResult> {
+  return requestJson<PreferenceMutationResult>(PREFERENCES_ENDPOINT, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ key, value }),
+  });
+}
+
+export async function resetPreference(key: string): Promise<PreferenceMutationResult> {
+  return requestJson<PreferenceMutationResult>(
+    `${PREFERENCES_ENDPOINT}?key=${encodeURIComponent(key)}`,
+    { method: "DELETE" },
+  );
+}
+
+export function groupPreferences(
+  entries: PreferenceEntry[],
+  groups: string[],
+): Array<{ group: string; entries: PreferenceEntry[] }> {
+  const buckets = new Map<string, PreferenceEntry[]>();
+  for (const entry of entries) {
+    const bucket = buckets.get(entry.group);
+    if (bucket) {
+      bucket.push(entry);
+      continue;
+    }
+    buckets.set(entry.group, [entry]);
+  }
+  const known = groups.filter((group) => (buckets.get(group)?.length ?? 0) > 0);
+  const unknown = [...buckets.keys()]
+    .filter((group) => !groups.includes(group))
+    .sort((a, b) => a.localeCompare(b));
+  return [...known, ...unknown].map((group) => ({
+    group,
+    entries: buckets.get(group) ?? [],
+  }));
+}
+
+function formatNumber(entry: PreferenceEntry, value: number): string {
+  const maximumFractionDigits = entry.value_type === "int" ? 0 : 2;
+  return new Intl.NumberFormat("en-US", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits,
+  }).format(value);
+}
+
+export function formatPreferenceValue(entry: PreferenceEntry, value: number | boolean): string {
+  const text =
+    typeof value === "boolean" ? (value ? "On" : "Off") : formatNumber(entry, value);
+  return entry.unit ? `${text} ${entry.unit}` : text;
+}
+
+export function parsePreferenceInput(
+  entry: PreferenceEntry,
+  raw: string,
+): { value: number } | { error: string } {
+  const trimmed = raw.trim();
+  if (!trimmed) return { error: "value is required" };
+  const value = Number(trimmed);
+  if (!Number.isFinite(value)) return { error: "value must be a number" };
+  if (entry.value_type === "int" && !Number.isInteger(value)) {
+    return { error: "value must be a whole number" };
+  }
+  const min = Number(entry.hard_min);
+  const max = Number(entry.hard_max);
+  if (value < min || value > max) {
+    return { error: `value must be between ${entry.hard_min} and ${entry.hard_max}` };
+  }
+  return { value };
+}

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -64,7 +64,7 @@ export type PiResponse = {
   error?: string;
 };
 
-export type WorkspaceSection = "dashboard" | "flow-analysis" | "options" | "portfolio" | "performance" | "orders" | "scanner" | "discover" | "watchlist" | "journal" | "regime" | "cta" | "alerts" | "workflow" | "ticker-detail" | "admin" | "profile";
+export type WorkspaceSection = "dashboard" | "flow-analysis" | "options" | "portfolio" | "performance" | "orders" | "scanner" | "discover" | "watchlist" | "journal" | "regime" | "cta" | "alerts" | "workflow" | "ticker-detail" | "admin" | "preferences" | "profile";
 
 export type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
 

--- a/web/tests/api-routes-smoke.test.ts
+++ b/web/tests/api-routes-smoke.test.ts
@@ -541,3 +541,40 @@ describe("GET /api/risk-free-rate", () => {
     expect(body.stale).toBe(true);
   });
 });
+
+describe("GET /api/preferences (FastAPI passthrough)", () => {
+  // Clerk is mocked per-test (doMock + doUnmock) so the shared module registry
+  // used by every other block in this file stays untouched.
+  it("returns 200 with the preferences payload for a signed-in user", async () => {
+    vi.doMock("@clerk/nextjs/server", () => ({
+      auth: vi.fn(async () => ({ userId: "user_smoke" })),
+    }));
+    mockRadonFetch.mockResolvedValueOnce({
+      preferences: [],
+      groups: ["Order Limits"],
+      store: { available: true, error: null, checked_at: "2026-08-11T17:02:11Z" },
+      generated_at: "2026-08-11T17:02:11Z",
+    });
+    const { GET } = await import("../app/api/preferences/route");
+    const res = await GET();
+    expectJsonResponse(res);
+    expect(res.status).toBe(200);
+    const body = (await jsonOf(res)) as Record<string, unknown>;
+    expect(Array.isArray(body.preferences)).toBe(true);
+    vi.doUnmock("@clerk/nextjs/server");
+  });
+
+  it("returns a 502 error envelope when FastAPI is unreachable", async () => {
+    vi.doMock("@clerk/nextjs/server", () => ({
+      auth: vi.fn(async () => ({ userId: "user_smoke" })),
+    }));
+    mockRadonFetch.mockRejectedValueOnce(new Error("connect ECONNREFUSED"));
+    const { GET } = await import("../app/api/preferences/route");
+    const res = await GET();
+    expectJsonResponse(res);
+    expect(res.status).toBe(502);
+    const body = (await jsonOf(res)) as Record<string, unknown>;
+    expect(body.code).toBe("UPSTREAM_ERROR");
+    vi.doUnmock("@clerk/nextjs/server");
+  });
+});

--- a/web/tests/data.test.ts
+++ b/web/tests/data.test.ts
@@ -196,6 +196,7 @@ describe("navItems", () => {
       "alerts",
       "workflow",
       "admin",
+      "preferences",
     ]);
   });
 });
@@ -221,6 +222,7 @@ describe("quickPromptsBySection", () => {
     "alerts",
     "workflow",
     "admin",
+    "preferences",
     "ticker-detail",
     "profile",
   ];
@@ -276,6 +278,7 @@ describe("sectionDescription", () => {
     "alerts",
     "workflow",
     "admin",
+    "preferences",
     "ticker-detail",
     "profile",
   ];

--- a/web/tests/preferences-api.test.ts
+++ b/web/tests/preferences-api.test.ts
@@ -1,0 +1,382 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * Preferences proxy route (`web/app/api/preferences/route.ts`) plus the browser
+ * helpers in `web/lib/preferences.ts`.
+ *
+ * The route is a thin authenticated proxy in front of FastAPI `/preferences`.
+ * GET requires a signed-in user; PUT and DELETE require the operator allowlist
+ * (default-deny). Upstream status codes are preserved so a 422 validation
+ * refusal never becomes a 500.
+ */
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+class MockRadonApiError extends Error {
+  status: number;
+  detail: string;
+  constructor(status: number, detail: string) {
+    super(`Radon API ${status}: ${detail}`);
+    this.name = "RadonApiError";
+    this.status = status;
+    this.detail = detail;
+  }
+}
+
+const mockRadonFetch = vi.fn();
+vi.mock("@/lib/radonApi", () => ({
+  radonFetch: mockRadonFetch,
+  RadonApiError: MockRadonApiError,
+}));
+
+let currentUserId: string | null = "user_signed_in";
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: vi.fn(async () => ({ userId: currentUserId })),
+}));
+
+const mockRequireDemoAdmin = vi.fn();
+vi.mock("@/lib/demo/adminAuth", () => ({
+  requireDemoAdmin: mockRequireDemoAdmin,
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures / helpers
+// ---------------------------------------------------------------------------
+
+const ENTRY = {
+  key: "RADON_MAX_ORDER_QTY",
+  label: "Max contracts per order",
+  group: "Order Limits",
+  value_type: "int",
+  value: 400,
+  default: 500,
+  hard_min: 1,
+  hard_max: 5000,
+  unit: "contracts",
+  description: "Hard ceiling on contracts per options or combo order.",
+  applies_immediately: true,
+  source: "db",
+  db_rejected: false,
+  updated_at: "2026-08-11T17:02:11Z",
+  updated_by: "user_x",
+};
+
+const STORE = { available: true, error: null, checked_at: "2026-08-11T17:02:11Z" };
+
+const PAYLOAD = {
+  preferences: [ENTRY],
+  groups: ["Order Limits", "Scanning", "Feature Flags", "IB Recovery", "Health Monitoring"],
+  store: STORE,
+  generated_at: "2026-08-11T17:02:11Z",
+};
+
+function req(url: string, init?: RequestInit): Request {
+  return new Request(url, init);
+}
+
+function putReq(body: string): Request {
+  return req("http://localhost/api/preferences", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body,
+  });
+}
+
+async function jsonOf(res: Response): Promise<Record<string, unknown>> {
+  const text = await res.text();
+  return text ? (JSON.parse(text) as Record<string, unknown>) : {};
+}
+
+async function loadRoute() {
+  return import("../app/api/preferences/route");
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  mockRadonFetch.mockReset();
+  mockRequireDemoAdmin.mockReset();
+  mockRequireDemoAdmin.mockResolvedValue("user_x");
+  currentUserId = "user_signed_in";
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// GET
+// ---------------------------------------------------------------------------
+
+describe("GET /api/preferences", () => {
+  it("returns 401 UNAUTHORIZED when no user is signed in", async () => {
+    currentUserId = null;
+    const { GET } = await loadRoute();
+    const res = await GET();
+    expect(res.status).toBe(401);
+    const body = await jsonOf(res);
+    expect(body.code).toBe("UNAUTHORIZED");
+    expect(body.error).toBe("Sign in required");
+    expect(mockRadonFetch).not.toHaveBeenCalled();
+  });
+
+  it("proxies to /preferences and returns the upstream payload unchanged", async () => {
+    mockRadonFetch.mockResolvedValueOnce(PAYLOAD);
+    const { GET } = await loadRoute();
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await jsonOf(res)).toEqual(PAYLOAD);
+    expect(mockRadonFetch).toHaveBeenCalledWith(
+      "/preferences",
+      expect.objectContaining({ method: "GET", timeout: 15_000 }),
+    );
+  });
+
+  it("sets no-store cache headers and a request id", async () => {
+    mockRadonFetch.mockResolvedValueOnce(PAYLOAD);
+    const { GET } = await loadRoute();
+    const res = await GET();
+    expect(res.headers.get("Cache-Control")).toContain("no-store");
+    expect(res.headers.get("X-Request-Id")).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PUT
+// ---------------------------------------------------------------------------
+
+describe("PUT /api/preferences", () => {
+  it("returns 403 FORBIDDEN and never calls FastAPI without an operator", async () => {
+    mockRequireDemoAdmin.mockResolvedValue(null);
+    const { PUT } = await loadRoute();
+    const res = await PUT(putReq(JSON.stringify({ key: "RADON_MAX_ORDER_QTY", value: 400 })));
+    expect(res.status).toBe(403);
+    const body = await jsonOf(res);
+    expect(body.code).toBe("FORBIDDEN");
+    expect(body.error).toBe("Operator authorization required");
+    expect(mockRadonFetch).not.toHaveBeenCalled();
+  });
+
+  it("forwards the value and the operator id to FastAPI", async () => {
+    mockRadonFetch.mockResolvedValueOnce({ preference: ENTRY, store: STORE });
+    const { PUT } = await loadRoute();
+    const res = await PUT(putReq(JSON.stringify({ key: "RADON_MAX_ORDER_QTY", value: 400 })));
+    expect(res.status).toBe(200);
+    expect(await jsonOf(res)).toEqual({ preference: ENTRY, store: STORE });
+    expect(mockRadonFetch).toHaveBeenCalledWith(
+      "/preferences/RADON_MAX_ORDER_QTY",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ value: 400, updated_by: "user_x" }),
+      }),
+    );
+  });
+
+  it("returns 400 VALIDATION_ERROR when key is missing", async () => {
+    const { PUT } = await loadRoute();
+    const res = await PUT(putReq(JSON.stringify({ value: 400 })));
+    expect(res.status).toBe(400);
+    const body = await jsonOf(res);
+    expect(body.code).toBe("VALIDATION_ERROR");
+    expect(body.error).toBe("key is required");
+    expect(mockRadonFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 VALIDATION_ERROR when value is missing", async () => {
+    const { PUT } = await loadRoute();
+    const res = await PUT(putReq(JSON.stringify({ key: "RADON_MAX_ORDER_QTY" })));
+    expect(res.status).toBe(400);
+    const body = await jsonOf(res);
+    expect(body.code).toBe("VALIDATION_ERROR");
+    expect(body.error).toBe("value is required");
+  });
+
+  it("returns 400 BAD_REQUEST on an unparseable body", async () => {
+    const { PUT } = await loadRoute();
+    const res = await PUT(putReq("{not json"));
+    expect(res.status).toBe(400);
+    const body = await jsonOf(res);
+    expect(body.code).toBe("BAD_REQUEST");
+    expect(body.error).toBe("Invalid JSON body");
+  });
+
+  it("URL-encodes the key into the upstream path", async () => {
+    mockRadonFetch.mockResolvedValueOnce({ preference: ENTRY, store: STORE });
+    const { PUT } = await loadRoute();
+    await PUT(putReq(JSON.stringify({ key: "WEIRD KEY/../x", value: 1 })));
+    expect(mockRadonFetch).toHaveBeenCalledWith(
+      "/preferences/WEIRD%20KEY%2F..%2Fx",
+      expect.anything(),
+    );
+  });
+
+  it("preserves an upstream 422 with the validation message, not a 500", async () => {
+    const message = "RADON_MAX_ORDER_QTY must be between 1 and 5000 (got 9000)";
+    mockRadonFetch.mockRejectedValueOnce(new MockRadonApiError(422, message));
+    const { PUT } = await loadRoute();
+    const res = await PUT(putReq(JSON.stringify({ key: "RADON_MAX_ORDER_QTY", value: 9000 })));
+    expect(res.status).toBe(422);
+    const body = await jsonOf(res);
+    expect(body.error).toBe(message);
+    expect(body.code).toBe("UPSTREAM_ERROR");
+  });
+
+  it("preserves an upstream 503 as DB_UNAVAILABLE", async () => {
+    mockRadonFetch.mockRejectedValueOnce(
+      new MockRadonApiError(503, "preferences store temporarily unavailable"),
+    );
+    const { PUT } = await loadRoute();
+    const res = await PUT(putReq(JSON.stringify({ key: "RADON_MAX_ORDER_QTY", value: 400 })));
+    expect(res.status).toBe(503);
+    expect((await jsonOf(res)).code).toBe("DB_UNAVAILABLE");
+  });
+
+  it("maps a non-RadonApiError throw to 502 UPSTREAM_ERROR", async () => {
+    mockRadonFetch.mockRejectedValueOnce(new Error("socket hang up"));
+    const { PUT } = await loadRoute();
+    const res = await PUT(putReq(JSON.stringify({ key: "RADON_MAX_ORDER_QTY", value: 400 })));
+    expect(res.status).toBe(502);
+    const body = await jsonOf(res);
+    expect(body.code).toBe("UPSTREAM_ERROR");
+    expect(body.error).toContain("socket hang up");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE
+// ---------------------------------------------------------------------------
+
+describe("DELETE /api/preferences", () => {
+  it("returns 403 without an operator", async () => {
+    mockRequireDemoAdmin.mockResolvedValue(null);
+    const { DELETE } = await loadRoute();
+    const res = await DELETE(
+      req("http://localhost/api/preferences?key=RADON_MAX_ORDER_QTY", { method: "DELETE" }),
+    );
+    expect(res.status).toBe(403);
+    expect(mockRadonFetch).not.toHaveBeenCalled();
+  });
+
+  it("clears the stored override through FastAPI with the encoded key", async () => {
+    mockRadonFetch.mockResolvedValueOnce({
+      preference: { ...ENTRY, source: "default", value: 500 },
+      store: STORE,
+    });
+    const { DELETE } = await loadRoute();
+    const res = await DELETE(
+      req("http://localhost/api/preferences?key=RADON_MAX_ORDER_QTY", { method: "DELETE" }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockRadonFetch).toHaveBeenCalledWith(
+      "/preferences/RADON_MAX_ORDER_QTY?updated_by=user_x",
+      expect.objectContaining({ method: "DELETE", timeout: 15_000 }),
+    );
+    const body = (await jsonOf(res)) as { preference: Record<string, unknown> };
+    expect(body.preference.source).toBe("default");
+  });
+
+  it("returns 400 VALIDATION_ERROR when the key query param is missing", async () => {
+    const { DELETE } = await loadRoute();
+    const res = await DELETE(req("http://localhost/api/preferences", { method: "DELETE" }));
+    expect(res.status).toBe(400);
+    const body = await jsonOf(res);
+    expect(body.code).toBe("VALIDATION_ERROR");
+    expect(body.error).toBe("key is required");
+    expect(mockRadonFetch).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// web/lib/preferences.ts helpers
+// ---------------------------------------------------------------------------
+
+describe("preferences client helpers", () => {
+  const boolEntry = {
+    ...ENTRY,
+    key: "RADON_KB_EMBED_DISABLED",
+    group: "Feature Flags",
+    value_type: "bool" as const,
+    value: true,
+    default: false,
+    hard_min: false,
+    hard_max: true,
+    unit: "",
+    applies_immediately: false,
+  };
+
+  it("groupPreferences respects the declared group order and drops empty groups", async () => {
+    const { groupPreferences } = await import("../lib/preferences");
+    const grouped = groupPreferences(
+      [
+        { ...ENTRY, key: "A" },
+        { ...boolEntry, key: "B" },
+        { ...ENTRY, key: "C", group: "Zebra" },
+      ] as never,
+      ["Order Limits", "Scanning", "Feature Flags"],
+    );
+    expect(grouped.map((g) => g.group)).toEqual(["Order Limits", "Feature Flags", "Zebra"]);
+    expect(grouped[0].entries.map((e) => e.key)).toEqual(["A"]);
+  });
+
+  it("formatPreferenceValue renders booleans and appends the unit", async () => {
+    const { formatPreferenceValue } = await import("../lib/preferences");
+    expect(formatPreferenceValue(boolEntry as never, true)).toBe("On");
+    expect(formatPreferenceValue(boolEntry as never, false)).toBe("Off");
+    expect(formatPreferenceValue(ENTRY as never, 5000)).toBe("5,000 contracts");
+    expect(
+      formatPreferenceValue({ ...ENTRY, value_type: "float", unit: "USD" } as never, 250000.5),
+    ).toBe("250,000.5 USD");
+  });
+
+  it("parsePreferenceInput rejects empty, non-numeric, non-integral and out-of-band values", async () => {
+    const { parsePreferenceInput } = await import("../lib/preferences");
+    expect(parsePreferenceInput(ENTRY as never, "   ")).toEqual({ error: "value is required" });
+    expect(parsePreferenceInput(ENTRY as never, "abc")).toEqual({ error: "value must be a number" });
+    expect(parsePreferenceInput(ENTRY as never, "400.5")).toEqual({
+      error: "value must be a whole number",
+    });
+    expect(parsePreferenceInput(ENTRY as never, "9000")).toEqual({
+      error: "value must be between 1 and 5000",
+    });
+    expect(parsePreferenceInput(ENTRY as never, " 400 ")).toEqual({ value: 400 });
+  });
+
+  it("savePreference throws PreferencesRequestError carrying the server code and message", async () => {
+    const { savePreference, PreferencesRequestError } = await import("../lib/preferences");
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ error: "RADON_MAX_ORDER_QTY must be between 1 and 5000 (got 9000)", code: "UPSTREAM_ERROR" }),
+        { status: 422, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+    await expect(savePreference("RADON_MAX_ORDER_QTY", 9000)).rejects.toBeInstanceOf(
+      PreferencesRequestError,
+    );
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/preferences",
+      expect.objectContaining({ method: "PUT" }),
+    );
+    vi.unstubAllGlobals();
+  });
+
+  it("fetchPreferences and resetPreference hit the proxy endpoints", async () => {
+    const { fetchPreferences, resetPreference } = await import("../lib/preferences");
+    const fetchSpy = vi.fn().mockImplementation(
+      async () =>
+        new Response(JSON.stringify(PAYLOAD), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+    await expect(fetchPreferences()).resolves.toEqual(PAYLOAD);
+    await resetPreference("RADON_MAX_ORDER_QTY");
+    expect(fetchSpy).toHaveBeenLastCalledWith(
+      "/api/preferences?key=RADON_MAX_ORDER_QTY",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+    vi.unstubAllGlobals();
+  });
+});

--- a/web/tests/preferences-section.test.tsx
+++ b/web/tests/preferences-section.test.tsx
@@ -1,0 +1,510 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * /preferences operator surface — shell registration + section behaviour.
+ *
+ * Part 1 pins the shared registration files by source inspection (modeled on
+ * tests/cta-page.test.ts): the WorkspaceSection union, the nav row, the quick
+ * prompts / description maps, the WorkspaceSections switch arm, the
+ * WorkspaceShell MetricCards exclusion, and the globals.css style block.
+ *
+ * Part 2 renders PreferencesSection against a mocked "@/lib/preferences" so
+ * this suite never depends on the network client implementation.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+
+const ROOT = join(__dirname, "..");
+const read = (rel: string) => readFileSync(join(ROOT, rel), "utf-8");
+
+// ---------------------------------------------------------------------------
+// "@/lib/preferences" mock. The pure helpers are implemented here to the
+// contract in the spec so the behaviour assertions stay meaningful; the three
+// network helpers are spies.
+// ---------------------------------------------------------------------------
+const mocks = vi.hoisted(() => {
+  class PreferencesRequestError extends Error {
+    readonly status: number;
+    readonly code: string;
+    constructor(status: number, code: string, message: string) {
+      super(message);
+      this.name = "PreferencesRequestError";
+      this.status = status;
+      this.code = code;
+    }
+  }
+  return {
+    PreferencesRequestError,
+    fetchPreferences: vi.fn(),
+    savePreference: vi.fn(),
+    resetPreference: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/preferences", () => ({
+  PreferencesRequestError: mocks.PreferencesRequestError,
+  fetchPreferences: mocks.fetchPreferences,
+  savePreference: mocks.savePreference,
+  resetPreference: mocks.resetPreference,
+  groupPreferences: (entries: any[], groups: string[]) => {
+    const known = groups.filter((g) => entries.some((e) => e.group === g));
+    const extra = Array.from(new Set(entries.map((e) => e.group)))
+      .filter((g) => !groups.includes(g))
+      .sort();
+    return [...known, ...extra].map((group) => ({
+      group,
+      entries: entries.filter((e) => e.group === group),
+    }));
+  },
+  formatPreferenceValue: (entry: any, value: number | boolean) => {
+    if (entry.value_type === "bool") {
+      return value ? "On" : "Off";
+    }
+    const n = Number(value);
+    const text = entry.value_type === "int"
+      ? new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(n)
+      : new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 }).format(n);
+    return entry.unit ? `${text} ${entry.unit}` : text;
+  },
+  parsePreferenceInput: (entry: any, raw: string) => {
+    const trimmed = raw.trim();
+    if (!trimmed) return { error: "value is required" };
+    const n = Number(trimmed);
+    if (!Number.isFinite(n)) return { error: "value must be a number" };
+    if (entry.value_type === "int" && !Number.isInteger(n)) {
+      return { error: "value must be a whole number" };
+    }
+    if (n < Number(entry.hard_min) || n > Number(entry.hard_max)) {
+      return { error: `value must be between ${entry.hard_min} and ${entry.hard_max}` };
+    }
+    return { value: n };
+  },
+}));
+
+import PreferencesSection from "@/components/PreferencesSection";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+type Entry = Record<string, unknown>;
+
+const QTY: Entry = {
+  key: "RADON_MAX_ORDER_QTY",
+  label: "Max contracts per order",
+  group: "Order Limits",
+  value_type: "int",
+  value: 400,
+  default: 500,
+  hard_min: 1,
+  hard_max: 5000,
+  unit: "contracts",
+  description: "Hard ceiling on contracts per options or combo order.",
+  applies_immediately: true,
+  source: "db",
+  db_rejected: false,
+  updated_at: "2026-08-11T17:02:11Z",
+  updated_by: "user_2abc",
+};
+
+const NOTIONAL: Entry = {
+  key: "RADON_MAX_ORDER_NOTIONAL",
+  label: "Max order notional",
+  group: "Order Limits",
+  value_type: "float",
+  value: 250000,
+  default: 250000,
+  hard_min: 1000,
+  hard_max: 5000000,
+  unit: "USD",
+  description: "Hard ceiling on dollar notional per order.",
+  applies_immediately: true,
+  source: "default",
+  db_rejected: false,
+  updated_at: null,
+  updated_by: null,
+};
+
+const KB: Entry = {
+  key: "RADON_KB_EMBED_DISABLED",
+  label: "Disable knowledge base embeddings",
+  group: "Feature Flags",
+  value_type: "bool",
+  value: false,
+  default: false,
+  hard_min: false,
+  hard_max: true,
+  unit: "",
+  description: "Turn off knowledge base vector embedding.",
+  applies_immediately: false,
+  source: "env",
+  db_rejected: false,
+  updated_at: null,
+  updated_by: null,
+};
+
+const WORKERS: Entry = {
+  key: "RADON_SCANNER_WORKERS",
+  label: "Watchlist scanner workers",
+  group: "Scanning",
+  value_type: "int",
+  value: 24,
+  default: 24,
+  hard_min: 1,
+  hard_max: 64,
+  unit: "threads",
+  description: "Concurrent worker threads for the watchlist scanner.",
+  applies_immediately: true,
+  source: "default",
+  db_rejected: false,
+  updated_at: null,
+  updated_by: null,
+};
+
+const STORE_OK = { available: true, error: null, checked_at: "2026-08-11T17:02:11Z" };
+
+function payload(overrides: Record<string, unknown> = {}) {
+  return {
+    preferences: [
+      structuredClone(QTY),
+      structuredClone(NOTIONAL),
+      structuredClone(WORKERS),
+      structuredClone(KB),
+    ],
+    groups: ["Order Limits", "Scanning", "Feature Flags"],
+    store: { ...STORE_OK },
+    generated_at: "2026-08-11T17:02:11Z",
+    ...overrides,
+  };
+}
+
+async function renderSection(p = payload()) {
+  mocks.fetchPreferences.mockResolvedValue(p);
+  render(<PreferencesSection />);
+  await screen.findByTestId("preference-row-RADON_MAX_ORDER_QTY");
+}
+
+beforeEach(() => {
+  mocks.fetchPreferences.mockReset();
+  mocks.savePreference.mockReset();
+  mocks.resetPreference.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ===========================================================================
+// Part 1 — shell registration, source inspection
+// ===========================================================================
+
+describe("shell registration", () => {
+  it("1. lib/types.ts WorkspaceSection union contains preferences", () => {
+    expect(read("lib/types.ts")).toMatch(/WorkspaceSection[^;]*"preferences"/s);
+  });
+
+  it("2. lib/data.ts navItems has a visible preferences row right after admin", async () => {
+    const { navItems } = await import("@/lib/data");
+    const prefs = navItems.find((n) => n.route === "preferences");
+    expect(prefs).toBeDefined();
+    expect(prefs?.href).toBe("/preferences");
+    expect(prefs?.group).toBe("operations");
+    expect(prefs?.hidden).toBeFalsy();
+    const routes = navItems.map((n) => n.route);
+    expect(routes.indexOf("preferences")).toBe(routes.indexOf("admin") + 1);
+  });
+
+  it("3. quickPrompts + description are populated and free of em dashes", async () => {
+    const { quickPromptsBySection, sectionDescription } = await import("@/lib/data");
+    const prompts = quickPromptsBySection.preferences;
+    expect(Array.isArray(prompts)).toBe(true);
+    expect(prompts.length).toBeGreaterThan(0);
+    for (const prompt of prompts) {
+      expect(typeof prompt).toBe("string");
+      expect(prompt.length).toBeGreaterThan(0);
+    }
+    const description = sectionDescription.preferences;
+    expect(typeof description).toBe("string");
+    expect(description.length).toBeGreaterThan(0);
+    expect(description).not.toContain("—");
+  });
+
+  it("4. WorkspaceSections renders the preferences arm", () => {
+    const src = read("components/WorkspaceSections.tsx");
+    expect(src).toContain('case "preferences"');
+    expect(src).toMatch(/import PreferencesSection from/);
+  });
+
+  it("5. WorkspaceShell excludes MetricCards and leaves headerOwnsPageHeading alone", () => {
+    const src = read("components/WorkspaceShell.tsx");
+    expect(src).toMatch(/activeSection !== "preferences"/);
+    const headerBlock = src.slice(
+      src.indexOf("const headerOwnsPageHeading"),
+      src.indexOf("const headerOwnsPageHeading") + 400,
+    );
+    expect(headerBlock).not.toContain("preferences");
+  });
+
+  it("6. globals.css preferences block uses brand tokens only, radius <= 4px", () => {
+    const css = read("app/globals.css");
+    const blocks = css.match(/[^{}]*\.preferences-[^{}]*\{[^}]*\}/g) ?? [];
+    expect(blocks.length).toBeGreaterThan(0);
+    for (const block of blocks) {
+      expect(block).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
+      expect(block).not.toMatch(/\brgba?\(/);
+      for (const m of block.matchAll(/border-radius:\s*([0-9.]+)px/g)) {
+        expect(Number(m[1])).toBeLessThanOrEqual(4);
+      }
+    }
+  });
+
+  it("7. resolveSectionFromPath maps /preferences", async () => {
+    const { resolveSectionFromPath } = await import("@/lib/chat");
+    expect(resolveSectionFromPath("/preferences", "dashboard")).toBe("preferences");
+  });
+});
+
+// ===========================================================================
+// Part 2 — PreferencesSection behaviour
+// ===========================================================================
+
+describe("PreferencesSection", () => {
+  it("8. renders one card per group and one row per entry", async () => {
+    await renderSection();
+    expect(screen.getByTestId("preferences-group-order-limits")).toBeTruthy();
+    expect(screen.getByTestId("preferences-group-feature-flags")).toBeTruthy();
+    expect(screen.getByTestId("preference-row-RADON_MAX_ORDER_QTY")).toBeTruthy();
+    expect(screen.getByTestId("preference-row-RADON_MAX_ORDER_NOTIONAL")).toBeTruthy();
+    expect(screen.getByTestId("preference-row-RADON_KB_EMBED_DISABLED")).toBeTruthy();
+  });
+
+  it("9. renders the source badge, default and allowed range", async () => {
+    await renderSection();
+    expect(screen.getByTestId("preference-source-RADON_MAX_ORDER_QTY").textContent).toBe("DB");
+    expect(screen.getByTestId("preference-source-RADON_MAX_ORDER_NOTIONAL").textContent).toBe("DEFAULT");
+    expect(screen.getByTestId("preference-source-RADON_KB_EMBED_DISABLED").textContent).toBe("ENV");
+    expect(screen.getByTestId("preference-default-RADON_MAX_ORDER_QTY").textContent).toContain("500 contracts");
+    expect(screen.getByTestId("preference-range-RADON_MAX_ORDER_QTY").textContent).toContain("1 to 5000");
+    expect(screen.getByTestId("preference-range-RADON_KB_EMBED_DISABLED").textContent).toContain("On or Off");
+  });
+
+  it("10. renders RESTART REQUIRED only for applies_immediately false entries", async () => {
+    await renderSection();
+    expect(screen.getByTestId("preference-restart-badge-RADON_KB_EMBED_DISABLED")).toBeTruthy();
+    expect(screen.queryByTestId("preference-restart-badge-RADON_MAX_ORDER_QTY")).toBeNull();
+  });
+
+  it("11. Save is disabled until the input changes and re-disables on revert", async () => {
+    await renderSection();
+    const input = screen.getByTestId("preference-input-RADON_MAX_ORDER_QTY") as HTMLInputElement;
+    const save = screen.getByTestId("preference-save-RADON_MAX_ORDER_QTY") as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+    fireEvent.change(input, { target: { value: "450" } });
+    expect(save.disabled).toBe(false);
+    fireEvent.change(input, { target: { value: "400" } });
+    expect(save.disabled).toBe(true);
+  });
+
+  it("12. Save calls savePreference and re-renders the row from the response", async () => {
+    await renderSection();
+    mocks.savePreference.mockResolvedValue({
+      preference: { ...structuredClone(NOTIONAL), value: 200000, source: "db", updated_by: "user_2abc" },
+      store: { ...STORE_OK },
+    });
+    const input = screen.getByTestId("preference-input-RADON_MAX_ORDER_NOTIONAL") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "200000" } });
+    fireEvent.click(screen.getByTestId("preference-save-RADON_MAX_ORDER_NOTIONAL"));
+    await waitFor(() => {
+      expect(screen.getByTestId("preference-source-RADON_MAX_ORDER_NOTIONAL").textContent).toBe("DB");
+    });
+    expect(mocks.savePreference).toHaveBeenCalledTimes(1);
+    expect(mocks.savePreference).toHaveBeenCalledWith("RADON_MAX_ORDER_NOTIONAL", 200000);
+    expect((screen.getByTestId("preference-input-RADON_MAX_ORDER_NOTIONAL") as HTMLInputElement).value).toBe("200000");
+  });
+
+  it("13. a rejected save renders the server message and keeps the server value", async () => {
+    await renderSection();
+    const message = "RADON_MAX_ORDER_QTY must be between 1 and 2500 (got 9000)";
+    mocks.savePreference.mockRejectedValue(new mocks.PreferencesRequestError(422, "OUT_OF_RANGE", message));
+    const input = screen.getByTestId("preference-input-RADON_MAX_ORDER_QTY") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "350" } });
+    fireEvent.click(screen.getByTestId("preference-save-RADON_MAX_ORDER_QTY"));
+    const err = await screen.findByTestId("preference-error-RADON_MAX_ORDER_QTY");
+    expect(err.textContent).toBe(message);
+    expect(err.getAttribute("role")).toBe("alert");
+    expect(screen.getByTestId("preference-source-RADON_MAX_ORDER_QTY").textContent).toBe("DB");
+    expect(screen.getByTestId("preference-default-RADON_MAX_ORDER_QTY").textContent).toContain("500 contracts");
+  });
+
+  it("14. Reset calls resetPreference and is disabled when source is not db", async () => {
+    await renderSection();
+    expect((screen.getByTestId("preference-reset-RADON_MAX_ORDER_NOTIONAL") as HTMLButtonElement).disabled).toBe(true);
+    const reset = screen.getByTestId("preference-reset-RADON_MAX_ORDER_QTY") as HTMLButtonElement;
+    expect(reset.disabled).toBe(false);
+    mocks.resetPreference.mockResolvedValue({
+      preference: { ...structuredClone(QTY), value: 500, source: "default", updated_at: null, updated_by: null },
+      store: { ...STORE_OK },
+    });
+    fireEvent.click(reset);
+    await waitFor(() => {
+      expect(screen.getByTestId("preference-source-RADON_MAX_ORDER_QTY").textContent).toBe("DEFAULT");
+    });
+    expect(mocks.resetPreference).toHaveBeenCalledWith("RADON_MAX_ORDER_QTY");
+    expect((screen.getByTestId("preference-input-RADON_MAX_ORDER_QTY") as HTMLInputElement).value).toBe("500");
+  });
+
+  it("15. client-side validation blocks Save without calling the API", async () => {
+    await renderSection();
+    const input = screen.getByTestId("preference-input-RADON_MAX_ORDER_QTY") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "9000" } });
+    expect(screen.getByTestId("preference-error-RADON_MAX_ORDER_QTY").textContent).toBe("value must be between 1 and 5000");
+    expect((screen.getByTestId("preference-save-RADON_MAX_ORDER_QTY") as HTMLButtonElement).disabled).toBe(true);
+    expect(mocks.savePreference).not.toHaveBeenCalled();
+  });
+
+  it("16. an unavailable store renders the banner and disables every control", async () => {
+    await renderSection(payload({ store: { available: false, error: "HranaHttpError: down", checked_at: null } }));
+    expect(screen.getByTestId("preferences-store-banner")).toBeTruthy();
+    for (const key of ["RADON_MAX_ORDER_QTY", "RADON_MAX_ORDER_NOTIONAL", "RADON_KB_EMBED_DISABLED"]) {
+      expect((screen.getByTestId(`preference-save-${key}`) as HTMLButtonElement).disabled).toBe(true);
+      expect((screen.getByTestId(`preference-reset-${key}`) as HTMLButtonElement).disabled).toBe(true);
+    }
+    expect((screen.getByTestId("preference-group-save-order-limits") as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("17. bool rows render a checkbox (not role=switch) and save true", async () => {
+    await renderSection();
+    const box = screen.getByTestId("preference-input-RADON_KB_EMBED_DISABLED") as HTMLInputElement;
+    expect(box.type).toBe("checkbox");
+    expect(screen.queryAllByRole("switch").length).toBe(0);
+    mocks.savePreference.mockResolvedValue({
+      preference: { ...structuredClone(KB), value: true, source: "db" },
+      store: { ...STORE_OK },
+    });
+    fireEvent.click(box);
+    fireEvent.click(screen.getByTestId("preference-save-RADON_KB_EMBED_DISABLED"));
+    await waitFor(() => {
+      expect(mocks.savePreference).toHaveBeenCalledWith("RADON_KB_EMBED_DISABLED", true);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("preference-source-RADON_KB_EMBED_DISABLED").textContent).toBe("DB");
+    });
+  });
+
+  it("18. a db_rejected entry renders the ignored badge", async () => {
+    const p = payload();
+    (p.preferences[0] as Record<string, unknown>).db_rejected = true;
+    await renderSection(p);
+    expect(screen.getByTestId("preference-rejected-RADON_MAX_ORDER_QTY")).toBeTruthy();
+    expect(screen.queryByTestId("preference-rejected-RADON_KB_EMBED_DISABLED")).toBeNull();
+  });
+
+  it("19. a failed initial fetch renders the page error, not a blank shell", async () => {
+    mocks.fetchPreferences.mockRejectedValue(new mocks.PreferencesRequestError(502, "UPSTREAM_ERROR", "preferences request failed"));
+    render(<PreferencesSection />);
+    const err = await screen.findByTestId("preferences-error");
+    expect(err.textContent).toBe("preferences request failed");
+    expect(err.getAttribute("role")).toBe("alert");
+  });
+
+  // -------------------------------------------------------------------------
+  // Widening a risk cap is the one destructive edit on this page: an extra
+  // zero in Max order notional silently quadruples the fat-finger stop. It
+  // gets the same type-to-confirm gate the gateway Stop control uses.
+  // -------------------------------------------------------------------------
+
+  it("20. raising an Order Limits cap requires typed confirmation before it saves", async () => {
+    await renderSection();
+    fireEvent.change(screen.getByTestId("preference-input-RADON_MAX_ORDER_NOTIONAL"), {
+      target: { value: "900000" },
+    });
+    fireEvent.click(screen.getByTestId("preference-save-RADON_MAX_ORDER_NOTIONAL"));
+
+    expect(mocks.savePreference).not.toHaveBeenCalled();
+    await screen.findByTestId("preference-widen-confirm");
+    // ConfirmDialog portals to document.body, so assert on the portal content.
+    expect(document.body.textContent).toContain("RADON_MAX_ORDER_NOTIONAL");
+    expect(document.body.textContent).toContain("Widen a risk cap");
+  });
+
+  it("21. the widen confirmation saves once the key is typed", async () => {
+    await renderSection();
+    mocks.savePreference.mockResolvedValue({
+      preference: { ...structuredClone(NOTIONAL), value: 900000, source: "db" },
+      store: { ...STORE_OK },
+    });
+    fireEvent.change(screen.getByTestId("preference-input-RADON_MAX_ORDER_NOTIONAL"), {
+      target: { value: "900000" },
+    });
+    fireEvent.click(screen.getByTestId("preference-save-RADON_MAX_ORDER_NOTIONAL"));
+
+    await screen.findByTestId("preference-widen-confirm");
+    fireEvent.change(screen.getByTestId("admin-confirm-typed-input"), {
+      target: { value: "RADON_MAX_ORDER_NOTIONAL" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /widen cap/i }));
+
+    await waitFor(() => {
+      expect(mocks.savePreference).toHaveBeenCalledWith("RADON_MAX_ORDER_NOTIONAL", 900000);
+    });
+  });
+
+  it("22. cancelling the widen confirmation leaves the cap untouched", async () => {
+    await renderSection();
+    fireEvent.change(screen.getByTestId("preference-input-RADON_MAX_ORDER_NOTIONAL"), {
+      target: { value: "900000" },
+    });
+    fireEvent.click(screen.getByTestId("preference-save-RADON_MAX_ORDER_NOTIONAL"));
+    await screen.findByTestId("preference-widen-confirm");
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("preference-widen-confirm")).toBeNull();
+    });
+    expect(mocks.savePreference).not.toHaveBeenCalled();
+  });
+
+  it("23. LOWERING an Order Limits cap saves without confirmation", async () => {
+    await renderSection();
+    mocks.savePreference.mockResolvedValue({
+      preference: { ...structuredClone(NOTIONAL), value: 100000, source: "db" },
+      store: { ...STORE_OK },
+    });
+    fireEvent.change(screen.getByTestId("preference-input-RADON_MAX_ORDER_NOTIONAL"), {
+      target: { value: "100000" },
+    });
+    fireEvent.click(screen.getByTestId("preference-save-RADON_MAX_ORDER_NOTIONAL"));
+
+    await waitFor(() => {
+      expect(mocks.savePreference).toHaveBeenCalledWith("RADON_MAX_ORDER_NOTIONAL", 100000);
+    });
+    expect(screen.queryByTestId("preference-widen-confirm")).toBeNull();
+  });
+
+  it("24. raising a non-risk preference saves without confirmation", async () => {
+    await renderSection();
+    mocks.savePreference.mockResolvedValue({
+      preference: { ...structuredClone(WORKERS), value: 40, source: "db" },
+      store: { ...STORE_OK },
+    });
+    fireEvent.change(screen.getByTestId("preference-input-RADON_SCANNER_WORKERS"), {
+      target: { value: "40" },
+    });
+    fireEvent.click(screen.getByTestId("preference-save-RADON_SCANNER_WORKERS"));
+
+    await waitFor(() => {
+      expect(mocks.savePreference).toHaveBeenCalledWith("RADON_SCANNER_WORKERS", 40);
+    });
+    expect(screen.queryByTestId("preference-widen-confirm")).toBeNull();
+  });
+
+  it("25. the unit is not repeated beside the input", async () => {
+    await renderSection();
+    const control = screen
+      .getByTestId("preference-row-RADON_MAX_ORDER_QTY")
+      .querySelector(".preferences-row__control");
+    expect(control).toBeTruthy();
+    expect(control?.textContent ?? "").not.toContain("contracts");
+  });
+});


### PR DESCRIPTION
Makes `RADON_MAX_ORDER_NOTIONAL` and its siblings settable from the UI instead of requiring an edit to `~/radon-cloud/.env` on Hetzner plus a `radon-api` restart.

## What ships

New `/preferences` page (Operations group, next to Operator) over a DB-backed registry in `scripts/app_preferences.py`. Eight keys, all read at call time by `radon-api` or a subprocess inheriting its environment:

| Group | Keys |
|---|---|
| Order Limits | `RADON_MAX_ORDER_QTY`, `RADON_MAX_STOCK_ORDER_QTY`, `RADON_MAX_ORDER_NOTIONAL`, `RADON_MAX_ORDERS_PER_MIN`, `RADON_WORKFLOW_MAX_ORDERS` |
| Scanning | `RADON_SCANNER_WORKERS`, `RADON_THETA_SCANNER_WORKERS`, `RADON_STRENGTH_SCANNER_WORKERS` |

## Safety properties

- **A stored value can never widen a cap.** Resolution is DB row > env var > code default. An env value outside the registry band is clamped into it; a DB value outside the band is **discarded**. The check is on the read path, so editing the Turso row directly cannot raise a cap. Verified live: a hand-written `99000000.0` notional row resolved to the 250,000 default with `db_rejected: true`.
- **The order path never gains inline I/O.** `resolve()`/`get_*()` read a process-local snapshot, never block and never raise. A dead Turso falls back to env/default, never to unlimited.
- **Short-lived processes never touch the store.** Background refresh is opt-in and enabled only in the `radon-api` lifespan; `ib_place_order.py` (a fresh interpreter per order) reads the environment overlay `bootstrap()` published at startup.
- **Every mutation is audited before it is applied.** `set`/`clear` write the append-only `app_preference_events` first; a failed audit write refuses the change. The actor comes from the authenticated principal, never the request body.
- **Widening takes type-to-confirm.** Raising an Order Limits value opens the same typed-confirmation dialog as the gateway Stop control. Lowering one saves directly.
- Hard bands are a small multiple of each default, so going past them stays a deliberate code change.

## Migration

`0046_app_preferences.sql` (`app_preferences` + `app_preference_events`). **Already applied to Turso** and verified, so the deploy's `migrate.py` run is a no-op.

## Verification

- pytest 5467 passed, 1 skipped
- vitest 5586 passed across 539 files
- `tsc --noEmit` clean
- Live browser check in dark and light against a real FastAPI: 8 rows / 2 groups, no horizontal overflow, widen dialog fires 0 PUTs until the key is typed then exactly one, lowering saves without a prompt
- Full API round-trip by curl: set, out-of-band 422, unknown-key 404, wrong-type 422, reset, and audit rows landing in Turso

## Notes for review

- Five keys from the first draft were cut: they are consumed only by standalone systemd units with their own `EnvironmentFile` and would never have seen a change. The registry test now fails if an inert key is added.
- Two audit rows from live verification remain in `app_preference_events`. Left in place rather than deleted from an append-only log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)