### PR TITLE
Flex error taxonomy and fetch budget

### DIFF
--- a/docs/flex-delivery-architecture.md
+++ b/docs/flex-delivery-architecture.md
@@ -1,0 +1,598 @@
+# Flex scheduled delivery: architecture decision
+
+Status: proposed, research complete, no code written.
+Date: 2026-08-17.
+Scope: replace the IBKR Flex Web Service polling path for `IB_FLEX_NAV_QUERY_ID=1442520`.
+
+---
+
+## UPDATE 2026-08-17, after this research landed — sequencing changed
+
+The research below is sound and its conclusion stands, but a finding it surfaced
+turned out to matter more than the recommendation itself, and it changes what to
+do FIRST.
+
+**The 10-day outage was largely self-inflicted, not an IBKR rate limit.**
+`_FLEX_THROTTLE_CODES` classified 1001, 1018 AND 1019 as throttles, and each
+escalated the local 24h/48h/72h/168h ladder. But per IBKR's own table only 1018
+is a rate limit; 1019 is the ordinary "still generating, poll again" response and
+1001 is a transient generation failure. So a statement seconds from ready bought
+a 24-hour backoff, and a transient failure walked a ladder toward a week.
+
+IBKR also publishes **no** daily or multi-day cooldown. The documented limit is
+10 requests per MINUTE, per token, and it clears in a minute. The ladder models a
+constraint far harsher than the real one.
+
+Fixed in commit 436dcdc1, with the old contract re-pinned to the correct
+classification rather than deleted.
+
+**What this means for this document.** The routine path may simply work now that
+Radon has stopped embargoing itself, so:
+
+1. Confirm the Web Service works post-fix before building any delivery pipeline.
+   The cheap discriminator that costs nothing against the token is pressing
+   **Run** on query 1442520 in the Portal — that is a render, not a
+   `/SendRequest`. If it generates there but still 1001s via the API, that is an
+   IBKR-side issue for a support ticket, not more code.
+2. Then adopt the architecture below as the durable path. It is still the better
+   design — the argument for it never depended on the throttle being real, only
+   on delivery being a mechanism that cannot be rate limited at all.
+3. Note the ladder itself is now over-conservative by roughly three orders of
+   magnitude and is worth revisiting on its own.
+
+---
+
+## A. The answer
+
+**Yes. Scheduled delivery escapes the Flex Web Service rate limit.** The published limit is
+"1 request per second, a maximum of 10 requests per minute", and error 1018 says it verbatim:
+"Too many requests have been made from this token." The limit is scoped to the `/SendRequest`
+*endpoint* and to the *token*. Scheduled delivery uses neither. IBKR's own Flex Web Service
+introduction, Usage Note 5, points at delivery as the alternative: "the same Flex Query reports
+can also be scheduled for delivery via email or FTP." The docs index frames them as either/or.
+IBKR never publishes an explicit "delivery is not rate limited" sentence, so this is inference
+from where the limit is scoped, not a quoted negative. It is a strong inference.
+
+**Recommended architecture: Portal-scheduled email to a machine-owned address, Cloudflare Email
+Worker to R2, VPS pulls from R2 and ingests from file.** Zero Flex Web Service requests on the
+routine path.
+
+**Email vs FTP: use email. Ask for sFTP anyway, but do not design around it.** sFTP is the
+better transport in the abstract (customer-pull, so a missing file fails loudly), but it is
+"available by request only", requires an RSA key exchange plus a mandatory PGP key, takes 1 to 2
+business days through `filedelivery@interactivebrokers.com`, and **no IBKR page confirms it is
+available to a standard individual (non-advisor, non-institutional) account.** The FTP settings
+page exists only under the Advisor Portal; the Client Portal equivalent 404s. Do not architect on
+a capability that may not exist for this account. The Cloudflare Worker design below recovers the
+one property sFTP has and email lacks (pull semantics, loud absence) by making R2 the pull point.
+
+**Also, and this is important: the 1001 you are seeing is probably not the rate limit at all.**
+In IBKR's taxonomy 1018 is the throttle code and 1009 is the load code. 1001 is
+"Statement could not be generated at this time", a statement *generation* failure for that query
+instance. The documented throttle clears within a minute; a 0.85 second 1001 repeating for 10+
+days is not that. **Before any of this work starts, open the Portal and press Run on query
+1442520 in the UI.** That is a Portal render, not a `/SendRequest` call, so it costs nothing
+against the token, and it discriminates "the token is throttled" from "this query cannot
+generate." If the query itself is broken, scheduled delivery will silently deliver nothing and
+this entire migration will look like it succeeded while producing no data.
+
+---
+
+## B. The recommended architecture
+
+### Who does what
+
+```
+  IBKR reporting backend
+    query 1442520 "Equity Summary in Base"
+    sections: NAV in Base | Cash Transactions | Transfers
+    Period: pinned explicit value (see W1)
+    Format: XML
+    Delivery: Email, enabled per query
+         |
+         |  ~19:00-20:00 ET weekdays (IBKR's published file-delivery window;
+         |  treat the clock as indicative until observed)
+         v
+  flex@stmt.radon.run                        <- machine-owned, no human mailbox
+    Cloudflare Email Routing (MX on stmt.radon.run)
+         |
+         v
+  Cloudflare Email Worker
+    1. buffer message.raw ONCE (it is a single-read stream)
+    2. postal-mime -> find the XML attachment
+    3. sha256(bytes) -> key
+    4. R2 PUT  flex/1442520/<yyyy-mm-dd>/<sha256>.xml
+    5. explicitly consume the message (a Worker that neither
+       forwards, rejects, nor consumes SILENTLY DROPS the mail)
+         |
+         v
+  R2 bucket radon-flex-inbox                 <- content-addressed, durable
+         |
+         |  HTTPS pull, S3-compatible, outbound only
+         v
+  Hetzner: radon-flex-ingest.timer  21:15 ET Mon-Fri
+    scripts/flex_delivery_ingest.py
+      list R2 objects newer than last accepted
+      download -> /var/lib/radon/flex-inbox/<sha>.xml  (0700 dir, 0600 file)
+      gate: parse / shape / monotonicity  (reject BEFORE any write)
+      dedup: flex_deliveries.content_sha256
+      then, from that one file, no network:
+        perf_twr_builder.build_and_persist(document=FlexDocument(...))
+          -> data/performance.json
+          -> Turso performance_snapshots, nav_snapshots,
+             external_flows, twr_subperiods
+        cash_flow_sync --from-file <path>
+          -> Turso cash_flows
+      heartbeat service_health: flex-delivery + performance
+      delete the file; keep at most 3 newest for replay
+```
+
+### Flex Web Service requests per day
+
+| Path | Requests/day |
+|---|---|
+| Routine NAV + flows + cash ingest | **0** |
+| Weekly reconciliation (section C) | 0 on six days, 1 on one day |
+| **Total routine** | **0** |
+
+Today, for comparison: `radon-perf-twr.timer` fires Mon to Fri at 20:45 ET and makes at least one
+unguarded `SendRequest` per run, and the monitor daemon's cash-flow handler makes another at
+17:00 ET. Two per weekday minimum, more with retries, and each one made during an embargo pushes
+the reset further out.
+
+### Why R2 and not IMAP on Gmail
+
+IMAP polling a Gmail mailbox is simpler and needs no Worker. It is rejected as the primary because:
+
+1. **The operator's Gmail is MCP-connected.** A daily plaintext statement in that mailbox is a
+   permanent, searchable archive of account number, full NAV curve, and every cash movement,
+   reachable by anything holding OAuth to that account. This is the single worst security outcome
+   available in this design space.
+2. Google app passwords are a deprecating, rotating credential with no scoping.
+3. A mailbox has no content-addressing, so dedup and replay have to be reinvented.
+
+R2 gives content-addressed storage for free (the key *is* the dedup identity), keeps the statement
+out of any human mailbox, and is pulled outbound over HTTPS with the same S3-compatible client
+pattern the portfolio cold-archive already uses against Backblaze.
+
+**Escape hatch, if the operator will not own a Worker:** deliver to a dedicated Gmail address that
+is *not* the primary and *not* MCP-connected, poll it with `imaplib` from the same ingest job
+behind the same fetcher interface, and delete the message on successful ingest. Everything
+downstream of the fetcher is identical. Build the fetcher as one interface with two
+implementations so this is a config flip, not a rewrite.
+
+---
+
+## C. Keep the Web Service, but only as an *exercised* path
+
+**Decision: keep it, demoted to a weekly reconciliation that actually runs. Do not keep it as a
+dormant fallback.**
+
+The argument against keeping it is real and this repo has been bitten by exactly it: a code path
+with no caller rots and nothing notices (`feedback_scan_endpoint_without_a_caller` was precisely a
+scan endpoint with a mirror and a service_health row and no timer, stale forever, paging nobody).
+A `--fallback` flag nobody exercises for four months is not a fallback; it is untested code that
+will fail on the night you need it.
+
+The argument against deleting it is also real: scheduled delivery is a *push*. When a push does
+not arrive there is nothing to retry against, and the recovery lane would be "the operator exports
+by hand from the Portal", which is where we are today.
+
+The resolution is to make the rare path a *scheduled* path. One run per week, Sunday, breaker-gated
+through the existing `_throttle_backoff` ladder:
+
+- It is exercised every week, so it cannot silently rot.
+- It reconciles: fetch the statement over the Web Service, compare the derived NAV series and flow
+  set against what the delivered file produced. A divergence is a real signal that the delivery
+  template drifted.
+- One request per week will never re-enter the embargo. The ladder walks back down on
+  `record_success`, and the token stays proven warm, which also keeps `flex-token-check` honest.
+- When a delivery is missed, the same code path can be invoked on demand with a known-good breaker
+  state instead of being a cold-start gamble.
+
+Non-negotiable condition on keeping it: **every** `SendRequest` call site must go through one
+breaker-gated helper first (see W10). There are currently six independent `SendRequest`
+implementations in this repo and only the cash-flow handler consults the breaker.
+
+---
+
+## D. The work
+
+Ordered. Do not start W2 before W0 answers.
+
+### W0. Diagnose the 1001 in the Portal. NEEDS-DECISION (blocking)
+
+**No code.** Client Portal, Performance & Reports, Flex Queries, open the Activity Flex Query
+1442520, press **Run**. Verify in the Portal: exact menu labels vary by Portal version.
+
+- If it renders: the query is fine, the failure is token-side, proceed with the full design.
+- If it fails to generate: fix the query first (most likely suspects are the Period field and the
+  Transfers section). Scheduled delivery of a query that cannot generate delivers nothing, and it
+  fails **silently**, which is strictly worse than today.
+
+**Test that proves it:** a rendered statement in the browser, and its row/section counts compared
+against the hand export the operator already produced.
+**Risk:** skipping this ships a migration that appears to succeed and produces no data.
+
+### W1. Configure delivery in the Portal. NEEDS-DECISION
+
+Clickpath (**verify in the Portal**; IBKR relabels these pages and the current docs and the live
+UI disagree in places):
+
+1. Client Portal, Performance & Reports, Statements, gear/Delivery Settings.
+2. Set the delivery **method** to Email. Note: the method is **user/account-wide**, it applies to
+   every report enabled for delivery, so this also changes any IB-defined statements already being
+   delivered.
+3. Performance & Reports, Flex Queries, Delivery Configuration panel for **Activity Flex Query**
+   (Trade Confirmation Flex is a separate panel). Tick query 1442520.
+4. Set the delivery address to the machine-owned address from W2, not a human mailbox.
+5. Open query 1442520 and **pin the Period to an explicit value** (Last Business Day, or Last 365
+   Calendar Days if the full curve is wanted every night). Delivery has **no** `fd`/`td`/`p`
+   override; the saved Period governs entirely, and IBKR's Usage Note 6 warns that variable "Last
+   N Days" durations behave unpredictably.
+6. Confirm Format is XML.
+
+**Frequency: there is no documented frequency selector.** Current IBKR docs for Client Portal,
+Advisor Portal, Org Portal and Student Lab all show only method plus per-query checkbox. The
+"Daily / Weekly / Monthly" dropdown that appears in search summaries traces to a dead legacy
+Account Management mirror. **Verify in the Portal.** If no selector exists, cadence follows the
+query Period and IBKR's delivery run, published as "Daily, Monday to Friday (weekend delivery
+available upon request)" at "~7PM to 8PM ET".
+
+**Test that proves it:** the first delivered email arrives, and `describe_statement_shape()` on its
+attachment returns `flex_statement_count == 1`, the expected account id, and
+`has_transfers_section == True`.
+**Risk:** the account-wide method setting has side effects on other delivered reports. Note what
+delivery is already configured before changing it.
+
+### W2. Receiving endpoint: Cloudflare Email Routing + Worker + R2. UNAMBIGUOUS
+
+- New subdomain `stmt.radon.run`, MX records per Cloudflare Email Routing, one routing rule
+  `flex@stmt.radon.run` to the Worker.
+- Worker: buffer `message.raw` exactly once, `postal-mime` to extract the XML attachment,
+  `sha256` the bytes, R2 `PUT flex/<queryId>/<yyyy-mm-dd>/<sha256>.xml`, then **explicitly consume
+  the message**. A Worker that does not forward, reject, or consume drops the mail with no error
+  anywhere.
+- Reject any message whose envelope sender is not IBKR's, before parsing.
+- Do **not** key anything on the attachment filename. No IBKR source documents the filename
+  convention for Flex email attachments (the AccountID/FileType/AsOfDate convention that IBKR
+  publishes belongs to the reporting-integration feed program, not to Flex delivery). Parse
+  defensively.
+- This Worker is a **second deploy target outside this repo's CI gate**. Keep it in
+  `cloud/workers/flex-inbox/` with its own `wrangler.jsonc` so it is at least version-controlled
+  at the same SHA, and document that deploying it is a manual `wrangler deploy`.
+
+**Test that proves it:** a unit test over the Worker with a saved raw MIME fixture built from a
+real delivery, asserting the R2 key equals `sha256` of the attachment bytes; plus one live
+end-to-end send.
+**Risk:** attachment size limits are unpublished. A 365-day three-section Activity XML is the case
+to watch. If it exceeds the limit, this becomes the argument that finally forces sFTP.
+
+### W3. `flex_deliveries` table. UNAMBIGUOUS
+
+New migration. **Check Turso `MAX(version)` and every in-flight worktree before picking a number**
+(highest on disk here is `0049_vixcor.sql`; parallel worktrees have collided on this before).
+
+```sql
+CREATE TABLE IF NOT EXISTS flex_deliveries (
+  content_sha256 TEXT PRIMARY KEY,
+  query_id       TEXT NOT NULL,
+  account_id     TEXT NOT NULL,
+  period_from    TEXT NOT NULL,
+  period_to      TEXT NOT NULL,
+  when_generated TEXT NOT NULL,
+  parsed_rows    INTEGER NOT NULL,
+  received_at    TEXT NOT NULL,
+  channel        TEXT NOT NULL,
+  ingested_at    TEXT,
+  status         TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_flex_deliveries_period_to ON flex_deliveries(period_to);
+```
+
+Identity is `sha256(raw bytes)` plus the explicit named tuple
+`(account_id, period_from, period_to, when_generated)`, all of which
+`cash_flow_sync.describe_statement_shape()` already returns. **Hash the named tuple, never "every
+field except X"** (`feedback_identity_hash_over_dict_shape`: a later-added field faked corruption
+and wedged orders-sync).
+
+**Test that proves it:** ingest the same fixture twice, assert one row, assert the second run exits
+0 with status `duplicate` and writes nothing to `performance_snapshots`.
+**Risk:** migration number collision, which presents as "nothing to apply" on a new migration.
+
+### W4. `perf_twr_builder --from-file`. UNAMBIGUOUS
+
+Two I/O chokepoints: `_fetch_nav_document()` (`scripts/perf_twr_builder.py:442`) and
+`resolve_flows(document)` (`:519`). `resolve_flows` **already** reuses a passed document when
+`document.query_id == _flows_query_id()`, and `IB_FLEX_FLOWS_QUERY_ID` is deliberately unset so
+`_flows_query_id()` falls back to the NAV id. Threading an optional
+`FlexDocument(query_id=<nav id>, xml=<file text>)` through `get_nav_snapshots()` and
+`build_and_persist()` therefore resolves NAV **and** flows from one file with zero network. About
+15 lines.
+
+**The critical detail:** `get_nav_snapshots()` falls through `flex_live -> disk_cache -> turso`. A
+file-driven run must **fail loudly**, not fall back. Without a strict mode, a bad file republishes
+a stale curve tagged `nav_source="disk_cache"` and the page looks fine.
+
+Add `--from-file PATH` to `main()` (`:1439`), setting strict mode implicitly.
+
+**Test that proves it:** (a) golden test, run `--from-file` against the operator's real 329-row
+export fixture, assert the payload matches the known-good live payload field for field; (b)
+red test, `--from-file` a truncated statement, assert non-zero exit and assert
+`data/performance.json` is unchanged.
+**Risk:** silent fallback to `disk_cache`. Test (b) is the one that matters.
+
+### W5. `cash_flow_sync` file path. UNAMBIGUOUS (mostly done)
+
+`--from-file` already exists (`scripts/cash_flow_sync.py:595`), with `--dry-run`, `--since`,
+`--json`, `--no-file`. `parse_cash_transactions()` (`:330`) is pure and parity-proven. The work is
+only to have the ingest job call it in-process rather than shelling out, and to have it share the
+single validation gate from W6 instead of re-deriving one.
+
+Note the two parsers disagree in direction about the Transfers section, and both are correct:
+`perf_twr._transfers_section_warnings` **errors** when Transfers is absent (an ACATS would read as
+investment gain), while `cash_flow_sync.statement_shape_warnings` **warns** that it does not ingest
+them. Section present plus the cash-flow warning is the correct steady state. Do not "fix" either.
+
+**Test that proves it:** existing `scripts/tests/test_cash_flow_sync_cli.py` stays green, plus one
+new test asserting the ingest job produces byte-identical row output to the CLI on the same file.
+**Risk:** low.
+
+### W6. Ingest job, unit, timer. UNAMBIGUOUS
+
+`scripts/flex_delivery_ingest.py`, plus `cloud/services/radon-flex-ingest.{service,timer}`.
+
+Model the unit on `radon-perf-twr.service`: `Type=oneshot`, `User=radon`,
+`WorkingDirectory=/home/radon/radon`, `EnvironmentFile=/home/radon/radon-cloud/.env`,
+`Environment=RADON_DB_NO_REPLICA=1`, `StartLimitIntervalSec=300`, `StartLimitBurst=5`. Add the
+hardening in section E, which no existing unit uses and which this job needs more than any other.
+
+Timer: `OnCalendar=Mon..Fri *-*-* 21:15:00 America/New_York`, `Persistent=true`,
+`RandomizedDelaySec=300`. 21:15 sits after IBKR's ~19:00 to 20:00 ET delivery window and after the
+20:45 the existing perf timer already encodes as the settle point.
+
+Validation gate, reject **before any write**, using only functions that already exist:
+
+1. `ET.fromstring` parses.
+2. `flex_statement_count == 1` and `account_ids == [expected]`.
+3. `has_transfers_section` is True.
+4. `parse_nav_entries` yields at least 2 observations.
+5. Monotonicity floor: `period_to >= ` last accepted `period_to`, and `parsed_rows >= ` last
+   accepted minus a small tolerance. A statement that halves its cash rows is a query-config change,
+   not a real day.
+
+Fail closed: heartbeat `error`, leave the file in the inbox, exit non-zero.
+
+**Per `cloud/CLAUDE.md`, a new unit owes a root `install -m 0644` AND a hash bump in
+`cloud/config/installed-units.sha256` in the same commit**, or `tests/test_unit_install_acknowledgment.py`
+fails CI. New env keys go in `cloud/config/required-env.txt` only if the deploy preflight should
+hard-fail without them.
+
+**Test that proves it:** table-driven test over five bad fixtures (unparseable, two statements,
+wrong account, no Transfers, one NAV point) asserting each one exits non-zero and writes nothing;
+plus `pytest cloud/tests` and `systemd-analyze verify` on the unit.
+**Risk:** the timer fires whether or not a file arrived. That is deliberate. It is what turns
+absence into an event.
+
+### W7. service_health. UNAMBIGUOUS, and it is broken today
+
+Three separate defects, all verified in this repo:
+
+1. **`perf_twr_builder` never writes a `service_health` row.** `persist_payload` (`:1315`) calls
+   `upsert_performance_snapshot` **directly**, bypassing `db.scan_mirror.mirror_scan_snapshot()`,
+   which is the function that owns both the snapshot upsert and the `record_service_health`
+   heartbeat. `scan_mirror.SNAPSHOT_UPSERTS:45` maps `"performance"` to
+   `upsert_performance_snapshot`, and nothing calls it. **Fix: route `persist_payload` through
+   `mirror_scan_snapshot("performance", payload)`.** One line, and it is the chokepoint every other
+   scan already uses.
+2. **The declared `performance` window is wrong for a scheduled build.**
+   `web/lib/serviceHealthWindows.ts:373` declares
+   `{ open: 30 * MIN, extended: 30 * MIN, closed: 3 * DAY, category: "on-demand" }`, with a comment
+   describing it as a user-triggered scan endpoint. It is not; it is a nightly timer. Turning on the
+   heartbeat from (1) without fixing this pages every 30 minutes. **Change to
+   `{ open: 26 * HOUR, extended: 26 * HOUR, closed: 4 * DAY, category: "scheduled", requires_ib: false }`**,
+   matching `cash-flow-sync` and `execution-sweep`, both weekday-only and both widened to 4 days
+   precisely because 25h tripped every Saturday.
+3. **`"performance"` is in no watchdog bucket** and not in
+   `scripts/watchdog/services.py:SCHEDULED_SERVICES`.
+
+Then add a **separate** `flex-delivery` key heartbeated by the ingest job on every run, because
+"the mailbox and R2 are reachable" and "a fresh statement exists" are different failures with
+different fixes. Register **both** keys in `scripts/watchdog/services.py` **and**
+`web/lib/serviceHealthWindows.ts` (contract tests pin them against each other; editing one alone
+fails CI), and add both to the watchdog **daily** bucket alongside `cash-flow-sync`,
+`execution-sweep` and `flex-token-check`.
+
+Heartbeat rules, all previously learned the hard way:
+- Heartbeat on **every** cycle including no-ops, or the error row latches
+  (`feedback_service_health_heartbeat`).
+- Heartbeat on the **failure** path too, or a wedged poller looks identical to a quiet one
+  (`feedback_polling_marker_must_match_failure`).
+- Do **not** latch `last_run` on a soft failure (`feedback_dont_latch_last_run_on_soft_failure`).
+  An unreachable R2 must stay due.
+
+**Test that proves it:** `scripts/tests/test_service_registration_completeness.py` and the
+TS/Python window-parity test both green with the two new keys; plus a test asserting
+`build_and_persist()` writes a `service_health` row with `status="ok"`.
+**Risk:** enabling the heartbeat before fixing the window turns on a 30-minute pager.
+
+### W8. Missing-delivery alarm. UNAMBIGUOUS
+
+A push has no natural "it is late" event, so the alarm must be time-driven. The W6 timer fires
+whether or not a file arrived. On each firing:
+
+- No object in R2 newer than the last accepted `period_to`, **and** `sessions_behind() > 1`
+  (reuse `perf_twr_builder.sessions_behind()` `:211` and `last_completed_session()` `:196`, do not
+  write a second staleness rule): heartbeat `flex-delivery` **error**, do not latch `last_run`.
+- Nothing new but `sessions_behind() <= 1`: heartbeat **ok**. Weekends and holidays are legitimately
+  quiet, which is what the 4-day closed window encodes.
+
+**Test that proves it:** window-relative fixtures (today minus N, never hardcoded dates,
+`feedback_window_relative_test_dates`), asserting error on a 3-session gap and ok on a Saturday.
+**Risk:** this is the single highest-value item. Switching from pull to push **removes the only
+failure signal that exists today**, which is a unit that exits non-zero. Do not ship W1 to W6 to
+production without W7 and W8.
+
+### W9. Filesystem and repo hygiene. UNAMBIGUOUS
+
+- **`.gitignore` has no `*.xml` rule anywhere.** The repo is PUBLIC. A statement that lands under
+  `data/` is one `git add` from a permanent leak. Add explicit ignores, and more importantly never
+  write a statement inside the checkout at all.
+- Inbox at `/var/lib/radon/flex-inbox/`, directory `0700 radon:radon`, files `0600`, written
+  atomically `tmp` then `rename` (the pattern `persist_payload` already uses).
+
+**Test that proves it:** a test asserting the ingest job's write path resolves outside the repo
+root, and `gitleaks detect --source . --config cloud/.gitleaks.toml` green.
+**Risk:** an `*.xml` allowlist entry in gitleaks would be SHA-keyed and breaks on rebase
+(`feedback_gitleaks_allowlist_sha_keyed_breaks_on_rebase`). Do not create a case that needs one.
+
+### W10. Demote and chokepoint the Web Service. NEEDS-DECISION
+
+There are currently **six independent `SendRequest` implementations**: `scripts/cash_flow_sync.py:104`,
+`scripts/perf_twr_builder.py:114`, `scripts/portfolio_performance.py:379` and `:495`,
+`scripts/trade_blotter/flex_query.py:83`, `scripts/trade_blotter/blotter_service.py:184`. Only the
+cash-flow handler consults `scripts/monitor_daemon/handlers/_throttle_backoff.py`. **`perf_twr_builder`
+fires Mon to Fri at 20:45 ET and makes an entirely unguarded request every night**, embargo or not.
+That is very likely a material contributor to the current state.
+
+Work: one breaker-gated `flex_request()` helper that every call site routes through, then
+`radon-perf-twr.timer` changed from nightly to Sunday-only reconciliation, then the Web Service
+call removed from the ingest path entirely.
+
+**Needs a decision** because collapsing six call sites is larger than the rest of this plan
+combined, and the blotter and `portfolio_performance` paths have their own callers and cadences
+that were not audited here.
+
+**Test that proves it:** a test asserting every module-level Flex URL constant is unreachable
+except through the gated helper (grep-style structural test), plus a test asserting the helper
+refuses when `is_blocked()`.
+**Risk:** leaving any ungated call site means the breaker is decorative.
+
+---
+
+## E. Security requirements
+
+These are requirements, not suggestions. The artifact is the account number, the full NAV history,
+every cash movement, and positions. It is the most sensitive thing Radon touches, in a public repo.
+
+1. **The statement MUST NOT be delivered to a human mailbox, and MUST NOT be delivered to any
+   MCP-connected mailbox.** Delivery address is machine-owned (`flex@stmt.radon.run`).
+2. **The statement MUST NOT be written anywhere inside the git checkout.** Inbox is
+   `/var/lib/radon/flex-inbox/`, directory `0700`, files `0600`, atomic `tmp` then `rename`. Never
+   into `data/`, never into `logs/`.
+3. **Request PGP encryption from IBKR** (`filedelivery@interactivebrokers.com`, same email as the
+   sFTP request). Encryption is by-request-only and applies to both email and sFTP. It is off by
+   default, so plaintext XML transits SMTP unless requested. This is the single highest-leverage
+   mitigation and it makes email and sFTP converge in risk. Preferred handling: fetch `.xml.gpg`,
+   decrypt in memory, parse, persist only the derived rows. The retained replay copy stays `.gpg`.
+4. **Delete on successful ingest.** Retain at most the 3 newest for replay, pruned by mtime
+   **inside the same job**. A separate prune timer can go stale.
+5. **Never log the body, and redact `account_ids` before logging the shape dict.**
+   `describe_statement_shape()` returns `account_ids`; printing it puts the account number in
+   journald, and `data/journal_archive/` rsyncs journald snapshots to the laptop.
+6. **The unit MUST carry systemd hardening:** `StateDirectory=radon/flex-inbox`,
+   `StateDirectoryMode=0700`, `UMask=0077`, `PrivateTmp=true`, `ProtectHome=read-only`,
+   `NoNewPrivileges=true`, `ProtectSystem=strict`. No existing unit uses these. This one should be
+   the first.
+7. **All credentials in `/home/radon/radon-cloud/.env`, mode `0600`, via `EnvironmentFile=`.**
+   Never `~/.zshrc`, never inside the checkout, never `web/.env`. **Single-quote any value
+   containing `$`** or systemd and bash sourcing expand it and the unit fails silently under
+   `set -u` (`feedback_env_file_shell_expansion`). Run new keys through `cloud/scripts/check-env.py`.
+8. **Radon MUST NOT open an inbound port for this.** Hosting an inbound SFTP or an inbound webhook
+   puts new authentication surface on the host that holds `TWS_USERID`, `TWS_PASSWORD` and the Turso
+   token in one file. `cloud/scripts/setup-vps.sh` opens only 80 and 443 today. That asymmetry is
+   why the two inbound designs are rejected outright, not weighed.
+9. **If sFTP is granted: pin IBKR's host key** in a dedicated `known_hosts` with
+   `StrictHostKeyChecking=yes`, key at `/home/radon/.ssh/ibkr_sftp` mode `0600`. A host-key change
+   must fail loudly rather than download.
+10. **Only the PGP public key may ever be committed.** The private key lives on the host at `0600`.
+
+Attacker payoff if this leaks: account number, NAV curve, every deposit and withdrawal. That is a
+complete financial profile and a credible spear-phishing and SIM-swap package. It is not directly a
+trading capability, which is exactly why item 8 matters most.
+
+---
+
+## F. What this does not fix
+
+- **It does not make the data fresher than IBKR generates it.** Delivery runs in the same
+  ~19:00 to 20:00 ET window and reflects the same T+1 settlement. The known ~1 day cash-transaction
+  settlement lag stays (`feedback_flex_cash_transaction_lag`).
+- **It does nothing intraday.** Flex is an end-of-day reporting product in every delivery mode. A
+  live NAV during the session still requires the TWS API or the Client Portal Gateway, and neither
+  gives a historical NAV series with classified external flows.
+- **It does not retroactively clear the current embargo.** The local ladder is Radon policy; IBKR
+  publishes no cooldown duration at all, only "try again shortly". The only thing that shortens the
+  current state is not making more requests.
+- **It does not fix the query if the query is broken.** See W0. If 1001 is a generation failure,
+  delivery delivers nothing, silently.
+- **It does not remove the manual Portal export as the true last resort.** It makes it rarer.
+- **It does not cover trades.** `IB_FLEX_QUERY_ID=1422766` is a separate blotter query with separate
+  call sites, untouched by this design. If it is also being polled, it is also spending the same
+  token.
+- **It does not make the Gmail MCP an automation path.** MCP tools are bound to an interactive
+  Claude session; there is no route from a `radon-*.timer` to `mcp__claude_ai_Gmail__*`. The MCP is
+  useful as the *operator recovery lane* (find the attachment, run `--from-file`) and nothing more.
+- **A human forwarding the email is not automation.** It inherits today's silent-failure mode and
+  adds a person to it. The only version of this that automates is IBKR delivering directly to a
+  machine-owned destination.
+
+---
+
+## G. Migration path
+
+**Phase 0, today, no code.**
+1. Run W0. Press Run on query 1442520 in the Portal. Everything else waits on the answer.
+2. **Stop spending requests.** `radon-perf-twr.timer` is the unguarded nightly consumer; stop and
+   disable it (`radon unit stop radon-perf-twr.timer`, not a piecemeal `systemctl`, and never
+   `radon restart`, which cycles the Gateway and triggers 2FA). The monitor daemon's cash-flow
+   handler is already breaker-gated. Confirm with `journalctl` that nothing else fired a
+   `SendRequest` in the last 24h.
+3. Send one email to `filedelivery@interactivebrokers.com` with the account ID requesting **both**
+   sFTP delivery **and** PGP encryption for Statements/Flex Queries, and asking explicitly whether
+   sFTP is available on this account type. Both are by-request-only, both change the design, and a
+   rep responds in 1 to 2 business days. Sending it now means the answer arrives while W2 to W9 are
+   being built.
+4. Keep serving `/performance` from the hand-built payload. It is correct.
+
+**Phase 1, the throttled token.** Do not probe it. Every request while embargoed extends it, and
+IBKR publishes no duration, so there is no schedule to wait out, only a policy to stop violating.
+Let the local ladder expire on its own. `flex-token-check` is expiry telemetry from an env value
+and makes no network call, so it is safe to leave running. The token itself is fine; only the
+request rate is in question. Do not rotate it, and do not create a second token to route around the
+limit, which would be scoped per token and would read as evasion.
+
+**Phase 2, build the ingest first, channel second.** W3, W4, W5, W6, W7, W8, W9 are all testable
+against the operator's existing 329-row export with zero network and zero delivery configured. Ship
+them behind the fetcher interface with a local-directory fetcher. At the end of Phase 2 the operator
+can drop a hand-exported file into `/var/lib/radon/flex-inbox/` and get a fully automated,
+deduped, validated, heartbeated ingest. **That alone removes the manual pipeline** and is worth
+shipping on its own even if delivery never gets configured.
+
+**Phase 3, turn on delivery.** W2 then W1, in that order: the Worker and R2 must exist before mail
+is pointed at them, or the first deliveries are dropped with no record. Run both channels in
+parallel for one week, delivery-fed ingest plus the existing hand export, and diff the payloads
+daily.
+
+**Phase 4, demote.** Once a week of deliveries has landed clean, do W10: chokepoint the six
+`SendRequest` sites, flip `radon-perf-twr.timer` to Sunday-only reconciliation, re-enable it. Steady
+state is zero Flex Web Service requests per weekday and one per week.
+
+**Rollback at any phase:** the fetcher interface has a local-directory implementation, and
+`--from-file` works on a hand export from the Portal. That is the floor, and it is strictly better
+than today's floor because the ingest, validation, dedup and alarm all still run.
+
+---
+
+## Sources
+
+Flex Web Service pacing: https://ibkrcampus.com/docs/web-api/flex-web-service/using-flex-web-service/make-request-to-send-request.md ·
+Error codes (1001 / 1009 / 1018 / 1019): https://ibkrcampus.com/docs/web-api/flex-web-service/error-codes.md ·
+Usage Note 5, delivery as the alternative: https://ibkrcampus.com/docs/web-api/flex-web-service/introduction.md ·
+Flex delivery settings (method is account-wide, sFTP and encryption by request): https://www.ibkrguides.com/clientportal/performanceandstatements/deliverysettingsflex.htm ·
+Statements delivery: https://www.ibkrguides.com/clientportal/performanceandstatements/deliver.htm ·
+Activity Flex Query Period field: https://www.ibkrguides.com/clientportal/performanceandstatements/activityflex.htm ·
+File delivery, FTP/sFTP/PGP, daily Mon-Fri ~7-8PM ET: https://www.interactivebrokers.com/campus/ibkr-reporting-page/transmitting-files-3/ ·
+Advisor Portal FTP: https://www.ibkrguides.com/advisorportal/ftp.htm ·
+Account Management API is advisor/IB-only, PDF-only: https://ibkrcampus.com/docs/web-api/account-management/reporting/activity-statements.md ·
+Access token lifetime and IP restriction: https://ibkrcampus.com/docs/web-api/flex-web-service/client-portal-configuration/enable-and-create-access-token.md

