### PR TITLE
fix(book): keep implied-spread rows on one montage line

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -9423,6 +9423,39 @@ tr {
   border: 1px solid color-mix(in srgb, var(--fault) 45%, transparent);
 }
 
+/* implied combo montage — one leg-venue pair per row, rest behind a count.
+   The venue cell stays a single line at every width so combo rows keep the
+   same rhythm as the stock / option montage they sit beside. */
+.book-row .book-mkt {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  white-space: nowrap;
+}
+.book-side.ask .book-row .book-mkt { justify-content: flex-end; }
+.book-venue-lead { overflow: hidden; text-overflow: ellipsis; }
+.book-venue-more {
+  flex: 0 0 auto;
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  line-height: 1.3;
+  color: var(--text-muted);
+  background: color-mix(in srgb, var(--text-muted) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--text-muted) 30%, transparent);
+}
+.book-montage-body.is-combo .book-side.bid .book-colhead,
+.book-montage-body.is-combo .book-side.bid .book-row { grid-template-columns: 132px minmax(0, 1fr) 70px; column-gap: 8px; }
+.book-montage-body.is-combo .book-side.ask .book-colhead,
+.book-montage-body.is-combo .book-side.ask .book-row { grid-template-columns: 70px minmax(0, 1fr) 132px; column-gap: 8px; }
+.cockpit--mobile .book-montage-body.is-combo .book-side.bid .book-colhead,
+.cockpit--mobile .book-montage-body.is-combo .book-side.bid .book-row { grid-template-columns: 82px minmax(0, 1fr) 48px; column-gap: 6px; }
+.cockpit--mobile .book-montage-body.is-combo .book-side.ask .book-colhead,
+.cockpit--mobile .book-montage-body.is-combo .book-side.ask .book-row { grid-template-columns: 48px minmax(0, 1fr) 82px; column-gap: 6px; }
+
 /* futures centered ladder DOM */
 .book-ladder-head {
   display: grid;

--- a/web/components/ticker-detail/DepthMontage.tsx
+++ b/web/components/ticker-detail/DepthMontage.tsx
@@ -10,6 +10,24 @@ type MontageLevel = DepthLevel & { firstOfLevel: boolean };
 type PriceClick = (p: Omit<OrderPrefill, "nonce">) => void;
 
 /**
+ * An implied combo level aggregates every leg-venue pair quoting that net
+ * price, so its venue string can carry dozens of entries. Rendering the whole
+ * set wraps the cell into a tall block that breaks the montage row rhythm —
+ * show the leading pair and count the rest, full set on hover.
+ */
+function venueCell(venues: string, side: "bid" | "ask", isCombo: boolean) {
+  const pairs = isCombo ? venues.split(" | ") : [venues];
+  const overflow = pairs.length - 1;
+  return (
+    <span className="book-mkt" key="m" title={overflow > 0 ? venues : undefined}>
+      {side === "ask" && overflow > 0 && <span className="book-venue-more">+{overflow}</span>}
+      <span className="book-venue-lead">{pairs[0]}</span>
+      {side === "bid" && overflow > 0 && <span className="book-venue-more">+{overflow}</span>}
+    </span>
+  );
+}
+
+/**
  * Two-sided montage for stocks (exchange / MPID L2 depth) and options
  * (per-exchange BBO). The two render identically except: stocks draw the
  * price-level edge marker (`firstOfLevel`) and treat index 0 as best; options
@@ -48,14 +66,14 @@ export function DepthMontage({ book, onPriceClick }: { book: DepthBook; onPriceC
     const cells =
       side === "bid"
         ? [
-            <span className="book-mkt" key="m">{mkt}</span>,
+            venueCell(mkt, side, isCombo),
             <span className="book-shares" key="s">{level.size}</span>,
             priceCell,
           ]
         : [
             priceCell,
             <span className="book-shares" key="s">{level.size}</span>,
-            <span className="book-mkt" key="m">{mkt}</span>,
+            venueCell(mkt, side, isCombo),
           ];
     // Click-to-fill: hitting a BID level = you'd hit the bid -> SELL; an ASK
     // level = you'd lift the offer -> BUY. Price flows to the ticket's limit.
@@ -83,7 +101,7 @@ export function DepthMontage({ book, onPriceClick }: { book: DepthBook; onPriceC
   };
 
   return (
-    <div className={`book-montage-body${isOption ? " is-option" : ""}`}>
+    <div className={`book-montage-body${isOption ? " is-option" : ""}${isCombo ? " is-combo" : ""}`}>
       {isOption && (
         <p className="book-montage-note">
           OPRA top of book. Each row is one exchange&apos;s best quote, not stacked

--- a/web/tests/synthetic-combo-book-render.test.tsx
+++ b/web/tests/synthetic-combo-book-render.test.tsx
@@ -79,4 +79,65 @@ describe("generalized implied combo book rendering", () => {
     expect(document.querySelector(".book-window")?.textContent).toContain("-1.80");
     expect(screen.queryByRole("button", { name: "Toggle Time and Sales" })).toBeNull();
   });
+
+  it("keeps a multi-venue combo row on one line — leading pair plus an overflow count", () => {
+    const spreadKeys = [keys[0], keys[1]];
+    const multiVenue = (
+      symbol: string,
+      bid: number,
+      ask: number,
+      bidVenues: string[],
+      askVenues: string[],
+    ): DepthBook => ({
+      symbol, kind: "option", entitled: true, isSmartDepth: true, feed: "OPRA BBO", timestamp,
+      bid: bidVenues.map((exchange, index) => ({
+        price: bid, size: 10, marketMaker: null, exchange, nbbo: index === 0,
+      })),
+      ask: askVenues.map((exchange, index) => ({
+        price: ask, size: 10, marketMaker: null, exchange, nbbo: index === 0,
+      })),
+    });
+
+    const spread: PortfolioPosition = {
+      ...position,
+      structure: "Bull Call Spread",
+      structure_type: "Bull Call Spread",
+      legs: [
+        { ...position.legs[0], direction: "LONG", strike: 50 },
+        { ...position.legs[1], direction: "SHORT", strike: 55 },
+      ],
+    };
+
+    render(
+      <TickerDetailProvider>
+        <BookTab
+          ticker="TEST"
+          position={spread}
+          prices={{
+            [spreadKeys[0]]: price(spreadKeys[0], 1, 1.1),
+            [spreadKeys[1]]: price(spreadKeys[1], 0.5, 0.6),
+          }}
+          openOrders={[]}
+          tickerPriceData={price("TEST-COMBO", 0.4, 0.6)}
+          depths={{
+            [spreadKeys[0]]: multiVenue(spreadKeys[0], 1, 1.1, ["AMEX", "BATS", "CBOE"], ["AMEX", "BATS", "CBOE"]),
+            [spreadKeys[1]]: multiVenue(spreadKeys[1], 0.5, 0.6, ["EDGX", "MIAX", "PHLX"], ["EDGX", "MIAX", "PHLX"]),
+          }}
+          tape={{}}
+          bookKey={spreadKeys.join("+")}
+          bookKind="combo"
+          bookOnly
+        />
+      </TickerDetailProvider>,
+    );
+
+    const venueCell = document.querySelector(".book-side.bid .book-row .book-mkt");
+    expect(venueCell).toBeTruthy();
+    // One venue pair on the row, never the whole pipe-joined set (which wraps
+    // into a 30-line block and blows the row height out of the montage).
+    expect(venueCell?.textContent).not.toContain("|");
+    expect(venueCell?.textContent).toContain("AMEX / EDGX");
+    expect(venueCell?.querySelector(".book-venue-more")?.textContent).toBe("+2");
+    expect(venueCell?.getAttribute("title")).toContain("|");
+  });
 });


### PR DESCRIPTION
## Problem

The IMPLIED SPREAD book on a combo ticker page rendered as two tall gradient blocks with a vertical wall of venue text, unlike every other order book in the app.

**Root cause:** an implied combo level aggregates *every* leg-venue pair quoting that net price, so `syntheticComboDepth.aggregate()` produces an exchange string like `AMEX / AMEX | BATS / AMEX | BOX / AMEX | …` (~23 pairs). `DepthMontage` dumped that whole string into the 52px venue cell, wrapping it into a **596px-tall** row.

## Fix

- Venue cell renders the leading pair + a `+N` overflow chip; full set stays in the `title` tooltip.
- Venue cell pinned to a single line (`nowrap` + ellipsis on the lead).
- Combo montage gets its own venue-column width on desktop (132px) and mobile (82px), with column gaps so size/price never collide.

Data is untouched — `aggregate()` still carries the full venue set; only presentation changed.

## Verification

Headless render of the real `<OrderBook kind="combo">` with a genuine `buildSyntheticComboDepth` book (16 call venues x 12 put venues):

| | before | after |
|---|---|---|
| combo bid row height @1200px | 596px | **29px** |
| combo bid row height @393px | — | **33px** |
| montage horizontal overflow | 0 | **0** (both widths) |
| option montage rows | 25-27px | **25-27px** (unchanged) |

Red/green TDD: new failing test in `synthetic-combo-book-render.test.tsx` pinned the pipe-joined string in the cell, then went green.

`web` vitest: **5870 passed, 1 failed** — the failure is `lib/tools/__tests__/ib-wrappers-db-source.test.ts` (missing `web/lib/tools/wrappers/ib-sync.ts`), which fails identically on the main checkout and is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)