### PR TITLE
fix(execution-sweep): recover carried-over journal gaps from executed_orders

### DIFF
--- a/scripts/monitor_daemon/handlers/evening_execution_sweep.py
+++ b/scripts/monitor_daemon/handlers/evening_execution_sweep.py
@@ -19,7 +19,19 @@ after-hours ones — are still visible on the evening session:
      write machinery — never a copy);
   3. mirrors the executions into ``executed_orders`` via
      ``db.writer.upsert_executed_order`` (idempotent on execId) so
-     journal_reconcile / journal-gap-sli can diff them.
+     journal_reconcile / journal-gap-sli can diff them;
+  4. recovers CARRIED-OVER gaps from ``executed_orders`` (Turso), not
+     from IB.
+
+Step 4 exists because steps 1-3 only ever see the CURRENT day: a day
+whose sweep never succeeded (dead gateway, daemon outage) leaves its
+after-hours fills orphaned forever, since the next evening's session no
+longer returns them. executed_orders still holds the durable payload, so
+the gap is repairable without IB — otherwise journal-gap-sli pages every
+cycle until a human runs backfill_journal_from_executed_orders.py by
+hand (incident 20260813T140500Z: IWM perm 1805918121 filled 16:24:50 ET
+on 2026-08-12, past journal_sync's 15-min post-close grace, while that
+evening's sweep burned its 3-attempt budget on an unreachable gateway).
 
 Failure handling follows the cash_flow_sync daily conventions: IB/DB
 unavailability RAISES so ``BaseHandler.run()`` never latches
@@ -67,6 +79,10 @@ FIRE_MINUTE_ET = 30
 # failed attempt embargoes 5 min via record_soft_failure; after this
 # many the next attempt waits for tomorrow's window.
 MAX_SOFT_ATTEMPTS_PER_ET_DAY = 3
+
+# Rolling window for carried-over gap recovery. Matches journal-gap-sli /
+# journal-reconcile so the sweep repairs exactly what those sensors alert on.
+GAP_RECOVERY_WINDOW_DAYS = 7
 
 
 def _now_utc() -> datetime:
@@ -195,17 +211,44 @@ class EveningExecutionSweepHandler(BaseHandler):
                 pass
 
         importer = JournalSyncHandler(ib_port=self.ib_port, client_id=self.client_id)
-        summary = importer.import_fills(fills, db=self._open_journal_db(importer))
+        journal_db = self._open_journal_db(importer)
+        summary = importer.import_fills(fills, db=journal_db)
         mirrored = self._mirror_executed_orders(executed_rows)
+        recovered = self._recover_carried_over_gaps(journal_db)
 
         result: Dict[str, Any] = {
             "status": "ok",
             "fills_seen": len(fills),
             "executed_mirrored": mirrored,
+            "gaps_recovered": recovered,
             "timestamp": datetime.now().isoformat(),
         }
         result.update(summary)
         return result
+
+    @staticmethod
+    def _recover_carried_over_gaps(db: Any) -> int:
+        """Close executed_orders-vs-journal gaps the IB session can't return.
+
+        The evening session only exposes the CURRENT day's executions, so a
+        day whose sweep never succeeded (dead gateway, daemon outage) leaves
+        its after-hours fills permanently orphaned: the next sweep pulls a
+        session that no longer contains them. ``executed_orders`` still holds
+        the durable payload, so residual gaps are repaired from Turso using
+        the same reconstruction the manual repair script uses — no second
+        copy of the labelling logic, idempotent on exec_id.
+
+        DB errors propagate: a failed recovery is a soft failure and the
+        journal import that already happened is idempotent on retry.
+        """
+        if db is None:
+            return 0
+        from backfill_journal_from_executed_orders import (  # noqa: PLC0415 — lazy
+            backfill,
+        )
+
+        actions = backfill(db, window_days=GAP_RECOVERY_WINDOW_DAYS, dry_run=False)
+        return sum(1 for a in actions if a.get("status") == "inserted_from_eo")
 
     @staticmethod
     def _open_journal_db(importer: Optional[JournalSyncHandler] = None) -> Any:

--- a/scripts/tests/test_monitor_daemon/test_evening_execution_sweep.py
+++ b/scripts/tests/test_monitor_daemon/test_evening_execution_sweep.py
@@ -12,6 +12,7 @@ machinery, mirroring executions into executed_orders.
 
 from __future__ import annotations
 
+import json
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -79,14 +80,31 @@ def _fill(*, exec_id: str, symbol: str = "URTY", side: str = "SLD", shares: int 
 
 
 class _FakeJournalDb:
-    """Minimal journal-table stand-in for _load_existing_from_journal."""
+    """Journal + executed_orders stand-in for the sweep's DB reads.
 
-    def __init__(self, rows: list[tuple] | None = None):
+    Dispatches on SQL shape: the sweep walks two different journal
+    projections — the 4-column loader (_load_existing_from_journal) and the
+    single-column coverage scan the carried-over gap recovery uses.
+
+    ``rows`` are (trade_id, payload, filled_at, written_at) tuples.
+    """
+
+    def __init__(
+        self,
+        rows: list[tuple] | None = None,
+        *,
+        executed_rows: list[tuple] | None = None,
+    ):
         self.rows = rows or []
+        self.executed_rows = executed_rows or []
 
     def execute(self, sql, params=None):
         cursor = MagicMock()
-        if "FROM journal" in sql:
+        if "FROM executed_orders" in sql:
+            cursor.fetchall.return_value = self.executed_rows
+        elif "SELECT payload FROM journal" in sql:
+            cursor.fetchall.return_value = [(r[1],) for r in self.rows]
+        elif "FROM journal" in sql:
             cursor.fetchall.return_value = self.rows
         else:
             cursor.fetchall.return_value = []
@@ -223,6 +241,127 @@ class TestSweepImport:
         assert result["executed_mirrored"] == 1
         assert mirrored.call_count == 1
         assert mirrored.call_args[0][0] == "0001.EVE.02"
+
+
+def _executed_order_row(
+    *,
+    exec_id: str,
+    symbol: str = "IWM",
+    side: str = "SLD",
+    quantity: float = 500.0,
+    price: float = 302.92,
+    when: datetime,
+) -> tuple:
+    """An executed_orders row as orders-sync / the sweep mirror writes it."""
+    payload = {
+        "execId": exec_id,
+        "permId": 900200,
+        "orderId": 295,
+        "clientId": 29,
+        "symbol": symbol,
+        "contract": {
+            "conId": 9579970,
+            "symbol": symbol,
+            "secType": "STK",
+            "currency": "USD",
+            "multiplier": 1,
+            "localSymbol": symbol,
+            "tradingClass": symbol,
+            "strike": 0.0,
+            "right": "?",
+            "expiry": None,
+        },
+        "side": side,
+        "quantity": quantity,
+        "price": price,
+        "avgPrice": price,
+        "cumQty": quantity,
+        "commission": 6.57,
+        "time": when.isoformat(),
+    }
+    fill_time = when.isoformat()
+    return (exec_id, json.dumps(payload), fill_time)
+
+
+class TestCarriedOverGapRecovery:
+    """A day whose sweep never succeeded leaves after-hours fills orphaned.
+
+    The live evening session only exposes the CURRENT day's executions, so a
+    later sweep can never re-pull them from IB. executed_orders holds the
+    durable payload, so the sweep must close residual gaps from Turso —
+    otherwise journal-gap-sli pages forever until a human runs
+    scripts/backfill_journal_from_executed_orders.py by hand.
+
+    Incident 20260813T140500Z: IWM perm 1805918121 filled 16:24:50 ET on
+    2026-08-12 (past journal_sync's 15-min post-close grace); that evening's
+    sweep burned its 3-attempt budget on an unreachable gateway.
+    """
+
+    @pytest.fixture
+    def captured_backfill_upserts(self, monkeypatch):
+        """The recovery path writes through db.writer, not journal_sync."""
+        import db.writer as writer_mod
+
+        upserts = MagicMock(name="upsert_journal_entry")
+        monkeypatch.setattr(writer_mod, "upsert_journal_entry", upserts)
+        return upserts
+
+    def test_recovers_prior_day_gap_the_session_no_longer_returns(
+        self, captured_journal_upserts, captured_backfill_upserts
+    ):
+        """Yesterday's orphaned fill is journaled from executed_orders."""
+        yesterday = datetime.now(timezone.utc) - timedelta(days=1)
+        orphan = _executed_order_row(exec_id="00010129.6a7d0497.01.01", when=yesterday)
+
+        h = EveningExecutionSweepHandler()
+        with patch(
+            "monitor_daemon.handlers.evening_execution_sweep.IBClient",
+            # Today's evening session: yesterday's execution is NOT in it.
+            return_value=_connected_client([]),
+        ), patch.object(
+            EveningExecutionSweepHandler,
+            "_open_journal_db",
+            return_value=_FakeJournalDb(executed_rows=[orphan]),
+        ), patch.object(
+            EveningExecutionSweepHandler, "_fetch_executed_rows", return_value=[],
+        ):
+            result = h.execute()
+
+        assert result["gaps_recovered"] == 1
+        assert captured_backfill_upserts.call_count == 1
+        trade_id = captured_backfill_upserts.call_args[0][0]
+        assert trade_id == "00010129.6a7d0497.01.01"
+
+    def test_already_journaled_gap_is_not_rewritten(
+        self, captured_journal_upserts, captured_backfill_upserts
+    ):
+        """Idempotent: an exec_id already covered in journal is left alone."""
+        yesterday = datetime.now(timezone.utc) - timedelta(days=1)
+        covered = _executed_order_row(exec_id="00010129.6a7d0497.01.01", when=yesterday)
+
+        h = EveningExecutionSweepHandler()
+        with patch(
+            "monitor_daemon.handlers.evening_execution_sweep.IBClient",
+            return_value=_connected_client([]),
+        ), patch.object(
+            EveningExecutionSweepHandler,
+            "_open_journal_db",
+            return_value=_FakeJournalDb(
+                [(
+                    "00010129.6a7d0497.01.01",
+                    '{"ib_exec_id": "00010129.6a7d0497.01.01"}',
+                    None,
+                    None,
+                )],
+                executed_rows=[covered],
+            ),
+        ), patch.object(
+            EveningExecutionSweepHandler, "_fetch_executed_rows", return_value=[],
+        ):
+            result = h.execute()
+
+        assert result["gaps_recovered"] == 0
+        assert captured_backfill_upserts.call_count == 0
 
 
 class TestSoftFailure:


### PR DESCRIPTION
## Incident

`20260813T140500Z-service-health-degraded` — P2, `journal-gap-sli` reporting 2 missing exec_ids for ~10h with no possible remediation.

## Root cause

The two gap exec_ids are **one** IWM sell (`permId 1805918121`, orderId 295) that IB split into two partial execution reports (500 + 300 = cumQty 800). It filled at **16:24:50 ET on 2026-08-12** — past `journal_sync`'s 15-minute post-close grace, so the real-time path never journaled it. `executed_orders` captured both rows one second after the fill, so the payload was durable in Turso the whole time.

The 20:30 ET evening sweep is the designed backstop for exactly this. But it sources from the **live IB session**, which only exposes the current day. Aug 12's sweep burned its 3-attempt budget on an unreachable gateway, and Aug 13's sweep pulls Aug 13's fills.

So the gap **never self-heals**. It pages every 5 minutes until a human runs `scripts/backfill_journal_from_executed_orders.py` by hand.

> This corrects the earlier automated diagnosis for `20260813T133500Z`, which classified an after-16:15-ET fill as "Fault 1 fallout, tonight's sweep self-heals". The sweep is same-day-only, so it does not.

## Fix

A fourth sweep step closes residual `executed_orders`-vs-journal gaps over the same 7-day window `journal-gap-sli` alerts on, sourcing from **Turso instead of IB**. It delegates to `backfill_journal_from_executed_orders.backfill` so the labelling/reconstruction logic is not duplicated, and stays idempotent on `exec_id`.

Net effect: a day whose sweep failed is repaired by the next sweep that succeeds.

## Tests

Red/green in `scripts/tests/test_monitor_daemon/test_evening_execution_sweep.py::TestCarriedOverGapRecovery`:

- `test_recovers_prior_day_gap_the_session_no_longer_returns` — seeds a prior-day `executed_orders` row with an empty journal and an evening session that returns nothing. Failed before the fix with `KeyError: 'gaps_recovered'`.
- `test_already_journaled_gap_is_not_rewritten` — idempotency.

The sweep's fake DB now dispatches on SQL shape, because the recovery walks a second journal projection (`SELECT payload FROM journal`) that the old 4-column fake answered with the wrong arity.

## Verification

| Gate | Result |
|---|---|
| `pytest scripts/tests` | 5273 passed, 1 skipped |
| `pytest cloud/tests` | 804 passed, 4 skipped |
| `vitest web/tests` | 5596 passed, 0 failed |

## Remaining

The 2 orphaned rows are still missing in prod. Dry-run of the repair is reviewed and correct (IWM SELL 500 @ 302.92 + SELL 300 @ 302.92, `filled_at 2026-08-12`). Once this ships, tonight's 20:30 ET sweep closes them automatically; running the backfill by hand clears the P2 sooner. Awaiting operator go-ahead on the manual run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
