### PR TITLE
reliability-weekend: remediation completes the backlog, never defers

### DIFF
--- a/.claude/skills/reliability-weekend/SKILL.md
+++ b/.claude/skills/reliability-weekend/SKILL.md
@@ -28,9 +28,16 @@ The mode is the first argument: `audit` (Saturday) or `remediate` (Sunday).
 5. **Respect the frozen contracts.** `RELIABILITY_AUDIT.md` finding IDs
    (R-###) and backlog IDs (REL-###) continue their numbering; never
    renumber or rewrite prior entries. `RELIABILITY_LOG.md` is append-only.
-6. **Bounded.** The wrapper enforces a wall-clock cap. Pace so the run
-   finishes cleanly: leave un-started work logged as `DEFERRED`, never
-   half-applied. Commit after every completed task, never mid-task.
+6. **Bounded per session, complete overall.** The wrapper enforces a
+   wall-clock cap per session and relaunches remediation as continuation
+   rounds until a session exits cleanly. Never leave work half-applied;
+   commit after every completed task, never mid-task, and push the branch
+   after every task commit so a killed round loses nothing. In remediate
+   mode, `DEFERRED` is not an allowed outcome: do not stop early to log
+   un-started work for a future date — keep working the backlog until it
+   is empty (the only non-DONE end state is `BLOCKED` with a root-cause
+   hypothesis after 3 genuine attempts). If the cap kills the session
+   mid-backlog, the wrapper's next round resumes from the committed state.
 
 ## Mode: audit (Saturday)
 
@@ -68,17 +75,23 @@ Goal: a DELTA audit — judge what changed, don't re-audit the world.
 
 ## Mode: remediate (Sunday)
 
-Goal: work the newest un-DONE P0/P1 backlog items (this weekend's first,
-then any older non-P2 stragglers), exactly by the PART B contract:
+Goal: work the ENTIRE un-DONE backlog to completion in severity order —
+P0, then P1, then P2 (this weekend's items first, then older stragglers)
+— exactly by the PART B contract. Deferring remaining items to a future
+run is not an outcome; every backlog item ends this weekend as DONE or
+BLOCKED-with-root-cause.
 
 1. Check out the weekend branch (create from `origin/main` if Saturday
    produced nothing; then this run only re-verifies drills — step 4).
+   If the branch already carries `REL-###` commits from an earlier round
+   of this weekend, this is a continuation: diff RELIABILITY_LOG.md
+   against the backlog and resume from the first un-DONE item.
 2. Per task, in severity order: (a) write the failing fault-injection
    test FIRST and show it red; (b) implement surgically; (c) show green;
    (d) run the full gates from the repo root (`python3.13 -m pytest`,
    `npx vitest run`, and `pytest cloud/tests` when units/cloud files
    changed); (e) append the RELIABILITY_LOG.md row with red/green counts;
-   (f) commit with the REL-### id. Forbidden moves: widening a catch
+   (f) commit with the REL-### id and push the branch. Forbidden moves: widening a catch
    block, adding a retry instead of understanding the failure, marking
    done on inspection, weakening an assertion, disabling a safety check.
 3. If blocked after 3 attempts on a task, log `BLOCKED` with a root-cause
@@ -90,8 +103,8 @@ then any older non-P2 stragglers), exactly by the PART B contract:
    `test_daemon_bounded`, `test_snapshot_unavailable`,
    `order-idempotency-durability`) plus three consecutive full-gate runs.
    Record the counts in the log.
-5. Push the branch; update the PR body with: tasks DONE/BLOCKED/DEFERRED
-   by severity, gate counts ×3, and anything needing the operator
+5. Push the branch; update the PR body with: tasks DONE/BLOCKED by
+   severity, gate counts ×3, and anything needing the operator
    (control-plane unit changes need the root bootstrap before merge —
    say so explicitly in the PR body when `cloud/services/*` changed).
 

--- a/.claude/skills/testing-weekend/SKILL.md
+++ b/.claude/skills/testing-weekend/SKILL.md
@@ -36,11 +36,12 @@ The mode is the first argument: `audit` (Saturday) or `remediate` (Sunday).
 6. **Bounded.** The wrapper enforces a wall-clock cap. Pace so the run
    finishes cleanly: leave un-started work logged as `DEFERRED`, never
    half-applied. Commit after every completed task, never mid-task.
-7. **Stay off the reliability loop's lane.** The same runner clone hosts
-   `/reliability-weekend` (audit Sat 22:00, remediate Sun 10:00, caps 2h/6h).
-   Your slots (audit Sat 19:00 cap 2h, remediate Sun 17:00 cap 6h) are
-   sized to never overlap it — do not reschedule yourself, and never edit
-   `RELIABILITY_AUDIT.md` / `RELIABILITY_LOG.md`.
+7. **Stay off the reliability loop's lane.** The reliability loop
+   (`/reliability-weekend`) runs in its own clone (`~/radon-weekend/radon`);
+   this loop runs in `~/radon-weekend/radon-testing`. Never operate in the
+   other loop's clone — both wrappers hard-reset their working tree per
+   round, so sharing one destroys in-flight work (2026-08-16 incident) —
+   and never edit `RELIABILITY_AUDIT.md` / `RELIABILITY_LOG.md`.
 
 ## Mode: audit (Saturday)
 