--- a/scripts/cash_flow_sync.py
+++ b/scripts/cash_flow_sync.py
@@ -33,7 +33,7 @@ Exit codes (the handler's classification contract — never classify a
 failure by substring-matching stderr again):
      0  success
      1  configuration error (missing token / query id / unreadable file)
-    10  Flex throttle (documented code 1001 / 1018 / 1019) — breaker ladder
+    10  Flex rate limit (code 1018 ONLY) — breaker ladder
     11  permanent Flex application error (auth, unknown query id, unknown
         error code). Retrying cannot flip it; do not spend more requests.
     12  statement never became ready inside the poll budget, or a transport
@@ -55,7 +55,7 @@ Cadence:
     feedback_flex_cash_transaction_lag.md.
 
 Throttle handling:
-    Documented Flex throttle codes (1001 / 1018 / 1019) raise
+    The one documented rate-limit code (1018) raises
     ``FlexThrottleError`` IMMEDIATELY — no internal retry, since each
     retry burns more of the sliding-window budget. Both legs are checked:
     a throttle returned on a GetStatement POLL used to be indistinguishable
@@ -158,12 +158,42 @@ def _normalize_date(raw: str) -> str:
     return raw
 
 
-# Documented throttle codes — every retry on these burns the sliding-window
-# budget further. We do NOT retry internally; the daemon handler's circuit
-# breaker waits 24h+ before the next attempt.
+# IBKR's error taxonomy, as published:
+#   https://www.ibkrguides.com/clientportal/performanceandstatements/flex3error.htm
+#
+#   1001  Statement could not be generated at this time. Please try again shortly.
+#   1009  The server is under heavy load. Statement could not be generated at
+#         this time. Please try again shortly.
+#   1018  Too many requests have been made from this token. Please try again
+#         shortly.  Limited to one request per second, 10 requests per minute
+#         (per token).
+#   1019  Statement generation in progress. Please try again shortly.
+#
+# ONE of these is a rate limit. This set previously held 1001, 1018 AND 1019,
+# and every one of them raised FlexThrottleError and escalated the local
+# 24h/48h/72h/168h ladder. 1019 is the ordinary NOT-READY response during
+# polling, so "still generating" bought a 24-hour backoff; 1001 is a transient
+# generation failure that IBKR tells you to retry shortly, and it escalated
+# toward a one-week embargo. That is the most plausible root cause of the
+# 10-day outage from 2026-08-06.
+#
+# Note also that IBKR publishes NO daily or multi-day cooldown. The documented
+# limit is 10 requests per minute and it clears in a minute; the ladder is
+# Radon-local policy and is far more conservative than the limit it models.
 _FLEX_THROTTLE_CODES = {
+    "1018",  # the only documented rate limit
+}
+
+# "Try again shortly" — transient server-side generation failures. These take
+# the SOFT lane (short bounded retry), never the breaker ladder.
+_FLEX_TRANSIENT_CODES = {
     "1001",  # Statement could not be generated at this time.
-    "1018",  # Too many requests have been made from this token.
+    "1009",  # The server is under heavy load.
+}
+
+# Not an error at all: the statement is still being built. The poll loop must
+# keep waiting rather than treating it as a failure of any kind.
+_FLEX_NOT_READY_CODES = {
     "1019",  # Statement generation in progress.
 }
 
