### PR TITLE
fix(chain): keep the order builder when the expiry dropdown changes

### DIFF
--- a/web/components/mobile/MobileChainLadder.tsx
+++ b/web/components/mobile/MobileChainLadder.tsx
@@ -369,14 +369,17 @@ export default function MobileChainLadder({
   const pendingIsCredit = pendingSignedNet != null ? pendingSignedNet < 0 : null;
 
   // P5: (strike,right) -> BUY/SELL for the active order legs, so the ladder can
-  // tint the cells that are already in the pending order.
+  // tint the cells that are already in the pending order. Scoped to the visible
+  // expiry — the builder survives an expiry change, so a leg from another
+  // expiry must not tint (and appear tappable-off on) this ladder.
   const legActionByKey = useMemo(() => {
     const map = new Map<string, "BUY" | "SELL">();
     for (const leg of orderLegs) {
+      if (leg.expiry !== selectedExpiry) continue;
       map.set(`${leg.strike}_${leg.right}`, leg.action);
     }
     return map;
-  }, [orderLegs]);
+  }, [orderLegs, selectedExpiry]);
 
   const expiryChips = useMemo(() => expirations.slice(0, 24), [expirations]);
   const showCalls = sideFilter !== "puts";

--- a/web/components/ticker-detail/OptionsChainTab.tsx
+++ b/web/components/ticker-detail/OptionsChainTab.tsx
@@ -1229,10 +1229,7 @@ export default function OptionsChainTab({
         ticker={ticker}
         expirations={expirations}
         selectedExpiry={selectedExpiry}
-        onSelectExpiry={(expiry) => {
-          setSelectedExpiry(expiry);
-          setOrderLegs([]);
-        }}
+        onSelectExpiry={(expiry) => setSelectedExpiry(expiry)}
         visibleStrikes={visibleStrikes}
         atmStrike={atmStrike}
         prices={prices}
@@ -1271,10 +1268,10 @@ export default function OptionsChainTab({
         <select
           className="chain-expiry-select"
           value={selectedExpiry ?? ""}
-          onChange={(e) => {
-            setSelectedExpiry(e.target.value || null);
-            setOrderLegs([]);
-          }}
+          // Browsing expiries must NOT wipe the builder — legs carry their own
+          // expiry through to the combo payload (calendars are legitimate).
+          // CLEAR is the only thing that empties it.
+          onChange={(e) => setSelectedExpiry(e.target.value || null)}
         >
           {expirations.map((exp) => (
             <option key={exp} value={exp}>

--- a/web/e2e/chain-expiry-preserves-builder.spec.ts
+++ b/web/e2e/chain-expiry-preserves-builder.spec.ts
@@ -1,0 +1,213 @@
+/**
+ * E2E: switching the chain EXPIRY dropdown must not wipe the order builder.
+ *
+ * Repro: build a leg on the near expiry, then pick a different expiry from the
+ * dropdown. The builder used to be cleared on every expiry change, so any work
+ * in progress vanished the moment the user looked at another date.
+ */
+
+import { test, expect } from "@playwright/test";
+
+const TICKER = "MU";
+const NEAR = "20260821";
+const FAR = "20260918";
+
+const PORTFOLIO_EMPTY = {
+  bankroll: 1_000_000,
+  peak_value: 1_000_000,
+  last_sync: new Date().toISOString(),
+  total_deployed_pct: 0,
+  total_deployed_dollars: 0,
+  remaining_capacity_pct: 100,
+  position_count: 0,
+  defined_risk_count: 0,
+  undefined_risk_count: 0,
+  avg_kelly_optimal: null,
+  exposure: {},
+  violations: [],
+  positions: [],
+};
+
+const ORDERS_EMPTY = {
+  last_sync: new Date().toISOString(),
+  open_orders: [],
+  executed_orders: [],
+  open_count: 0,
+  executed_count: 0,
+};
+
+function quote(symbol: string, bid: number, ask: number, last: number) {
+  return {
+    symbol,
+    last,
+    lastIsCalculated: false,
+    bid,
+    ask,
+    bidSize: 25,
+    askSize: 25,
+    volume: 1_000,
+    high: null,
+    low: null,
+    open: null,
+    close: last,
+    week52High: null,
+    week52Low: null,
+    avgVolume: null,
+    delta: 0.4,
+    gamma: null,
+    theta: null,
+    vega: null,
+    impliedVol: 0.45,
+    undPrice: 120,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+const PRICE_FIXTURES: Record<string, unknown> = {
+  [TICKER]: quote(TICKER, 119.9, 120.1, 120),
+  [`${TICKER}_${NEAR}_125_C`]: quote(`${TICKER}_${NEAR}_125_C`, 3.1, 3.5, 3.3),
+  [`${TICKER}_${FAR}_125_C`]: quote(`${TICKER}_${FAR}_125_C`, 5.1, 5.5, 5.3),
+};
+
+/**
+ * Only the price relay is mocked. The Next dev server's own HMR socket must
+ * keep the native implementation — it calls `addEventListener`, which a bare
+ * on*-handler stub does not have, and the resulting TypeError tears down the
+ * page before the chain ever loads.
+ */
+function installMockWebSocket(page: import("@playwright/test").Page) {
+  return page.addInitScript((priceFixtures) => {
+    const NativeWebSocket = window.WebSocket;
+    const isRelay = (url: string) => url.includes(":8765") || url.includes("/ws");
+
+    class MockWebSocket {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+      url: string;
+      readyState = MockWebSocket.CONNECTING;
+      onopen: ((event?: unknown) => void) | null = null;
+      onmessage: ((event: { data: string }) => void) | null = null;
+      onclose: ((event?: unknown) => void) | null = null;
+      onerror: ((event?: unknown) => void) | null = null;
+      constructor(url: string) {
+        this.url = url;
+        setTimeout(() => {
+          this.readyState = MockWebSocket.OPEN;
+          this.onopen?.({});
+          this.emit({
+            type: "status",
+            ib_connected: true,
+            ib_issue: null,
+            ib_status_message: null,
+            subscriptions: [],
+          });
+        }, 0);
+      }
+      addEventListener(type: string, listener: (event: unknown) => void) {
+        if (type === "open") this.onopen = listener;
+        if (type === "message") this.onmessage = listener as (e: { data: string }) => void;
+        if (type === "close") this.onclose = listener;
+        if (type === "error") this.onerror = listener;
+      }
+      removeEventListener() {}
+      send(raw: string) {
+        const message = JSON.parse(raw) as {
+          action?: string;
+          symbols?: string[];
+          contracts?: Array<{ symbol: string; expiry: string; strike: number; right: "C" | "P" }>;
+        };
+        if (message.action !== "subscribe") return;
+        const updates: Record<string, unknown> = {};
+        for (const symbol of message.symbols ?? []) {
+          if (priceFixtures[symbol]) updates[symbol] = priceFixtures[symbol];
+        }
+        for (const contract of message.contracts ?? []) {
+          const expiry = String(contract.expiry).replace(/-/g, "");
+          const key = `${String(contract.symbol).toUpperCase()}_${expiry}_${Number(contract.strike)}_${contract.right}`;
+          if (priceFixtures[key]) updates[key] = priceFixtures[key];
+        }
+        if (Object.keys(updates).length > 0) this.emit({ type: "batch", updates });
+      }
+      close() {
+        this.readyState = MockWebSocket.CLOSED;
+        this.onclose?.({});
+      }
+      emit(payload: unknown) {
+        this.onmessage?.({ data: JSON.stringify(payload) });
+      }
+    }
+    // @ts-expect-error test-only replacement
+    window.WebSocket = function (url: string, protocols?: string | string[]) {
+      // @ts-expect-error test-only replacement
+      return isRelay(String(url)) ? new MockWebSocket(String(url)) : new NativeWebSocket(url, protocols);
+    };
+    Object.assign(window.WebSocket, {
+      CONNECTING: 0,
+      OPEN: 1,
+      CLOSING: 2,
+      CLOSED: 3,
+    });
+  }, PRICE_FIXTURES);
+}
+
+async function stubApis(page: import("@playwright/test").Page) {
+  const json = (body: unknown) => ({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+  await page.route("**/api/portfolio", (route) => route.fulfill(json(PORTFOLIO_EMPTY)));
+  await page.route("**/api/orders", (route) => route.fulfill(json(ORDERS_EMPTY)));
+  await page.route("**/api/regime", (route) => route.fulfill(json({ score: 15, cri: { score: 15 } })));
+  await page.route("**/api/ib-status", (route) => route.fulfill(json({ connected: true })));
+  await page.route("**/api/blotter", (route) =>
+    route.fulfill(
+      json({ as_of: new Date().toISOString(), summary: { realized_pnl: 0 }, closed_trades: [], open_trades: [] }),
+    ),
+  );
+  await page.route("**/api/ticker/**", (route) =>
+    route.fulfill(json({ uw_info: { name: "Micron Technology", sector: "Technology" }, stock_state: {}, profile: {}, stats: {} })),
+  );
+  await page.route("**/api/options/expirations*", (route) =>
+    route.fulfill(json({ symbol: TICKER, expirations: [NEAR, FAR] })),
+  );
+  await page.route("**/api/options/chain*", (route) => {
+    const expiry = new URL(route.request().url()).searchParams.get("expiry") ?? NEAR;
+    return route.fulfill(json({ symbol: TICKER, expiry, exchange: "SMART", strikes: [115, 120, 125], multiplier: "100" }));
+  });
+}
+
+test.describe("Options chain expiry switch", () => {
+  test("keeps the order builder and its legs when the expiry changes", async ({ page }) => {
+    await page.unrouteAll({ behavior: "ignoreErrors" });
+    await installMockWebSocket(page);
+    await stubApis(page);
+
+    await page.goto(`/${TICKER}?tab=chain`);
+
+    const detail = page.locator(".ticker-detail-page");
+    await detail.waitFor({ timeout: 15_000 });
+    await detail.locator(".chain-grid").waitFor();
+
+    const expirySelect = detail.locator("select.chain-expiry-select").first();
+    await expect(expirySelect).toHaveValue(NEAR);
+
+    const row125 = detail.getByRole("row", { name: /\$125\.00/ }).first();
+    await row125.locator(".chain-mid.chain-clickable").first().click();
+
+    const orderBuilder = detail.locator(".order-builder");
+    await expect(orderBuilder).toBeVisible();
+    await expect(orderBuilder).toContainText("1x $125 Call");
+    await page.screenshot({ path: "test-results/chain-expiry-before.png", fullPage: false });
+
+    await expirySelect.selectOption(FAR);
+    await expect(expirySelect).toHaveValue(FAR);
+
+    await expect(orderBuilder).toBeVisible();
+    await expect(orderBuilder).toContainText("1x $125 Call");
+    await expect(orderBuilder.locator('[data-testid="order-builder-leg"]')).toHaveCount(1);
+    await page.screenshot({ path: "test-results/chain-expiry-after.png", fullPage: false });
+  });
+});

--- a/web/tests/chain-expiry-preserves-legs.test.tsx
+++ b/web/tests/chain-expiry-preserves-legs.test.tsx
@@ -1,0 +1,191 @@
+// @vitest-environment jsdom
+//
+// Changing the chain EXPIRY dropdown must NOT wipe the order builder. Legs
+// carry their own expiry all the way into the combo payload, so browsing to a
+// different expiry (or building a calendar) has to keep what is already there.
+// Only the explicit CLEAR control empties the builder.
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+
+import TickerDetailContent from "../components/TickerDetailContent";
+import { TickerDetailProvider } from "../lib/TickerDetailContext";
+import { OrderActionsProvider } from "../lib/OrderActionsContext";
+import type { OrdersData, PortfolioData } from "../lib/types";
+import type { PriceData } from "../lib/pricesProtocol";
+
+let searchParamsString = "";
+const replaceMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(searchParamsString),
+  usePathname: () => "/MU",
+  useRouter: () => ({
+    replace: replaceMock,
+    push: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock("../components/PriceChart", () => ({
+  default: () => React.createElement("div", { "data-testid": "price-chart" }),
+}));
+vi.mock("../components/QuoteTelemetry", () => ({
+  TickerQuoteTelemetry: () => React.createElement("div", { "data-testid": "quote-telemetry" }),
+}));
+
+const MU_PRICE: PriceData = {
+  symbol: "MU", last: 967.78, lastIsCalculated: false, bid: 967.5, ask: 968.0,
+  bidSize: 100, askSize: 100, volume: 1000, high: null, low: null, open: null,
+  close: 960, week52High: null, week52Low: null, avgVolume: null, delta: null,
+  gamma: null, theta: null, vega: null, impliedVol: null, undPrice: null,
+  timestamp: new Date().toISOString(),
+};
+
+const PORTFOLIO: PortfolioData = {
+  bankroll: 100_000, peak_value: 100_000, last_sync: new Date().toISOString(),
+  total_deployed_pct: 0, total_deployed_dollars: 0, remaining_capacity_pct: 100,
+  position_count: 0, defined_risk_count: 0, undefined_risk_count: 0,
+  avg_kelly_optimal: null, positions: [],
+};
+const ORDERS: OrdersData = {
+  last_sync: new Date().toISOString(), open_orders: [], executed_orders: [],
+  open_count: 0, executed_count: 0,
+};
+
+const fetchMock = vi.fn<typeof fetch>();
+
+function futureExpiry(days: number) {
+  const date = new Date();
+  date.setUTCHours(0, 0, 0, 0);
+  date.setUTCDate(date.getUTCDate() + days);
+  const dashed = date.toISOString().slice(0, 10);
+  return { dashed, compact: dashed.replaceAll("-", "") };
+}
+
+const NEAR_EXPIRY = futureExpiry(14);
+const FAR_EXPIRY = futureExpiry(42);
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve(
+    new Response(JSON.stringify(body), { status: 200, headers: { "Content-Type": "application/json" } }),
+  );
+}
+
+function renderChain() {
+  return render(
+    React.createElement(
+      OrderActionsProvider,
+      null,
+      React.createElement(
+        TickerDetailProvider,
+        null,
+        React.createElement(TickerDetailContent, {
+          ticker: "MU",
+          activeTab: "c",
+          onTabChange: vi.fn(),
+          prices: { MU: MU_PRICE },
+          fundamentals: {},
+          portfolio: PORTFOLIO,
+          orders: ORDERS,
+          theme: "dark",
+        }),
+      ),
+    ),
+  );
+}
+
+function findStrikeRow(strike: number) {
+  const strikeCell = Array.from(document.querySelectorAll("td.chain-strike")).find(
+    (cell) => Number((cell.textContent ?? "").replace(/[^0-9.]/g, "")) === strike,
+  );
+  if (!strikeCell) throw new Error(`No chain row for strike ${strike}`);
+  return strikeCell.closest("tr")!;
+}
+
+function clickCallAsk(strike: number) {
+  const row = findStrikeRow(strike);
+  // Call side renders first: bid (SELL), mid (BUY), ask (BUY).
+  const callAsk = row.querySelectorAll("td.chain-clickable")[2];
+  fireEvent.click(callAsk);
+}
+
+describe("Options chain expiry change", () => {
+  beforeEach(() => {
+    searchParamsString = "tab=chain";
+    replaceMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+    Object.defineProperty(Element.prototype, "scrollTo", { configurable: true, value: vi.fn() });
+    if (!("scrollIntoView" in HTMLElement.prototype)) {
+      Object.defineProperty(HTMLElement.prototype, "scrollIntoView", { configurable: true, value: vi.fn() });
+    } else {
+      vi.spyOn(HTMLElement.prototype, "scrollIntoView").mockImplementation(() => {});
+    }
+    fetchMock.mockImplementation((input) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : String(input.url);
+      if (url.includes("/api/options/expirations")) {
+        return jsonResponse({ symbol: "MU", expirations: [NEAR_EXPIRY.compact, FAR_EXPIRY.compact] });
+      }
+      if (url.includes("/api/options/chain")) {
+        const expiry = url.includes(FAR_EXPIRY.compact) ? FAR_EXPIRY.compact : NEAR_EXPIRY.compact;
+        return jsonResponse({ symbol: "MU", expiry, strikes: [950, 960, 970] });
+      }
+      if (url.includes("/api/risk-free-rate")) return jsonResponse({ rate: 0 });
+      if (url.includes("/api/ticker/info")) return jsonResponse({ stock_state: {}, uw_info: {}, profile: {}, stats: {} });
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps built legs when the expiry dropdown changes", async () => {
+    renderChain();
+
+    const expirySelect = (await screen.findAllByRole("combobox"))[0] as HTMLSelectElement;
+    await waitFor(() => expect(expirySelect.value).toBe(NEAR_EXPIRY.compact));
+    await waitFor(() => findStrikeRow(970));
+
+    clickCallAsk(970);
+
+    const builder = await waitFor(() => {
+      const el = document.querySelector(".order-builder");
+      if (!el) throw new Error("order builder not rendered");
+      return el as HTMLElement;
+    });
+    expect(builder.textContent).toContain("1x $970 Call");
+
+    fireEvent.change(expirySelect, { target: { value: FAR_EXPIRY.compact } });
+    await waitFor(() => expect(expirySelect.value).toBe(FAR_EXPIRY.compact));
+
+    const stillThere = document.querySelector(".order-builder") as HTMLElement | null;
+    expect(stillThere).not.toBeNull();
+    expect(stillThere!.textContent).toContain("1x $970 Call");
+    // The leg keeps the expiry it was built on, not the newly selected one.
+    expect(stillThere!.textContent).toContain(NEAR_EXPIRY.dashed);
+    expect(within(stillThere!).getAllByTestId("order-builder-leg").length).toBe(1);
+  });
+
+  it("clears the builder only on the explicit CLEAR control", async () => {
+    renderChain();
+
+    const expirySelect = (await screen.findAllByRole("combobox"))[0] as HTMLSelectElement;
+    await waitFor(() => expect(expirySelect.value).toBe(NEAR_EXPIRY.compact));
+    await waitFor(() => findStrikeRow(970));
+
+    clickCallAsk(970);
+    const builder = await waitFor(() => {
+      const el = document.querySelector(".order-builder");
+      if (!el) throw new Error("order builder not rendered");
+      return el as HTMLElement;
+    });
+
+    fireEvent.click(within(builder).getByRole("button", { name: /CLEAR/i }));
+    await waitFor(() => expect(document.querySelector(".order-builder")).toBeNull());
+  });
+});

--- a/web/tests/mobile-chain-leg-tint-expiry-scope.test.tsx
+++ b/web/tests/mobile-chain-leg-tint-expiry-scope.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+//
+// The mobile ladder tints cells that are already in the pending order. Since
+// the builder survives an expiry change, that tint MUST be scoped to the
+// visible expiry — otherwise a leg built on another expiry lights up an
+// unrelated strike on the current ladder.
+
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import MobileChainLadder from "../components/mobile/MobileChainLadder";
+import { optionKey } from "../lib/pricesProtocol";
+import type { OrderLeg } from "../lib/optionsChainUtils";
+
+const NEAR = "20260821";
+const FAR = "20260918";
+const TICKER = "MU";
+
+function strikeRow(strike: number) {
+  return {
+    strike,
+    callKey: optionKey({ symbol: TICKER, expiry: NEAR, strike, right: "C" }),
+    putKey: optionKey({ symbol: TICKER, expiry: NEAR, strike, right: "P" }),
+  };
+}
+
+function leg(expiry: string): OrderLeg {
+  return {
+    id: `${TICKER}_${expiry}_970_C`,
+    action: "BUY",
+    right: "C",
+    strike: 970,
+    expiry,
+    quantity: 1,
+    limitPrice: null,
+    priceManuallySet: false,
+  };
+}
+
+function renderLadder(legs: OrderLeg[]) {
+  Object.defineProperty(Element.prototype, "scrollTo", { configurable: true, value: vi.fn() });
+  return render(
+    React.createElement(MobileChainLadder, {
+      ticker: TICKER,
+      expirations: [NEAR, FAR],
+      selectedExpiry: NEAR,
+      onSelectExpiry: vi.fn(),
+      visibleStrikes: [strikeRow(960), strikeRow(970)],
+      atmStrike: 970,
+      prices: {},
+      currentPrice: 967.78,
+      sideFilter: "both" as const,
+      onSideFilterChange: vi.fn(),
+      strikesPerSide: 15,
+      onStrikesPerSideChange: vi.fn(),
+      orderLegs: legs,
+      portfolio: null,
+    }),
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("Mobile chain ladder leg tint", () => {
+  it("tints a cell whose leg is on the visible expiry", () => {
+    renderLadder([leg(NEAR)]);
+    const cell = screen.getByTestId("mobile-chain-call-970");
+    expect(cell.getAttribute("aria-pressed")).toBe("true");
+    expect(cell.className).toContain("mobile-chain__cell--selected-buy");
+  });
+
+  it("leaves the cell untinted when the leg belongs to another expiry", () => {
+    renderLadder([leg(FAR)]);
+    const cell = screen.getByTestId("mobile-chain-call-970");
+    expect(cell.getAttribute("aria-pressed")).toBe("false");
+    expect(cell.className).not.toContain("selected-buy");
+  });
+});


### PR DESCRIPTION
Changing EXPIRY on the options chain cleared every leg in the order builder, so any in-progress order vanished the moment the user looked at another date.

Legs already carry their own expiry through `detectStructure`, the risk gate, and the combo payload, so there is nothing to reset — CLEAR is the only control that empties the builder. Same fix on the mobile ladder's expiry chips; its pending-order tint is now scoped to the visible expiry so a leg from another date can't light up an unrelated strike.

Verification
- `tests/chain-expiry-preserves-legs.test.tsx` — red before the fix (builder gone after the switch), green after; second case pins that CLEAR still empties it.
- `tests/mobile-chain-leg-tint-expiry-scope.test.tsx` — red without the expiry guard.
- `e2e/chain-expiry-preserves-builder.spec.ts` — Playwright drives the real dropdown; screenshot confirms the chain moves to 2026-09-18 while the builder keeps `BUY 1x $125 Call 2026-08-21`.
- Full web vitest suite: 551 files / 5676 tests passing. tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xzwe38dMw6p3moQXnjDGUu