### PR TITLE
feat(agent-ui): agent primitives wired into chat, newsfeed, workflow and scanner

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -19491,3 +19491,174 @@ body[data-mobile="true"] .alerts-rule__channel {
     text-align: left;
   }
 }
+
+/* ═══════════════════════════════════════════════════════════════════════
+   Agent UI primitives — append to radon/web/app/globals.css
+   Adopted from beautifului.dev, re-skinned to Radon tokens. All colors are
+   existing vars; motion uses the sanctioned 2.4s pulse + 150ms --ease-out.
+   ═══════════════════════════════════════════════════════════════════════ */
+
+/* — Shared atoms — */
+.agent-dot {
+  width: 6px; height: 6px; flex: none;
+  background: var(--text-muted);
+  display: inline-block; /* square, never round — house rule */
+}
+.agent-dot--signal { background: var(--signal-core); }
+.agent-dot--warn { background: var(--warn); }
+.agent-dot--muted { background: var(--text-muted); }
+.agent-dot--pulse { animation: agent-pulse 2.4s ease-in-out infinite; }
+@keyframes agent-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
+
+.agent-chip {
+  font-family: var(--font-mono);
+  font-size: 10px; letter-spacing: 0.06em; text-transform: uppercase;
+  padding: 2px 8px; border-radius: 999px;
+  border: 1px solid var(--line-grid);
+  color: var(--text-secondary); background: transparent;
+  white-space: nowrap;
+}
+.agent-chip--signal { border-color: var(--signal-core); color: var(--signal-core-text); background: rgba(5, 173, 152, 0.08); }
+.agent-chip--warn { border-color: var(--warn); color: var(--warn-text); background: rgba(245, 166, 35, 0.09); }
+.agent-chip--engine { border-color: var(--extreme); color: var(--extreme); }
+.agent-chip--action { cursor: pointer; transition: var(--transition-controls); }
+.agent-chip--action:hover { background: var(--bg-panel-raised); color: var(--text-primary); }
+
+/* Shared panel head pattern */
+.engine-trace__head, .approval-gate__head, .task-runs__head, .proposal-card__head {
+  display: flex; align-items: center; gap: 8px;
+  height: 32px; padding: 0 12px;
+  border-bottom: 1px solid var(--line-grid);
+}
+.approval-gate__module, .task-runs__module, .proposal-card__module {
+  font-family: var(--font-mono); font-size: var(--text-meta);
+  letter-spacing: 0.08em; color: var(--text-muted);
+}
+.engine-trace__title, .approval-gate__title, .task-runs__title, .proposal-card__title {
+  font-size: var(--text-panel-title); font-weight: 600; color: var(--text-primary);
+}
+
+/* — EngineTrace — */
+.engine-trace { background: var(--bg-panel); border: 1px solid var(--line-grid); border-radius: 4px; }
+.engine-trace__head { width: 100%; background: none; cursor: pointer; text-align: left; }
+.engine-trace__chips { display: flex; gap: 6px; }
+.engine-trace__elapsed { margin-left: auto; font-family: var(--font-mono); font-size: var(--text-meta); letter-spacing: 0.08em; color: var(--text-muted); }
+.engine-trace__body { padding: 4px 12px 12px; }
+.engine-trace__steps { list-style: none; margin: 0; padding: 0; }
+.engine-trace__step { display: flex; align-items: center; gap: 10px; padding: 7px 0; border-bottom: 1px solid var(--line-grid); }
+.engine-trace__step-label { flex: 1; font-size: var(--text-label); color: var(--text-primary); }
+.engine-trace__step[data-state="waiting"] .engine-trace__step-label { color: var(--text-muted); }
+.engine-trace__step-meta { font-family: var(--font-mono); font-size: var(--text-meta); letter-spacing: 0.08em; color: var(--text-muted); text-transform: uppercase; }
+.engine-trace__reasoning { margin: 10px 0 0; font-size: var(--text-label); line-height: 1.55; color: var(--text-secondary); }
+
+/* — ApprovalGate — */
+.approval-gate { background: var(--bg-panel); border: 1px solid var(--line-grid); border-radius: 4px; }
+.approval-gate__head .agent-chip--warn { margin-left: auto; }
+.approval-gate__body { padding: 12px; display: flex; flex-direction: column; gap: 8px; }
+.approval-gate__statement { margin: 0; font-size: var(--text-body); line-height: 1.5; color: var(--text-primary); }
+.approval-gate__options { display: flex; flex-direction: column; gap: 6px; }
+.approval-gate__option {
+  display: flex; justify-content: space-between; align-items: center; gap: 12px;
+  padding: 9px 12px; border: 1px solid var(--line-grid); border-radius: 4px;
+  background: var(--bg-panel); cursor: pointer; text-align: left;
+  transition: var(--transition-controls);
+}
+.approval-gate__option:hover { background: var(--bg-panel-raised); }
+.approval-gate__option[data-selected="true"] { border-color: var(--signal-core); background: rgba(5, 173, 152, 0.08); }
+.approval-gate__option-label { font-size: var(--text-label); color: var(--text-primary); }
+.approval-gate__option-meta { font-family: var(--font-mono); font-size: var(--text-meta); letter-spacing: 0.08em; color: var(--text-muted); text-transform: uppercase; }
+.approval-gate__option[data-selected="true"] .approval-gate__option-meta { color: var(--signal-core-text); }
+.approval-gate__actions { display: flex; align-items: center; gap: 8px; margin-top: 4px; }
+.approval-gate__expiry { margin-left: auto; font-family: var(--font-mono); font-size: var(--text-meta); letter-spacing: 0.08em; color: var(--text-muted); }
+
+/* — TaskRuns — */
+.task-runs { background: var(--bg-panel); border: 1px solid var(--line-grid); border-radius: 4px; }
+.task-runs__status { margin-left: auto; display: flex; align-items: center; gap: 6px; font-family: var(--font-mono); font-size: var(--text-meta); letter-spacing: 0.08em; color: var(--warn-text); }
+.task-runs__list { list-style: none; margin: 0; padding: 4px 12px 8px; }
+.task-runs__task { border-bottom: 1px solid var(--line-grid); padding: 8px 0; }
+.task-runs__task:last-child { border-bottom: none; }
+.task-runs__row { display: flex; align-items: center; gap: 10px; }
+.task-runs__index { width: 14px; font-family: var(--font-mono); font-size: 10px; color: var(--text-muted); }
+.task-runs__task-title { flex: 1; font-size: var(--text-label); font-weight: 500; color: var(--text-primary); }
+.task-runs__task[data-state="queued"] .task-runs__task-title { color: var(--text-muted); }
+.task-runs__task-meta { font-family: var(--font-mono); font-size: var(--text-meta); letter-spacing: 0.08em; color: var(--text-muted); text-transform: uppercase; }
+.task-runs__substeps { list-style: none; margin: 6px 0 0; padding: 0 0 0 40px; display: flex; flex-direction: column; gap: 4px; }
+.task-runs__substep { display: flex; justify-content: space-between; font-family: var(--font-mono); font-size: var(--text-meta); color: var(--text-secondary); }
+.task-runs__substep-meta { color: var(--text-muted); }
+
+/* — AskComposer — */
+.ask-composer { border: 1px solid var(--line-grid); border-radius: 4px; background: var(--bg-panel); }
+.ask-composer:focus-within { border-color: var(--border-focus); }
+.ask-composer__sources { display: flex; gap: 6px; flex-wrap: wrap; padding: 8px 12px 0; }
+.ask-composer__source {
+  font-family: var(--font-mono); font-size: var(--text-meta);
+  color: var(--signal-core-text); background: rgba(5, 173, 152, 0.08);
+  border: 1px solid var(--signal-core); border-radius: 3px; padding: 0 5px;
+  cursor: pointer;
+}
+.ask-composer__input {
+  width: 100%; box-sizing: border-box; resize: none;
+  padding: 10px 12px; border: none; background: transparent;
+  font-family: var(--font-sans); font-size: var(--text-body); line-height: 1.5;
+  color: var(--text-primary);
+}
+.ask-composer__input:focus { outline: none; }
+.ask-composer__rail { display: flex; align-items: center; gap: 8px; border-top: 1px solid var(--line-grid); padding: 8px 12px; }
+.ask-composer__spacer { flex: 1; }
+.ask-composer__engine { display: flex; align-items: center; gap: 6px; border: 1px solid var(--line-grid); border-radius: 4px; padding: 3px 8px; }
+.ask-composer__engine-label { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.08em; color: var(--text-muted); }
+.ask-composer__engine select {
+  background: transparent; border: none; color: var(--text-secondary);
+  font-family: var(--font-mono); font-size: var(--text-meta); letter-spacing: 0.06em;
+}
+.ask-composer__send {
+  display: flex; align-items: center; gap: 6px;
+  font-family: var(--font-mono); font-size: var(--text-meta); font-weight: 600; letter-spacing: 0.06em;
+  padding: 6px 14px; border-radius: 4px; border: 1px solid var(--accent-bg);
+  background: var(--accent-bg); color: var(--accent-text); cursor: pointer;
+  transition: var(--transition-controls);
+}
+.ask-composer__send:disabled { opacity: 0.45; cursor: default; }
+
+/* — AnalysisSources — */
+.analysis-sources { display: flex; flex-direction: column; gap: 6px; margin-top: 10px; }
+.analysis-sources__label { display: flex; align-items: center; gap: 6px; font-family: var(--font-mono); font-size: var(--text-meta); letter-spacing: 0.08em; color: var(--text-muted); }
+.analysis-sources__grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 6px; }
+.analysis-sources__row {
+  display: flex; justify-content: space-between; align-items: center; gap: 8px;
+  padding: 6px 10px; border: 1px solid var(--line-grid); border-radius: 4px;
+  font-family: var(--font-mono); font-size: var(--text-meta);
+  color: var(--text-secondary); text-decoration: none;
+  transition: var(--transition-controls);
+}
+.analysis-sources__row:hover { background: var(--bg-panel-raised); }
+.analysis-sources__name { color: var(--text-primary); }
+.analysis-sources__feed { color: var(--text-muted); }
+.analysis-sources__followups { display: flex; gap: 6px; flex-wrap: wrap; }
+.inline-source-mark {
+  font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.04em;
+  color: var(--signal-core-text); border: 1px solid var(--signal-core);
+  border-radius: 999px; padding: 0 5px; text-decoration: none;
+  vertical-align: 1px; margin: 0 1px;
+}
+
+/* — ProposalCard — */
+.proposal-card { background: var(--bg-panel); border: 1px solid var(--line-grid); border-radius: 4px; }
+.proposal-card__chips { margin-left: auto; display: flex; gap: 6px; }
+.proposal-card__body { padding: 12px; display: flex; flex-direction: column; gap: 10px; }
+.proposal-card__statement { margin: 0; font-size: var(--text-body); line-height: 1.5; color: var(--text-primary); }
+.proposal-card__confidence-row { display: flex; justify-content: space-between; margin-bottom: 4px; font-family: var(--font-mono); font-size: var(--text-meta); letter-spacing: 0.08em; color: var(--text-muted); }
+.proposal-card__confidence-value { color: var(--signal-core-text); }
+.proposal-card__meter { height: 4px; background: var(--line-grid); border-radius: 2px; overflow: hidden; }
+.proposal-card__meter-fill { height: 100%; background: linear-gradient(90deg, var(--signal-deep), var(--signal-strong)); border-radius: 2px; transition: width 150ms var(--ease-out); }
+.proposal-card__alts { display: flex; flex-direction: column; gap: 6px; }
+.proposal-card__alts-label { font-family: var(--font-mono); font-size: var(--text-meta); letter-spacing: 0.08em; color: var(--text-muted); }
+.proposal-card__alt { display: flex; justify-content: space-between; align-items: center; gap: 12px; padding: 7px 10px; border: 1px solid var(--line-grid); border-radius: 4px; font-size: var(--text-label); color: var(--text-secondary); }
+.proposal-card__alt-meta { font-family: var(--font-mono); font-size: var(--text-meta); letter-spacing: 0.08em; color: var(--text-muted); text-transform: uppercase; }
+.proposal-card__actions { display: flex; gap: 8px; }
+
+/* — Reduced motion — */
+@media (prefers-reduced-motion: reduce) {
+  .agent-dot--pulse { animation: none; opacity: 0.8; }
+  .proposal-card__meter-fill { transition: none; }
+}

--- a/web/app/workflow/WorkflowComposer.tsx
+++ b/web/app/workflow/WorkflowComposer.tsx
@@ -26,6 +26,8 @@ import {
   type SavedWorkflow,
   WORKFLOW_PALETTE,
 } from "./workflowClient";
+import { TaskRuns, type AgentTask } from "@/components/agent";
+import { graphToRunningTasks, runReportToTasks } from "@/lib/agent/workflowTasks";
 
 // F14 — minimal working flow-pipeline canvas. Palette adds nodes; edges connect
 // them; Save persists to Turso; Run executes server-side (Python executor). An