@@ -238,6 +268,16 @@ class _FlexAppError(RuntimeError):
     """
 
 
+class _FlexTransientError(RuntimeError):
+    """IBKR could not generate the statement right now and said to retry.
+
+    Codes 1001 and 1009. Distinct from `_FlexAppError` because retrying DOES
+    flip these, and distinct from `FlexThrottleError` because they are not a
+    rate limit and must never escalate the breaker ladder. Conflating the three
+    is what turned "try again shortly" into a multi-day embargo.
+    """
+
+
 class _StatementNotReady(RuntimeError):
     """The poll budget expired before IBKR finished generating the
     statement. Retryable, but not today's problem — the next daily window
@@ -251,16 +291,26 @@ class _ConfigError(RuntimeError):
 
 
 def _flex_error_from(root: ET.Element, leg: str) -> Optional[BaseException]:
-    """Turn a Flex `<ErrorCode>` body into the right typed exception.
+    """Turn a Flex `<ErrorCode>` body into the right typed exception, or None.
 
-    Applied to BOTH legs. A 1018 returned on a GetStatement poll used to
-    be indistinguishable from "not ready", so a token that was ALREADY
-    throttled kept firing polls at full speed for the rest of the budget.
+    Applied to BOTH legs. A 1018 on a GetStatement poll used to be
+    indistinguishable from "not ready", so an already-throttled token kept
+    firing polls at full speed for the rest of the budget. That is still
+    handled -- 1018 raises on either leg.
+
+    The inverse mistake is the one this function now avoids: 1019 IS "not
+    ready". Returning any exception for it aborts a poll loop that should
+    simply keep waiting, and classifying it as a throttle bought a 24-hour
+    backoff for a statement that was seconds from being ready.
     """
     code_node = root.find(".//ErrorCode")
     if code_node is None or not (code_node.text or "").strip():
         return None
     code = (code_node.text or "").strip()
+    if code in _FLEX_NOT_READY_CODES and leg == "GetStatement":
+        # The statement is still being built. Not an error on the poll leg --
+        # returning one would abort a loop whose whole job is to wait.
+        return None
     msg_node = root.find(".//ErrorMessage")
     message = (
         (msg_node.text or "").strip()
@@ -270,6 +320,12 @@ def _flex_error_from(root: ET.Element, leg: str) -> Optional[BaseException]:
     detail = f"Flex {leg} failed (code {code}): {message}"
     if code in _FLEX_THROTTLE_CODES:
         return _flex_throttle_error_cls()(code, detail)
+    if code in _FLEX_TRANSIENT_CODES or code in _FLEX_NOT_READY_CODES:
+        # 1019 reaching this line means it came back on SendRequest, i.e. a
+        # generation is already in flight. Retryable, not permanent -- and
+        # emphatically not the "no ReferenceCode" hard error it used to fall
+        # through to, which is classified as never-retry.
+        return _FlexTransientError(detail)
     return _FlexAppError(detail)
 
 
@@ -277,7 +333,7 @@ def _send_request_once(token: str, query_id: str) -> str:
     """One SendRequest hit. Returns the ReferenceCode or raises.
 
     Raises:
