### PR TITLE
Keep the Foreman factory as a sibling app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ Sub-directory CLAUDE.md files auto-load when cwd is anywhere under that subtree.
 - `docs/brand-identity.md` — brand tokens, signal semantics, voice
 - `docs/cloud-services.md` — Hetzner runbook (services, schedulers, deploy)
 - `docs/grok-page-responder.md` — VPS P1 auto-fix + live-deploy Pushover
+- `docs/factory.md` — Foreman software factory (sibling Vercel app `joemccann/radon-factory`): label `factory`, draft PR, human merge
 - `docs/unusual_whales_api.md` — UW endpoint surface
 
 ---

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,6 +12,7 @@ Radon is a single-operator project authored AI-first. The operator directs codin
 |---|---|---|
 | Claude Code | Primary coding agent | `CLAUDE.md` (root) + 8 subsystem `CLAUDE.md` files that auto-load by cwd |
 | Codex | Second agent, used for parallel or rescue work | `AGENTS.md` mirrors beside each `CLAUDE.md`, plus `.pi/` |
+| Foreman | Unattended GitHub-issue factory (draft PR only) | sibling [`joemccann/radon-factory`](https://github.com/joemccann/radon-factory) + [`docs/factory.md`](docs/factory.md) |
 
 The `AGENTS.md` files intentionally mirror the `CLAUDE.md` hierarchy rather than sharing one file: each agent has its own discovery convention, and mirroring keeps either agent fully functional without the other. When a runbook changes, both copies change in the same commit.
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Durable facts. History and mechanism live in the owner file, not here.
 - **CMD+J.** Quotes, priced UW chains, and `evaluate.py` run from the in-app assistant. KB miss is not a dead end.
 - **Stop orders.** Desktop and mobile tickets place `STP` and `STP LMT` through `/api/orders/place`.
 - **Incidents.** Watchdog artifacts under `data/incidents/`. Triage with `/incident <path>`. Cases: [`docs/incident-runbook.md`](docs/incident-runbook.md).
+- **Factory.** GitHub issues labeled `factory` become draft PRs via Foreman in [`joemccann/radon-factory`](https://github.com/joemccann/radon-factory). Contract: [`docs/factory.md`](docs/factory.md).
 
 ## What's where
 
@@ -176,6 +177,7 @@ Durable facts. History and mechanism live in the owner file, not here.
 | Incident cases and `/incident` playbook | [`docs/incident-runbook.md`](docs/incident-runbook.md) |
 | Regime and scanner indicator specs | [`docs/indicators/README.md`](docs/indicators/README.md) |
 | Equibles market-structure API | [`docs/equibles-api.md`](docs/equibles-api.md) |
+| Software factory (Foreman, draft PRs from labeled issues) | [`docs/factory.md`](docs/factory.md) |
 | CLI commands and test runners | [`docs/scripts-reference.md`](docs/scripts-reference.md) |
 | Strategy specs (Dark Pool, LEAP, GARCH, VCG-R, CRI, Risk Reversal) | [`docs/strategies.md`](docs/strategies.md) |
 | VCG-R research notes | [`docs/cross_asset_volatility_credit_gap_spec_(VCG).md`](docs/cross_asset_volatility_credit_gap_spec_(VCG).md) |

--- a/docs/factory.md
+++ b/docs/factory.md
@@ -1,0 +1,54 @@
+# Radon software factory
+
+Foreman in [`joemccann/radon-factory`](https://github.com/joemccann/radon-factory) is the GitHub-issue SDLC loop for this repo. It is a sibling Vercel eve app, not a Hetzner unit and not an in-tree `factory/` directory. It stops at a **draft pull request**. A person marks ready and merges. Merge is the deploy trigger.
+
+It does **never merge**. It does **never push main**. Direct pushes to `main` / `master` are refused in the factory app.
+
+## Intake
+
+- Intake label `factory`. Unattended run. Labeler must have triage or above.
+- `@mention` the factory bot on an issue or PR (owners, members, collaborators).
+- Red CI on a `factory/` branch the factory itself pushed: one diagnosis + fix loop, capped.
+
+Do not label P1 incidents `factory`. That loop is [`grok-page-responder.md`](grok-page-responder.md).
+
+## In scope
+
+UI, copy, tests, docs, indicator vertical slices that follow `.claude/skills/new-indicator`, CI/test-only changes, reliability findings that do not touch IB.
+
+## Stop classes (Classifier `needs_clarification`, Reviewer `reject`)
+
+- IB Gateway, 2FA, docker, or host control of the broker
+- placing, modifying, or cancelling a live order
+- the trading halt or order-routing caps
+- production .env, Clerk, Turso tokens, IB_FLEX, UW_TOKEN, archive keys
+- deploy.sh, systemd control-plane, privileged VPS helpers
+- a P1 incident or watchdog page
+
+## Rails the stations must follow
+
+- Red/green TDD. Focused `bunx vitest` / `python3.13 scripts/run_pytest_affected.py`.
+- `git add` by path. Never `git add -A`.
+- No Playwright / chrome-cdp in the sandbox. Live browser is a human step.
+- Never load production secrets into the sandbox. Setup is `scripts/factory_sandbox_setup.sh` (bun + pip only).
+- Factory brain writes: trusted callers only. Unattended runs cannot poison it.
+
+## Deploy the factory app
+
+From the `joemccann/radon-factory` checkout, Node 24, with a Vercel project linked:
+
+1. `pnpm install && pnpm validate`
+2. `vercel connect create github --triggers` then attach at `/eve/v1/github`
+3. Set `FACTORY_REPO=joemccann/radon`, `FACTORY_LABEL=factory`, `FACTORY_BRANCH_PREFIX=factory/`
+4. After this setup script is on radon `main`, set `FACTORY_SETUP_COMMAND=bash scripts/factory_sandbox_setup.sh`
+5. Create a Blob store. `eve deploy`
+6. Install the GitHub App on `joemccann/radon` with contents, issues, and pull request write.
+7. First live run: a docs or test-only issue. You merge.
+
+Linear is not wired. Do not set a Linear connector.
+
+Upstream template: `vercel-labs/eve-software-factory-template`.
+
+## Operate
+
+Failed run: flawed (prompt/eval), blocked (sandbox/dep), or manual (correct refusal). Fix the factory, not the ticket, unless the ticket was wrong.

--- a/docs/owners.json
+++ b/docs/owners.json
@@ -35,6 +35,12 @@
       "owners": ["docs/operations.md", "docs/cloud-services.md"]
     },
     {
+      "id": "factory",
+      "globs": ["scripts/factory_sandbox_setup.sh"],
+      "owners": ["docs/factory.md"],
+      "note": "Sandbox setup that runs inside the radon checkout for the sibling Foreman app."
+    },
+    {
       "id": "cli",
       "globs": [".pi/commands.json"],
       "owners": ["docs/scripts-reference.md"]

--- a/scripts/factory_sandbox_setup.sh
+++ b/scripts/factory_sandbox_setup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Runs inside the joemccann/radon checkout in a Vercel Sandbox (FACTORY_SETUP_COMMAND).
+# Installs bun workspaces and Python test deps. Never sources env files.
+set -euo pipefail
+
+if ! command -v bun >/dev/null 2>&1; then
+  curl -fsSL https://bun.sh/install | bash
+  export PATH="${HOME}/.bun/bin:${PATH}"
+fi
+
+bun install --frozen-lockfile
+bun install --frozen-lockfile --cwd web
+
+PY=python3
+if command -v python3.13 >/dev/null 2>&1; then
+  PY=python3.13
+fi
+
+"${PY}" -m pip install --user \
+  -r requirements.txt \
+  -r scripts/requirements-api.txt \
+  pytest pytest-cov

--- a/scripts/tests/test_factory_contract.py
+++ b/scripts/tests/test_factory_contract.py
@@ -1,0 +1,79 @@
+"""Static rails for the sibling Radon software factory.
+
+The Foreman app lives in joemccann/radon-factory, not under factory/ here.
+These checks keep the stop-list, branch prefix, and secret boundary from
+drifting without a docs/factory.md update.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent.parent
+_DOCS = _ROOT / "docs" / "factory.md"
+_SETUP = _ROOT / "scripts" / "factory_sandbox_setup.sh"
+_OWNERS = _ROOT / "docs" / "owners.json"
+
+STOP_TOKENS = (
+    "IB Gateway",
+    "live order",
+    "trading halt",
+    "production .env",
+    "deploy.sh",
+    "P1",
+    "UW_TOKEN",
+    "IB_FLEX",
+)
+
+
+def _read(path: Path) -> str:
+    assert path.is_file(), f"missing {path.relative_to(_ROOT)}"
+    return path.read_text(encoding="utf-8")
+
+
+class TestFactoryIsSibling:
+    def test_factory_app_is_not_in_this_repo(self):
+        assert not (_ROOT / "factory").exists()
+
+
+class TestFactoryDocs:
+    def test_owner_doc_states_the_human_merge_gate(self):
+        text = _read(_DOCS)
+        for token in (
+            "draft pull request",
+            "never merge",
+            "never push main",
+            "label `factory`",
+            "factory/",
+            "joemccann/radon-factory",
+        ):
+            assert token in text, token
+
+    def test_owner_doc_lists_every_stop_class(self):
+        text = _read(_DOCS)
+        missing = [t for t in STOP_TOKENS if t not in text]
+        assert not missing, missing
+
+
+class TestSandboxSetup:
+    def test_setup_script_never_sources_env(self):
+        text = _read(_SETUP)
+        assert "set -a" not in text
+        assert ". .env" not in text
+        assert "source .env" not in text
+        assert "radon-cloud/.env" not in text
+        assert "IB_FLEX" not in text
+        assert "UW_TOKEN" not in text
+        assert "bun install" in text
+        assert "requirements.txt" in text
+
+
+class TestFactoryOwners:
+    def test_owners_map_covers_setup_script(self):
+        data = json.loads(_read(_OWNERS))
+        rules = [r for r in data["rules"] if r.get("id") == "factory"]
+        assert len(rules) == 1
+        rule = rules[0]
+        assert "scripts/factory_sandbox_setup.sh" in rule["globs"]
+        assert "factory/**" not in rule["globs"]
+        assert "docs/factory.md" in rule["owners"]


### PR DESCRIPTION
## Summary
- Lands only the radon-side Foreman contract: `docs/factory.md`, sandbox setup, and tests.
- The eve app stays in `joemccann/radon-factory`. This replaces in-tree `factory/` vendoring from #26.

## Test plan
- [x] `python3.13 scripts/run_pytest_affected.py --files scripts/tests/test_factory_contract.py scripts/tests/test_docs_contract.py -- -q` (11 passed)
- [ ] After merge, set `FACTORY_SETUP_COMMAND=bash scripts/factory_sandbox_setup.sh` on the Vercel factory project
- [ ] Close #26 without merging


Made with [Cursor](https://cursor.com)