### PR TITLE
Shrink the Flex backoff ladder from 312 hours to one

### DIFF
--- a/scripts/monitor_daemon/CLAUDE.md
+++ b/scripts/monitor_daemon/CLAUDE.md
@@ -42,6 +42,8 @@ Full rule in `web/CLAUDE.md` §Combo / BAG Order Guardrails point 7. Python side
 
 ## Where Other Daemons Live
 
-- `cash_flow_sync` runs once per ET trading day at 17:00 ET. Throttle-aware backoff on Flex 1001/1018/1019. Reads `IB_FLEX_NAV_QUERY_ID=1497709`. Don't repurpose for trade pulls.
+- `cash_flow_sync` runs once per ET trading day at 17:00 ET. Reads `IB_FLEX_NAV_QUERY_ID=1442520` (the Activity query "Equity Summary in Base", three sections: NAV in Base, Cash Transactions, Transfers). Don't repurpose for trade pulls.
+
+  **Only Flex code 1018 is a rate limit** — IBKR publishes one request per second, ten per minute, per token, and no daily or multi-day cooldown anywhere. The breaker ladder is 90s → 5m → 15m → 1h. It was 24h → 48h → 72h → 168h and also fired on **1001** (transient generation failure) and **1019** (*"statement generation in progress"* — the ordinary not-ready response during polling). A statement seconds from ready therefore bought a 24-hour backoff, and a few transient failures walked to a week: that is the 10-day outage from 2026-08-06. 1001/1009 take the soft lane; 1019 on a poll is not an error at all. See `docs/flex-delivery-architecture.md`.
 - `flex_token_check` runs daily, alerts on expiry.
 - `replica_watchdog` is disabled before subprocess or health writes when `data/replica.db` is absent. While the file exists it is event-driven — only writes `service_health` when it actually heals. Use the 24h staleness window only for that applicable state (event-driven writer windows rule in `feedback_event_driven_writer_windows.md`).

