### PR TITLE
weekend wrappers: force checkout so a dead run cannot wedge the next one

### DIFF
--- a/scripts/reliability_weekend.sh
+++ b/scripts/reliability_weekend.sh
@@ -69,7 +69,7 @@ echo "[weekend] $MODE start $STAMP repo=$REPO cap=${CAP_SECS}s" | tee -a "$RUN_L
 # Fresh ground truth. Any leftover state from a killed prior run is
 # discarded — the branch/PR on GitHub is the durable state.
 git fetch origin --quiet
-git checkout --quiet main
+git checkout -f --quiet main
 git reset --hard --quiet origin/main
 git clean -fdq --exclude=.radon-weekend-runner --exclude=logs/ --exclude=.env --exclude=.env.ib-mode --exclude=web/.env
 

--- a/scripts/testing_weekend.sh
+++ b/scripts/testing_weekend.sh
@@ -74,7 +74,7 @@ echo "[testing-weekend] $MODE start $STAMP repo=$REPO cap=${CAP_SECS}s" | tee -a
 # Fresh ground truth. Any leftover state from a killed prior run is
 # discarded — the branch/PR on GitHub is the durable state.
 git fetch origin --quiet
-git checkout --quiet main
+git checkout -f --quiet main
 git reset --hard --quiet origin/main
 git clean -fdq --exclude=.radon-weekend-runner --exclude=logs/ --exclude=.env --exclude=.env.ib-mode --exclude=web/.env
 


### PR DESCRIPTION
A run killed mid-task leaves the runner clone dirty on the weekend branch. Plain `git checkout main` then refuses ("Your local changes to TEST_AUDIT.md would be overwritten") and `set -e` crashes every subsequent run before the agent starts — this wedged the testing loop twice tonight (CRASHED comments on #40) until the clone was cleaned by hand.

One-word fix in both weekend wrappers: `git checkout -f --quiet main` restores the documented discard-leftovers contract.

Verified in a scratch repo: dirty tracked file on a side branch → plain checkout refuses (red), `checkout -f` lands on main (green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)