--- a/config/com.radon.testing-audit.plist
+++ b/config/com.radon.testing-audit.plist
@@ -26,8 +26,8 @@
         <string>__HOME__</string>
     </dict>
 
-    <!-- Saturday 19:00 local — cap 2h ends 21:00, an hour before the
-         reliability audit fires at 22:00 in the same runner clone. -->
+    <!-- Saturday 19:00 local. Runs in the testing loop's own clone;
+         no shared working tree with the reliability loop. -->
     <key>StartCalendarInterval</key>
     <dict>
         <key>Weekday</key>

--- a/config/com.radon.testing-remediate.plist
+++ b/config/com.radon.testing-remediate.plist
@@ -26,8 +26,8 @@
         <string>__HOME__</string>
     </dict>
 
-    <!-- Sunday 17:00 local — the reliability remediation (Sun 10:00,
-         cap 6h) is guaranteed finished by 16:00 in the same runner clone. -->
+    <!-- Sunday 17:00 local. Runs in the testing loop's own clone;
+         no shared working tree with the reliability loop. -->
     <key>StartCalendarInterval</key>
     <dict>
         <key>Weekday</key>

--- a/scripts/reliability_weekend.sh
+++ b/scripts/reliability_weekend.sh
@@ -19,8 +19,13 @@ MODE="${1:?usage: reliability_weekend.sh audit|remediate}"
 }
 
 REPO="${RADON_WEEKEND_REPO:-$HOME/radon-weekend/radon}"
-# Audit fans out ~6 read agents (cap 2h); remediation is the long half (cap 6h).
+# Audit fans out ~6 read agents (cap 2h); remediation is the long half (cap 6h
+# per round). Remediation must finish the backlog, not defer it to a future
+# weekend: a round that dies on the cap (or crashes) is relaunched as a
+# continuation round against the same weekend branch — per-task commits are the
+# durable state — until a round exits 0 or the backstop trips.
 CAP_SECS=$([[ "$MODE" == "audit" ]] && echo 7200 || echo 21600)
+MAX_ROUNDS=$([[ "$MODE" == "remediate" ]] && echo 8 || echo 1)
 DEADMAN_TITLE="Weekend reliability runner"
 DEADMAN_LABEL="reliability-weekend"
 
@@ -73,12 +78,25 @@ git checkout -f --quiet main
 git reset --hard --quiet origin/main
 git clean -fdq --exclude=.radon-weekend-runner --exclude=logs/ --exclude=.env --exclude=.env.ib-mode --exclude=web/.env
 
-set +e
-timeout "$CAP_SECS" claude -p "/reliability-weekend $MODE" \
-  --dangerously-skip-permissions \
-  --output-format text >> "$RUN_LOG" 2>&1
-RC=$?
-set -e
+ROUND=1
+while :; do
+  echo "[weekend] $MODE round $ROUND/$MAX_ROUNDS" | tee -a "$RUN_LOG"
+  set +e
+  timeout "$CAP_SECS" claude -p "/reliability-weekend $MODE" \
+    --dangerously-skip-permissions \
+    --output-format text >> "$RUN_LOG" 2>&1
+  RC=$?
+  set -e
+  [[ $RC -ne 0 && $ROUND -lt $MAX_ROUNDS ]] || break
+  report "ROUND $ROUND $([[ $RC -eq 124 ]] && echo TIMEOUT || echo "FAILED (exit $RC)") — continuing" \
+    "backlog not finished; relaunching a continuation round (committed tasks are durable on the weekend branch)"
+  ROUND=$((ROUND+1))
+  # Re-ground for the continuation: a killed session may leave a dirty tree.
+  # main is force-reset; the local weekend branch and its commits survive.
+  git checkout -f --quiet main
+  git reset --hard --quiet origin/main
+  git clean -fdq --exclude=.radon-weekend-runner --exclude=logs/ --exclude=.env --exclude=.env.ib-mode --exclude=web/.env
+done
 trap - ERR
 
 TAIL="$(tail -c 1500 "$RUN_LOG" 2>/dev/null || true)"

--- a/scripts/setup_testing_weekend.sh
+++ b/scripts/setup_testing_weekend.sh
@@ -4,15 +4,19 @@
 #
 #   bash scripts/setup_testing_weekend.sh
 #
-# Reuses the SAME dedicated clone as the reliability loop
-# (~/radon-weekend/radon — never edit it by hand; every run hard-resets
-# it to origin/main), installs the two launchd jobs (Sat 19:00 audit,
-# Sun 17:00 remediate — slotted around the reliability jobs at Sat 22:00
-# / Sun 10:00 so caps can never overlap), and verifies the toolchain.
+# Provisions the testing loop's OWN dedicated clone
+# (~/radon-weekend/radon-testing — never edit it by hand; every run
+# hard-resets it to origin/main), installs the two launchd jobs (Sat
+# 19:00 audit, Sun 17:00 remediate), and verifies the toolchain. The
+# clone is deliberately separate from the reliability loop's
+# (~/radon-weekend/radon): both loops hard-reset their working tree per
+# round and the reliability loop's continuation rounds make its wall
+# clock unbounded, so sharing a clone destroys in-flight work
+# (2026-08-16 incident).
 set -euo pipefail
 
 WEEKEND_ROOT="${RADON_WEEKEND_ROOT:-$HOME/radon-weekend}"