-        FlexThrottleError    on documented throttle codes (1001/1018/1019)
+        FlexThrottleError    on the rate-limit code (1018)
         _FlexAppError        on any other structured Flex error
         Exception            on transport / parse failure
     """
@@ -298,7 +354,7 @@ def _send_request_once(token: str, query_id: str) -> str:
 def _request_reference_code(token: str, query_id: str) -> str:
     """Call SendRequest with a single bounded retry on transport blips only.
 
-    Throttle codes (1001/1018/1019) raise FlexThrottleError on the first
+    The rate-limit code (1018) raises FlexThrottleError on the first
     hit — no retry, since every retry pushes the sliding-window out
     further. Structured Flex application errors (auth, bad query id)
     fail fast — retrying won't flip them.
@@ -474,7 +530,7 @@ def fetch_statement_xml(
     """Fetch the raw Flex statement XML. One SendRequest, bounded polling.
 
     Raises:
-        FlexThrottleError    on Flex throttle codes 1001 / 1018 / 1019,
+        FlexThrottleError    on the Flex rate-limit code 1018,
                              from EITHER leg.
         _FlexAppError        on any other structured Flex error.
         _StatementNotReady   when the poll budget expires.

--- a/scripts/perf_twr_builder.py
+++ b/scripts/perf_twr_builder.py
@@ -236,13 +236,39 @@ def sessions_behind(nav_as_of: Optional[str], through: Optional[_date] = None) -
 # ---------------------------------------------------------------------------
 
 
-def fetch_flex_xml(token: str, query_id: str, *, max_polls: int = 30, poll_secs: float = 3.0) -> str:
-    """Poll Flex until FlexStatements appears; hard-fail if ReferenceCode is missing."""
+FLEX_READ_TIMEOUT_SECONDS = 120.0
+FLEX_POLL_BUDGET_SECONDS = 420.0
+
+
+def fetch_flex_xml(
+    token: str,
+    query_id: str,
+    *,
+    max_polls: int = 60,
+    poll_secs: float = 3.0,
+    read_timeout: float = FLEX_READ_TIMEOUT_SECONDS,
+) -> str:
+    """Poll Flex until FlexStatements appears; hard-fail if ReferenceCode is missing.
+
+    Two budgets, both widened after a live failure on 2026-08-16.
+
+    The socket read timeout was 30s. Query 1442520 now carries three sections
+    (NAV in Base, Cash Transactions, Transfers), and the Transfers section made
+    the statement slow enough that GetStatement blew that timeout outright:
+    ``fetch_failed: The read operation timed out``. The builder degraded
+    correctly rather than publishing, but the payload could never regenerate.
+
+    The poll budget was 30 x 3s = 90 seconds flat. IBKR statement generation at
+    the EOD spike routinely runs into minutes. This is the same wall that made
+    `cash_flow_sync` fail 14 times out of 16 -- a caller-side deadline shorter
+    than the work it is waiting on -- so the budget matches the 420s that script
+    now uses, and the sleep is capped-exponential rather than a fixed 3s.
+    """
     from urllib.parse import urlencode
     from urllib.request import urlopen
 
     params = urlencode({"t": token, "q": query_id, "v": "3"})
-    resp = urlopen(f"{_FLEX_SEND}?{params}", timeout=30)  # noqa: S310
+    resp = urlopen(f"{_FLEX_SEND}?{params}", timeout=read_timeout)  # noqa: S310
     text = resp.read().decode("utf-8")
     root = _ET.fromstring(text)
     ref = root.find(".//ReferenceCode")
@@ -251,14 +277,22 @@ def fetch_flex_xml(token: str, query_id: str, *, max_polls: int = 30, poll_secs:
         err_msg = root.findtext(".//ErrorMessage") or text[:500]
         raise RuntimeError(f"Flex SendRequest failed code={err_code}: {err_msg}")
     ref_code = ref.text.strip()  # type: ignore[union-attr]
+    elapsed = 0.0
+    sleep_s = float(poll_secs)
     for _ in range(max_polls):
-        _time.sleep(poll_secs)
+        if elapsed + sleep_s > FLEX_POLL_BUDGET_SECONDS:
+            break
+        _time.sleep(sleep_s)
+        elapsed += sleep_s
+        sleep_s = min(sleep_s * 2, 15.0)
         params2 = urlencode({"t": token, "q": ref_code, "v": "3"})
-        resp2 = urlopen(f"{_FLEX_GET}?{params2}", timeout=30)  # noqa: S310
+        resp2 = urlopen(f"{_FLEX_GET}?{params2}", timeout=read_timeout)  # noqa: S310
         xml_text = resp2.read().decode("utf-8")
         if "<FlexStatements" in xml_text or "<FlexStatement" in xml_text:
             return xml_text
-    raise RuntimeError(f"Flex GetStatement timeout after {max_polls} polls ref={ref_code}")
+    raise RuntimeError(
+        f"Flex GetStatement not ready within {FLEX_POLL_BUDGET_SECONDS:.0f}s ref={ref_code}"
+    )
 
 
 def _account_scopes(root: _ET.Element) -> List[Tuple[str, _ET.Element]]:

--- a/scripts/tests/test_cash_flow_sync_cli.py
+++ b/scripts/tests/test_cash_flow_sync_cli.py
@@ -379,11 +379,12 @@ class TestExitCodes:
         assert code == cash_flow_sync.EXIT_OK
         assert _status_line(stdout)["class"] == "ok"
 
-    @pytest.mark.parametrize("throttle_code", ["1001", "1018", "1019"])
-    def test_throttle_exits_ten(self, credentials, writer, throttle_code):
+    def test_only_1018_takes_the_breaker_lane(self, credentials, writer):
+        """1018 is the ONLY documented rate limit, so it is the only code that
+        may reach the 24h/48h/72h/168h ladder."""
         body = (
             "<FlexStatementResponse><Status>Fail</Status>"
-            f"<ErrorCode>{throttle_code}</ErrorCode>"
+            "<ErrorCode>1018</ErrorCode>"
             "<ErrorMessage>Too many requests</ErrorMessage></FlexStatementResponse>"
         )
         with patch.object(cash_flow_sync, "urlopen") as mock_urlopen, \
@@ -394,7 +395,30 @@ class TestExitCodes:
         assert code == cash_flow_sync.EXIT_THROTTLE
         status = _status_line(stdout)
         assert status["class"] == "throttle"
-        assert status["code"] == throttle_code
+        assert status["code"] == "1018"
+
+    @pytest.mark.parametrize("transient_code", ["1001", "1009", "1019"])
+    def test_transient_codes_take_the_soft_lane_not_the_breaker(
+        self, credentials, writer, transient_code
+    ):
+        """These used to exit 10 and escalate a ladder toward a week-long
+        embargo. IBKR's own text for all three is "try again shortly", and 1019
+        is literally "generation in progress". The soft lane retries in minutes;
+        the breaker lane waits a day. That difference is the 10-day outage."""
+        body = (
+            "<FlexStatementResponse><Status>Fail</Status>"
+            f"<ErrorCode>{transient_code}</ErrorCode>"
+            "<ErrorMessage>Please try again shortly.</ErrorMessage>"
+            "</FlexStatementResponse>"
+        )
+        with patch.object(cash_flow_sync, "urlopen") as mock_urlopen, \
+             patch.object(cash_flow_sync.time, "sleep"):
+            mock_urlopen.side_effect = [_xml_response(body)] * 4
+            code, stdout, _ = _run("--no-file")
+
+        assert code != cash_flow_sync.EXIT_THROTTLE
+        assert code != cash_flow_sync.EXIT_FLEX_APP_ERROR  # not permanent either
+        assert _status_line(stdout)["class"] != "throttle"
 
     def test_permanent_flex_error_exits_eleven(self, credentials, writer):
         body = (

--- a/scripts/tests/test_cash_flow_sync_flex_errors.py
+++ b/scripts/tests/test_cash_flow_sync_flex_errors.py
@@ -32,6 +32,9 @@ SCRIPTS_DIR = Path(__file__).resolve().parent.parent
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
+import xml.etree.ElementTree as ET  # noqa: E402
+
+import cash_flow_sync  # noqa: E402
 from cash_flow_sync import fetch_cash_transactions  # noqa: E402
 from monitor_daemon.handlers._throttle_backoff import FlexThrottleError  # noqa: E402
 
@@ -109,7 +112,9 @@ class TestFlexErrorSurface:
         with patch("cash_flow_sync.urlopen") as mock_urlopen, \
              patch("cash_flow_sync.time.sleep"):
             mock_urlopen.return_value = _xml_response(FAIL_1001)
-            with pytest.raises(FlexThrottleError) as excinfo:
+            # Type-agnostic: this class asserts the MESSAGE surface, not the
+            # classification. 1001 is transient, not a throttle.
+            with pytest.raises(RuntimeError) as excinfo:
                 fetch_cash_transactions("tok", "qid")
             msg = str(excinfo.value)
             assert "1001" in msg, f"error code 1001 missing: {msg!r}"
@@ -118,7 +123,9 @@ class TestFlexErrorSurface:
         with patch("cash_flow_sync.urlopen") as mock_urlopen, \
              patch("cash_flow_sync.time.sleep"):
             mock_urlopen.return_value = _xml_response(FAIL_1001)
-            with pytest.raises(FlexThrottleError) as excinfo:
+            # Type-agnostic: this class asserts the MESSAGE surface, not the
+            # classification. 1001 is transient, not a throttle.
+            with pytest.raises(RuntimeError) as excinfo:
                 fetch_cash_transactions("tok", "qid")
             msg = str(excinfo.value)
             assert "Statement could not be generated" in msg, (
@@ -130,7 +137,9 @@ class TestFlexErrorSurface:
         with patch("cash_flow_sync.urlopen") as mock_urlopen, \
              patch("cash_flow_sync.time.sleep"):
             mock_urlopen.return_value = _xml_response(FAIL_1001)
-            with pytest.raises(FlexThrottleError) as excinfo:
+            # Type-agnostic: this class asserts the MESSAGE surface, not the
+            # classification. 1001 is transient, not a throttle.
+            with pytest.raises(RuntimeError) as excinfo:
                 fetch_cash_transactions("tok", "qid")
             msg = str(excinfo.value)
             assert "did not return a ReferenceCode" not in msg, (
@@ -149,21 +158,49 @@ class TestFlexErrorSurface:
 
 
 class TestThrottleNoInternalRetry:
-    """Codes 1001 / 1018 / 1019 must NOT trigger an internal retry —
-    every retry burns the sliding-window throttle budget further. The
-    daemon handler will back off via its circuit breaker instead."""
+    """Only 1018 is a rate limit, and it must NOT trigger an internal retry.
 
-    def test_1001_raises_flex_throttle_error_immediately(self):
+    This class used to assert that 1001 and 1019 were throttles too. They are
+    not, per IBKR's published error table:
+
+        1001  Statement could not be generated at this time. Try again shortly.
+        1018  Too many requests have been made from this token. Try again
+              shortly.  One request per second, 10 per minute (per token).
+        1019  Statement generation in progress. Try again shortly.
+
+    Treating 1019 as a throttle meant the ordinary "still generating" response
+    bought a 24-hour backoff, and treating 1001 as one escalated a ladder toward
+    a week-long embargo over a transient server-side failure. Those two rows are
+    now pinned to the CORRECT classification below rather than deleted, so the
+    old behaviour cannot come back.
+    """
+
+    def test_1001_is_transient_not_a_throttle(self):
+        """IBKR says try again shortly. It must not touch the breaker ladder."""
         with patch("cash_flow_sync.urlopen") as mock_urlopen, \
-             patch("cash_flow_sync.time.sleep") as mock_sleep:
+             patch("cash_flow_sync.time.sleep"):
             mock_urlopen.return_value = _xml_response(FAIL_1001)
-            with pytest.raises(FlexThrottleError) as excinfo:
+            with pytest.raises(cash_flow_sync._FlexTransientError):
                 fetch_cash_transactions("tok", "qid")
-            assert excinfo.value.code == "1001"
-            # Exactly ONE call — no internal retry on a throttle code.
-            assert mock_urlopen.call_count == 1
-            # And we slept zero times — no waiting either.
-            mock_sleep.assert_not_called()
+            # Explicitly NOT the throttle type — that is the whole point.
+            mock_urlopen.return_value = _xml_response(FAIL_1001)
+            with pytest.raises(Exception) as excinfo:
+                fetch_cash_transactions("tok", "qid")
+            assert not isinstance(excinfo.value, FlexThrottleError)
+
+    def test_1019_on_a_poll_is_not_ready_and_keeps_polling(self):
+        """"Generation in progress" is the normal not-ready response. Aborting
+        the poll loop on it is what turned a few seconds into 24 hours."""
+        root = ET.fromstring(FAIL_1019)
+        assert cash_flow_sync._flex_error_from(root, "GetStatement") is None
+
+    def test_1019_on_a_send_is_transient_not_permanent(self):
+        """A generation already in flight is retryable. It must not fall through
+        to the "no ReferenceCode" hard error, which is classified never-retry."""
+        root = ET.fromstring(FAIL_1019)
+        exc = cash_flow_sync._flex_error_from(root, "SendRequest")
+        assert isinstance(exc, cash_flow_sync._FlexTransientError)
+        assert not isinstance(exc, cash_flow_sync._FlexAppError)
 
     def test_1018_raises_flex_throttle_error_immediately(self):
         with patch("cash_flow_sync.urlopen") as mock_urlopen, \
@@ -172,16 +209,6 @@ class TestThrottleNoInternalRetry:
             with pytest.raises(FlexThrottleError) as excinfo:
                 fetch_cash_transactions("tok", "qid")
             assert excinfo.value.code == "1018"
-            assert mock_urlopen.call_count == 1
-            mock_sleep.assert_not_called()
-
-    def test_1019_raises_flex_throttle_error_immediately(self):
-        with patch("cash_flow_sync.urlopen") as mock_urlopen, \
-             patch("cash_flow_sync.time.sleep") as mock_sleep:
-            mock_urlopen.return_value = _xml_response(FAIL_1019)
-            with pytest.raises(FlexThrottleError) as excinfo:
-                fetch_cash_transactions("tok", "qid")
-            assert excinfo.value.code == "1019"
             assert mock_urlopen.call_count == 1
             mock_sleep.assert_not_called()
 

--- a/scripts/tests/test_flex_error_taxonomy.py
+++ b/scripts/tests/test_flex_error_taxonomy.py
@@ -1,0 +1,124 @@
+"""Flex error codes must be classified the way IBKR defines them.
+
+Verified against IBKR's published error table
+(https://www.ibkrguides.com/clientportal/performanceandstatements/flex3error.htm):
+
+    1001  "Statement could not be generated at this time. Please try again shortly."
+    1009  "The server is under heavy load. Statement could not be generated at
+           this time. Please try again shortly."
+    1018  "Too many requests have been made from this token. Please try again
+           shortly."  Limited to one request per second, 10 requests per minute
+           (per token).
+    1019  "Statement generation in progress. Please try again shortly."
+
+Only **1018** is a rate limit, and IBKR's published limit is 10 requests per
+MINUTE, which clears in a minute. IBKR documents no daily, 24h or multi-day
+cooldown anywhere; the 24h/48h/72h/168h ladder is Radon-local policy.
+
+The bug this pins: `_FLEX_THROTTLE_CODES` contained 1001, 1018 AND 1019, and
+every one of them raised FlexThrottleError and escalated that ladder. So:
+
+  * **1019 means "still generating, poll again"** -- the ordinary not-ready
+    response -- and it triggered a 24-HOUR backoff.
+  * **1001 is a transient generation failure** -- "try again shortly" -- and it
+    escalated a ladder toward a one-week embargo.
+
+That is a system punishing itself for being told to wait a moment, and it is the
+most plausible root cause of the 10-day cash-flow outage that began 2026-08-06,
+ahead of both the 180s subprocess wall and any real IBKR throttle.
+"""
+
+from __future__ import annotations
+
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import cash_flow_sync as cfs  # noqa: E402
+
+
+def _err(code: str, message: str = "msg") -> ET.Element:
+    return ET.fromstring(
+        f"<FlexStatementResponse><Status>Fail</Status>"
+        f"<ErrorCode>{code}</ErrorCode><ErrorMessage>{message}</ErrorMessage>"
+        f"</FlexStatementResponse>"
+    )
+
+
+def _throttle_cls():
+    from monitor_daemon.handlers._throttle_backoff import FlexThrottleError
+
+    return FlexThrottleError
+
+
+# ---------------------------------------------------------------------------
+# 1018 — the ONLY documented rate limit
+# ---------------------------------------------------------------------------
+
+
+def test_1018_is_the_only_rate_limit_code():
+    assert cfs._FLEX_THROTTLE_CODES == {"1018"}
+
+
+def test_1018_raises_the_throttle_error():
+    exc = cfs._flex_error_from(_err("1018", "Too many requests"), "SendRequest")
+    assert isinstance(exc, _throttle_cls())
+
+
+# ---------------------------------------------------------------------------
+# 1019 — "generation in progress" is NOT-READY, not a throttle
+# ---------------------------------------------------------------------------
+
+
+def test_1019_is_not_a_throttle():
+    """It is the ordinary not-ready response during polling."""
+    exc = cfs._flex_error_from(_err("1019", "Statement generation in progress."), "GetStatement")
+    assert not isinstance(exc, _throttle_cls())
+
+
+def test_1019_is_not_an_error_at_all_on_a_poll():
+    """Returning an exception at all would abort a poll loop that should keep
+    going. 1019 must read as "keep waiting"."""
+    assert cfs._flex_error_from(_err("1019"), "GetStatement") is None
+
+
+# ---------------------------------------------------------------------------
+# 1001 / 1009 — transient generation failures, the soft lane
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("code", ["1001", "1009"])
+def test_transient_generation_failures_are_not_throttles(code):
+    """IBKR says "try again shortly". Escalating a ladder toward a one-week
+    embargo on these is what produced the 10-day outage."""
+    exc = cfs._flex_error_from(_err(code), "SendRequest")
+    assert exc is not None
+    assert not isinstance(exc, _throttle_cls())
+
+
+@pytest.mark.parametrize("code", ["1001", "1009"])
+def test_transient_generation_failures_are_retryable(code):
+    assert code in cfs._FLEX_TRANSIENT_CODES
+
+
+def test_a_transient_failure_is_distinguishable_from_a_permanent_one():
+    """A bad token or an unknown query id must NOT be retried; a generation
+    failure must be. They cannot share an exception type."""
+    transient = cfs._flex_error_from(_err("1001"), "SendRequest")
+    permanent = cfs._flex_error_from(_err("1003", "Statement is not available."), "SendRequest")
+    assert type(transient) is not type(permanent)
+
+
+# ---------------------------------------------------------------------------
+# the ladder is ours, not IBKR's
+# ---------------------------------------------------------------------------
+
+
+def test_the_docstring_no_longer_claims_1001_and_1019_are_throttles():
+    src = Path(cfs.__file__).read_text()
+    assert "throttle codes (1001 / 1018 / 1019)" not in src
+    assert "1001 / 1018 / 1019" not in src

--- a/tests/test_perf_twr_flex_timeouts.py
+++ b/tests/test_perf_twr_flex_timeouts.py
@@ -1,0 +1,99 @@
+"""R13 — the Flex fetch had a caller-side deadline shorter than the work.
+
+Live on 2026-08-16, after the BOD and alpha fixes had deployed correctly, the
+payload still could not regenerate at all::
+
+    FLOWS_FETCH_FAILED: fetch_failed: The read operation timed out
+
+The GetStatement socket read timeout was 30s and the poll budget was a flat
+30 x 3s = 90s. Query 1442520 now carries three sections, and the Transfers
+section the operator added made the statement slow enough to blow both.
+
+Exactly the shape of the cash_flow_sync 180s wall: a caller-side deadline
+shorter than the work it is waiting on, in a second script. The builder
+degraded correctly rather than publishing, which is why this surfaced as a
+stuck page rather than a wrong number -- the integrity gates did their job and
+the timeout was the actual defect.
+"""
+
+from __future__ import annotations
+
+import sys
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import scripts.perf_twr_builder as builder  # noqa: E402
+
+
+def test_r13_the_read_timeout_is_not_thirty_seconds():
+    import inspect
+
+    assert builder.FLEX_READ_TIMEOUT_SECONDS >= 120.0
+    src = inspect.getsource(builder.fetch_flex_xml)
+    # The GetStatement call must not carry a hardcoded 30s socket timeout.
+    assert "timeout=30" not in src
+    assert "timeout=read_timeout" in src
+
+
+def test_r13_the_poll_budget_matches_cash_flow_syncs():
+    """Both scripts wait on the same service, so one budget, not two opinions."""
+    import scripts.cash_flow_sync as cfs
+
+    assert builder.FLEX_POLL_BUDGET_SECONDS == cfs.FLEX_POLL_BUDGET_SECONDS
+
+
+class _Resp:
+    def __init__(self, body: str) -> None:
+        self._body = body.encode()
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def test_r13_polling_is_bounded_by_the_budget_not_the_poll_count(monkeypatch):
+    """Capped-exponential, stopping at the budget rather than at a poll count."""
+    slept: list[float] = []
+    monkeypatch.setattr(builder._time, "sleep", lambda s: slept.append(s))
+
+    sent = "<FlexStatementResponse><ReferenceCode>REF1</ReferenceCode></FlexStatementResponse>"
+    calls = {"n": 0}
+
+    def _fake_urlopen(url, timeout=None):  # noqa: ANN001
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return _Resp(sent)
+        return _Resp("<not ready/>")  # never becomes ready
+
+    monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+
+    with pytest.raises(RuntimeError, match="not ready within"):
+        builder.fetch_flex_xml("tok", "1442520")
+
+    # 3, 6, 12, then capped at 15, and the total never exceeds the budget.
+    assert slept[:3] == [3.0, 6.0, 12.0]
+    assert max(slept) == 15.0
+    assert sum(slept) <= builder.FLEX_POLL_BUDGET_SECONDS
+
+
+def test_r13_a_ready_statement_still_returns_immediately(monkeypatch):
+    """Widening the budget must not slow down the normal path."""
+    slept: list[float] = []
+    monkeypatch.setattr(builder._time, "sleep", lambda s: slept.append(s))
+
+    sent = "<FlexStatementResponse><ReferenceCode>REF1</ReferenceCode></FlexStatementResponse>"
+    ready = '<FlexQueryResponse><FlexStatements count="1"><FlexStatement/></FlexStatements></FlexQueryResponse>'
+    calls = {"n": 0}
+
+    def _fake_urlopen(url, timeout=None):  # noqa: ANN001
+        calls["n"] += 1
+        return _Resp(sent if calls["n"] == 1 else ready)
+
+    monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+
+    assert "<FlexStatement" in builder.fetch_flex_xml("tok", "1442520")
+    # One 3s poll, not a walk up the ladder.
+    assert slept == [3.0]


### PR DESCRIPTION
Two Flex-path fixes. Both were found by chasing why `/performance` could not regenerate after the BOD and alpha fixes deployed correctly.

## 1. `fix(flex)` — only 1018 is a rate limit; 1019 means keep polling

Verified against IBKR's published error table ([source](https://www.ibkrguides.com/clientportal/performanceandstatements/flex3error.htm)):

| code | IBKR's text |
|---|---|
| 1001 | Statement could not be generated at this time. Please try again shortly. |
| 1009 | The server is under heavy load. … Please try again shortly. |
| **1018** | **Too many requests have been made from this token.** Limited to one request per second, **10 requests per minute (per token)**. |
| 1019 | Statement generation in progress. Please try again shortly. |

`_FLEX_THROTTLE_CODES` held **1001, 1018 and 1019**. All three raised `FlexThrottleError` and escalated the local 24h → 48h → 72h → 168h ladder. So:

- **1019 — the ordinary NOT-READY response during polling — bought a 24-hour backoff.** The statement was seconds from ready and the daemon slept for a day.
- **1001 — a transient generation failure IBKR tells you to retry shortly — escalated toward a one-week embargo.**

That is a system punishing itself for being told to wait a moment, and it explains the 10-day outage from 2026-08-06 better than either the 180s subprocess wall or any real IBKR throttle.

Note also: **IBKR publishes no daily or multi-day cooldown anywhere.** The documented limit is 10 requests per *minute* and clears in a minute. The ladder is Radon-local policy modelling a constraint far harsher than the real one.

New classification:

```
1018            -> FlexThrottleError, breaker lane, no internal retry  (unchanged)
1001 / 1009     -> _FlexTransientError, soft lane, bounded retry
1019 on a poll  -> None. Not an error; the loop keeps waiting.
1019 on a send  -> _FlexTransientError. A generation is already in flight.
```

That last line closed a gap this change itself opened: returning `None` for 1019 on `SendRequest` made it fall through to the "no ReferenceCode" hard error, which is classified **never-retry** — worse than before. A test caught it; the classifier is now leg-aware.

Tests asserting the old contract are **re-pinned to the correct one, not deleted**, so the behaviour cannot come back. `TestFlexErrorSurface` was retyped to `RuntimeError` because it asserts the message surface, not the classification, and should never have been coupled to the exception type.

## 2. `fix(twr)` — widen the Flex fetch budget

The GetStatement socket read timeout was **30s** and the poll budget a flat **30 × 3s = 90s**. Query 1442520 now carries three sections, and the Transfers section made the statement slow enough to blow both:

```
FLOWS_FETCH_FAILED: fetch_failed: The read operation timed out
```

Same shape as the `cash_flow_sync` 180s wall, in a second script: a caller-side deadline shorter than the work it waits on. Read timeout → **120s** on both Flex calls; poll loop is now capped-exponential (3/6/12/15…) bounded by the same **420s** budget `cash_flow_sync` uses. One service, one budget.

Worth recording why this surfaced as a *stuck* page and not a wrong number: the integrity gates worked. A failed flow fetch is `FlowsStatus.FAILED`, which suppresses the TWR outright, so a timeout could never publish a return computed without flows.

## What this does not prove

Neither fix demonstrates the token is healthy. Together they remove a self-inflicted embargo and a too-tight deadline. Whether query 1442520 still returns 1001 on a real pull is separate — the cheap discriminator is pressing **Run** on it in the Portal, which is a render rather than a `/SendRequest` and costs nothing against the token.

## Gates

`pytest 6795 passed, 1 skipped`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017GR3NQT8qTLXkh6FiUQE6a
