### PR TITLE
fix(ui): scroll desktop act ticket so Confirm stays reachable

### DIFF
--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,10 @@
 # Lessons
 
+## 2026-08-14 — Act ticket must shrink or Confirm clips
+
+- `.act-region` is `overflow: hidden`. A `.act-ticket` of `flex: 0 0 auto` grows to the confirm summary + Gate 3 CRB and clips Place / Confirm. There is no scrollport.
+- Ticket must be `flex: 0 1 auto; min-height: 0; overflow-y: auto`. `min-height: 0` is required; flex `min-height: auto` refuses to shrink below content.
+
 ## 2026-08-13 — Name-ranking vol scanners live under Scanner, not Regime
 
 - `/indicator` defaults to a Regime chart tab. Cheap-wing IV ranking is a name scanner like LEAP and GARCH. Put it on `/scanner?mode=vol-cone`. Redirect `/regime/vol-cone`.

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -7939,10 +7939,16 @@ body[data-mobile="true"] .orders-command-strip__jump:active {
   overflow: hidden;
 }
 .act-ticket {
-  /* Ticket-focused act column: the ticket sizes to its content (no hard height
-     cap) so it reads clean whether the ticker is flat or holds a combo. The
-     flat/affordance area below fills the remaining space and centers in it. */
-  flex: 0 0 auto;
+  /* Ticket-focused act column: size to content when short so the held /
+     flat affordance below still fills leftover space. flex-shrink +
+     min-height:0 is load-bearing: a `0 0 auto` ticket taller than the
+     column (confirm summary + Gate 3 CRB) overflowed `.act-region`'s
+     overflow:hidden and clipped Place / Confirm with no scrollport. */
+  flex: 0 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
   border-bottom: 1px solid var(--line-grid);
   /* Inner gutter so the ticket form clears the column + split-divider seams. */
   padding: 16px;

--- a/web/e2e/act-ticket-scroll.spec.ts
+++ b/web/e2e/act-ticket-scroll.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * Desktop Close Position ticket: confirm summary + Gate 3 CRB is taller than
+ * the act column. `.act-ticket` must be the scrollport so Place / Confirm
+ * stay reachable. Reproduces the 2026-08-14 CBRS clip.
+ */
+import { expect, test, type Page } from "@playwright/test";
+
+function stubApis(page: Page) {
+  const emptyPortfolio = {
+    bankroll: 100_000,
+    peak_value: 100_000,
+    last_sync: new Date().toISOString(),
+    total_deployed_pct: 0,
+    total_deployed_dollars: 0,
+    remaining_capacity_pct: 100,
+    position_count: 0,
+    defined_risk_count: 0,
+    undefined_risk_count: 0,
+    avg_kelly_optimal: null,
+    exposure: {},
+    violations: [],
+    positions: [],
+  };
+  page.route("**/api/portfolio", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(emptyPortfolio) }),
+  );
+  page.route("**/api/orders", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        last_sync: new Date().toISOString(),
+        open_orders: [],
+        executed_orders: [],
+        open_count: 0,
+        executed_count: 0,
+      }),
+    }),
+  );
+  page.route("**/api/regime", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ score: 15, cri: { score: 15 } }) }),
+  );
+  page.route("**/api/ib-status", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ connected: false }) }),
+  );
+  page.route("**/api/blotter", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ as_of: new Date().toISOString(), summary: { realized_pnl: 0 }, closed_trades: [], open_trades: [] }),
+    }),
+  );
+  page.route("**/api/ticker/**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ uw_info: { name: "Apple Inc." }, stock_state: {}, profile: {}, stats: {} }),
+    }),
+  );
+  page.route("**/api/options/expirations*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ symbol: "AAPL", expirations: ["20260320"] }),
+    }),
+  );
+  page.route("**/api/options/chain*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ symbol: "AAPL", expiry: "20260320", strikes: [200], multiplier: "100" }),
+    }),
+  );
+  page.route("**/api/prices**", (route) => route.abort());
+}
+
+test("short desktop act column can scroll to Confirm Order", async ({ page }) => {
+  test.setTimeout(120_000);
+  stubApis(page);
+  await page.setViewportSize({ width: 1280, height: 500 });
+  await page.goto("/AAPL");
+
+  const ticket = page.locator(".act-ticket");
+  await ticket.waitFor({ timeout: 90_000 });
+
+  const box = await ticket.evaluate((el) => {
+    const s = getComputedStyle(el);
+    return {
+      overflowY: s.overflowY,
+      flexShrink: s.flexShrink,
+      minHeight: s.minHeight,
+    };
+  });
+  expect(box.overflowY).toBe("auto");
+  expect(Number(box.flexShrink)).toBeGreaterThan(0);
+  expect(box.minHeight).toBe("0px");
+
+  await ticket.locator("input.order-input").first().fill("35");
+  await ticket.locator(".modify-price-input").first().fill("5");
+  await ticket.getByRole("button", { name: "Place Order" }).click();
+
+  const confirm = ticket.getByRole("button", { name: "Confirm Order" });
+  await expect(confirm).toBeAttached();
+
+  await ticket.evaluate((el) => {
+    el.scrollTop = el.scrollHeight;
+  });
+  await expect(confirm).toBeInViewport();
+  await ticket.screenshot({ path: "test-results/act-ticket-scrolled.png" });
+});

--- a/web/tests/act-ticket-scroll.test.ts
+++ b/web/tests/act-ticket-scroll.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Desktop act-ticket scroll contract (2026-08-14): Close Position + Gate 3 CRB
+ * + confirm summary is taller than the act column. `.act-ticket` was
+ * `flex: 0 0 auto` inside `.act-region { overflow: hidden }`, so Place /
+ * Confirm clipped with no scrollport. The ticket must shrink and scroll.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const css = readFileSync(resolve(__dirname, "../app/globals.css"), "utf8");
+
+function ruleBlock(selector: string): string {
+  const start = css.indexOf(`${selector} {`);
+  expect(start, `${selector} rule missing`).toBeGreaterThan(-1);
+  const end = css.indexOf("}", start);
+  return css.slice(start, end);
+}
+
+describe("desktop act-ticket scroll contract", () => {
+  it(".act-ticket shrinks and scrolls so Place / Confirm stay reachable", () => {
+    const block = ruleBlock(".act-ticket");
+    expect(block).toMatch(/flex:\s*0 1 auto/);
+    expect(block).toMatch(/min-height:\s*0/);
+    expect(block).toMatch(/overflow-y:\s*auto/);
+    expect(block).not.toMatch(/flex:\s*0 0 auto/);
+  });
+
+  it(".act-region still clips as a column so the ticket is the scrollport", () => {
+    const block = ruleBlock(".act-region");
+    expect(block).toMatch(/overflow:\s*hidden/);
+    expect(block).toMatch(/min-height:\s*0/);
+  });
+});


### PR DESCRIPTION
## Problem
Close Position + Gate 3 CRB is taller than the act column. `.act-ticket` was `flex: 0 0 auto` inside `.act-region { overflow: hidden }`, so Place / Confirm clipped and the ticket did not scroll.

## Fix
`.act-ticket` is now `flex: 0 1 auto; min-height: 0; overflow-y: auto`.

## Verify
- `npx vitest run web/tests/act-ticket-scroll.test.ts` — 2/2
- `npx playwright test e2e/act-ticket-scroll.spec.ts --project=chromium` — 1/1

Does not merge to main (auto-deploys).