--- a/scripts/monitor_daemon/handlers/_throttle_backoff.py
+++ b/scripts/monitor_daemon/handlers/_throttle_backoff.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python3
 """Throttle-aware exponential backoff for Flex Web Service polling.
 
-IBKR Flex Web Service uses a sliding-window rate limit. **Every request
-during throttle — including failures — pushes the reset further out.**
-The cure is to back off aggressively on documented throttle codes
-(1001 / 1018 / 1019) and refuse to probe again until the window clears.
+Scoped to ONE error code. IBKR's 1018 row is the only documented rate limit:
+
+    "Too many requests have been made from this token. Please try again
+     shortly.  Limited to one request per second, 10 requests per minute
+     (per token)."
+    https://www.ibkrguides.com/clientportal/performanceandstatements/flex3error.htm
+
+That is a ONE MINUTE window, and IBKR documents no daily, multi-day or weekly
+cooldown anywhere. 1001 and 1019 are NOT rate limits and must never reach this
+module; see `cash_flow_sync._FLEX_THROTTLE_CODES`.
 
 State machine:
 
@@ -12,12 +18,25 @@ State machine:
     throttle hit → counter++; embargo = THROTTLE_EMBARGO[counter-1].
     transient    → no escalation; embargo = SOFT_EMBARGO_SECS (one cycle).
 
-Embargo schedule (capped at 168h / one week):
+Embargo schedule (capped at 1h):
 
-    1st throttle:  24h
-    2nd throttle:  48h
-    3rd throttle:  72h
-    4th+ throttle: 168h
+    1st 1018:   90s   — just past the documented window
+    2nd 1018:    5m
+    3rd 1018:   15m
+    4th+ 1018:   1h   — cap
+
+**Why this changed.** The ladder was 24h → 48h → 72h → 168h, modelling a
+constraint roughly three orders of magnitude harsher than the one IBKR actually
+imposes; a full walk cost 312 hours. Paired with the classifier bug that treated
+1001 and 1019 as throttles, a statement seconds from ready could put the sync to
+sleep for a day and a few transient failures could walk it to a week. That is
+the 10-day outage from 2026-08-06.
+
+It still escalates, deliberately. A second 1018 ninety seconds after the first
+means something is making sustained requests rather than the once-a-day call
+this handler makes, and there is a known uncontrolled consumer in
+`portfolio_performance.py` (up to two on-demand requests per page render, no
+breaker). Escalating in minutes surfaces that without hiding the data for a week.
 
 Stored as a plain dict so the calling handler can persist it via
 ``BaseHandler.get_state`` / ``set_state`` and survive daemon restarts.
@@ -31,10 +50,10 @@ from typing import Any, Dict, Optional
 # Embargo durations in seconds, indexed by (counter - 1). The last entry
 # is the cap that all further attempts use.
 THROTTLE_EMBARGO_SECS = (
-    24 * 60 * 60,    # 24h after 1st throttle
-    48 * 60 * 60,    # 48h after 2nd
-    72 * 60 * 60,    # 72h after 3rd
-    168 * 60 * 60,   # 168h (1 week) cap
+    90,              # 90s after 1st — just past IBKR's documented 1-minute window
+    5 * 60,          # 5m after 2nd
+    15 * 60,         # 15m after 3rd
+    60 * 60,         # 1h cap
 )
 
 # A non-throttle transient (network blip, parse error) does not escalate.

--- a/scripts/monitor_daemon/handlers/cash_flow_sync.py
+++ b/scripts/monitor_daemon/handlers/cash_flow_sync.py
@@ -14,11 +14,19 @@ burned ~24h of cash flow visibility this way). Cash flows publish once
 per day; one well-timed daily call after market close is sufficient
 and stays inside the rate budget.
 
-Throttle handling: documented Flex codes 1001 / 1018 / 1019 trigger an
-exponential circuit breaker (24h -> 48h -> 72h -> 168h capped) via
-``_throttle_backoff``. The breaker composes with the daily 17:00 ET
-window: when the embargo says "not before tomorrow", the handler still
-waits until tomorrow at 17:00 ET — never a partial-day re-probe.
+Throttle handling: the one documented rate-limit code (1018) triggers an
+exponential circuit breaker (90s -> 5m -> 15m -> 1h capped) via
+``_throttle_backoff``. IBKR's published 1018 limit is one request per
+second and ten per minute, per token, so the ladder is measured in
+minutes; it used to run 24h -> 168h, three orders of magnitude harsher
+than the constraint it modelled. The breaker composes with the daily
+17:00 ET window: an embargo that outlives the window still defers to
+tomorrow at 17:00 ET rather than re-probing mid-day.
+
+1001 and 1019 are NOT rate limits and never reach the breaker. 1019 is
+"statement generation in progress" and 1001 is a transient generation
+failure; both take the soft lane, bounded by
+``MAX_SOFT_ATTEMPTS_PER_ET_DAY``.
 
 Wired into monitor_daemon via scripts/monitor_daemon/run.py:create_daemon().
 """
@@ -386,9 +394,11 @@ class CashFlowSyncHandler(BaseHandler):
         if flex_class is not None:
             return "soft"
 
