### PR TITLE
Weekend testing audit/remediation service

### DIFF
--- a/.claude/skills/testing-weekend/SKILL.md
+++ b/.claude/skills/testing-weekend/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: testing-weekend
+description: Weekend testing loop - Saturday delta-audit of test-suite health for everything merged since the last audited SHA (new findings appended to TEST_AUDIT.md), Sunday red/green remediation of new P0/P1 findings on a PR branch. Runs unattended on the always-on runner via scripts/testing_weekend.sh; invoke as /testing-weekend audit or /testing-weekend remediate.
+---
+
+# Testing Weekend Loop
+
+You are a test-infrastructure engineer with decades of experience in trading
+systems. This skill runs UNATTENDED — no human can answer questions. The
+standard is the one set by the 2026-08-07 audit (`TEST_AUDIT.md`): tests
+exist to stop a real-money defect from shipping, so the question for every
+suite is not "does it pass" but "what defect would it actually catch."
+
+The mode is the first argument: `audit` (Saturday) or `remediate` (Sunday).
+
+## Hard rails (both modes — violating any of these is a failed run)
+
+1. **Never touch the IB Gateway.** No restarts, no 2FA-push-risking calls,
+   no `radon restart`, no docker commands against it. Tests use fakes/mocks
+   only — never a live IB connection, never a live order.
+2. **Never push to `main`.** All changes land on a branch
+   `testing/weekend-<YYYY-MM-DD>` and a PR. The Monday human merge is the
+   deploy trigger.
+3. **Never run against the operator's working clone.** Refuse (exit
+   nonzero, say why) unless the file `.radon-weekend-runner` exists in the
+   repo root — that marker means this is the dedicated runner clone.
+4. **Respect the frozen contracts.** `TEST_AUDIT.md` backlog IDs (T-###)
+   continue their numbering; never renumber or rewrite prior entries.
+   `TEST_LOG.md` is append-only. The PART A audit body (§1–§10) is frozen —
+   new findings go in dated `## Delta audit` sections only.
+5. **Never weaken a test to go green.** Forbidden: deleting or skipping a
+   failing test, loosening an assertion, widening a tolerance, marking done
+   on inspection, lowering a coverage ratchet. A ratchet that measures
+   dishonestly gets fixed by correcting the measurement, and the threshold
+   moves only per the T-050 rule (report, never silently lower).
+6. **Bounded.** The wrapper enforces a wall-clock cap. Pace so the run
+   finishes cleanly: leave un-started work logged as `DEFERRED`, never
+   half-applied. Commit after every completed task, never mid-task.
+7. **Stay off the reliability loop's lane.** The same runner clone hosts
+   `/reliability-weekend` (audit Sat 22:00, remediate Sun 10:00, caps 2h/6h).
+   Your slots (audit Sat 19:00 cap 2h, remediate Sun 17:00 cap 6h) are
+   sized to never overlap it — do not reschedule yourself, and never edit
+   `RELIABILITY_AUDIT.md` / `RELIABILITY_LOG.md`.
+
+## Mode: audit (Saturday)
+
+Goal: a DELTA audit of TEST-SUITE HEALTH — judge what changed, don't
+re-audit the world. Reliability of the production system is the other
+loop's job; yours is whether the tests guarding it are real.
+
+1. Read `TEST_AUDIT.md` §Audit ledger for the last audited SHA. Compute
+   the changed surface: `git log --stat <last-sha>..HEAD`. If the range is
+   empty, append a ledger line saying so and stop (still a successful run).
+2. Read `TEST_LOG.md` and the `NEW_FINDINGS` appendix — open items there
+   (e2e testid backlog, `next start` Day Move divergence, held-out specs)
+   are standing candidates every audit re-triages.
+3. Fan out parallel read-only agents over the delta, one per rubric
+   dimension that plausibly applies:
+   - **New/changed source without tests** — money-path and daemon changes
+     merged with no failing-test-first evidence and no coverage;
+   - **Net-negative tests** — self-asserting literals, copy-pasted logic
+     mirrors, source-string grepping, tests that pin a bug as correct;
+   - **Fragile mechanisms** — sleeps, `waitForTimeout`, nth-child/CSS
+     selectors where a testid belongs, wall-clock dates (window-relative
+     dates rule), cwd/NODE_ENV-sensitive assertions;
+   - **Gate drift** — new test files or directories NOT reached by the CI
+     invocations (`ci.yml` pytest/vitest/cloud commands, Playwright CI
+     subset), and CI-gated suites whose exclusions grew.
+   Every claim must cite file:line from actual code, never inferred from
+   names. Scope agents to the diff plus its blast radius, not the tree.
+4. Additionally run the standing sweeps regardless of diff:
+   - the CI-gated suites once each from the repo root (`python3.13 -m
+     pytest`, `npx vitest run`, `pytest cloud/tests`) — record counts;
+     any flake here re-runs the suspect file in isolation before being
+     called a finding;
+   - re-run 3× ONLY the test files touched in the delta (determinism
+     check scoped to fit the cap);
+   - coverage-ratchet honesty: thresholds unchanged, measurement not
+     newly inflated (T-050 class), no new blanket excludes;
+   - grep for new `test.skip` / `it.skip` / `pytest.mark.skip` /
+     `xfail` introduced in the delta without a linked T-### or issue.
+5. Dedupe against ALL existing T-### findings. Append genuinely-new
+   findings to `TEST_AUDIT.md` under a dated `## Delta audit <date>`
+   section (cite file:line, severity P0/P1/P2, continuing T-numbers) and
+   add backlog rows with red/green acceptance criteria. Update the §Audit
+   ledger line: `Audited through: <HEAD sha> on <date> — <n> new findings`.
+6. Commit to the weekend branch, push the branch, and open (or update)
+   the weekend PR titled `Testing weekend <date>` with the delta summary
+   in the body. Zero new findings still opens/updates the PR — the PR is
+   the dead-man signal that the run happened.
+
+## Mode: remediate (Sunday)
+
+Goal: work the newest un-DONE P0/P1 backlog items (this weekend's first,
+then any older non-P2 stragglers), exactly by the PART B contract:
+
+1. Check out the weekend branch (create from `origin/main` if Saturday
+   produced nothing; then this run only re-verifies gates — step 4).
+2. Per task, in severity order: (a) demonstrate the gap red FIRST — for a
+   missing test, write it and show it fail against the defect (or show it
+   catch a deliberate mutation of the source when the code is currently
+   correct); for a net-negative test, show what real defect it passes
+   over; (b) implement surgically; (c) show green; (d) run the full gates
+   from the repo root (`python3.13 -m pytest`, `npx vitest run`, and
+   `pytest cloud/tests` when units/cloud files changed); (e) append the
+   TEST_LOG.md row with red/green counts; (f) commit with the T-### id.
+   Source-code fixes are in scope ONLY when a test correctly fails
+   against a real defect the audit identified — fix the defect, keep the
+   test; never the reverse.
+3. If blocked after 3 attempts on a task, log `BLOCKED` with a root-cause
+   hypothesis and move on.
+4. Always finish with three consecutive full-gate runs (pytest + vitest +
+   cloud) and record the counts ×3 in the log.
+5. Push the branch; update the PR body with: tasks DONE/BLOCKED/DEFERRED
+   by severity, gate counts ×3, and anything needing the operator (e.g. a
+   ratchet-threshold decision per the T-050 rule, or CI workflow changes
+   that need a human eye before merge).
+
+## Self-improvement
+
+At the end of either mode, if the run itself hit friction (a wrong
+assumption in this skill, a missing rail, a flaky step), append a short
+dated bullet to `## Lessons` below and include it in the commit. That is
+how this loop improves as the codebase grows.
+
+## Lessons
+
+_(none yet)_

--- a/.gitignore
+++ b/.gitignore
@@ -206,6 +206,7 @@ web/verify-regime-internals.mjs
 !/.claude/skills/incident-response/
 !/.claude/skills/long-horizon-jobs/
 !/.claude/skills/reliability-weekend/
+!/.claude/skills/testing-weekend/
 /.pi/skills/
 /skills-lock.json
 /radon-dark-full.png

--- a/TEST_AUDIT.md
+++ b/TEST_AUDIT.md
@@ -1373,3 +1373,11 @@ _Discoveries made during PART B land here; they do not expand the frozen backlog
 - **E2E testid backlog (open):** the wave-2 repair agents catalogued ~17 places where specs must hang on CSS classes/nth-child because components expose no `data-testid`/role (MetricCards cards+toggles, AssetCockpit ticket anchor, OrderTab submit buttons, SharePnl trigger/popover/toggles, exec-group rows, toast kinds). Full list in the wave-2 workflow result (`tasks/wlnotw78h.output`); adopting them removes the dominant residual fragility class in `web/e2e/`.
 - **`next dev` cannot run in the CI Playwright container (open, infra):** neither turbopack nor webpack `next dev` readies inside `mcr.microsoft.com/playwright` — cold-compiling this app's heavy routes on demand hangs in the resource-constrained container (CI runs 31268084987 / 31268824260 timed out after the middleware line). The `e2e-financial-smoke` job therefore builds once and serves a prebuilt `next start` (the perimeter-smoke pattern). A follow-up could give the container more resources or warm the dev routes, but production start is the pragmatic path.
 - **Day Move renders differently under `next start` vs `next dev` (open, possible prod bug):** `day-move-ib-daily-pnl.spec.ts` asserts the IB-daily Day Move value (`acct.daily_pnl` → `-$3,688`), which renders under the dev server but shows "MARKET CLOSED / ---" under a production `next start` with the identical portfolio stub — even though sibling `account_summary` fields (Net Liq etc.) render fine in both. Reproduced 3/3 in isolation. The spec is HELD OUT of the CI subset (still runs locally) pending a decision on whether this is an SSR/hydration ordering bug in the TodayPnlRow Day Move path or a harness artifact; it is the one spec that does not survive the dev→prod server switch.
+
+## 11 · Audit ledger
+
+The weekend loop (`.claude/skills/testing-weekend/`) reads the last line
+here to scope its Saturday delta audit, and appends one line per run.
+Delta findings continue the T-### numbering in dated `## Delta audit` sections.
+
+- Audited through: `d681d247` on 2026-08-08 — initial full audit (T-001…T-054, PART A frozen 2026-08-07 at `2a75496a`) + PART B remediation waves (PRs #13/#14).

--- a/TEST_LOG.md
+++ b/TEST_LOG.md
@@ -1,0 +1,8 @@
+# TEST_LOG.md — testing remediation execution log
+
+**Contract:** `TEST_AUDIT.md` §9 (frozen backlog T-001…T-054) plus any T-### rows appended by weekend delta audits. Every fix ships with its own proof: red before the fix (a new test failing against the defect, or catching a deliberate source mutation when the code is currently correct), green after, full suite green before commit. BLOCKED requires a root-cause hypothesis. New discoveries → `TEST_AUDIT.md` NEW_FINDINGS, not mid-loop chases. Append-only; maintained by the weekend loop (`.claude/skills/testing-weekend/`).
+
+**Prior work (pre-log):** the original PART B waves landed via PRs #13/#14 (`test-hardening-wave2`, merged 2026-08-08 as `d681d247`) before this log existed; their evidence lives in the PR bodies and `TEST_AUDIT.md` NEW_FINDINGS. Open stragglers at log creation: T-050 (coverage-ratchet honesty — needs a maintainer threshold decision).
+
+| Task | Status | Commits | Evidence |
+|---|---|---|---|

--- a/config/com.radon.testing-audit.plist
+++ b/config/com.radon.testing-audit.plist
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.radon.testing-audit</string>
+
+    <!-- __WEEKEND_REPO__ is substituted by scripts/setup_testing_weekend.sh -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>__WEEKEND_REPO__/scripts/testing_weekend.sh</string>
+        <string>audit</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__WEEKEND_REPO__</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:__HOME__/.local/bin</string>
+        <key>RADON_WEEKEND_REPO</key>
+        <string>__WEEKEND_REPO__</string>
+        <key>HOME</key>
+        <string>__HOME__</string>
+    </dict>
+
+    <!-- Saturday 19:00 local — cap 2h ends 21:00, an hour before the
+         reliability audit fires at 22:00 in the same runner clone. -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Weekday</key>
+        <integer>6</integer>
+        <key>Hour</key>
+        <integer>19</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>StandardOutPath</key>
+    <string>__WEEKEND_REPO__/logs/testing-weekend/launchd-audit.log</string>
+    <key>StandardErrorPath</key>
+    <string>__WEEKEND_REPO__/logs/testing-weekend/launchd-audit.err</string>
+</dict>
+</plist>

--- a/config/com.radon.testing-remediate.plist
+++ b/config/com.radon.testing-remediate.plist
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.radon.testing-remediate</string>
+
+    <!-- __WEEKEND_REPO__ is substituted by scripts/setup_testing_weekend.sh -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>__WEEKEND_REPO__/scripts/testing_weekend.sh</string>
+        <string>remediate</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__WEEKEND_REPO__</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:__HOME__/.local/bin</string>
+        <key>RADON_WEEKEND_REPO</key>
+        <string>__WEEKEND_REPO__</string>
+        <key>HOME</key>
+        <string>__HOME__</string>
+    </dict>
+
+    <!-- Sunday 17:00 local — the reliability remediation (Sun 10:00,
+         cap 6h) is guaranteed finished by 16:00 in the same runner clone. -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Weekday</key>
+        <integer>0</integer>
+        <key>Hour</key>
+        <integer>17</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>StandardOutPath</key>
+    <string>__WEEKEND_REPO__/logs/testing-weekend/launchd-remediate.log</string>
+    <key>StandardErrorPath</key>
+    <string>__WEEKEND_REPO__/logs/testing-weekend/launchd-remediate.err</string>
+</dict>
+</plist>

--- a/scripts/setup_testing_weekend.sh
+++ b/scripts/setup_testing_weekend.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# One-command setup of the weekend testing loop on the always-on runner
+# (Mac mini). Run ON THE MINI from any checkout of the repo:
+#
+#   bash scripts/setup_testing_weekend.sh
+#
+# Reuses the SAME dedicated clone as the reliability loop
+# (~/radon-weekend/radon — never edit it by hand; every run hard-resets
+# it to origin/main), installs the two launchd jobs (Sat 19:00 audit,
+# Sun 17:00 remediate — slotted around the reliability jobs at Sat 22:00
+# / Sun 10:00 so caps can never overlap), and verifies the toolchain.
+set -euo pipefail
+
+WEEKEND_ROOT="${RADON_WEEKEND_ROOT:-$HOME/radon-weekend}"
+WEEKEND_REPO="$WEEKEND_ROOT/radon"
+LAUNCH_AGENTS="$HOME/Library/LaunchAgents"
+ORIGIN_URL="$(git config --get remote.origin.url 2>/dev/null || echo git@github.com:joemccann/radon.git)"
+
+fail=0
+check() {
+  local name="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    echo "  ok  $name"
+  else
+    echo "  MISSING  $name  ($*)"
+    fail=1
+  fi
+}
+
+echo "[1/4] toolchain"
+check "claude CLI"        command -v claude
+check "gh CLI (authed)"   gh auth status
+check "python3.13"        command -v python3.13
+check "pytest"            python3.13 -c "import pytest"
+check "bun"               command -v bun
+check "node"              command -v node
+check "git ssh to origin" git ls-remote --exit-code "$ORIGIN_URL" HEAD
+if [[ $fail -ne 0 ]]; then
+  echo "Fix the MISSING items above, then re-run."
+fi
+
+echo "[2/4] dedicated runner clone at $WEEKEND_REPO"
+mkdir -p "$WEEKEND_ROOT"
+if [[ ! -d "$WEEKEND_REPO/.git" ]]; then
+  git clone "$ORIGIN_URL" "$WEEKEND_REPO"
+fi
+touch "$WEEKEND_REPO/.radon-weekend-runner"
+mkdir -p "$WEEKEND_REPO/logs/testing-weekend"
+
+echo "[3/4] python + web dependencies in the runner clone"
+( cd "$WEEKEND_REPO" \
+  && python3.13 -m pip install -q -r requirements.txt \
+  && bun install --frozen-lockfile >/dev/null \
+  && cd web && bun install --frozen-lockfile >/dev/null )
+
+echo "[4/4] launchd jobs"
+mkdir -p "$LAUNCH_AGENTS"
+for name in testing-audit testing-remediate; do
+  src="$WEEKEND_REPO/config/com.radon.${name}.plist"
+  dst="$LAUNCH_AGENTS/com.radon.${name}.plist"
+  sed -e "s|__WEEKEND_REPO__|$WEEKEND_REPO|g" -e "s|__HOME__|$HOME|g" \
+    "$src" > "$dst"
+  plutil -lint "$dst" >/dev/null
+  launchctl unload "$dst" 2>/dev/null || true
+  launchctl load "$dst"
+  echo "  loaded $dst"
+done
+
+echo
+echo "Done. Schedule: audit Sat 19:00, remediate Sun 17:00 (local time),"
+echo "slotted around the reliability loop (Sat 22:00 / Sun 10:00)."
+echo "Dead-man: GitHub issue labeled 'testing-weekend' gets a comment"
+echo "per run — no weekend comment means the runner did not fire."
+echo "Smoke test now with:"
+echo "  RADON_WEEKEND_REPO=$WEEKEND_REPO bash $WEEKEND_REPO/scripts/testing_weekend.sh audit"

--- a/scripts/testing_weekend.sh
+++ b/scripts/testing_weekend.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Weekend testing loop runner — invoked by launchd on the always-on
+# runner (Mac mini). Saturday: /testing-weekend audit. Sunday:
+# /testing-weekend remediate. See .claude/skills/testing-weekend/.
+#
+# Shares the dedicated runner clone with the reliability loop; the
+# launchd slots (audit Sat 19:00 cap 2h, remediate Sun 17:00 cap 6h) are
+# sized so the two loops never overlap (reliability: Sat 22:00 / Sun
+# 10:00, caps 2h/6h).
+#
+# Safety model:
+#   - runs ONLY in the dedicated runner clone (marker file required);
+#     the clone is hard-reset to origin/main every run, so it must never
+#     be a working checkout anyone edits by hand.
+#   - the agent never pushes main (skill rail); this wrapper's only git
+#     writes are fetch/reset on the runner clone.
+#   - wall-clock capped; every outcome (incl. crash) is reported to the
+#     rolling GitHub issue so a silent-dead runner is visible Monday.
+set -euo pipefail
+
+MODE="${1:?usage: testing_weekend.sh audit|remediate}"
+[[ "$MODE" == "audit" || "$MODE" == "remediate" ]] || {
+  echo "unknown mode: $MODE" >&2; exit 2;
+}
+
+REPO="${RADON_WEEKEND_REPO:-$HOME/radon-weekend/radon}"
+# Audit fans out read agents (cap 2h); remediation is the long half (cap 6h).
+CAP_SECS=$([[ "$MODE" == "audit" ]] && echo 7200 || echo 21600)
+DEADMAN_TITLE="Weekend testing runner"
+DEADMAN_LABEL="testing-weekend"
+
+cd "$REPO"
+[[ -f .radon-weekend-runner ]] || {
+  echo "REFUSING: $REPO is not the dedicated weekend runner clone" >&2
+  exit 2
+}
+
+LOG_DIR="$REPO/logs/testing-weekend"
+mkdir -p "$LOG_DIR"
+STAMP="$(date +%Y%m%dT%H%M%S)"
+RUN_LOG="$LOG_DIR/$MODE-$STAMP.log"
+# Keep the newest 30 run logs.
+ls -1t "$LOG_DIR" 2>/dev/null | tail -n +31 | while IFS= read -r old; do
+  rm -f -- "$LOG_DIR/$old"
+done
+
+report() {
+  # Dead-man: one rolling issue, a comment per run. Failure to report
+  # must not mask the run's own exit code.
+  local status="$1" detail="$2"
+  local body="**${MODE}** ${STAMP} — **${status}**
+${detail}
+log: \`${RUN_LOG##*/}\` on the runner"
+  local issue
+  issue="$(gh issue list --label "$DEADMAN_LABEL" --state open \
+    --json number -q '.[0].number' 2>/dev/null || true)"
+  if [[ -z "$issue" ]]; then
+    gh issue create --title "$DEADMAN_TITLE" --label "$DEADMAN_LABEL" \
+      --body "Rolling dead-man for the weekend testing loop. A missing weekend comment means the runner did not fire." \
+      >/dev/null 2>&1 || return 0
+    issue="$(gh issue list --label "$DEADMAN_LABEL" --state open \
+      --json number -q '.[0].number' 2>/dev/null || true)"
+  fi
+  [[ -n "$issue" ]] && gh issue comment "$issue" --body "$body" >/dev/null 2>&1 || true
+}
+
+on_crash() {
+  report "CRASHED (exit $?)" "wrapper died before the agent finished — check the runner"
+}
+trap on_crash ERR
+
+echo "[testing-weekend] $MODE start $STAMP repo=$REPO cap=${CAP_SECS}s" | tee -a "$RUN_LOG"
+
+# Fresh ground truth. Any leftover state from a killed prior run is
+# discarded — the branch/PR on GitHub is the durable state.
+git fetch origin --quiet
+git checkout --quiet main
+git reset --hard --quiet origin/main
+git clean -fdq --exclude=.radon-weekend-runner --exclude=logs/ --exclude=.env --exclude=.env.ib-mode --exclude=web/.env
+
+set +e
+timeout "$CAP_SECS" claude -p "/testing-weekend $MODE" \
+  --dangerously-skip-permissions \
+  --output-format text >> "$RUN_LOG" 2>&1
+RC=$?
+set -e
+trap - ERR
+
+TAIL="$(tail -c 1500 "$RUN_LOG" 2>/dev/null || true)"
+if [[ $RC -eq 0 ]]; then
+  report "OK" "\`\`\`
+${TAIL}
+\`\`\`"
+elif [[ $RC -eq 124 ]]; then
+  report "TIMEOUT after ${CAP_SECS}s" "partial work may exist on the weekend branch/PR
+\`\`\`
+${TAIL}
+\`\`\`"
+else
+  report "FAILED (exit $RC)" "\`\`\`
+${TAIL}
+\`\`\`"
+fi
+echo "[testing-weekend] $MODE done rc=$RC" | tee -a "$RUN_LOG"
+exit "$RC"


### PR DESCRIPTION
Mirrors the reliability-weekend loop for test-suite health, per the ask to give the 2026-08-07 test audit the same recurring weekend treatment.

- `.claude/skills/testing-weekend/SKILL.md` — Saturday delta audit (T-### findings appended to `TEST_AUDIT.md` delta sections), Sunday red/green remediation. Hard rails: never touch the Gateway, never push main, runner-clone marker required, never weaken a test to go green, never edit the reliability contracts.
- `scripts/testing_weekend.sh` — launchd wrapper: hard-reset runner clone, wall-clock caps (audit 2h / remediate 6h), dead-man rolling GitHub issue labeled `testing-weekend`.
- `scripts/setup_testing_weekend.sh` — one-command install on the runner; reuses the existing `~/radon-weekend/radon` clone.
- `config/com.radon.testing-{audit,remediate}.plist` — Sat 19:00 / Sun 17:00, slotted so caps can never overlap the reliability jobs (Sat 22:00 / Sun 10:00).
- `TEST_LOG.md` — new append-only execution log (RELIABILITY_LOG.md pattern); notes prior PART B waves landed via PRs #13/#14 and the open T-050 straggler.
- `TEST_AUDIT.md` — §11 audit ledger added, baselined at `d681d247` (wave-2 merge, 2026-08-08).

Verified: `bash -n` both scripts, `plutil -lint` both plists, wrapper refusal paths (non-runner clone and bad mode both exit 2). No code under test changed; CI gates run on this PR.

After merge, install on the runner: `bash scripts/setup_testing_weekend.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)