@@ -41,6 +43,9 @@ function Canvas() {
   const [saved, setSaved] = useState<SavedWorkflow[]>([]);
   const [status, setStatus] = useState<string>("");
   const [report, setReport] = useState<RunReport | null>(null);
+  // Non-null only while a run is in flight; the executor returns its report in
+  // one shot, so this is the only window where per-node state is "running".
+  const [runningTasks, setRunningTasks] = useState<AgentTask[] | null>(null);
 
   useEffect(() => {
     listWorkflows()
@@ -96,6 +101,9 @@ function Canvas() {
   const onRun = useCallback(async () => {
     const graph = currentGraph();
     try {
+      // Set before the await so the per-node run state is visible while the
+      // executor works; the finally clears it on success, cancel and error.
+      setRunningTasks(graphToRunningTasks(graph));
       const result = await runWorkflowAfterConfirmation(graph, window.confirm, runWorkflow);
       if (!result) {
         setStatus("Run cancelled");
@@ -106,6 +114,8 @@ function Canvas() {
       setStatus(describeRunReport(result));
     } catch (err) {
       setStatus(err instanceof Error ? err.message : "Run failed");
+    } finally {
+      setRunningTasks(null);
     }
   }, [currentGraph]);
 
@@ -187,7 +197,13 @@ function Canvas() {
         </div>
       </div>
 
-      {report ? <RunReportStrip report={report} /> : null}
+      {runningTasks ? (
+        <div style={reportStyle}>
+          <TaskRuns tasks={runningTasks} />
+        </div>
+      ) : report ? (
+        <RunReportStrip report={report} />
+      ) : null}
     </div>
   );
 }
@@ -200,11 +216,7 @@ function RunReportStrip({ report }: { report: RunReport }) {
       </strong>
       <span style={{ marginLeft: 12 }}>{describeRunReport(report)}</span>
       <div style={{ marginTop: 8, display: "flex", gap: 8, flexWrap: "wrap" }}>
-        {report.steps.map((step) => (
-          <span key={step.node_id} style={stepChipStyle(step.blocked)}>
-            {step.node_type} ({step.rows_in} to {step.rows_out})
-          </span>
-        ))}
+        <TaskRuns tasks={runReportToTasks(report)} />
       </div>
     </div>
   );
@@ -318,16 +330,6 @@ const reportStyle: React.CSSProperties = {
   background: "var(--bg-panel)",
   fontSize: 12,
 };
-
-function stepChipStyle(blocked: boolean): React.CSSProperties {
-  return {
-    border: `1px solid ${blocked ? "var(--negative)" : "var(--border)"}`,
-    borderRadius: 4,
-    padding: "2px 8px",
-    fontFamily: "var(--font-mono)",
-    color: blocked ? "var(--negative)" : "var(--text-secondary)",
-  };
-}
 
 export default function WorkflowComposer() {
   return (

--- a/web/components/ChatLauncher.tsx
+++ b/web/components/ChatLauncher.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import ChatPanel from "@/components/ChatPanel";
+import { subscribeAsk } from "@/lib/agent/askBus";
 import type { WorkspaceSection } from "@/lib/types";
 import type { PortfolioData } from "@/lib/types";
 
@@ -19,6 +20,18 @@ type ChatLauncherProps = {
 
 export default function ChatLauncher({ activeSection, portfolio }: ChatLauncherProps) {
   const [open, setOpen] = useState(false);
+  // A prompt handed over from another surface (newsfeed follow-up chips).
+  // Consumed once by ChatPanel, then cleared so it can't re-fire on re-render.
+  const [seedPrompt, setSeedPrompt] = useState<string | null>(null);
+
+  useEffect(
+    () =>
+      subscribeAsk((prompt) => {
+        setSeedPrompt(prompt);
+        setOpen(true);
+      }),
+    [],
+  );
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
@@ -55,7 +68,13 @@ export default function ChatLauncher({ activeSection, portfolio }: ChatLauncherP
           <span className="chat-launcher__kicker">Radon Chat</span>
           <span className="chat-launcher__hint">Esc to dismiss</span>
         </div>
-        <ChatPanel activeSection={activeSection} portfolio={portfolio} />
+        <ChatPanel
+          activeSection={activeSection}
+          portfolio={portfolio}
+          isOpen={open}
+          seedPrompt={seedPrompt}
+          onSeedConsumed={() => setSeedPrompt(null)}
+        />
       </div>
     </div>
   );

--- a/web/components/ChatPanel.tsx
+++ b/web/components/ChatPanel.tsx
@@ -1,8 +1,17 @@
 "use client";
 
-import { type FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Send, ArrowDown, Copy, Check } from "lucide-react";
-import type { ApiMessage, AssistantOrderProposal, Message, PortfolioData, WorkspaceSection } from "@/lib/types";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ArrowDown, Copy, Check } from "lucide-react";
+import { ApprovalGate, AskComposer, EngineTrace } from "@/components/agent";
+import { buildTurnSteps, describeEngines } from "@/lib/agent/turnSteps";
+import type {
+  ApiMessage,
+  AssistantOrderProposal,
+  AssistantToolEvent,
+  Message,
+  PortfolioData,
+  WorkspaceSection,
+} from "@/lib/types";
 import { quickPromptsBySection } from "@/lib/data";
 import { createTimestamp } from "@/lib/utils";
 import {
@@ -20,6 +29,17 @@ import type { OrderRiskInput, OrderRiskState } from "@/lib/order/risk/useOrderRi
 type ChatPanelProps = {
   activeSection: WorkspaceSection;
   portfolio?: PortfolioData | null;
+  /**
+   * Overlay open flag, forwarded to AskComposer's `focusKey` so the composer
+   * takes focus on every ⌘J open (replaces the old composerRef focus effect).
+   */
+  isOpen?: boolean;
+  /**
+   * A prompt handed over from another surface (e.g. a newsfeed follow-up chip).
+   * Sent once on arrival, then reported back via onSeedConsumed.
+   */
+  seedPrompt?: string | null;
+  onSeedConsumed?: () => void;
 };
 
 /**
@@ -31,16 +51,6 @@ type ChatPanelProps = {
 type ChatStatus = "idle" | "submitted" | "streaming" | "done" | "error";
 
 const STICK_THRESHOLD_PX = 80;
-
-function TypingIndicator() {
-  return (
-    <div className="chat-typing" aria-hidden="true">
-      <span className="chat-typing-dot" />
-      <span className="chat-typing-dot" />
-      <span className="chat-typing-dot" />
-    </div>
-  );
-}
 
 function CopyButton({ content }: { content: string }) {
   const [copied, setCopied] = useState(false);
@@ -86,12 +96,21 @@ function proposalRiskInput(proposal: AssistantOrderProposal | null): OrderRiskIn
   };
 }
 
-export default function ChatPanel({ activeSection, portfolio }: ChatPanelProps) {
-  const [query, setQuery] = useState("");
+export default function ChatPanel({
+  activeSection,
+  portfolio,
+  isOpen = true,
+  seedPrompt = null,
+  onSeedConsumed,
+}: ChatPanelProps) {
   const [messages, setMessages] = useState<Message[]>([]);
   const [status, setStatus] = useState<ChatStatus>("idle");
   const [lastError, setLastError] = useState("");
   const [proposal, setProposal] = useState<AssistantOrderProposal | null>(null);
+  // Tool telemetry for the turn in flight. Reset per send so a finished turn's
+  // trace can't leak into the next one.
+  const [turnTools, setTurnTools] = useState<AssistantToolEvent[]>([]);
+  const [turnModel, setTurnModel] = useState<string | null>(null);
   const [isPlacing, setPlacing] = useState(false);
   const [riskState, setRiskState] = useState<OrderRiskState | null>(null);
   const riskInput = useMemo(() => proposalRiskInput(proposal), [proposal]);
@@ -99,14 +118,7 @@ export default function ChatPanel({ activeSection, portfolio }: ChatPanelProps) 
 
   const messagesRef = useRef<HTMLDivElement | null>(null);
   const atBottomRef = useRef(true);
-  const composingRef = useRef(false);
-  const composerRef = useRef<HTMLTextAreaElement | null>(null);
 
-  // ChatPanel mounts inside the ⌘J overlay; the operator expects to type
-  // immediately, so the composer takes focus on open.
-  useEffect(() => {
-    composerRef.current?.focus();
-  }, []);
   const sectionPrompts = quickPromptsBySection[activeSection];
   const isBusy = status === "submitted" || status === "streaming";
 
@@ -137,13 +149,8 @@ export default function ChatPanel({ activeSection, portfolio }: ChatPanelProps) 
     scrollToBottom();
   }, [scrollToBottom]);
 
-  const sendMessage = async (eventOrPrompt: FormEvent<HTMLFormElement> | string) => {
-    if (typeof eventOrPrompt !== "string") {
-      eventOrPrompt.preventDefault();
-    }
-
-    const nextPrompt = typeof eventOrPrompt === "string" ? eventOrPrompt : query;
-    const cleaned = nextPrompt.trim();
+  const sendMessage = async (prompt: string) => {
+    const cleaned = prompt.trim();
     if (!cleaned || isBusy) {
       return;
     }
@@ -177,9 +184,10 @@ export default function ChatPanel({ activeSection, portfolio }: ChatPanelProps) 
     };
 
     setMessages((current) => [...current, userMessage, assistantMessage]);
-    setQuery("");
     setStatus("submitted");
     setLastError("");
+    setTurnTools([]);
+    setTurnModel(null);
 
     try {
       const piCommand = routeToPiPrompt(cleaned);
@@ -189,6 +197,8 @@ export default function ChatPanel({ activeSection, portfolio }: ChatPanelProps) 
         await streamMessage(assistantId, assistantContent, setMessages);
       } else {
         const turn = await requestAssistantTurn(conversation, cleaned);
+        setTurnTools(turn.toolEvents);
+        setTurnModel(turn.model);
         setStatus("streaming");
         await streamMessage(assistantId, turn.content, setMessages);
         // F7: never auto-execute. A destructive order proposal is surfaced as
@@ -219,6 +229,20 @@ export default function ChatPanel({ activeSection, portfolio }: ChatPanelProps) 
     }
   };
 
+  // A handed-over prompt sends itself once on arrival. Both callbacks are read
+  // through refs so an inline parent arrow (new identity every render) can't
+  // turn this into a send loop; the effect keys on the prompt alone.
+  const sendMessageRef = useRef(sendMessage);
+  sendMessageRef.current = sendMessage;
+  const onSeedConsumedRef = useRef(onSeedConsumed);
+  onSeedConsumedRef.current = onSeedConsumed;
+
+  useEffect(() => {
+    if (!seedPrompt) return;
+    void sendMessageRef.current(seedPrompt);
+    onSeedConsumedRef.current?.();
+  }, [seedPrompt]);
+
   const confirmProposal = async () => {
     if (!proposal || isPlacing || !riskState?.okToSubmit) return;
     setPlacing(true);
@@ -247,18 +271,6 @@ export default function ChatPanel({ activeSection, portfolio }: ChatPanelProps) 
   const cancelProposal = () => {
     if (isPlacing) return;
     setProposal(null);
-  };
-
-  const onComposerKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (
-      event.key === "Enter" &&
-      !event.shiftKey &&
-      !composingRef.current &&
-      !event.nativeEvent.isComposing
-    ) {
-      event.preventDefault();
-      void sendMessage(query);
-    }
   };
 
   const lastAssistantId = [...messages].reverse().find((m) => m.role === "assistant")?.id ?? null;
@@ -316,7 +328,10 @@ export default function ChatPanel({ activeSection, portfolio }: ChatPanelProps) 
                       </div>
                       <div className="chat-message-body">
                         {isPending ? (
-                          <TypingIndicator />
+                          <EngineTrace
+                            steps={buildTurnSteps(turnTools, status === "error" ? "error" : "submitted")}
+                            engines={describeEngines(turnModel)}
+                          />
                         ) : (
                           <>
                             <MarkdownRenderer content={message.content} />
@@ -352,36 +367,29 @@ export default function ChatPanel({ activeSection, portfolio }: ChatPanelProps) 
 
           {lastError ? <div className="chat-error">{lastError}</div> : null}
 
+          {/* F7: never auto-execute. TODO(agent-ui): when the assistant returns
+              sized alternatives (split clips, hold), map them into `options` and
+              pass the confirmed option id through to placeProposedOrder. */}
           {proposal ? (
-            <div className="chat-order-confirm" role="group" aria-label="Order confirmation">
-              <div className="chat-order-confirm-header">CONFIRM ORDER</div>
-              <div className="chat-order-confirm-summary">{proposal.summary}</div>
+            <>
+              {/* The order-risk chokepoint stays mandatory: the gate renders the
+                  risk verdict and confirmProposal refuses unless okToSubmit. */}
               <OrderRiskGate
                 input={riskInput}
                 portfolio={portfolio}
                 surface="assistant-chat"
                 onState={setRiskState}
               />
-              <div className="chat-order-confirm-note">This order is not sent until you confirm.</div>
-              <div className="chat-order-confirm-actions">
-                <button
-                  type="button"
-                  className="btn-secondary"
-                  onClick={cancelProposal}
-                  disabled={isPlacing}
-                >
-                  Cancel
-                </button>
-                <button
-                  type="button"
-                  className="btn-primary"
-                  onClick={confirmProposal}
-                  disabled={isPlacing}
-                >
-                  {isPlacing ? "Placing..." : "Confirm"}
-                </button>
-              </div>
-            </div>
+              <ApprovalGate
+                title="Confirmation required"
+                body={proposal.summary}
+                options={[{ id: "route", label: "Route as proposed", meta: "AS PROPOSED" }]}
+                busy={isPlacing}
+                confirmDisabled={riskState?.okToSubmit !== true}
+                onConfirm={() => void confirmProposal()}
+                onDismiss={cancelProposal}
+              />
+            </>
           ) : null}
 
           <div className="chat-composer">
@@ -399,36 +407,11 @@ export default function ChatPanel({ activeSection, portfolio }: ChatPanelProps) 
                 ))}
               </div>
             ) : null}
-            <form suppressHydrationWarning className="chat-input-row" onSubmit={sendMessage}>
-              <textarea
-                suppressHydrationWarning
-                ref={composerRef}
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
-                onKeyDown={onComposerKeyDown}
-                onCompositionStart={() => {
-                  composingRef.current = true;
-                }}
-                onCompositionEnd={() => {
-                  composingRef.current = false;
-                }}
-                placeholder="Ask Grok for flow analysis, risk checks, action items..."
-                className="chat-textarea"
-                aria-label="Message Grok assistant"
-                rows={1}
-                maxLength={1000}
-              />
-              <button
-                suppressHydrationWarning
-                className="chat-send"
-                type="submit"
-                disabled={!query.trim() || isBusy}
-                title="Send (Enter)"
-                aria-label="Send message"
-              >
-                <Send size={14} />
-              </button>
-            </form>
+            <AskComposer
+              busy={isBusy}
+              focusKey={isOpen}
+              onSubmit={(text) => void sendMessage(text)}
+            />
           </div>
         </div>
     </div>

--- a/web/components/NewsfeedLightbox.tsx
+++ b/web/components/NewsfeedLightbox.tsx
@@ -9,6 +9,9 @@ import { formatAbsolute, formatRelative, formatTime } from "@/lib/newsfeedTime";
 import { useDialogChrome } from "@/lib/useDialogChrome";
 import { useBookmarks } from "@/lib/useBookmarks";
 import StarToggle from "@/components/StarToggle";
+import { AnalysisSources } from "@/components/agent";
+import { buildAnalysisSources, buildFollowUps } from "@/lib/agent/analysisSources";
+import { emitAsk } from "@/lib/agent/askBus";
 
 export type NewsfeedLightboxFocus = {
   post: MarketEarPost & { href: string; isoTimestamp: string };
@@ -210,6 +213,12 @@ export default function NewsfeedLightbox({
             {post.content ? (
               <p className="newsfeed-lightbox__body">{post.content}</p>
             ) : null}
+
+            <AnalysisSources
+              sources={buildAnalysisSources(post)}
+              followUps={buildFollowUps(post)}
+              onFollowUp={emitAsk}
+            />
 
             {tags.length > 0 ? (
               <div className="newsfeed-lightbox__tags">

--- a/web/components/ThetaHarvesterScanner.tsx
+++ b/web/components/ThetaHarvesterScanner.tsx
@@ -8,6 +8,8 @@ import InfoTooltip from "./InfoTooltip";
 import ScannerInstrumentShell from "./ScannerInstrumentShell";
 import SectionEmptyState from "./SectionEmptyState";
 import { useWatchlist } from "@/lib/useWatchlist";
+import { ProposalCard } from "@/components/agent";
+import { buildScannerProposal } from "@/lib/agent/scannerProposal";
 import { formatExpiry } from "@/lib/optionsChainUtils";
 import type { ThetaHarvesterData, ThetaHarvesterEarnings, ThetaHarvesterLeg, ThetaHarvesterResult } from "@/lib/types";
 
@@ -350,7 +352,9 @@ export default function ThetaHarvesterScanner({
   const [minDteInput, setMinDteInput] = useState(String(THETA_DEFAULT_SCAN_PARAMS.minDte));
   const [maxDteInput, setMaxDteInput] = useState(String(THETA_DEFAULT_SCAN_PARAMS.maxDte));
   const [minCreditInput, setMinCreditInput] = useState(String(THETA_DEFAULT_SCAN_PARAMS.minCredit));
-  const rows = data?.results ?? [];
+  // Memoised so the `?? []` fallback doesn't hand a fresh array identity to
+  // every downstream useMemo on each render.
+  const rows = useMemo(() => data?.results ?? [], [data?.results]);
 
   // Overhaul state: local sort (desc-first per column), chip filter, one
   // expanded row, multi-select, and a keyboard cursor (J/K/Enter/Space).
@@ -374,6 +378,17 @@ export default function ThetaHarvesterScanner({
       .slice()
       .sort((a, b) => (value(a) - value(b)) * sortDir);
   }, [rows, activeChip, sortKey, sortDir]);
+
+  // Ranked by score REGARDLESS of the operator's display sort — "top-ranked
+  // candidate" means highest composite, not whatever floated to row 1 after a
+  // sort by DTE. Returns null unless the engine itself rated the leader
+  // actionable, so most scans render the table alone.
+  const proposal = useMemo(
+    () => buildScannerProposal(rows.slice().sort((a, b) => b.score - a.score)),
+    [rows],
+  );
+  const [dismissedProposal, setDismissedProposal] = useState<string | null>(null);
+  const showProposal = proposal && dismissedProposal !== proposal.ticker;
 
   const scoreBounds = useMemo(() => {
     const scores = sorted.map((r) => r.score).filter((s) => Number.isFinite(s));
@@ -551,6 +566,18 @@ export default function ThetaHarvesterScanner({
       className="theta-harvester"
       testId="theta-harvester-section"
     >
+      {/* Accept never routes an order — it opens the instrument, where every
+          order surface is already behind <OrderRiskGate>. */}
+      {showProposal ? (
+        <ProposalCard
+          engines={["THETA"]}
+          statement={proposal.statement}
+          confidence={proposal.confidence}
+          alternatives={proposal.alternatives}
+          onAccept={() => router.push(`/${proposal.ticker}`)}
+          onDismiss={() => setDismissedProposal(proposal.ticker)}
+        />
+      ) : null}
       {loading ? (
         <div className="section-body">
           <div className="snapshot-card__empty">Sampling theta surface...</div>

--- a/web/components/agent/AnalysisSources.tsx
+++ b/web/components/agent/AnalysisSources.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+/**
+ * AnalysisSources — source provenance + follow-ups for streamed analysis.
+ * Adopted from beautifului.dev "Streaming Text". Renders under analysis
+ * prose (Live Market Analysis, chat replies): a source grid mapping each
+ * claim window to its feed, and follow-up chips that re-enter the composer.
+ * Confidence and source over adjectives — house voice §"Content".
+ */
+
+export type AnalysisSource = {
+  id: string;
+  /** Display name, e.g. "Unusual Whales flow". */
+  name: string;
+  /** Feed telemetry, e.g. "uw feed", "ib feed", "derived". */
+  feed: string;
+  href?: string;
+};
+
+type AnalysisSourcesProps = {
+  sources: AnalysisSource[];
+  followUps?: string[];
+  onFollowUp?: (prompt: string) => void;
+};
+
+export default function AnalysisSources({ sources, followUps = [], onFollowUp }: AnalysisSourcesProps) {
+  return (
+    <div className="analysis-sources">
+      {sources.length ? (
+        <>
+          <div className="analysis-sources__label">
+            SOURCES <span className="agent-chip agent-chip--signal">{sources.length}</span>
+          </div>
+          <div className="analysis-sources__grid">
+            {sources.map((s) => (
+              <a
+                key={s.id}
+                className="analysis-sources__row"
+                href={s.href ?? "#"}
+                onClick={s.href ? undefined : (e) => e.preventDefault()}
+              >
+                <span className="analysis-sources__name">{s.name}</span>
+                <span className="analysis-sources__feed">{s.feed}</span>
+              </a>
+            ))}
+          </div>
+        </>
+      ) : null}
+      {followUps.length ? (
+        <>
+          <div className="analysis-sources__label">FOLLOW-UPS</div>
+          <div className="analysis-sources__followups">
+            {followUps.map((f) => (
+              <button key={f} type="button" className="agent-chip agent-chip--action" onClick={() => onFollowUp?.(f)}>
+                {f}
+              </button>
+            ))}
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * InlineSourceMark — tiny capsule cited inline in prose ("UW", "IB").
+ * Usage: <InlineSourceMark label="UW" /> immediately after the claim.
+ */
+export function InlineSourceMark({ label, href }: { label: string; href?: string }) {
+  const Tag = href ? "a" : "span";
+  return (
+    <Tag className="inline-source-mark" href={href}>
+      {label}
+    </Tag>
+  );
+}

--- a/web/components/agent/ApprovalGate.tsx
+++ b/web/components/agent/ApprovalGate.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * ApprovalGate — structured human-in-the-loop confirmation. Adopted from
+ * beautifului.dev "Approval Card". Upgrades the flat chat-order-confirm
+ * banner: selectable handling options with per-option risk telemetry, an
+ * optional expiry, and explicit Confirm/Dismiss. Never auto-executes (F7).
+ */
+
+export type GateOption = {
+  id: string;
+  label: string;
+  /** Mono meta on the right, e.g. "2.1× BAND", "NO ROUTE". */
+  meta?: string;
+};
+
+type ApprovalGateProps = {
+  title?: string;
+  /** Declarative condition statement, e.g. the order summary + why gated. */
+  body: string;
+  options: GateOption[];
+  defaultOptionId?: string;
+  /** Mono expiry telemetry, e.g. "EXPIRES 09:32:00 ET". */
+  expiry?: string;
+  busy?: boolean;
+  /**
+   * Blocks confirmation while leaving Dismiss live — for an upstream gate that
+   * has not cleared yet (e.g. OrderRiskGate's coverage still resolving).
+   * Distinct from `busy`, which means "this gate is itself routing".
+   */
+  confirmDisabled?: boolean;
+  onConfirm: (optionId: string) => void;
+  onDismiss: () => void;
+};
+
+export default function ApprovalGate({
+  title = "Confirmation required",
+  body,
+  options,
+  defaultOptionId,
+  expiry,
+  busy = false,
+  confirmDisabled = false,
+  onConfirm,
+  onDismiss,
+}: ApprovalGateProps) {
+  const [selected, setSelected] = useState(defaultOptionId ?? options[0]?.id ?? "");
+  return (
+    <section className="approval-gate" role="group" aria-label={title}>
+      <div className="approval-gate__head">
+        <span className="approval-gate__module">OPERATOR / GATE</span>
+        <span className="approval-gate__title">{title}</span>
+        <span className="agent-chip agent-chip--warn">HUMAN-IN-LOOP</span>
+      </div>
+      <div className="approval-gate__body">
+        <p className="approval-gate__statement">{body}</p>
+        <div className="approval-gate__options" role="radiogroup" aria-label="Handling options">
+          {options.map((opt) => (
+            <button
+              key={opt.id}
+              type="button"
+              role="radio"
+              aria-checked={selected === opt.id}
+              className="approval-gate__option"
+              data-selected={selected === opt.id}
+              disabled={busy}
+              onClick={() => setSelected(opt.id)}
+            >
+              <span className="approval-gate__option-label">{opt.label}</span>
+              {opt.meta ? <span className="approval-gate__option-meta">{opt.meta}</span> : null}
+            </button>
+          ))}
+        </div>
+        <div className="approval-gate__actions">
+          <button
+            type="button"
+            className="btn-primary"
+            disabled={busy || confirmDisabled || !selected}
+            onClick={() => onConfirm(selected)}
+          >
+            {busy ? "Routing…" : "Confirm selection"}
+          </button>
+          <button type="button" className="btn-secondary" disabled={busy} onClick={onDismiss}>
+            Dismiss
+          </button>
+          {expiry ? <span className="approval-gate__expiry">{expiry}</span> : null}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/components/agent/AskComposer.tsx
+++ b/web/components/agent/AskComposer.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import {
+  type FormEvent,
+  type KeyboardEvent,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { Send } from "lucide-react";
+
+/**
+ * AskComposer — conversational composer adopted from beautifului.dev
+ * "Prompt Bar" (Vanilla variant; the pill variant is rejected — 4px radius).
+ * Adds @-instrument source tokens, a / commands hint, and an engine picker
+ * in place of a model picker. Preserves ChatPanel's Enter-to-send and IME
+ * composition guards. Rendered inside .chat-composer.
+ */
+
+export const ENGINES = ["AUTO", "SPECTRAL", "EIGEN", "MARKOV", "LAPLACE"] as const;
+export type Engine = (typeof ENGINES)[number];
+
+type AskComposerProps = {
+  placeholder?: string;
+  busy?: boolean;
+  /** Scoped instruments shown as source tokens, e.g. ["MU", "NDX"]. */
+  sources?: string[];
+  onRemoveSource?: (symbol: string) => void;
+  /**
+   * Focuses the textarea on mount and whenever this value changes. Pass the
+   * panel-open flag / open count so the ⌘J autofocus behavior is preserved
+   * (replaces ChatPanel's composerRef focus effect).
+   */
+  focusKey?: string | number | boolean;
+  onSubmit: (text: string, engine: Engine) => void;
+};
+
+export default function AskComposer({
+  placeholder = "Ask about flow, risk, structure. @ to scope an instrument, / for commands.",
+  busy = false,
+  sources = [],
+  onRemoveSource,
+  focusKey,
+  onSubmit,
+}: AskComposerProps) {
+  const [text, setText] = useState("");
+  const [engine, setEngine] = useState<Engine>("AUTO");
+  const composingRef = useRef(false);
+  const inputRef = useRef<HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    if (focusKey === false) return;
+    inputRef.current?.focus();
+  }, [focusKey]);
+
+  const submit = () => {
+    const cleaned = text.trim();
+    if (!cleaned || busy) return;
+    onSubmit(cleaned, engine);
+    setText("");
+    inputRef.current?.focus();
+  };
+
+  const onFormSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    submit();
+  };
+
+  const onKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (
+      event.key === "Enter" &&
+      !event.shiftKey &&
+      !composingRef.current &&
+      !event.nativeEvent.isComposing
+    ) {
+      event.preventDefault();
+      submit();
+    }
+  };
+
+  return (
+    <form className="ask-composer" onSubmit={onFormSubmit}>
+      {sources.length ? (
+        <div className="ask-composer__sources" aria-label="Scoped instruments">
+          {sources.map((s) => (
+            <button
+              key={s}
+              type="button"
+              className="ask-composer__source"
+              onClick={() => onRemoveSource?.(s)}
+              title={`Remove @${s}`}
+            >
+              @{s}
+            </button>
+          ))}
+        </div>
+      ) : null}
+      <textarea
+        ref={inputRef}
+        className="ask-composer__input"
+        value={text}
+        rows={1}
+        maxLength={1000}
+        placeholder={placeholder}
+        aria-label="Ask Radon"
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={onKeyDown}
+        onCompositionStart={() => {
+          composingRef.current = true;
+        }}
+        onCompositionEnd={() => {
+          composingRef.current = false;
+        }}
+      />
+      <div className="ask-composer__rail">
+        <span className="agent-chip">@ SOURCES</span>
+        <span className="agent-chip">/ COMMANDS</span>
+        <span className="ask-composer__spacer" />
+        <label className="ask-composer__engine">
+          <span className="ask-composer__engine-label">ENGINE</span>
+          <select
+            value={engine}
+            aria-label="Engine"
+            onChange={(e) => setEngine(e.target.value as Engine)}
+          >
+            {ENGINES.map((e) => (
+              <option key={e} value={e}>
+                {e}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button
+          type="submit"
+          className="ask-composer__send"
+          disabled={!text.trim() || busy}
+          title="Send (Enter)"
+          aria-label="Send"
+        >
+          <Send size={13} />
+          ASK
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/web/components/agent/EngineTrace.tsx
+++ b/web/components/agent/EngineTrace.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+/**
+ * EngineTrace — expandable reasoning trace for engine turns (Spectral, Eigen,
+ * Markov, Laplace). Adopted from beautifului.dev "Thinking", re-skinned to the
+ * instrument grammar: square status dots, mono telemetry, per-step timing,
+ * a one-line declarative reasoning summary. Drop-in replacement for the
+ * typing-dots indicator once the backend emits step events.
+ */
+
+export type TraceStepState = "done" | "running" | "waiting";
+
+export type TraceStep = {
+  id: string;
+  label: string;
+  /** Mono meta on the right — elapsed time ("1.8s") or "—" while waiting. */
+  meta?: string;
+  state: TraceStepState;
+};
+
+type EngineTraceProps = {
+  /** Engine chips shown in the header, e.g. ["SPECTRAL", "EIGEN"]. */
+  engines?: string[];
+  steps: TraceStep[];
+  /** Total elapsed, mono in the header ("4.2S"). */
+  elapsed?: string;
+  /** Declarative one-line summary once available. */
+  reasoning?: string;
+  /** Collapsed shows only the header row. Default expanded while running. */
+  collapsed?: boolean;
+  onToggle?: () => void;
+};
+
+export default function EngineTrace({
+  engines = [],
+  steps,
+  elapsed,
+  reasoning,
+  collapsed = false,
+  onToggle,
+}: EngineTraceProps) {
+  const running = steps.some((s) => s.state === "running");
+  return (
+    <section className="engine-trace" aria-label="Engine trace" data-running={running}>
+      <button
+        type="button"
+        className="engine-trace__head"
+        onClick={onToggle}
+        aria-expanded={!collapsed}
+      >
+        <span className={`agent-dot${running ? " agent-dot--pulse agent-dot--warn" : " agent-dot--signal"}`} aria-hidden="true" />
+        <span className="engine-trace__title">Engine trace</span>
+        <span className="engine-trace__chips">
+          {engines.map((e) => (
+            <span key={e} className="agent-chip agent-chip--engine">{e}</span>
+          ))}
+        </span>
+        {elapsed ? <span className="engine-trace__elapsed">{elapsed}</span> : null}
+      </button>
+      {!collapsed ? (
+        <div className="engine-trace__body">
+          <ol className="engine-trace__steps">
+            {steps.map((step) => (
+              <li key={step.id} className="engine-trace__step" data-state={step.state}>
+                <span
+                  className={`agent-dot${
+                    step.state === "running"
+                      ? " agent-dot--pulse agent-dot--warn"
+                      : step.state === "done"
+                        ? " agent-dot--signal"
+                        : " agent-dot--muted"
+                  }`}
+                  aria-hidden="true"
+                />
+                <span className="engine-trace__step-label">{step.label}</span>
+                <span className="engine-trace__step-meta">{step.meta ?? "—"}</span>
+              </li>
+            ))}
+          </ol>
+          {reasoning ? <p className="engine-trace__reasoning">{reasoning}</p> : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/web/components/agent/ProposalCard.tsx
+++ b/web/components/agent/ProposalCard.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+/**
+ * ProposalCard — actionable engine proposal with a confidence meter and
+ * ranked alternatives. Adopted from beautifului.dev "Recommendation Card".
+ * Rendered by Scanner for the top-ranked candidate when an engine emits an
+ * actionable interpretation. Accept never routes an order directly — it
+ * hands off to ApprovalGate when execution is implied.
+ */
+
+export type ProposalAlternative = {
+  id: string;
+  label: string;
+  /** Mono verdict, e.g. "NEEDS REVIEW", "NO SIGNAL". */
+  meta: string;
+};
+
+type ProposalCardProps = {
+  /** Engine chips, e.g. ["MARKOV", "SPECTRAL"]. */
+  engines?: string[];
+  /** Declarative proposal statement. */
+  statement: string;
+  /** 0–1. */
+  confidence: number;
+  /** Mono confidence caption, e.g. "0.82 · HIGH". Derived if omitted. */
+  confidenceLabel?: string;
+  alternatives?: ProposalAlternative[];
+  busy?: boolean;
+  onAccept: () => void;
+  onDismiss: () => void;
+};
+
+function defaultLabel(c: number) {
+  const band = c >= 0.75 ? "HIGH" : c >= 0.5 ? "MODERATE" : "LOW";
+  return `${c.toFixed(2)} · ${band}`;
+}
+
+export default function ProposalCard({
+  engines = [],
+  statement,
+  confidence,
+  confidenceLabel,
+  alternatives = [],
+  busy = false,
+  onAccept,
+  onDismiss,
+}: ProposalCardProps) {
+  const pct = Math.round(Math.min(1, Math.max(0, confidence)) * 100);
+  return (
+    <section className="proposal-card" aria-label="Proposed action">
+      <div className="proposal-card__head">
+        <span className="proposal-card__module">SCANNER / PROPOSAL</span>
+        <span className="proposal-card__title">Proposed action</span>
+        <span className="proposal-card__chips">
+          {engines.map((e) => (
+            <span key={e} className="agent-chip agent-chip--engine">{e}</span>
+          ))}
+        </span>
+      </div>
+      <div className="proposal-card__body">
+        <p className="proposal-card__statement">{statement}</p>
+        <div className="proposal-card__confidence">
+          <div className="proposal-card__confidence-row">
+            <span>CONFIDENCE</span>
+            <span className="proposal-card__confidence-value">
+              {confidenceLabel ?? defaultLabel(confidence)}
+            </span>
+          </div>
+          <div
+            className="proposal-card__meter"
+            role="meter"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={pct}
+            aria-label="Confidence"
+          >
+            <div className="proposal-card__meter-fill" style={{ width: `${pct}%` }} />
+          </div>
+        </div>
+        {alternatives.length ? (
+          <div className="proposal-card__alts">
+            <div className="proposal-card__alts-label">ALTERNATIVES</div>
+            {alternatives.map((a) => (
+              <div key={a.id} className="proposal-card__alt">
+                <span>{a.label}</span>
+                <span className="proposal-card__alt-meta">{a.meta}</span>
+              </div>
+            ))}
+          </div>
+        ) : null}
+        <div className="proposal-card__actions">
+          <button type="button" className="btn-primary" disabled={busy} onClick={onAccept}>
+            Accept
+          </button>
+          <button type="button" className="btn-secondary" disabled={busy} onClick={onDismiss}>
+            Dismiss
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/components/agent/TaskRuns.tsx
+++ b/web/components/agent/TaskRuns.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+/**
+ * TaskRuns — live agent task status with nested sub-step telemetry. Adopted
+ * from beautifului.dev "Task Rows". Replaces the static Workflow job list.
+ */
+
+export type TaskState = "done" | "running" | "queued";
+
+export type SubStep = { label: string; meta: string };
+
+export type AgentTask = {
+  id: string;
+  title: string;
+  /** Mono count meta, e.g. "34 INSTR", "4 BOOKS". */
+  meta?: string;
+  state: TaskState;
+  steps?: SubStep[];
+};
+
+const STATE_LABEL: Record<TaskState, string> = {
+  done: "COMPLETED",
+  running: "RUNNING",
+  queued: "QUEUED",
+};
+
+export default function TaskRuns({ tasks }: { tasks: AgentTask[] }) {
+  const active = tasks.filter((t) => t.state === "running").length;
+  return (
+    <section className="task-runs" aria-label="Agent runs">
+      <div className="task-runs__head">
+        <span className="task-runs__module">WORKFLOW</span>
+        <span className="task-runs__title">Agent runs</span>
+        <span className="task-runs__status">
+          {active > 0 ? (
+            <>
+              <span className="agent-dot agent-dot--warn agent-dot--pulse" aria-hidden="true" />
+              {active} ACTIVE
+            </>
+          ) : (
+            "IDLE"
+          )}
+        </span>
+      </div>
+      <ol className="task-runs__list">
+        {tasks.map((task, i) => (
+          <li key={task.id} className="task-runs__task" data-state={task.state}>
+            <div className="task-runs__row">
+              <span className="task-runs__index">{i + 1}</span>
+              <span
+                className={`agent-dot${
+                  task.state === "running"
+                    ? " agent-dot--warn agent-dot--pulse"
+                    : task.state === "done"
+                      ? " agent-dot--signal"
+                      : " agent-dot--muted"
+                }`}
+                aria-hidden="true"
+              />
+              <span className="task-runs__task-title">{task.title}</span>
+              {task.meta ? <span className="task-runs__task-meta">{task.meta}</span> : null}
+              <span
+                className={`agent-chip${
+                  task.state === "done"
+                    ? " agent-chip--signal"
+                    : task.state === "running"
+                      ? " agent-chip--warn"
+                      : ""
+                }`}
+              >
+                {STATE_LABEL[task.state]}
+              </span>
+            </div>
+            {task.steps?.length ? (
+              <ul className="task-runs__substeps">
+                {task.steps.map((s) => (
+                  <li key={s.label} className="task-runs__substep">
+                    <span>{s.label}</span>
+                    <span className="task-runs__substep-meta">{s.meta}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/web/components/agent/index.ts
+++ b/web/components/agent/index.ts
@@ -1,0 +1,6 @@
+export { default as EngineTrace, type TraceStep, type TraceStepState } from "./EngineTrace";
+export { default as ApprovalGate, type GateOption } from "./ApprovalGate";
+export { default as TaskRuns, type AgentTask, type SubStep, type TaskState } from "./TaskRuns";
+export { default as AskComposer, ENGINES, type Engine } from "./AskComposer";
+export { default as AnalysisSources, InlineSourceMark, type AnalysisSource } from "./AnalysisSources";
+export { default as ProposalCard, type ProposalAlternative } from "./ProposalCard";

--- a/web/lib/agent/analysisSources.ts
+++ b/web/lib/agent/analysisSources.ts
@@ -1,0 +1,93 @@
+/**
+ * Analysis sources — provenance + follow-ups for a newsfeed story.
+ *
+ * The newsfeed tagging pipeline is genuinely two-stage (text tagger + vision
+ * tagger, see scripts/newsfeed/CLAUDE.md), and every post carries the origin
+ * article href. That is real provenance, so AnalysisSources renders it rather
+ * than inventing citations: the article itself, plus whichever taggers actually
+ * contributed to this post.
+ *
+ * Follow-ups are derived from the post's own tags — ticker-shaped tags become
+ * flow prompts, which is the question an operator actually asks next.
+ */
+
+import type { AnalysisSource } from "@/components/agent";
+
+type SourcePost = {
+  href?: string;
+  tags?: string[];
+  tags_text?: string[];
+  tags_vision?: string[];
+};
+
+/** Bare hostname for display, e.g. "themarketear.com". */
+function hostnameOf(href: string): string | null {
+  try {
+    return new URL(href).hostname.replace(/^www\./, "");
+  } catch {
+    return null;
+  }
+}
+
+function countLabel(count: number): string {
+  return `${count} tag${count === 1 ? "" : "s"}`;
+}
+
+/**
+ * Provenance rows for one post. Order is most- to least-direct: the article,
+ * then the taggers that annotated it. Returns an empty array when the post has
+ * no href and no tagger output — AnalysisSources renders nothing rather than an
+ * empty SOURCES header.
+ */
+export function buildAnalysisSources(post: SourcePost): AnalysisSource[] {
+  const sources: AnalysisSource[] = [];
+
+  if (post.href) {
+    const host = hostnameOf(post.href);
+    if (host) {
+      sources.push({ id: "article", name: host, feed: "newsfeed", href: post.href });
+    }
+  }
+
+  const textTags = post.tags_text ?? [];
+  if (textTags.length) {
+    sources.push({ id: "tagger-text", name: "Text tagger", feed: countLabel(textTags.length) });
+  }
+
+  const visionTags = post.tags_vision ?? [];
+  if (visionTags.length) {
+    sources.push({ id: "tagger-vision", name: "Vision tagger", feed: countLabel(visionTags.length) });
+  }
+
+  return sources;
+}
+
+/**
+ * A tag is treated as an instrument when it looks like a ticker: 1-5 uppercase
+ * letters. The taxonomy is UPPERCASE throughout, so a case-sensitive test is
+ * what separates "MU" from "FED RATES".
+ */
+function isInstrumentTag(tag: string): boolean {
+  return /^[A-Z]{1,5}$/.test(tag);
+}
+
+const MAX_FOLLOW_UPS = 3;
+
+/**
+ * Follow-up prompts for the story. Instrument tags become flow questions; the
+ * result is capped so the chip row cannot overrun the lightbox.
+ */
+export function buildFollowUps(post: SourcePost): string[] {
+  const tags = post.tags ?? [];
+  const seen = new Set<string>();
+  const prompts: string[] = [];
+
+  for (const tag of tags) {
+    if (!isInstrumentTag(tag) || seen.has(tag)) continue;
+    seen.add(tag);
+    prompts.push(`Scan ${tag} flow`);
+    if (prompts.length >= MAX_FOLLOW_UPS) break;
+  }
+
+  return prompts;
+}

--- a/web/lib/agent/askBus.ts
+++ b/web/lib/agent/askBus.ts
@@ -1,0 +1,34 @@
+/**
+ * Ask bus — lets a surface hand a prompt to the ⌘J chat overlay.
+ *
+ * AnalysisSources' follow-up chips live inside the newsfeed lightbox, which is
+ * portalled to document.body and has no path to ChatLauncher's local `open`
+ * state. Rather than lift chat state into a global provider for one caller,
+ * this is a two-function DOM event bus: the chip emits, the launcher listens,
+ * opens itself and sends the prompt.
+ *
+ * Deliberately DOM-event based (not a module-level singleton) so it survives
+ * fast-refresh and stays inert during SSR.
+ */
+
+const ASK_EVENT = "radon:ask";
+
+export type AskDetail = { prompt: string };
+
+/** Fire-and-forget. No-op during SSR, where there is no chat mounted anyway. */
+export function emitAsk(prompt: string): void {
+  const cleaned = prompt.trim();
+  if (!cleaned || typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent<AskDetail>(ASK_EVENT, { detail: { prompt: cleaned } }));
+}
+
+/** Returns an unsubscribe fn; safe to call during SSR (returns a no-op). */
+export function subscribeAsk(handler: (prompt: string) => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  const listener = (event: Event) => {
+    const detail = (event as CustomEvent<AskDetail>).detail;
+    if (detail?.prompt) handler(detail.prompt);
+  };
+  window.addEventListener(ASK_EVENT, listener);
+  return () => window.removeEventListener(ASK_EVENT, listener);
+}

--- a/web/lib/agent/scannerProposal.ts
+++ b/web/lib/agent/scannerProposal.ts
@@ -1,0 +1,71 @@
+/**
+ * Scanner proposal — promotes the top-ranked theta candidate to a ProposalCard.
+ *
+ * "Actionable" is not a presentation choice: the scanner already emits a
+ * verdict and a gate map per candidate. A row is proposal-worthy only when the
+ * engine called it THETA_HARVEST *and* every gate passed. Anything else stays
+ * in the table, which is why this returns null far more often than not.
+ *
+ * Confidence is the scanner's own composite score on its native 0-100 scale,
+ * normalised to 0-1. Deliberately NOT rescaled against the visible result set:
+ * a relative scale would pin the top row at 1.00 on every scan, however weak
+ * the field.
+ */
+
+import type { ProposalAlternative } from "@/components/agent";
+import type { ThetaHarvesterResult } from "@/lib/types";
+
+export type ScannerProposal = {
+  ticker: string;
+  statement: string;
+  confidence: number;
+  alternatives: ProposalAlternative[];
+};
+
+const ACTIONABLE_VERDICT = "THETA_HARVEST";
+const MAX_ALTERNATIVES = 3;
+
+function allGatesPass(result: ThetaHarvesterResult): boolean {
+  const gates = result.gates ?? {};
+  const values = Object.values(gates);
+  if (!values.length) return false;
+  return values.every(Boolean);
+}
+
+/** A candidate the engine itself rated actionable. */
+export function isActionable(result: ThetaHarvesterResult): boolean {
+  return result.verdict === ACTIONABLE_VERDICT && allGatesPass(result) && !result.errors?.length;
+}
+
+function statementFor(result: ThetaHarvesterResult): string {
+  const setup = result.setup?.trim();
+  if (setup) return setup;
+  const edge = Number.isFinite(result.iv_rv_edge) ? result.iv_rv_edge.toFixed(1) : "---";
+  return `${result.ticker} ${result.structure} — IV/RV edge ${edge}, range score ${result.range_score}.`;
+}
+
+function alternativesFrom(rest: ThetaHarvesterResult[]): ProposalAlternative[] {
+  return rest.slice(0, MAX_ALTERNATIVES).map((row) => ({
+    id: row.ticker,
+    label: `${row.ticker} ${row.structure}`,
+    meta: row.verdict === ACTIONABLE_VERDICT ? `SCORE ${Math.round(row.score)}` : row.verdict,
+  }));
+}
+
+/**
+ * Builds the proposal from an ALREADY-SORTED result list (the scanner sorts by
+ * the operator's chosen key). Returns null when the leading row is not
+ * actionable — the caller renders the table alone.
+ */
+export function buildScannerProposal(sorted: ThetaHarvesterResult[]): ScannerProposal | null {
+  const [top, ...rest] = sorted;
+  if (!top || !isActionable(top)) return null;
+
+  const score = Number.isFinite(top.score) ? top.score : 0;
+  return {
+    ticker: top.ticker,
+    statement: statementFor(top),
+    confidence: Math.max(0, Math.min(1, score / 100)),
+    alternatives: alternativesFrom(rest),
+  };
+}

--- a/web/lib/agent/turnSteps.ts
+++ b/web/lib/agent/turnSteps.ts
@@ -1,0 +1,110 @@
+/**
+ * Turn steps — maps the assistant loop's tool telemetry onto EngineTrace's
+ * step model.
+ *
+ * `/api/assistant` already returns `toolEvents` (one per tool call the agentic
+ * loop made) and `rounds`; the client just discarded them. This module is the
+ * translation layer, kept pure so the trace can be unit-tested without
+ * rendering the chat.
+ *
+ * Step ordering mirrors execution order: every completed tool call, then a
+ * trailing synthetic step for the phase the turn is currently in. A turn that
+ * has not yet come back from the network has no tool events at all, so it shows
+ * a single running "Routing request" step — the drop-in for the typing dots.
+ */
+
+import type { TraceStep } from "@/components/agent";
+import type { AssistantToolEvent } from "@/lib/types";
+
+/** Chat request lifecycle, mirrored from ChatPanel's ChatStatus. */
+export type TurnPhase = "submitted" | "streaming" | "done" | "error";
+
+const TOOL_LABELS: Record<string, string> = {
+  get_flow: "Read dark-pool flow",
+  run_scan: "Run scanner",
+  get_gex: "Read gamma exposure",
+  get_portfolio: "Read portfolio",
+  search_knowledge: "Search knowledge base",
+  find_prior_evals: "Find prior evaluations",
+  get_realized_pnl: "Read realized P&L",
+  query_journal: "Query trade journal",
+  place_order: "Stage order proposal",
+};
+
+/**
+ * Human-readable label for a tool. Falls back to de-snake-casing the raw name
+ * so a newly added tool degrades to something readable instead of vanishing.
+ */
+export function describeTool(name: string): string {
+  const known = TOOL_LABELS[name];
+  if (known) return known;
+  const words = name.replace(/_/g, " ").trim();
+  if (!words) return "Tool call";
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+function toolMeta(event: AssistantToolEvent): string {
+  if (!event.ok) return "FAILED";
+  if (event.repeated) return "CACHED";
+  return "OK";
+}
+
+/**
+ * The trailing synthetic step describing what the turn is doing right now.
+ * `done` contributes no trailing step — every real step has already settled.
+ */
+function phaseStep(phase: TurnPhase, hasTools: boolean): TraceStep | null {
+  if (phase === "submitted") {
+    return {
+      id: "phase-route",
+      label: hasTools ? "Reasoning over tool results" : "Routing request",
+      state: "running",
+    };
+  }
+  if (phase === "streaming") {
+    return { id: "phase-compose", label: "Composing response", state: "running" };
+  }
+  if (phase === "error") {
+    return { id: "phase-error", label: "Turn failed", meta: "ERROR", state: "waiting" };
+  }
+  return null;
+}
+
+/**
+ * Builds the ordered trace for a turn. Tool events are always settled by the
+ * time the client sees them — the loop runs server-side and returns once — so
+ * they render as `done` (or `waiting` when the call itself errored).
+ */
+export function buildTurnSteps(toolEvents: AssistantToolEvent[], phase: TurnPhase): TraceStep[] {
+  const steps: TraceStep[] = toolEvents.map((event, index) => ({
+    id: `tool-${index}-${event.name}`,
+    label: describeTool(event.name),
+    meta: toolMeta(event),
+    state: event.ok ? "done" : "waiting",
+  }));
+
+  const trailing = phaseStep(phase, steps.length > 0);
+  if (trailing) steps.push(trailing);
+  return steps;
+}
+
+/**
+ * Engine chips for the trace header. The loop reports the concrete model id;
+ * SPECTRAL is Radon's house name for the default reasoning engine, so an
+ * unknown/absent model still labels the turn rather than rendering bare.
+ */
+export function describeEngines(model?: string | null): string[] {
+  if (!model) return ["SPECTRAL"];
+  const normalized = model.toLowerCase();
+  if (normalized.includes("grok")) return ["GROK"];
+  if (normalized.includes("claude") || normalized.includes("opus") || normalized.includes("sonnet")) {
+    return ["CLAUDE"];
+  }
+  return [model.toUpperCase()];
+}
+
+/** Mono elapsed telemetry for the trace header, e.g. "4.2S". */
+export function formatElapsed(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "";
+  return `${(ms / 1000).toFixed(1)}S`;
+}

--- a/web/lib/agent/workflowTasks.ts
+++ b/web/lib/agent/workflowTasks.ts
@@ -1,0 +1,66 @@
+/**
+ * Workflow tasks — maps a pipeline graph + its run report onto TaskRuns.
+ *
+ * The executor already returns a per-node RunReport (rows in/out, which node
+ * blocked, which gate failed). That is the live run state TaskRuns wants; the
+ * Workflow surface previously threw it away into a one-line status string.
+ *
+ * Two entry points because a run has two observable states:
+ *   - in flight  → graphToRunningTasks: nodes from the graph, first one running
+ *   - settled    → runReportToTasks: real per-node row counts and the block point
+ */
+
+import type { AgentTask, SubStep, TaskState } from "@/components/agent";
+import type { RunReport, RunStep, WorkflowGraph } from "@/app/workflow/workflowClient";
+
+function nodeTitle(nodeType: string, nodeId: string): string {
+  const label = nodeType.replace(/_/g, " ");
+  const titled = label.charAt(0).toUpperCase() + label.slice(1);
+  return `${titled} · ${nodeId}`;
+}
+
+function stepSubSteps(step: RunStep): SubStep[] {
+  const subs: SubStep[] = [
+    { label: "rows in", meta: String(step.rows_in) },
+    { label: "rows out", meta: String(step.rows_out) },
+  ];
+
+  const gate = step.info?.gate;
+  if (typeof gate === "string" && gate) {
+    subs.push({ label: "gate", meta: gate.toUpperCase() });
+  }
+  return subs;
+}
+
+/**
+ * Per-node tasks for a settled run. Everything up to the blocking node ran, so
+ * it reads `done`; the blocking node itself is `queued` — it halted rather than
+ * completing, and TaskRuns has no failure state by design (the block reason is
+ * carried in the sub-steps and the surface's own status strip).
+ */
+export function runReportToTasks(report: RunReport): AgentTask[] {
+  return report.steps.map((step) => {
+    const state: TaskState = step.blocked ? "queued" : "done";
+    return {
+      id: step.node_id,
+      title: nodeTitle(step.node_type, step.node_id),
+      meta: `${step.rows_out} ROWS`,
+      state,
+      steps: stepSubSteps(step),
+    };
+  });
+}
+
+/**
+ * Per-node tasks while a run is in flight. The executor returns the whole
+ * report at once rather than streaming, so the first node shows `running` and
+ * the rest `queued` — an honest "started, not yet reported" rather than a fake
+ * progress animation across every node.
+ */
+export function graphToRunningTasks(graph: WorkflowGraph): AgentTask[] {
+  return graph.nodes.map((node, index) => ({
+    id: node.id,
+    title: nodeTitle(node.type, node.id),
+    state: index === 0 ? "running" : "queued",
+  }));
+}

--- a/web/lib/chat.ts
+++ b/web/lib/chat.ts
@@ -3,6 +3,7 @@ import type {
   ApiMessage,
   AssistantOrderProposal,
   AssistantResponse,
+  AssistantToolEvent,
   Message,
   PiResponse,
   WorkspaceSection,
@@ -186,6 +187,10 @@ export async function requestAssistantReply(history: ApiMessage[], latestMessage
 export type AssistantTurn = {
   content: string;
   proposal: AssistantOrderProposal | null;
+  /** Per-tool-call telemetry from the agentic loop; drives <EngineTrace>. */
+  toolEvents: AssistantToolEvent[];
+  /** Concrete model id the loop ran on; drives the trace's engine chip. */
+  model: string | null;
 };
 
 /**
@@ -210,7 +215,7 @@ export async function requestAssistantTurn(
 
   if (!response.ok) {
     const message = payload?.error ? `Error: ${payload.error}` : "Assistant service returned an error.";
-    return { content: message, proposal: null };
+    return { content: message, proposal: null, toolEvents: [], model: null };
   }
 
   const content =
@@ -218,7 +223,12 @@ export async function requestAssistantTurn(
       ? formatAssistantPayload(payload.content)
       : fallbackReply(latestMessage);
 
-  return { content, proposal: payload?.proposal ?? null };
+  return {
+    content,
+    proposal: payload?.proposal ?? null,
+    toolEvents: Array.isArray(payload?.toolEvents) ? payload.toolEvents : [],
+    model: typeof payload?.model === "string" ? payload.model : null,
+  };
 }
 
 /**

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -38,6 +38,8 @@ export type AssistantToolEvent = {
   input: Record<string, unknown>;
   ok: boolean;
   error?: string;
+  /** Loop de-duplicated an identical call and replayed the cached result. */
+  repeated?: boolean;
 };
 
 export type AssistantOrderProposal = {

--- a/web/tests/agent-approval-gate.test.tsx
+++ b/web/tests/agent-approval-gate.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+//
+// ApprovalGate — human-in-the-loop confirmation primitive (web/components/agent).
+//
+// This is the F7 chokepoint: the gate NEVER auto-executes. It surfaces handling
+// options as a radiogroup, tracks exactly one selection, and hands that option's
+// id to onConfirm. ChatPanel routes a proposed order through it, so a regression
+// that confirms the wrong option (or confirms while busy) routes the wrong order.
+//
+// Invariants pinned here:
+//   1. First option is selected by default; defaultOptionId overrides.
+//   2. Clicking an option moves the selection (aria-checked follows).
+//   3. onConfirm receives the SELECTED option id, not the first / not the label.
+//   4. busy disables confirm, dismiss, and option selection.
+//   5. Dismiss never calls onConfirm.
+
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import ApprovalGate, { type GateOption } from "../components/agent/ApprovalGate";
+
+const OPTIONS: GateOption[] = [
+  { id: "route", label: "Route as proposed", meta: "AS PROPOSED" },
+  { id: "halve", label: "Route at half size", meta: "0.5x CLIP" },
+  { id: "hold", label: "Hold for review", meta: "NO ROUTE" },
+];
+
+function renderGate(overrides: Partial<React.ComponentProps<typeof ApprovalGate>> = {}) {
+  const onConfirm = vi.fn();
+  const onDismiss = vi.fn();
+  const utils = render(
+    <ApprovalGate
+      body="BUY 10 MU 2026-09-18 $120C @ 4.20 debit."
+      options={OPTIONS}
+      onConfirm={onConfirm}
+      onDismiss={onDismiss}
+      {...overrides}
+    />,
+  );
+  return { ...utils, onConfirm, onDismiss };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ApprovalGate — option selection", () => {
+  it("selects the first option by default", () => {
+    renderGate();
+    const radios = screen.getAllByRole("radio");
+    expect(radios).toHaveLength(3);
+    expect(radios[0].getAttribute("aria-checked")).toBe("true");
+    expect(radios[1].getAttribute("aria-checked")).toBe("false");
+    expect(radios[2].getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("honours defaultOptionId over first-option fallback", () => {
+    renderGate({ defaultOptionId: "hold" });
+    const radios = screen.getAllByRole("radio");
+    expect(radios[0].getAttribute("aria-checked")).toBe("false");
+    expect(radios[2].getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("moves the selection when another option is clicked", () => {
+    renderGate();
+    fireEvent.click(screen.getByText("Route at half size"));
+    const radios = screen.getAllByRole("radio");
+    expect(radios[0].getAttribute("aria-checked")).toBe("false");
+    expect(radios[1].getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("renders the declarative body statement and per-option meta", () => {
+    renderGate();
+    expect(screen.getByText("BUY 10 MU 2026-09-18 $120C @ 4.20 debit.")).toBeTruthy();
+    expect(screen.getByText("AS PROPOSED")).toBeTruthy();
+    expect(screen.getByText("NO ROUTE")).toBeTruthy();
+  });
+});
+
+describe("ApprovalGate — onConfirm(optionId)", () => {
+  it("confirms the default option id when nothing is clicked", () => {
+    const { onConfirm } = renderGate();
+    fireEvent.click(screen.getByText("Confirm selection"));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledWith("route");
+  });
+
+  it("confirms the NEWLY selected option id, not the default", () => {
+    const { onConfirm } = renderGate();
+    fireEvent.click(screen.getByText("Hold for review"));
+    fireEvent.click(screen.getByText("Confirm selection"));
+    expect(onConfirm).toHaveBeenCalledWith("hold");
+  });
+
+  it("never fires onConfirm when dismissed", () => {
+    const { onConfirm, onDismiss } = renderGate();
+    fireEvent.click(screen.getByText("Dismiss"));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});
+
+describe("ApprovalGate — busy state", () => {
+  it("disables confirm, dismiss and option selection while routing", () => {
+    const { onConfirm, onDismiss } = renderGate({ busy: true });
+
+    const confirm = screen.getByText("Routing…") as HTMLButtonElement;
+    expect(confirm.disabled).toBe(true);
+    expect((screen.getByText("Dismiss") as HTMLButtonElement).disabled).toBe(true);
+    for (const radio of screen.getAllByRole("radio")) {
+      expect((radio as HTMLButtonElement).disabled).toBe(true);
+    }
+
+    fireEvent.click(confirm);
+    fireEvent.click(screen.getByText("Dismiss"));
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("shows the settled confirm label when not busy", () => {
+    renderGate();
+    expect(screen.getByText("Confirm selection")).toBeTruthy();
+    expect(screen.queryByText("Routing…")).toBeNull();
+  });
+});

--- a/web/tests/agent-ask-composer.test.tsx
+++ b/web/tests/agent-ask-composer.test.tsx
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+//
+// AskComposer — the chat composer that replaces ChatPanel's inline textarea/form.
+//
+// The submit semantics it inherits from ChatPanel are the whole point of this
+// spec: Enter sends, Shift+Enter inserts a newline, and an in-flight IME
+// composition suppresses BOTH (a CJK/emoji candidate-window Enter commits the
+// candidate — sending there fires a half-typed prompt at the assistant).
+//
+// focusKey replaces ChatPanel's composerRef focus effect: it focuses on mount and
+// on every change, so the ⌘J overlay still lands the caret in the composer.
+
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import AskComposer from "../components/agent/AskComposer";
+
+function renderComposer(overrides: Partial<React.ComponentProps<typeof AskComposer>> = {}) {
+  const onSubmit = vi.fn();
+  const utils = render(<AskComposer onSubmit={onSubmit} {...overrides} />);
+  const textarea = screen.getByLabelText("Ask Radon") as HTMLTextAreaElement;
+  return { ...utils, onSubmit, textarea };
+}
+
+function type(textarea: HTMLTextAreaElement, value: string) {
+  fireEvent.change(textarea, { target: { value } });
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AskComposer — Enter to send", () => {
+  it("submits the trimmed text on bare Enter", () => {
+    const { onSubmit, textarea } = renderComposer();
+    type(textarea, "  scan MU flow  ");
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0][0]).toBe("scan MU flow");
+  });
+
+  it("passes the selected engine as the second argument (AUTO by default)", () => {
+    const { onSubmit, textarea } = renderComposer();
+    type(textarea, "risk check");
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(onSubmit.mock.calls[0][1]).toBe("AUTO");
+  });
+
+  it("clears the textarea after a send", () => {
+    const { textarea } = renderComposer();
+    type(textarea, "scan MU flow");
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(textarea.value).toBe("");
+  });
+
+  it("does not send whitespace-only input", () => {
+    const { onSubmit, textarea } = renderComposer();
+    type(textarea, "   ");
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("does not send while busy", () => {
+    const { onSubmit, textarea } = renderComposer({ busy: true });
+    type(textarea, "scan MU flow");
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("submits on the send button click", () => {
+    const { onSubmit, textarea } = renderComposer();
+    type(textarea, "scan MU flow");
+    fireEvent.click(screen.getByLabelText("Send"));
+
+    expect(onSubmit).toHaveBeenCalledWith("scan MU flow", "AUTO");
+  });
+
+  it("disables the send button on empty input and enables it once typed", () => {
+    const { textarea } = renderComposer();
+    const send = screen.getByLabelText("Send") as HTMLButtonElement;
+    expect(send.disabled).toBe(true);
+
+    type(textarea, "scan MU flow");
+    expect(send.disabled).toBe(false);
+  });
+});
+
+describe("AskComposer — Shift+Enter inserts a newline", () => {
+  it("does NOT submit when Shift is held", () => {
+    const { onSubmit, textarea } = renderComposer();
+    type(textarea, "line one");
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("leaves the draft intact so the newline survives", () => {
+    const { textarea } = renderComposer();
+    type(textarea, "line one");
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
+
+    expect(textarea.value).toBe("line one");
+  });
+});
+
+describe("AskComposer — IME composition guard", () => {
+  it("does NOT submit on Enter while a composition session is open", () => {
+    const { onSubmit, textarea } = renderComposer();
+    type(textarea, "ミュー");
+    fireEvent.compositionStart(textarea);
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("does NOT submit when the native event reports isComposing", () => {
+    const { onSubmit, textarea } = renderComposer();
+    type(textarea, "ミュー");
+    fireEvent.keyDown(textarea, { key: "Enter", isComposing: true });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("submits again once the composition has ended", () => {
+    const { onSubmit, textarea } = renderComposer();
+    type(textarea, "ミュー");
+    fireEvent.compositionStart(textarea);
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    fireEvent.compositionEnd(textarea);
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSubmit).toHaveBeenCalledWith("ミュー", "AUTO");
+  });
+});
+
+describe("AskComposer — focusKey autofocus", () => {
+  it("focuses the textarea on mount", () => {
+    const { textarea } = renderComposer({ focusKey: true });
+    expect(document.activeElement).toBe(textarea);
+  });
+
+  it("re-focuses when focusKey changes", () => {
+    const onSubmit = vi.fn();
+    const { rerender } = render(<AskComposer onSubmit={onSubmit} focusKey={1} />);
+    const textarea = screen.getByLabelText("Ask Radon") as HTMLTextAreaElement;
+
+    textarea.blur();
+    expect(document.activeElement).not.toBe(textarea);
+
+    rerender(<AskComposer onSubmit={onSubmit} focusKey={2} />);
+    expect(document.activeElement).toBe(textarea);
+  });
+
+  it("does not steal focus when focusKey is false (panel closed)", () => {
+    const { textarea } = renderComposer({ focusKey: false });
+    expect(document.activeElement).not.toBe(textarea);
+  });
+});

--- a/web/tests/agent-derivations.test.ts
+++ b/web/tests/agent-derivations.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Pure derivations feeding the four remaining agent primitives.
+ *
+ * Each of these replaces what would otherwise be placeholder props: the trace
+ * comes from the assistant loop's real tool telemetry, sources from the real
+ * two-stage tagging pipeline, tasks from the executor's real RunReport, and the
+ * scanner proposal from the engine's own verdict + gate map.
+ *
+ * The invariant worth protecting across all four: when the underlying data is
+ * absent or not actionable, these return empty/null so the surface renders
+ * nothing — never a fabricated citation, score, or run.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { buildTurnSteps, describeEngines, describeTool, formatElapsed } from "../lib/agent/turnSteps";
+import { buildAnalysisSources, buildFollowUps } from "../lib/agent/analysisSources";
+import { graphToRunningTasks, runReportToTasks } from "../lib/agent/workflowTasks";
+import { buildScannerProposal, isActionable } from "../lib/agent/scannerProposal";
+import type { RunReport } from "../app/workflow/workflowClient";
+import type { AssistantToolEvent, ThetaHarvesterResult } from "../lib/types";
+
+// ── EngineTrace ────────────────────────────────────────────────────────────
+
+describe("buildTurnSteps", () => {
+  const flow: AssistantToolEvent = { name: "get_flow", input: {}, ok: true };
+  const gex: AssistantToolEvent = { name: "get_gex", input: {}, ok: true };
+
+  it("shows a single running step before any tool has run", () => {
+    const steps = buildTurnSteps([], "submitted");
+    expect(steps).toHaveLength(1);
+    expect(steps[0].label).toBe("Routing request");
+    expect(steps[0].state).toBe("running");
+  });
+
+  it("renames the trailing step once tools have returned", () => {
+    const steps = buildTurnSteps([flow], "submitted");
+    expect(steps[steps.length - 1].label).toBe("Reasoning over tool results");
+  });
+
+  it("maps each tool event to a settled step in execution order", () => {
+    const steps = buildTurnSteps([flow, gex], "streaming");
+    expect(steps.map((s) => s.label)).toEqual([
+      "Read dark-pool flow",
+      "Read gamma exposure",
+      "Composing response",
+    ]);
+    expect(steps[0].state).toBe("done");
+    expect(steps[1].state).toBe("done");
+  });
+
+  it("marks a failed tool call as unsettled with FAILED meta", () => {
+    const steps = buildTurnSteps([{ name: "get_flow", input: {}, ok: false, error: "boom" }], "done");
+    expect(steps[0].state).toBe("waiting");
+    expect(steps[0].meta).toBe("FAILED");
+  });
+
+  it("tags a repeated call as CACHED", () => {
+    const steps = buildTurnSteps([{ name: "get_gex", input: {}, ok: true, repeated: true }], "done");
+    expect(steps[0].meta).toBe("CACHED");
+  });
+
+  it("adds no trailing step once the turn is done", () => {
+    const steps = buildTurnSteps([flow], "done");
+    expect(steps).toHaveLength(1);
+    expect(steps[0].state).toBe("done");
+  });
+
+  it("surfaces an error phase as its own step", () => {
+    const steps = buildTurnSteps([], "error");
+    expect(steps[0].meta).toBe("ERROR");
+  });
+
+  it("de-snake-cases an unknown tool rather than dropping it", () => {
+    expect(describeTool("get_brand_new_thing")).toBe("Get brand new thing");
+    expect(describeTool("get_flow")).toBe("Read dark-pool flow");
+  });
+});
+
+describe("describeEngines / formatElapsed", () => {
+  it("falls back to SPECTRAL when the model is unknown", () => {
+    expect(describeEngines(null)).toEqual(["SPECTRAL"]);
+    expect(describeEngines(undefined)).toEqual(["SPECTRAL"]);
+  });
+
+  it("names the provider family from the model id", () => {
+    expect(describeEngines("grok-4-latest")).toEqual(["GROK"]);
+    expect(describeEngines("claude-opus-5")).toEqual(["CLAUDE"]);
+  });
+
+  it("formats elapsed as mono seconds and rejects nonsense", () => {
+    expect(formatElapsed(4200)).toBe("4.2S");
+    expect(formatElapsed(-1)).toBe("");
+    expect(formatElapsed(Number.NaN)).toBe("");
+  });
+});
+
+// ── AnalysisSources ────────────────────────────────────────────────────────
+
+describe("buildAnalysisSources", () => {
+  it("returns nothing for a post with no href and no tagger output", () => {
+    expect(buildAnalysisSources({})).toEqual([]);
+  });
+
+  it("lists the article host first, then whichever taggers contributed", () => {
+    const sources = buildAnalysisSources({
+      href: "https://www.themarketear.com/posts/abc",
+      tags_text: ["MU", "FED"],
+      tags_vision: ["CHART"],
+    });
+    expect(sources.map((s) => s.id)).toEqual(["article", "tagger-text", "tagger-vision"]);
+    expect(sources[0].name).toBe("themarketear.com");
+    expect(sources[1].feed).toBe("2 tags");
+    expect(sources[2].feed).toBe("1 tag");
+  });
+
+  it("omits a tagger that produced nothing", () => {
+    const sources = buildAnalysisSources({ href: "https://x.com/a", tags_text: ["MU"] });
+    expect(sources.map((s) => s.id)).toEqual(["article", "tagger-text"]);
+  });
+
+  it("drops an unparseable href instead of rendering a broken row", () => {
+    expect(buildAnalysisSources({ href: "not a url" })).toEqual([]);
+  });
+});
+
+describe("buildFollowUps", () => {
+  it("turns ticker-shaped tags into flow prompts", () => {
+    expect(buildFollowUps({ tags: ["MU", "NVDA"] })).toEqual(["Scan MU flow", "Scan NVDA flow"]);
+  });
+
+  it("ignores prose tags and lowercase noise", () => {
+    expect(buildFollowUps({ tags: ["FED RATES", "macro", "MU"] })).toEqual(["Scan MU flow"]);
+  });
+
+  it("dedupes and caps at three", () => {
+    expect(buildFollowUps({ tags: ["MU", "MU", "A", "B", "C", "D"] })).toEqual([
+      "Scan MU flow",
+      "Scan A flow",
+      "Scan B flow",
+    ]);
+  });
+
+  it("returns nothing when there are no tags", () => {
+    expect(buildFollowUps({})).toEqual([]);
+  });
+});
+
+// ── TaskRuns ───────────────────────────────────────────────────────────────
+
+function report(overrides: Partial<RunReport> = {}): RunReport {
+  return {
+    ok: true,
+    blocked_by: null,
+    blocked_gate: null,
+    requires_confirmation: false,
+    steps: [],
+    final_rows: [],
+    ...overrides,
+  };
+}
+
+describe("runReportToTasks", () => {
+  it("maps executed nodes to done with their real row counts", () => {
+    const tasks = runReportToTasks(
+      report({
+        steps: [
+          { node_id: "n1", node_type: "universe", rows_in: 0, rows_out: 34, blocked: false, info: {} },
+          { node_id: "n2", node_type: "filter", rows_in: 34, rows_out: 6, blocked: false, info: {} },
+        ],
+      }),
+    );
+
+    expect(tasks.map((t) => t.state)).toEqual(["done", "done"]);
+    expect(tasks[0].title).toBe("Universe · n1");
+    expect(tasks[1].meta).toBe("6 ROWS");
+    expect(tasks[1].steps).toEqual([
+      { label: "rows in", meta: "34" },
+      { label: "rows out", meta: "6" },
+    ]);
+  });
+
+  it("leaves a blocked node queued and names the gate that stopped it", () => {
+    const tasks = runReportToTasks(
+      report({
+        ok: false,
+        blocked_by: "n2",
+        blocked_gate: "convexity",
+        steps: [
+          { node_id: "n1", node_type: "universe", rows_in: 0, rows_out: 4, blocked: false, info: {} },
+          { node_id: "n2", node_type: "order", rows_in: 4, rows_out: 0, blocked: true, info: { gate: "convexity" } },
+        ],
+      }),
+    );
+
+    expect(tasks[0].state).toBe("done");
+    expect(tasks[1].state).toBe("queued");
+    expect(tasks[1].steps).toContainEqual({ label: "gate", meta: "CONVEXITY" });
+  });
+
+  it("returns nothing for a report with no steps", () => {
+    expect(runReportToTasks(report())).toEqual([]);
+  });
+});
+
+describe("graphToRunningTasks", () => {
+  it("marks only the first node running and queues the rest", () => {
+    const tasks = graphToRunningTasks({
+      nodes: [
+        { id: "a", type: "universe", params: {} },
+        { id: "b", type: "filter", params: {} },
+        { id: "c", type: "order", params: {} },
+      ],
+      edges: [],
+    });
+    expect(tasks.map((t) => t.state)).toEqual(["running", "queued", "queued"]);
+  });
+
+  it("handles an empty graph", () => {
+    expect(graphToRunningTasks({ nodes: [], edges: [] })).toEqual([]);
+  });
+});
+
+// ── ProposalCard ───────────────────────────────────────────────────────────
+
+function candidate(overrides: Partial<ThetaHarvesterResult> = {}): ThetaHarvesterResult {
+  return {
+    ticker: "MU",
+    score: 97,
+    verdict: "THETA_HARVEST",
+    structure: "short strangle" as ThetaHarvesterResult["structure"],
+    spot: 142,
+    iv: 0.51,
+    hv20: 0.33,
+    hv60: 0.35,
+    iv_rv_edge: 18,
+    iv_rv_ratio: 1.5,
+    trend_20d_pct: 1.2,
+    range_score: 82,
+    dealer_support: "SUPPORT",
+    net_gex: 1,
+    gex_flip: 140,
+    setup: "MU short strangle — IV/RV edge 18, dealer support intact.",
+    gates: { convexity: true, edge: true, risk: true },
+    errors: [],
+    ...overrides,
+  };
+}
+
+describe("isActionable", () => {
+  it("accepts a THETA_HARVEST verdict with every gate passing", () => {
+    expect(isActionable(candidate())).toBe(true);
+  });
+
+  it("rejects a non-harvest verdict", () => {
+    expect(isActionable(candidate({ verdict: "WATCHLIST" }))).toBe(false);
+  });
+
+  it("rejects a failing gate", () => {
+    expect(isActionable(candidate({ gates: { convexity: true, edge: false } }))).toBe(false);
+  });
+
+  it("rejects an empty gate map — unproven is not actionable", () => {
+    expect(isActionable(candidate({ gates: {} }))).toBe(false);
+  });
+
+  it("rejects a candidate that recorded errors", () => {
+    expect(isActionable(candidate({ errors: ["no chain"] }))).toBe(false);
+  });
+});
+
+describe("buildScannerProposal", () => {
+  it("returns null on an empty scan", () => {
+    expect(buildScannerProposal([])).toBeNull();
+  });
+
+  it("returns null when the leading row is not actionable", () => {
+    expect(buildScannerProposal([candidate({ verdict: "WATCHLIST" }), candidate()])).toBeNull();
+  });
+
+  it("uses the engine's absolute score as confidence, not a relative rescale", () => {
+    const proposal = buildScannerProposal([candidate({ score: 82 })]);
+    expect(proposal?.confidence).toBeCloseTo(0.82, 5);
+  });
+
+  it("clamps a score outside 0-100", () => {
+    expect(buildScannerProposal([candidate({ score: 140 })])?.confidence).toBe(1);
+    expect(buildScannerProposal([candidate({ score: -5 })])?.confidence).toBe(0);
+  });
+
+  it("carries the engine's own setup text as the statement", () => {
+    const proposal = buildScannerProposal([candidate()]);
+    expect(proposal?.statement).toBe("MU short strangle — IV/RV edge 18, dealer support intact.");
+    expect(proposal?.ticker).toBe("MU");
+  });
+
+  it("lists the next ranked rows as alternatives, capped at three", () => {
+    const proposal = buildScannerProposal([
+      candidate(),
+      candidate({ ticker: "NVDA", score: 91 }),
+      candidate({ ticker: "AMD", verdict: "WATCHLIST" }),
+      candidate({ ticker: "INTC", score: 88 }),
+      candidate({ ticker: "QCOM", score: 87 }),
+    ]);
+    expect(proposal?.alternatives).toHaveLength(3);
+    expect(proposal?.alternatives[0]).toEqual({ id: "NVDA", label: "NVDA short strangle", meta: "SCORE 91" });
+    expect(proposal?.alternatives[1].meta).toBe("WATCHLIST");
+  });
+});

--- a/web/tests/agent-integration.test.tsx
+++ b/web/tests/agent-integration.test.tsx
@@ -1,0 +1,209 @@
+// @vitest-environment jsdom
+//
+// Wiring tests for the four agent primitives at their real integration points.
+// The derivations are unit-tested in agent-derivations.test.ts; this file pins
+// that each surface actually renders them, and that the ask-bus handoff from
+// the newsfeed lightbox reaches the chat overlay.
+
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { emitAsk, subscribeAsk } from "../lib/agent/askBus";
+import AnalysisSources from "../components/agent/AnalysisSources";
+import { buildAnalysisSources, buildFollowUps } from "../lib/agent/analysisSources";
+import TaskRuns from "../components/agent/TaskRuns";
+import { runReportToTasks } from "../lib/agent/workflowTasks";
+import ProposalCard from "../components/agent/ProposalCard";
+import { buildScannerProposal } from "../lib/agent/scannerProposal";
+import type { ThetaHarvesterResult } from "../lib/types";
+
+afterEach(cleanup);
+
+describe("askBus", () => {
+  it("delivers an emitted prompt to a subscriber", () => {
+    const seen: string[] = [];
+    const unsubscribe = subscribeAsk((p) => seen.push(p));
+
+    emitAsk("Scan MU flow");
+    expect(seen).toEqual(["Scan MU flow"]);
+
+    unsubscribe();
+    emitAsk("Scan NVDA flow");
+    expect(seen).toEqual(["Scan MU flow"]);
+  });
+
+  it("ignores an empty prompt", () => {
+    const handler = vi.fn();
+    const unsubscribe = subscribeAsk(handler);
+    emitAsk("   ");
+    expect(handler).not.toHaveBeenCalled();
+    unsubscribe();
+  });
+});
+
+describe("AnalysisSources — newsfeed wiring", () => {
+  const post = {
+    href: "https://www.themarketear.com/posts/abc",
+    tags: ["MU", "FED RATES"],
+    tags_text: ["MU"],
+    tags_vision: ["CHART"],
+  };
+
+  it("renders real provenance rows derived from the post", () => {
+    render(
+      <AnalysisSources sources={buildAnalysisSources(post)} followUps={buildFollowUps(post)} />,
+    );
+    expect(screen.getByText("themarketear.com")).toBeTruthy();
+    expect(screen.getByText("Text tagger")).toBeTruthy();
+    expect(screen.getByText("Vision tagger")).toBeTruthy();
+  });
+
+  it("hands a clicked follow-up to the ask bus", () => {
+    const received: string[] = [];
+    const unsubscribe = subscribeAsk((p) => received.push(p));
+
+    render(
+      <AnalysisSources
+        sources={buildAnalysisSources(post)}
+        followUps={buildFollowUps(post)}
+        onFollowUp={emitAsk}
+      />,
+    );
+    fireEvent.click(screen.getByText("Scan MU flow"));
+
+    expect(received).toEqual(["Scan MU flow"]);
+    unsubscribe();
+  });
+
+  it("renders nothing for a post with no provenance and no follow-ups", () => {
+    const { container } = render(
+      <AnalysisSources sources={buildAnalysisSources({})} followUps={buildFollowUps({})} />,
+    );
+    expect(container.querySelector(".analysis-sources__label")).toBeNull();
+  });
+});
+
+describe("TaskRuns — workflow wiring", () => {
+  it("renders one row per executed node with its real row counts", () => {
+    const tasks = runReportToTasks({
+      ok: false,
+      blocked_by: "n2",
+      blocked_gate: "convexity",
+      requires_confirmation: false,
+      steps: [
+        { node_id: "n1", node_type: "universe", rows_in: 0, rows_out: 34, blocked: false, info: {} },
+        { node_id: "n2", node_type: "order", rows_in: 34, rows_out: 0, blocked: true, info: { gate: "convexity" } },
+      ],
+      final_rows: [],
+    });
+
+    render(<TaskRuns tasks={tasks} />);
+    expect(screen.getByText("Universe · n1")).toBeTruthy();
+    expect(screen.getByText("34 ROWS")).toBeTruthy();
+    expect(screen.getByText("COMPLETED")).toBeTruthy();
+    expect(screen.getByText("QUEUED")).toBeTruthy();
+    expect(screen.getByText("CONVEXITY")).toBeTruthy();
+  });
+});
+
+describe("ProposalCard — scanner wiring", () => {
+  const actionable: ThetaHarvesterResult = {
+    ticker: "MU",
+    score: 97,
+    verdict: "THETA_HARVEST",
+    structure: "short strangle" as ThetaHarvesterResult["structure"],
+    spot: 142,
+    iv: 0.51,
+    hv20: 0.33,
+    hv60: 0.35,
+    iv_rv_edge: 18,
+    iv_rv_ratio: 1.5,
+    trend_20d_pct: 1.2,
+    range_score: 82,
+    dealer_support: "SUPPORT",
+    net_gex: 1,
+    gex_flip: 140,
+    setup: "MU short strangle — IV/RV edge 18.",
+    gates: { convexity: true, edge: true },
+    errors: [],
+  };
+
+  it("renders the engine's statement and confidence meter", () => {
+    const proposal = buildScannerProposal([actionable])!;
+    render(
+      <ProposalCard
+        engines={["THETA"]}
+        statement={proposal.statement}
+        confidence={proposal.confidence}
+        alternatives={proposal.alternatives}
+        onAccept={() => {}}
+        onDismiss={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("MU short strangle — IV/RV edge 18.")).toBeTruthy();
+    expect(screen.getByText("0.97 · HIGH")).toBeTruthy();
+    expect(screen.getByRole("meter").getAttribute("aria-valuenow")).toBe("97");
+  });
+
+  it("accept and dismiss are distinct actions — accept never routes an order itself", () => {
+    const onAccept = vi.fn();
+    const onDismiss = vi.fn();
+    const proposal = buildScannerProposal([actionable])!;
+    render(
+      <ProposalCard
+        statement={proposal.statement}
+        confidence={proposal.confidence}
+        onAccept={onAccept}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Dismiss"));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onAccept).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText("Accept"));
+    expect(onAccept).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("EngineTrace — chat wiring", () => {
+  it("shows the trace while a turn is pending and clears it when content lands", async () => {
+    let resolveTurn: (value: unknown) => void = () => {};
+    const pending = new Promise((resolve) => {
+      resolveTurn = resolve;
+    });
+    const fetchMock = vi.fn(async () => {
+      const body = await pending;
+      return { ok: true, status: 200, json: async () => body } as Response;
+    });
+    // @ts-expect-error test stub
+    global.fetch = fetchMock;
+
+    const ChatPanel = (await import("../components/ChatPanel")).default;
+    const { container } = render(<ChatPanel activeSection="dashboard" />);
+
+    fireEvent.change(screen.getByLabelText("Ask Radon"), { target: { value: "read MU flow" } });
+    fireEvent.submit(screen.getByLabelText("Ask Radon").closest("form")!);
+
+    await waitFor(() => {
+      expect(container.querySelector(".engine-trace")).not.toBeNull();
+    });
+    expect(screen.getByText("Routing request")).toBeTruthy();
+
+    resolveTurn({
+      content: "Flow read.",
+      model: "grok-4-latest",
+      toolEvents: [{ name: "get_flow", input: {}, ok: true }],
+    });
+
+    await waitFor(
+      () => {
+        expect(container.querySelector(".engine-trace")).toBeNull();
+      },
+      { timeout: 4000 },
+    );
+  });
+});

--- a/web/tests/chat-launcher-focus.test.tsx
+++ b/web/tests/chat-launcher-focus.test.tsx
@@ -16,7 +16,9 @@ describe("ChatLauncher", () => {
 
     fireEvent.keyDown(document, { key: "j", ctrlKey: true });
 
-    const composer = await screen.findByLabelText("Message Grok assistant");
+    // Autofocus now comes from AskComposer's `focusKey` (fed the launcher's
+    // open flag), not ChatPanel's removed composerRef effect.
+    const composer = await screen.findByLabelText("Ask Radon");
     await waitFor(() => expect(document.activeElement).toBe(composer));
 
     fireEvent.keyDown(document, { key: "Escape" });

--- a/web/tests/chat-order-confirm.test.tsx
+++ b/web/tests/chat-order-confirm.test.tsx
@@ -6,10 +6,14 @@
  * The assistant route returns a structured order proposal for `place_order`:
  *   { tool, destructive, input, summary, toolUseId }
  *
- * ChatPanel must render it as a confirm card (summary + Confirm / Cancel) and:
+ * ChatPanel must render it as a confirm card (summary + Confirm / Dismiss) and:
  *   - NEVER auto-execute (no placement fetch until the operator clicks Confirm),
  *   - Confirm POSTs the proposed order to the placement path,
- *   - Cancel dismisses the card without placing anything.
+ *   - Dismiss clears the card without placing anything.
+ *
+ * The card is now <ApprovalGate> (web/components/agent) rather than the flat
+ * .chat-order-confirm banner, and the composer is <AskComposer> — hence the
+ * "Ask Radon" composer label and the "Dismiss" (was "Cancel") action below.
  *
  * All network is mocked.
  */
@@ -64,7 +68,7 @@ const PROPOSAL = {
 };
 
 async function sendNonCommandMessage(text: string) {
-  const textarea = screen.getByLabelText("Message Grok assistant");
+  const textarea = screen.getByLabelText("Ask Radon");
   fireEvent.change(textarea, { target: { value: text } });
   const form = textarea.closest("form")!;
   fireEvent.submit(form);
@@ -87,7 +91,7 @@ describe("ChatPanel order-confirm card", () => {
       expect(screen.getAllByText(PROPOSAL.summary)).toHaveLength(2);
     });
     expect(screen.getByRole("button", { name: /confirm/i })).toBeTruthy();
-    expect(screen.getByRole("button", { name: /cancel/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /dismiss/i })).toBeTruthy();
   });
 
   it("does NOT auto-execute the order (no placement call before Confirm)", async () => {
@@ -135,7 +139,7 @@ describe("ChatPanel order-confirm card", () => {
     expect(sentBody.idempotencyKey).toMatch(/^[0-9a-f-]{36}$/);
   });
 
-  it("Cancel dismisses the card and places nothing", async () => {
+  it("Dismiss clears the card and places nothing", async () => {
     const { calls } = mockFetchSequence({
       "/api/assistant": () => ({ content: "Proposing an order.", proposal: PROPOSAL }),
     });
@@ -143,8 +147,8 @@ describe("ChatPanel order-confirm card", () => {
     render(<ChatPanel activeSection="dashboard" portfolio={{ positions: [] } as never} />);
     await sendNonCommandMessage("buy me some wulf calls");
 
-    await waitFor(() => screen.getByRole("button", { name: /cancel/i }));
-    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    await waitFor(() => screen.getByRole("button", { name: /dismiss/i }));
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
 
     await waitFor(() => {
       expect(screen.queryByText(PROPOSAL.summary)).toBeNull();

--- a/web/tests/chat-streaming-ux.test.tsx
+++ b/web/tests/chat-streaming-ux.test.tsx
@@ -36,7 +36,10 @@ describe("ChatPanel streaming UX", () => {
     expect(buttons.some((b) => /portfolio/i.test(b.textContent ?? ""))).toBe(true);
   });
 
-  it("renders a typing indicator (not 'No output.') while a turn is in flight", async () => {
+  // The pending affordance is now <EngineTrace> (a real step trace fed by the
+  // loop's tool telemetry) rather than the three typing dots; the invariant
+  // under test is unchanged — a pending turn shows progress, never "No output."
+  it("renders an engine trace (not 'No output.') while a turn is in flight", async () => {
     let resolveTurn: (value: unknown) => void = () => {};
     const pending = new Promise((resolve) => {
       resolveTurn = resolve;
@@ -49,12 +52,12 @@ describe("ChatPanel streaming UX", () => {
     global.fetch = fetchMock;
 
     const { container } = render(<ChatPanel activeSection="portfolio" />);
-    const textarea = screen.getByLabelText("Message Grok assistant");
+    const textarea = screen.getByLabelText("Ask Radon");
     fireEvent.change(textarea, { target: { value: "hello there" } });
     fireEvent.submit(textarea.closest("form")!);
 
     await waitFor(() => {
-      expect(container.querySelector(".chat-typing")).not.toBeNull();
+      expect(container.querySelector(".engine-trace")).not.toBeNull();
     });
     expect(screen.queryByText("No output.")).toBeNull();
     expect(screen.queryByText(/Analyzing flow, structure/i)).toBeNull();
@@ -63,7 +66,7 @@ describe("ChatPanel streaming UX", () => {
 
     await waitFor(
       () => {
-        expect(container.querySelector(".chat-typing")).toBeNull();
+        expect(container.querySelector(".engine-trace")).toBeNull();
       },
       { timeout: 4000 },
     );
@@ -84,7 +87,7 @@ describe("ChatPanel streaming UX", () => {
     global.fetch = fetchMock;
 
     render(<ChatPanel activeSection="portfolio" />);
-    const textarea = screen.getByLabelText("Message Grok assistant");
+    const textarea = screen.getByLabelText("Ask Radon");
     fireEvent.change(textarea, { target: { value: "/portfolio" } });
     fireEvent.submit(textarea.closest("form")!);
 


### PR DESCRIPTION
Adopts six agent-UI primitives and wires each to real payloads. Ported onto the current `main` lineage.

## What lands

New: `web/components/agent/*` (6 components + barrel), pure derivations in `web/lib/agent/*`, agent styles appended to `globals.css` (additive only, no existing rule touched).

| Surface | Component | Data source |
|---|---|---|
| ChatPanel | `ApprovalGate` | replaces the flat `chat-order-confirm` banner |
| ChatPanel | `AskComposer` | replaces the inline textarea/form |
| ChatPanel | `EngineTrace` | `toolEvents` + `model`, already returned by `/api/assistant` and previously discarded by `requestAssistantTurn` |
| NewsfeedLightbox | `AnalysisSources` | origin article + whichever of the text/vision taggers annotated the post |
| WorkflowComposer | `TaskRuns` | the executor's `RunReport` (per-node rows in/out, blocking node + gate) |
| ThetaHarvesterScanner | `ProposalCard` | top-ranked candidate, only when the engine rated it `THETA_HARVEST` with all gates passing |

No new dependencies.

## Review focus — `OrderRiskGate`

`main` has since wired `OrderRiskGate` into the chat confirm card. This branch replaces that block with `ApprovalGate`, so the two had to be reconciled rather than one side taken:

- `OrderRiskGate` still renders, above `ApprovalGate`, and `confirmProposal`'s existing `okToSubmit` guard is untouched.
- That guard blocked placement but left the button enabled (a dead click). `ApprovalGate` gains a `confirmDisabled` prop — distinct from `busy` so Dismiss stays live — wired to `riskState?.okToSubmit !== true`.

Other conflicts: `globals.css` (both sides appended at EOF, both kept), `ChatLauncher` (`portfolio` + `isOpen`/`seedPrompt` unioned), `WorkflowComposer` (kept `runWorkflowAfterConfirmation`; `setRunningTasks` moved before the await so run state is visible).

## Design notes

- Confidence on `ProposalCard` is the scanner's absolute 0-100 composite, deliberately **not** rescaled against the visible set — a relative scale pins the leader at 1.00 on every scan however weak the field.
- An in-flight workflow run marks only the first node running; the executor returns its report in one shot, so anything else would be a fake progress animation.
- Newsfeed follow-up chips reach the chat through a small DOM-event ask bus — the lightbox is portalled to `document.body` and has no path to `ChatLauncher`'s local state.
- `Accept` on `ProposalCard` opens the instrument (where order surfaces are already gated); it never routes an order.

## Verification

- `bun run typecheck` clean
- `bun run lint` 0 errors, 11 warnings (all pre-existing, untouched files)
- `bun run build` passes, output-trace audit passes
- 73 agent + chat tests pass (`agent-*`, `chat-order-confirm`, `chat-streaming-ux`, `chat-launcher-focus`)

## Open question for CI

The full suite reports 2 failures out of ~5893 and the failing files shift between runs. Every file this PR touches passes in isolation. The one deterministic failure reproduced was `newsfeed-taxonomy.test.ts` (`ERR_MODULE_NOT_FOUND` on `web/scripts/newsfeed/taxonomy.js`) — a file this PR does not touch, unmodified in the tree, and a cwd-resolution issue. **Not proven pre-existing** — a clean baseline comparison was not obtained. Please let CI arbitrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)