-        if "FlexThrottleError" in message or any(
-            f"code {code}" in message for code in ("1001", "1018", "1019")
-        ):
+        # Legacy substring fallback, for a subprocess predating the typed
+        # exit-code contract. 1018 ONLY: 1001 is a transient generation failure
+        # and 1019 is "still generating", and routing either into the breaker
+        # lane is what turned "try again shortly" into a multi-day embargo.
+        if "FlexThrottleError" in message or "code 1018" in message:
             logger.warning(
                 "cash_flow_sync throttle classified by stderr substring, not exit "
                 "code — the subprocess predates the typed exit-code contract"

--- a/scripts/tests/test_monitor_daemon/test_cash_flow_sync_cadence.py
+++ b/scripts/tests/test_monitor_daemon/test_cash_flow_sync_cadence.py
@@ -199,10 +199,11 @@ class TestCircuitBreakerCadence:
 
         now = _et_to_utc(2026, 5, 11, 17, 30)
         h = self._fresh_handler()
-        # Pretend a throttle just landed; 24h embargo.
+        # Pretend a 1018 just landed. The first rung is 90s — IBKR's documented
+        # window is one minute, not one day.
         h._backoff_state = record_throttle({"throttle_count": 0, "blocked_until": None}, now_utc=now)
-        # 1h later, still in window → blocked.
-        later = now + timedelta(hours=1)
+        # 60s later, still inside the 90s window → blocked.
+        later = now + timedelta(seconds=60)
         with patch(
             "monitor_daemon.handlers.cash_flow_sync._now_utc", return_value=later
         ):

--- a/scripts/tests/test_monitor_daemon/test_cash_flow_sync_exit_codes.py
+++ b/scripts/tests/test_monitor_daemon/test_cash_flow_sync_exit_codes.py
@@ -147,12 +147,16 @@ class TestExitCodeClassification:
         self, credentials, health_rows
     ):
         """Deprecated fallback: a subprocess from an older deploy exits 1
-        with the code in stderr. Must still reach the ladder."""
+        with the code in stderr. Must still reach the ladder.
+
+        1018 only. The fallback used to match 1001 and 1019 too, so a legacy
+        subprocess reporting "still generating" reached the breaker lane."""
         handler = CashFlowSyncHandler()
         legacy = SimpleNamespace(
             returncode=1,
             stdout="",
-            stderr="ERR: cash flow fetch failed: Flex throttle (code 1001): busy\n",
+            stderr="ERR: cash flow fetch failed: Flex throttle (code 1018): "
+                   "Too many requests have been made from this token\n",
         )
         with patch.object(handler_mod.subprocess, "run", return_value=legacy):
             handler.run()

--- a/scripts/tests/test_monitor_daemon/test_cash_flow_sync_timeout_retry_budget.py
+++ b/scripts/tests/test_monitor_daemon/test_cash_flow_sync_timeout_retry_budget.py
@@ -50,6 +50,10 @@ SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
+from monitor_daemon.handlers.cash_flow_sync import (  # noqa: E402
+    MAX_SOFT_ATTEMPTS_PER_ET_DAY,
+)
+
 ET = ZoneInfo("America/New_York")
 
 # Budget derived from the module docstring ("one well-timed daily call
@@ -209,13 +213,23 @@ class TestPollBudgetOrdering:
 
 
 class TestIncidentTimelineIsBestCase:
-    """The 2026-08-03 production sequence — timeout -> 5-min soft embargo
-    -> retry -> 1001 -> 24h breaker — stops after exactly 2 SendRequests.
-    This PASSES today and pins the interaction; it exists to document
-    that the bounded outcome currently depends on IBKR volunteering a
-    documented throttle code on the retry, which is luck, not a guard."""
+    """The 2026-08-03 production sequence, re-pinned to the corrected taxonomy.
 
