### PR TITLE
fix(execution-ledger): pin the execution identity hash to an explicit field set

### DIFF
--- a/scripts/db/writer.py
+++ b/scripts/db/writer.py
@@ -1182,6 +1182,55 @@ def upsert_open_order(perm_id: int, payload: dict[str, Any]) -> None:
     db.commit()
 
 
+# The execution-identity contract: exactly these normalized fields define a
+# fill's lifecycle identity, and the stored payload_sha256 is computed over
+# them. This is PINNED on purpose (test_position_return_capital.py asserts the
+# tuple) — it must never be derived from "whatever normalize_execution returns".
+#
+# 2026-08-13: it was `{k: v for k, v in item.items() if k != "commission"}`,
+# so when commit 4eaaf5e9 added `revision` and `source_exec_id` to
+# normalize_execution for reversal splitting, every one of the 76 stored facts
+# silently hashed differently and orders-sync aborted with "execution fact
+# conflict" on the first pre-existing exec_id it re-synced, freezing
+# executed_orders / open_orders.
+#
+# `commission` is excluded because commission/realized-P&L reports arrive
+# after execDetails; late enrichment is not an execution correction.
+# `revision` is excluded because it is already part of the row's primary key,
+# and `source_exec_id` because it merely defaults back to exec_id.
+_LIFECYCLE_HASH_FIELDS: tuple[str, ...] = (
+    "account_id",
+    "con_id",
+    "currency",
+    "exec_id",
+    "filled_at",
+    "multiplier",
+    "order_ref",
+    "perm_id",
+    "price",
+    "quantity",
+    "sec_type",
+    "side",
+    "signed_quantity",
+    "symbol",
+)
+
+
+def _execution_identity_hash(item: dict[str, Any]) -> str:
+    """Hash the pinned lifecycle identity of a normalized execution.
+
+    Only the fields in ``_LIFECYCLE_HASH_FIELDS`` participate. A missing field
+    is a hard error rather than a silently different hash, so renaming one in
+    normalize_execution fails loudly instead of invalidating stored history.
+    """
+    import hashlib
+
+    lifecycle_payload = {key: item[key] for key in _LIFECYCLE_HASH_FIELDS}
+    return hashlib.sha256(
+        json.dumps(lifecycle_payload, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
 def upsert_position_execution_fact(payload: dict[str, Any], *, db: Any = None) -> bool:
     """Persist a lossless IB execution fact without overwriting its identity.
 
@@ -1189,8 +1238,6 @@ def upsert_position_execution_fact(payload: dict[str, Any], *, db: Any = None) -
     different canonical payload is a hard conflict rather than a silent
     replacement, because lifecycle history must not be rewritten in place.
     """
-    import hashlib
-
     try:
         from ..position_return_capital import normalize_execution
     except ImportError:  # pragma: no cover - flat scripts/ import mode
@@ -1199,13 +1246,7 @@ def upsert_position_execution_fact(payload: dict[str, Any], *, db: Any = None) -
     item = normalize_execution(payload)
     revision = int(payload.get("revision") or 1)
     canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
-    # Commission/realized-P&L reports can arrive after execDetails. They do
-    # not change lifecycle identity, so late enrichment must not manufacture
-    # an execution correction or conflict.
-    lifecycle_payload = {key: value for key, value in item.items() if key != "commission"}
-    payload_hash = hashlib.sha256(
-        json.dumps(lifecycle_payload, sort_keys=True, separators=(",", ":")).encode()
-    ).hexdigest()
+    payload_hash = _execution_identity_hash(item)
     target = db or get_db()
     row = target.execute(
         """SELECT payload_sha256 FROM position_execution_facts

--- a/scripts/rehash_position_execution_facts.py
+++ b/scripts/rehash_position_execution_facts.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Re-derive payload_sha256 for position_execution_facts rows.
+
+The stored hash is a fingerprint of the row's own canonical payload, so
+recomputing it from that payload is a re-derivation, not a rewrite of
+history: no row's facts change, only the fingerprint that indexes them.
+
+Needed whenever the identity-hash contract moves. On 2026-08-13 commit
+4eaaf5e9 added `revision` / `source_exec_id` to normalize_execution while
+upsert_position_execution_fact hashed "every field except commission", so
+70 of 76 stored facts hashed differently overnight and orders-sync aborted
+with "execution fact conflict" on the first pre-existing exec_id it
+re-synced — freezing executed_orders and open_orders. Pinning the hash to
+_LIFECYCLE_HASH_FIELDS restores those 70; the 6 rows written under the
+transient scheme are repaired here.
+
+--dry-run is DEFAULT TRUE. Pass --execute to write.
+
+Usage
+─────
+  python3 scripts/rehash_position_execution_facts.py
+  python3 scripts/rehash_position_execution_facts.py --execute
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+try:
+    from dotenv import load_dotenv
+
+    for _candidate in (_SCRIPTS_DIR.parent / ".env", _SCRIPTS_DIR.parent / "web" / ".env"):
+        if _candidate.exists():
+            load_dotenv(str(_candidate))
+except ImportError:  # pragma: no cover - dotenv optional
+    pass
+
+logging.basicConfig(
+    format="%(asctime)s  %(levelname)-7s  %(message)s",
+    datefmt="%H:%M:%S",
+    level=logging.INFO,
+)
+log = logging.getLogger("rehash_execution_facts")
+
+# Reads a bounded page at a time — the direct-to-cloud Hrana pipeline 502s on
+# unbounded reads of payload-carrying tables (scripts/CLAUDE.md §Hrana bounding).
+PAGE_SIZE = 200
+
+
+def _assert_not_under_pytest() -> None:
+    if os.environ.get("PYTEST_CURRENT_TEST") and not os.environ.get("RADON_DB_TEST_WRITE_OK"):
+        raise RuntimeError(
+            "rehash_position_execution_facts: refusing to run under "
+            "PYTEST_CURRENT_TEST without RADON_DB_TEST_WRITE_OK=1 "
+            "(feedback_test_pollution_to_production)"
+        )
+
+
+def find_stale_rows(db: Any) -> list[dict[str, Any]]:
+    """Rows whose stored hash disagrees with the current pinned contract."""
+    from db.writer import _execution_identity_hash
+    from position_return_capital import normalize_execution
+
+    stale: list[dict[str, Any]] = []
+    offset = 0
+    while True:
+        page = db.execute(
+            "SELECT account_id, exec_id, revision, payload_sha256, payload "
+            "FROM position_execution_facts ORDER BY ingested_at LIMIT ? OFFSET ?",
+            (PAGE_SIZE, offset),
+        ).fetchall()
+        if not page:
+            break
+        for account_id, exec_id, revision, stored_hash, payload in page:
+            try:
+                item = normalize_execution(json.loads(payload))
+            except Exception as exc:  # noqa: BLE001
+                log.warning("  SKIP  %s — payload does not normalize: %s", exec_id, exc)
+                continue
+            expected = _execution_identity_hash(item)
+            if expected != stored_hash:
+                stale.append(
+                    {
+                        "account_id": account_id,
+                        "exec_id": exec_id,
+                        "revision": revision,
+                        "stored": stored_hash,
+                        "expected": expected,
+                    }
+                )
+        offset += PAGE_SIZE
+    return stale
+
+
+def rehash(db: Any, *, dry_run: bool = True) -> list[dict[str, Any]]:
+    """Re-derive stale fingerprints. Returns the rows acted on."""
+    stale = find_stale_rows(db)
+    log.info("rows needing re-derivation: %d", len(stale))
+    for row in stale:
+        if dry_run:
+            log.info(
+                "  DRY   %s rev=%s  %s -> %s",
+                row["exec_id"], row["revision"], row["stored"][:12], row["expected"][:12],
+            )
+            continue
+        db.execute(
+            "UPDATE position_execution_facts SET payload_sha256 = ? "
+            "WHERE account_id = ? AND exec_id = ? AND revision = ?",
+            (row["expected"], row["account_id"], row["exec_id"], row["revision"]),
+        )
+        log.info(
+            "  FIXED %s rev=%s  %s -> %s",
+            row["exec_id"], row["revision"], row["stored"][:12], row["expected"][:12],
+        )
+    if not dry_run and stale:
+        db.commit()
+    return stale
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Re-derive payload_sha256 for position_execution_facts rows."
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Write the re-derived hashes (default is a dry run).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    _assert_not_under_pytest()
+
+    from db.client import get_db
+
+    db = get_db()
+    acted = rehash(db, dry_run=not args.execute)
+    mode = "EXECUTE" if args.execute else "DRY-RUN"
+    log.info("Done — %s, rows=%d", mode, len(acted))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_position_return_capital.py
+++ b/tests/test_position_return_capital.py
@@ -336,6 +336,72 @@ def test_execution_fact_hash_conflict_raises_instead_of_overwriting():
         raise AssertionError("conflicting immutable execution was overwritten")
 
 
+def test_identity_hash_field_set_is_pinned():
+    """The hashed field set is a contract, not whatever normalize_execution
+    happens to return. Adding a field there must be a deliberate act.
+
+    2026-08-13: commit 4eaaf5e9 added `revision` and `source_exec_id` to
+    normalize_execution for reversal splitting. The hash covered every field
+    except `commission`, so 70 of 76 stored facts instantly hashed differently
+    and orders-sync aborted with `execution fact conflict` on the first
+    pre-existing exec_id it re-synced.
+    """
+    from db.writer import _LIFECYCLE_HASH_FIELDS
+
+    assert _LIFECYCLE_HASH_FIELDS == (
+        "account_id",
+        "con_id",
+        "currency",
+        "exec_id",
+        "filled_at",
+        "multiplier",
+        "order_ref",
+        "perm_id",
+        "price",
+        "quantity",
+        "sec_type",
+        "side",
+        "signed_quantity",
+        "symbol",
+    )
+
+
+def test_new_normalize_execution_field_does_not_manufacture_a_conflict(monkeypatch):
+    """A field added to normalize_execution must not rewrite stored identities."""
+    import db.writer as writer_mod
+    from position_return_capital import normalize_execution as real_normalize
+
+    db = _ledger_db()
+    assert upsert_position_execution_fact(_execution("E1"), db=db) is True
+
+    def normalize_with_new_field(raw):
+        item = real_normalize(raw)
+        item["some_future_field"] = "added by a later feature"
+        return item
+
+    monkeypatch.setattr(writer_mod, "normalize_execution", normalize_with_new_field, raising=False)
+    monkeypatch.setattr(
+        "position_return_capital.normalize_execution", normalize_with_new_field
+    )
+
+    # Same execution, unchanged lifecycle facts — must be a no-op, not a raise.
+    assert upsert_position_execution_fact(_execution("E1"), db=db) is False
+
+
+def test_real_lifecycle_change_still_conflicts(monkeypatch):
+    """Pinning must not blunt the guard: a changed fact still raises."""
+    db = _ledger_db()
+    assert upsert_position_execution_fact(_execution("E1"), db=db) is True
+    for field, value in (("price", 9.99), ("quantity", 11), ("side", "SLD")):
+        changed = {**_execution("E1"), field: value}
+        try:
+            upsert_position_execution_fact(changed, db=db)
+        except ValueError as exc:
+            assert "execution fact conflict" in str(exc)
+        else:  # pragma: no cover - safety assertion
+            raise AssertionError(f"changed {field} was silently accepted")
+
+
 def test_late_commission_enrichment_is_not_treated_as_execution_correction():
     db = _ledger_db()
     initial = {**_execution("E1"), "commission": 0}


### PR DESCRIPTION
## Symptom

`orders-sync` stuck in `error`:

```
execution fact conflict for <acct>:0002abdd.6a7daed5.01.01:1
```

`executed_orders` and `open_orders` both froze at `2026-08-13T19:59:52Z`.

## Root cause

`upsert_position_execution_fact` computed the stored identity fingerprint as **"every `normalize_execution` field except `commission`"**. That turned an internal dict shape into a storage contract: adding any field to `normalize_execution` silently changes the identity of every execution ever stored.

Commit `4eaaf5e9` ("remediate DeepSec security report") did exactly that, adding two fields for reversal splitting:

```diff
   "sec_type": ...,
   "commission": _number(raw.get("commission") or 0),
+  "revision": max(0, int(raw.get("revision") or 0)),
+  "source_exec_id": str(raw.get("source_exec_id") or exec_id),
```

Proof against production — the pre-`4eaaf5e9` 14-field set reproduces the stored hash byte for byte:

```
stored payload_sha256   3b633f8d9ad91bfd789753baa58df6bf9d75d51f03d53d42a7940514dce77063
14-field (pre-4eaaf5e9) 3b633f8d9ad91bfd789753baa58df6bf9d75d51f03d53d42a7940514dce77063  ← match
16-field (current)      456c8cee0e19926f93c357ac850fd0a0c3b9d984ed11be74dc9843aca96cf5ec
```

Clean cutover across all 76 rows:

```
70 stale   2026-08-10T20:00:02Z → 2026-08-13T16:13:18Z   old 14-field schema
 6 match   2026-08-13T19:13:38Z → 2026-08-13T19:13:39Z   new 16-field schema
```

`ib_orders._dual_write_orders_to_db` re-raises `ValueError` from the fact write, so the first pre-existing exec_id aborted the whole `executed_orders` loop. It stopped at 19:59:52Z only because that is 15:59:52 ET and `orders-sync` is `market_hours_class="intraday"` — it would have re-broken every cycle after the next open, with 70 of 76 facts primed to trip it.

## Fix

Pin the hash to an explicit `_LIFECYCLE_HASH_FIELDS` tuple. A missing field now raises loudly instead of yielding a different hash, and the tuple is asserted by a test so future additions are deliberate.

The tuple is the pre-`4eaaf5e9` set, so the 70 rows validate again. Excluding `revision` (already in the row's primary key) and `source_exec_id` (defaults to `exec_id`) is correct on the merits, not only for back-compat.

`scripts/rehash_position_execution_facts.py` re-derives fingerprints for the 6 rows written under the transient scheme — a re-derivation from each row's own canonical payload, not a rewrite of facts. Dry-run default, pytest guard, paginated reads per the Hrana bounding rule.

## Tests

- `test_new_normalize_execution_field_does_not_manufacture_a_conflict` — reproduced the exact production `ValueError: execution fact conflict for U1:E1:1` before the fix.
- `test_identity_hash_field_set_is_pinned` — pins the tuple.
- `test_real_lifecycle_change_still_conflicts` — proves pinning does not blunt the guard (price/quantity/side changes still raise).

| Gate | Result |
|---|---|
| `pytest scripts/tests tests` | 5500 passed, 1 skipped |
| `pytest cloud/tests` | 825 passed, 4 skipped |

One unrelated ordering flake (`test_run_portfolio_refresh_retry`) passed in isolation.

## Production state

Repair already applied and verified:

```
rows agreeing with pinned contract : 76
rows still stale                   : 0
re-sync of 0002abdd.6a7daed5.01.01 : OK, wrote_new_row=False (idempotent no-op)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
