### PR TITLE
fix(perf): Advanced pill stops claiming GATED over live metrics; unrot the chain-expiry e2e

### DIFF
--- a/web/components/PerformancePanel.tsx
+++ b/web/components/PerformancePanel.tsx
@@ -429,6 +429,10 @@ export default function PerformancePanel({ portfolioLastSync = null, marketState
 
   const coreCards = useMemo(() => (view ? buildCoreCards(view) : []), [view]);
   const advancedCards = useMemo(() => (view ? buildAdvancedCards(view) : []), [view]);
+  const advancedGatedCount = useMemo(
+    () => advancedCards.filter((card) => card.value === EMPTY).length,
+    [advancedCards],
+  );
   const allCards = useMemo(() => [...coreCards, ...advancedCards], [coreCards, advancedCards]);
   const activeCard = useMemo(() => allCards.find((c) => c.id === activeCardId) ?? null, [activeCardId, allCards]);
 
@@ -508,7 +512,7 @@ export default function PerformancePanel({ portfolioLastSync = null, marketState
             <div className="performance-methodology-footer" data-testid="performance-methodology">
               <span className="performance-meta-label">Method</span>
               <span className="performance-meta-value">
-                Time-weighted, end-of-day flow convention, chained geometrically
+                Time-weighted, beginning-of-day flow convention, chained geometrically
               </span>
               <span className="performance-meta-label">NAV as of</span>
               <span className="performance-meta-value">{view.navAsOf || EMPTY}</span>
@@ -651,7 +655,13 @@ export default function PerformancePanel({ portfolioLastSync = null, marketState
             <TrendingDown size={14} />
             Advanced
           </div>
-          <span className="pill neutral">GATED</span>
+          {/* Reflect reality. This pill was hardcoded to "GATED" and sat above
+              six populated metrics, which reads as a broken page. */}
+          {advancedGatedCount > 0 ? (
+            <span className="pill neutral">
+              {advancedGatedCount} OF {advancedCards.length} GATED
+            </span>
+          ) : null}
         </div>
         <div className="section-body" style={{ padding: 0 }}>
           <div className="metrics-grid">
@@ -769,7 +779,7 @@ export default function PerformancePanel({ portfolioLastSync = null, marketState
           </div>
         </div>
         <div className="performance-methodology-copy">
-          Time-weighted return, end-of-day flow convention, chained geometrically. External capital (deposits,
+          Time-weighted return, beginning-of-day flow convention, chained geometrically. External capital (deposits,
           withdrawals, ACATS and internal transfers) is removed from return; fees and borrow are returns, not flows.
           Volatility and ratios scale by {TWR_GATES.TRADING_DAYS} sessions; annualization uses an Act/
           {TWR_GATES.DAYS_PER_YEAR} day count. Any metric under its gate reports the reason it is missing rather than a

--- a/web/components/mobile/MobilePerformancePanel.tsx
+++ b/web/components/mobile/MobilePerformancePanel.tsx
@@ -464,6 +464,10 @@ export default function MobilePerformancePanel({ portfolioLastSync = null, marke
 
   const coreCards = useMemo(() => (view ? buildCoreCards(view) : []), [view]);
   const advancedCards = useMemo(() => (view ? buildAdvancedCards(view) : []), [view]);
+  const advancedGatedCount = useMemo(
+    () => advancedCards.filter((card) => card.value === EMPTY).length,
+    [advancedCards],
+  );
   const allCards = useMemo(() => [...coreCards, ...advancedCards], [coreCards, advancedCards]);
   const activeCard = useMemo(() => allCards.find((c) => c.id === activeCardId) ?? null, [activeCardId, allCards]);
 
@@ -570,7 +574,7 @@ export default function MobilePerformancePanel({ portfolioLastSync = null, marke
                 color: "var(--text-muted)",
               }}
             >
-              <div>Time-weighted, end-of-day flow convention, chained geometrically</div>
+              <div>Time-weighted, beginning-of-day flow convention, chained geometrically</div>
               <div style={{ marginTop: 4 }}>NAV as of {view.navAsOf || EMPTY}</div>
             </div>
           </div>
@@ -725,9 +729,11 @@ export default function MobilePerformancePanel({ portfolioLastSync = null, marke
             <span className="pill neutral" style={{ fontSize: 9, marginLeft: 4 }} data-testid="mobile-advanced-count">
               {advancedOpen ? "OPEN" : "COLLAPSED"}
             </span>
-            <span className="pill neutral" style={{ fontSize: 9 }}>
-              GATED
-            </span>
+            {advancedGatedCount > 0 ? (
+              <span className="pill neutral" style={{ fontSize: 9 }}>
+                {advancedGatedCount} OF {advancedCards.length} GATED
+              </span>
+            ) : null}
           </span>
           <ChevronDown
             size={14}
@@ -893,7 +899,7 @@ export default function MobilePerformancePanel({ portfolioLastSync = null, marke
                   color: "var(--text-muted)",
                 }}
               >
-                Time-weighted return, end-of-day flow convention, chained geometrically. External capital is removed
+                Time-weighted return, beginning-of-day flow convention, chained geometrically. External capital is removed
                 from return; fees and borrow are returns, not flows. Volatility and ratios scale by{" "}
                 {TWR_GATES.TRADING_DAYS} sessions; annualization uses an Act/{TWR_GATES.DAYS_PER_YEAR} day count.
               </div>

--- a/web/e2e/chain-expiry-preserves-builder.spec.ts
+++ b/web/e2e/chain-expiry-preserves-builder.spec.ts
@@ -9,8 +9,30 @@
 import { test, expect } from "@playwright/test";
 
 const TICKER = "MU";
-const NEAR = "20260821";
-const FAR = "20260918";
+
+/**
+ * Window-relative expiries. These were hardcoded "20260821" / "20260918" and
+ * rotted on 2026-08-14: `OptionsChainTab` defaults to the first expiry with
+ * >= 7 DTE, so once the near date came inside a week the chain correctly
+ * skipped it and the assertion at `toHaveValue(NEAR)` started reading the FAR
+ * date instead. The component was right; the fixture had aged into its rule.
+ *
+ * Both dates are Fridays comfortably past the 7-DTE cut, so the default
+ * resolves to NEAR on any day this runs.
+ */
+function fridayInDays(days: number): string {
+  const d = new Date();
+  d.setUTCHours(0, 0, 0, 0);
+  d.setUTCDate(d.getUTCDate() + days);
+  while (d.getUTCDay() !== 5) d.setUTCDate(d.getUTCDate() + 1); // 5 = Friday
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}${m}${day}`;
+}
+
+const NEAR = fridayInDays(14);
+const FAR = fridayInDays(42);
 
 const PORTFOLIO_EMPTY = {
   bankroll: 1_000_000,


### PR DESCRIPTION
Two fixes, both surfaced while chasing "https://app.radon.run/performance still broken".

**1. The Advanced pill lied.** `<span className="pill neutral">GATED</span>` was a hardcoded literal on both the desktop and mobile performance panels, so it rendered GATED directly above six populated metrics (MWR IRR +164.79%, Beta 2.00, Alpha +101.21%, Tracking Error 82.73%, VaR −7.27%, CVaR −11.09%). It now counts cards actually sitting on the `EMPTY` sentinel and renders `N OF M GATED`, or nothing at all when nothing is gated.

**2. Methodology copy contradicted the math.** The footnote still read "end-of-day flow convention" two lines under `FLOW CONVENTION: bod` and `CURVE TYPE: twr_daily_bod`. Corrected to beginning-of-day on both panels.

**3. Chain-expiry e2e date rot.** `NEAR`/`FAR` were hardcoded `20260821`/`20260918`. `OptionsChainTab` defaults to the first expiry with >= 7 DTE, so once 08-21 came inside a week the component correctly skipped it and `toHaveValue(NEAR)` started reading the FAR date. This is the failure currently red on main's non-gating Playwright job. Both dates are now Fridays derived from the run date.

### Not in this PR
I also had a fix for `previous-close-yahoo-daily-array.test.ts` (UTC vs ET "today"). Main already carries a **better** version from #38 that uses the real trading calendar via `isUsTradingDay`, so holidays are handled too. Dropped mine and kept main's.

### Verification
- 6439 vitest pass, 0 fail
- `tsc --noEmit` clean
- The performance payload itself was verified correct and is unchanged by this PR: TWR +90.81%, external flows $135,411.85 (matches IBKR to the cent), `nav_source: flex_live`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017GR3NQT8qTLXkh6FiUQE6a