-    def test_timeout_then_1001_engages_24h_breaker_after_two_attempts(self):
+    Originally: timeout -> 5-min soft embargo -> retry -> 1001 -> 24h breaker,
+    and the docstring conceded the bound "depends on IBKR volunteering a
+    documented throttle code on the retry, which is luck, not a guard."
+
+    1001 is not a throttle (IBKR: "Statement could not be generated at this
+    time. Please try again shortly."), so that luck is gone -- and the guard it
+    wished for is what bounds the sequence now: MAX_SOFT_ATTEMPTS_PER_ET_DAY.
+    Three attempts in an ET day, then nothing until tomorrow, whatever IBKR
+    happens to return.
+
+    This is strictly better. The old path bought a 24-HOUR embargo off a
+    transient generation failure; the new one spends a bounded three attempts
+    and stops."""
+
+    def test_timeout_then_1001_is_bounded_by_the_daily_cap_not_a_breaker(self):
         from monitor_daemon.handlers import _throttle_backoff
 
         start = _recent_past_trading_day_17et()
@@ -224,8 +238,11 @@ class TestIncidentTimelineIsBestCase:
         outcomes = iter(
             [
                 RuntimeError("cash_flow_sync timed out after 180s"),
-                _throttle_backoff.FlexThrottleError(
-                    "1001", "Statement could not be generated at this time"
+                # 1001 can no longer produce a FlexThrottleError. Fabricating
+                # one here would test an exception the code cannot raise.
+                RuntimeError(
+                    "Flex SendRequest failed (code 1001): Statement could not "
+                    "be generated at this time. Please try again shortly."
                 ),
             ]
         )
@@ -260,17 +277,38 @@ class TestIncidentTimelineIsBestCase:
             assert handler.is_due() is True
             handler.run()
         assert attempts["n"] == 2
-        assert handler._backoff_state["throttle_count"] == 1
+        # 1001 is transient: it must NOT have touched the breaker ladder.
+        assert handler._backoff_state.get("throttle_count", 0) == 0
 
-        # 24h breaker: not due for the rest of the evening nor before
-        # the embargo expires the next day.
+        # The daily cap is what bounds this now. A third attempt is allowed,
+        # and it is the last one of the ET day.
+        third = refire + timedelta(minutes=8)
+        outcomes_extra = iter([RuntimeError("cash_flow_sync timed out after 180s")])
+
+        def inner_again():
+            attempts["n"] += 1
+            raise next(outcomes_extra)
+
+        handler._execute_inner = inner_again  # type: ignore[method-assign]
+        with patch(
+            "monitor_daemon.handlers.cash_flow_sync._now_utc", return_value=third
+        ):
+            assert handler.is_due() is True
+            handler.run()
+        assert attempts["n"] == MAX_SOFT_ATTEMPTS_PER_ET_DAY == 3
+
+        # Capped for the rest of the ET day, without a multi-day embargo.
         for probe in (
-            refire + timedelta(hours=2),
-            refire + timedelta(hours=23),
+            third + timedelta(minutes=30),
+            third + timedelta(hours=2),
         ):
             with patch(
                 "monitor_daemon.handlers.cash_flow_sync._now_utc",
                 return_value=probe,
             ):
                 assert handler.is_due() is False
-        assert attempts["n"] == 2
+        assert attempts["n"] == MAX_SOFT_ATTEMPTS_PER_ET_DAY
+
+        # And crucially: bounded WITHOUT a multi-day embargo. The breaker was
+        # never engaged, because nothing here was a rate limit.
+        assert handler._backoff_state.get("throttle_count", 0) == 0

--- a/scripts/tests/test_monitor_daemon/test_throttle_backoff.py
+++ b/scripts/tests/test_monitor_daemon/test_throttle_backoff.py
@@ -42,53 +42,59 @@ class TestInitialState:
 
 
 class TestEscalation:
-    def test_first_throttle_embargoes_24h(self):
+    """The ladder models IBKR's ACTUAL 1018 limit: one request per second,
+    10 per minute, per token. A one-minute window.
+
+    It was 24h -> 48h -> 72h -> 168h, three orders of magnitude harsher than the
+    constraint it claimed to model; a full walk cost 312 hours. Re-pinned here
+    rather than deleted so the old durations cannot come back.
+    """
+
+    def test_first_throttle_embargoes_ninety_seconds(self):
         state = record_throttle(initial_state(), now_utc=NOW)
         assert state["throttle_count"] == 1
-        until = blocked_until(state)
-        assert until == NOW + timedelta(hours=24)
+        # Just past IBKR's documented 60s window.
+        assert blocked_until(state) == NOW + timedelta(seconds=90)
 
-    def test_second_throttle_embargoes_48h(self):
+    def test_second_throttle_embargoes_five_minutes(self):
         s1 = record_throttle(initial_state(), now_utc=NOW)
-        s2 = record_throttle(s1, now_utc=NOW + timedelta(hours=25))
+        s2 = record_throttle(s1, now_utc=NOW + timedelta(minutes=2))
         assert s2["throttle_count"] == 2
-        until = blocked_until(s2)
-        assert until == NOW + timedelta(hours=25) + timedelta(hours=48)
+        assert blocked_until(s2) == NOW + timedelta(minutes=2) + timedelta(minutes=5)
 
-    def test_third_throttle_embargoes_72h(self):
+    def test_third_throttle_embargoes_fifteen_minutes(self):
         s = initial_state()
         for _ in range(3):
             s = record_throttle(s, now_utc=NOW)
         assert s["throttle_count"] == 3
-        until = blocked_until(s)
-        assert until == NOW + timedelta(hours=72)
+        assert blocked_until(s) == NOW + timedelta(minutes=15)
 
-    def test_fourth_throttle_caps_at_168h(self):
+    def test_fourth_throttle_caps_at_one_hour(self):
         s = initial_state()
         for _ in range(4):
             s = record_throttle(s, now_utc=NOW)
         assert s["throttle_count"] == 4
-        until = blocked_until(s)
-        assert until == NOW + timedelta(hours=168)
+        assert blocked_until(s) == NOW + timedelta(hours=1)
 
-    def test_seventh_throttle_still_capped_at_168h(self):
+    def test_seventh_throttle_still_capped_at_one_hour(self):
         s = initial_state()
         for _ in range(7):
             s = record_throttle(s, now_utc=NOW)
         assert s["throttle_count"] == 7
-        until = blocked_until(s)
         # Cap is honored regardless of counter value.
-        assert until == NOW + timedelta(hours=168)
+        assert blocked_until(s) == NOW + timedelta(hours=1)
+        # Anti-pin: the superseded week-long cap.
+        assert blocked_until(s) != NOW + timedelta(hours=168)
 
 
 class TestBlockedQuery:
     def test_is_blocked_before_window_expires(self):
         s = record_throttle(initial_state(), now_utc=NOW)
-        assert is_blocked(s, now_utc=NOW + timedelta(hours=23)) is True
+        assert is_blocked(s, now_utc=NOW + timedelta(seconds=60)) is True
 
     def test_is_not_blocked_after_window_expires(self):
         s = record_throttle(initial_state(), now_utc=NOW)
-        assert is_blocked(s, now_utc=NOW + timedelta(hours=25)) is False
+        assert is_blocked(s, now_utc=NOW + timedelta(seconds=120)) is False
 
     def test_is_blocked_handles_naive_iso_string(self):
         # Daemon state.json may end up with naive timestamps.

--- a/scripts/tests/test_monitor_daemon/test_throttle_ladder_matches_ibkr.py
+++ b/scripts/tests/test_monitor_daemon/test_throttle_ladder_matches_ibkr.py
@@ -1,0 +1,88 @@
+"""The backoff ladder must model IBKR's actual rate limit.
+
+IBKR's published limit, from the 1018 row of their error table
+(https://www.ibkrguides.com/clientportal/performanceandstatements/flex3error.htm):
+
+    "Too many requests have been made from this token. Please try again
+     shortly.  Limited to one request per second, 10 requests per minute
+     (per token)."
+
+That is a ONE MINUTE window. IBKR documents no daily, multi-day or weekly
+cooldown anywhere.
+
+The ladder was 24h -> 48h -> 72h -> 168h: a model of a constraint roughly three
+orders of magnitude harsher than the one that exists. Combined with the
+classifier bug that treated 1001 and 1019 as throttles (fixed in 436dcdc1), a
+statement that was seconds from ready could put the sync to sleep for a day, and
+a few transient failures could walk it to a week.
+
+The corrected ladder still escalates -- a second 1018 sixty seconds after the
+first means something is making sustained requests, and this repo has a
+known uncontrolled consumer in portfolio_performance.py -- but it escalates in
+minutes, and it is bounded by an hour rather than a week.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from monitor_daemon.handlers import _throttle_backoff as tb  # noqa: E402
+
+NOW = datetime(2026, 8, 17, 21, 0, 0, tzinfo=timezone.utc)
+
+# IBKR's documented window, in seconds.
+IBKR_WINDOW_SECS = 60
+
+
+def test_the_first_backoff_is_on_the_order_of_ibkrs_window():
+    """A 1018 clears in a minute. The first wait must be minutes, not a day."""
+    first = tb.THROTTLE_EMBARGO_SECS[0]
+    assert first >= IBKR_WINDOW_SECS, "must wait at least the documented window"
+    assert first <= 5 * 60, f"first backoff {first}s models a limit IBKR does not impose"
+
+
+def test_the_cap_is_an_hour_not_a_week():
+    cap = tb.THROTTLE_EMBARGO_SECS[-1]
+    assert cap <= 60 * 60, f"cap {cap}s is longer than any documented IBKR cooldown"
+    # 168h was the old cap. It must be gone.
+    assert cap != 168 * 60 * 60
+
+
+def test_the_ladder_still_escalates():
+    """Sustained 1018s mean a real consumer problem, so keep escalating -- just
+    in minutes rather than days."""
+    secs = tb.THROTTLE_EMBARGO_SECS
+    assert len(secs) >= 3
+    assert list(secs) == sorted(secs), "the ladder must be monotonically increasing"
+    assert secs[0] < secs[-1]
+
+
+def test_a_full_ladder_walk_costs_under_two_hours():
+    """The whole point. Walking every rung used to cost 24+48+72+168 = 312 HOURS
+    before the cap even engaged."""
+    total = sum(tb.THROTTLE_EMBARGO_SECS)
+    assert total <= 2 * 60 * 60, f"a full walk is {total / 3600:.1f}h"
+    # The superseded ladder, pinned so it cannot come back.
+    assert total != (24 + 48 + 72 + 168) * 3600
+
+
+def test_recording_a_throttle_sets_a_minutes_scale_embargo():
+    state = tb.record_throttle({}, now_utc=NOW)
+    blocked = datetime.fromisoformat(state["blocked_until"])
+    waited = (blocked - NOW).total_seconds()
+    assert IBKR_WINDOW_SECS <= waited <= 5 * 60
+
+
+def test_a_success_still_clears_the_counter():
+    state = tb.record_throttle({}, now_utc=NOW)
+    state = tb.record_throttle(state, now_utc=NOW)
+    assert state["throttle_count"] == 2
+    cleared = tb.record_success(state)
+    assert cleared.get("throttle_count", 0) == 0
+    assert not cleared.get("blocked_until")


### PR DESCRIPTION
The ladder was `24h → 48h → 72h → 168h`. IBKR's 1018 row reads:

> "Too many requests have been made from this token. Please try again shortly. **Limited to one request per second, 10 requests per minute (per token).**"

A **one minute** window. IBKR publishes no daily, multi-day or weekly cooldown anywhere. The ladder modelled a constraint roughly **three orders of magnitude** harsher than the real one, and a full walk cost **312 hours** before the cap even engaged.

Now `90s → 5m → 15m → 1h`. First rung just past IBKR's documented window; cap at an hour.

**It still escalates, on purpose.** A second 1018 ninety seconds after the first means something is making sustained requests rather than the once-a-day call this handler makes — and there is a known uncontrolled consumer in `portfolio_performance.py` (up to two on-demand requests per page render, no breaker). Escalating in minutes surfaces that instead of hiding the data for a week.

## Two more places were still routing non-throttles into the breaker lane

- **The handler's legacy stderr fallback** substring-matched `code 1001`, `code 1018` **and** `code 1019`, independently of the script's classifier — so a subprocess reporting *"still generating"* reached the ladder even after 436dcdc1 fixed the script. Now 1018 only.
- **A test fabricated a `FlexThrottleError("1001")`** the code can no longer raise. Re-pinned to the real sequence: the 2026-08-03 timeline is now bounded by `MAX_SOFT_ATTEMPTS_PER_ET_DAY` rather than a breaker — which is the guard its own docstring said it wished for (*"luck, not a guard"*).

## Test contract

Every duration pin re-pinned rather than deleted, with the superseded 168h cap kept as an explicit anti-pin. Stale references corrected in the handler docstring and `scripts/monitor_daemon/CLAUDE.md`, which also still documented the retired query id `1497709`.

## Gates

`pytest 6802 passed, 1 skipped`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017GR3NQT8qTLXkh6FiUQE6a