-WEEKEND_REPO="$WEEKEND_ROOT/radon"
+WEEKEND_REPO="$WEEKEND_ROOT/radon-testing"
 LAUNCH_AGENTS="$HOME/Library/LaunchAgents"
 ORIGIN_URL="$(git config --get remote.origin.url 2>/dev/null || echo git@github.com:joemccann/radon.git)"
 
@@ -68,7 +72,7 @@ done
 
 echo
 echo "Done. Schedule: audit Sat 19:00, remediate Sun 17:00 (local time),"
-echo "slotted around the reliability loop (Sat 22:00 / Sun 10:00)."
+echo "in the testing loop's own clone at $WEEKEND_REPO."
 echo "Dead-man: GitHub issue labeled 'testing-weekend' gets a comment"
 echo "per run — no weekend comment means the runner did not fire."
 echo "Smoke test now with:"

--- a/scripts/testing_weekend.sh
+++ b/scripts/testing_weekend.sh
@@ -3,10 +3,14 @@
 # runner (Mac mini). Saturday: /testing-weekend audit. Sunday:
 # /testing-weekend remediate. See .claude/skills/testing-weekend/.
 #
-# Shares the dedicated runner clone with the reliability loop; the
-# launchd slots (audit Sat 19:00 cap 2h, remediate Sun 17:00 cap 6h) are
-# sized so the two loops never overlap (reliability: Sat 22:00 / Sun
-# 10:00, caps 2h/6h).
+# Runs in its OWN dedicated clone (~/radon-weekend/radon-testing), never
+# the reliability loop's (~/radon-weekend/radon). Both wrappers hard-reset
+# and clean their clone on every round, so two loops in one working tree
+# destroy each other's checkouts and in-flight work — observed 2026-08-16
+# when this loop's audit checked out its branch under a running
+# reliability remediation. Schedule slotting is NOT sufficient isolation:
+# the reliability loop relaunches continuation rounds until its backlog
+# is done, so its wall clock is unbounded.
 #
 # Safety model:
 #   - runs ONLY in the dedicated runner clone (marker file required);
@@ -23,7 +27,7 @@ MODE="${1:?usage: testing_weekend.sh audit|remediate}"
   echo "unknown mode: $MODE" >&2; exit 2;
 }
 
-REPO="${RADON_WEEKEND_REPO:-$HOME/radon-weekend/radon}"
+REPO="${RADON_WEEKEND_REPO:-$HOME/radon-weekend/radon-testing}"
 # Audit fans out read agents (cap 2h); remediation is the long half (cap 6h).
 CAP_SECS=$([[ "$MODE" == "audit" ]] && echo 7200 || echo 21600)
 DEADMAN_TITLE="Weekend testing runner"


### PR DESCRIPTION
Per operator request: remediations must all complete in the same weekend run, not defer to a future date — and the two weekend loops must not be able to destroy each other's work.

- **Wrapper** (`scripts/reliability_weekend.sh`): the single capped remediate session becomes continuation rounds — a round that times out (or crashes) is reported to the dead-man issue and relaunched against the same weekend branch, up to a backstop of 8 rounds; per-task commits are the durable state and `main` is force-re-grounded between rounds while the local weekend branch survives. Audit mode is unchanged (1 round).
- **Skill** (`.claude/skills/reliability-weekend/SKILL.md`): remediate works the ENTIRE un-DONE backlog P0→P1→P2; `DEFERRED` is no longer an allowed outcome (only DONE or BLOCKED-with-root-cause after 3 attempts); continuation rounds resume from the first un-DONE item by diffing RELIABILITY_LOG.md against the backlog; the branch is pushed after every task commit so a killed round loses nothing.
- **Dedicated testing-loop clone** (`scripts/testing_weekend.sh`, `scripts/setup_testing_weekend.sh`, testing skill + plist templates): the testing loop moves from the shared `~/radon-weekend/radon` to its own `~/radon-weekend/radon-testing`. The old design relied on schedule slotting, which unbounded continuation rounds break — and broke anyway on 2026-08-16 when the testing audit hard-checked-out its branch under a running remediation, wiping in-flight work. Both wrappers hard-reset their working tree per round; separate clones make the collision impossible.

**Already applied on the runner (Mac mini):** `~/radon-weekend/radon-testing` provisioned (marker, env files, bun deps root+web, python deps verified) and both `com.radon.testing-{audit,remediate}` launchd jobs regenerated + reloaded pointing at it via `RADON_WEEKEND_REPO`, so the separation is live now regardless of merge timing.

The already-deferred REL-027…REL-038 items were remediated in PR #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)