### PR TITLE
fix(perf): a fallback NAV source is provenance, not staleness

### DIFF
--- a/docs/performance-refactor-spec.md
+++ b/docs/performance-refactor-spec.md
@@ -612,15 +612,15 @@ Any warning of severity `error` forces at least `degraded`. Any warning of sever
 
 **Gate 1 — external flows.** `status == "ok"` requires `flows.status in {OK, EMPTY_VERIFIED}`. `FAILED` => `degraded`, `twr: null`. `EMPTY_VERIFIED` publishes normally but stamps `flows_status: "empty_verified"` in the payload so an operator can see that "no deposits" was *observed*, not *assumed*.
 
-**Gate 2 — NAV freshness.** `status == "ok"` requires `nav_source == "flex_live"` **and** `sessions_behind(period_end) <= NAV_STALENESS_BUDGET_SESSIONS`. `sessions_behind` uses `scripts/utils/market_calendar` (the same holiday source of truth as `marketCalendar.js`), not naive date subtraction. Any other combination:
+**Gate 2 — NAV freshness.** `status == "ok"` requires `sessions_behind(period_end) <= NAV_STALENESS_BUDGET_SESSIONS`. It does **not** require `nav_source == "flex_live"`: revised 2026-08-17 after a cached NAV of `2026-08-14`, read on `2026-08-17`, floored the payload to `stale` and blanked every gated metric — even though IBKR is T+1 and a live fetch would have returned that exact date. Provenance and freshness are different questions and only the second may hide a number; age is separately policed by `_NAV_DISK_MAX_AGE_DAYS` and by the read layer re-deriving `sessionsBehind` from `nav_as_of`. `sessions_behind` uses `scripts/utils/market_calendar` (the same holiday source of truth as `marketCalendar.js`), not naive date subtraction. Any other combination:
 
 | `nav_source` | sessions behind | status | warning |
 |---|---|---|---|
 | `flex_live` | <= 2 | `ok` | — |
 | `flex_live` | > 2 | `stale` | `NAV_STALE` (warn) |
-| `disk_cache` | <= 2 | `stale` | `NAV_SOURCE_DISK` (warn) |
+| `disk_cache` | <= 2 | `ok` | `NAV_SOURCE_DISK` (info) |
 | `disk_cache` | > 2 | `degraded` | `NAV_SOURCE_DISK` + `NAV_STALE` (error) |
-| `turso` | <= 2 | `stale` | `NAV_SOURCE_TURSO` (warn) |
+| `turso` | <= 2 | `ok` | `NAV_SOURCE_TURSO` (info) |
 | `turso` | > 2 | `degraded` | `NAV_SOURCE_TURSO` + `NAV_STALE` (error) |
 | none | — | `unavailable` | `NAV_UNAVAILABLE` (error) |
 

--- a/scripts/perf_twr_builder.py
+++ b/scripts/perf_twr_builder.py
@@ -689,7 +689,13 @@ def _freshness_warnings(nav_source: str, behind: int, nav_as_of: Optional[str]) 
         out.append(
             _warning(
                 source_code,
-                "error" if stale else "warn",
+                # Provenance, not freshness. `warn` floors the payload to
+                # "stale" (_SEVERITY_FLOOR), and the render layer gates the TWR
+                # on "stale" exactly as on "degraded" -- so serving a perfectly
+                # current NAV from a cache blanked the whole page. Age is
+                # already policed by _NAV_DISK_MAX_AGE_DAYS here and by the
+                # read layer re-deriving sessionsBehind from nav_as_of.
+                "error" if stale else "info",
                 f"NAV came from the {nav_source} fallback, not a live Flex fetch.",
                 nav_source=nav_source,
                 nav_as_of=nav_as_of,

--- a/tests/test_perf_twr_fallback_source_is_not_staleness.py
+++ b/tests/test_perf_twr_fallback_source_is_not_staleness.py
@@ -1,0 +1,86 @@
+"""A fallback SOURCE is provenance, not staleness.
+
+Incident 2026-08-17, final act. After giving flows a Turso fallback, the
+builder produced `flows=ok` but `status=stale`, and the render layer gates the
+TWR on `stale` exactly as it gates on `degraded` — so the page was still blank.
+
+`_freshness_warnings` emitted `NAV_SOURCE_DISK` at severity `warn`, and
+`_SEVERITY_FLOOR` maps `warn -> stale`. So the payload was floored to "stale"
+because the NAV *came from a cache*, even though the cached NAV was 2026-08-14
+— which is precisely what a live Flex fetch would have returned at that moment,
+IBKR being T+1.
+
+Two independent things were being conflated:
+
+  * WHERE the NAV came from (flex / disk_cache / turso) -- provenance
+  * HOW OLD the NAV is (`behind` vs NAV_STALENESS_BUDGET_SESSIONS) -- freshness
+
+Only the second should gate a number. Age is already policed twice: the builder
+refuses a disk cache older than `_NAV_DISK_MAX_AGE_DAYS`, and the read layer
+re-derives `sessionsBehind` from `nav_as_of` against the current clock. A
+source-based floor adds nothing and suppresses correct data.
+
+So: within the staleness budget, a fallback source is `info` (surface the
+provenance, publish the number). Past the budget it stays `error`.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.lib import twr_gates  # noqa: E402
+from scripts.perf_twr_builder import _freshness_warnings  # noqa: E402
+
+BUDGET = twr_gates.NAV_STALENESS_BUDGET_SESSIONS
+NAV_AS_OF = "2026-08-14"
+
+
+def _by_code(warnings, code):
+    for w in warnings:
+        if w.get("code") == code:
+            return w
+    return None
+
+
+class TestFallbackSourceWithinBudget:
+    @pytest.mark.parametrize("nav_source", ["disk_cache", "turso"])
+    def test_source_warning_is_info_not_warn(self, nav_source):
+        """The exact production case: NAV one session behind, served from a
+        fallback. `warn` floors the payload to `stale`, which blanks the page."""
+        warnings = _freshness_warnings(nav_source, behind=1, nav_as_of=NAV_AS_OF)
+
+        w = _by_code(warnings, f"NAV_SOURCE_{'DISK' if nav_source == 'disk_cache' else 'TURSO'}")
+        assert w is not None, "provenance must still be surfaced"
+        assert w["severity"] == "info", (
+            "a fallback source inside the freshness budget is provenance, "
+            "not a reason to suppress every metric"
+        )
+
+    def test_provenance_is_still_reported(self):
+        """Downgrading severity must not hide WHERE the NAV came from."""
+        warnings = _freshness_warnings("disk_cache", behind=1, nav_as_of=NAV_AS_OF)
+        w = _by_code(warnings, "NAV_SOURCE_DISK")
+        assert w["context"]["nav_source"] == "disk_cache"
+        assert "disk_cache" in w["message"]
+
+    def test_at_the_budget_edge_it_is_still_info(self):
+        warnings = _freshness_warnings("disk_cache", behind=BUDGET, nav_as_of=NAV_AS_OF)
+        assert _by_code(warnings, "NAV_SOURCE_DISK")["severity"] == "info"
+
+
+class TestGenuinelyStaleStillEscalates:
+    def test_past_the_budget_the_source_warning_is_an_error(self):
+        """Old data is a real defect and must keep gating."""
+        warnings = _freshness_warnings("disk_cache", behind=BUDGET + 1, nav_as_of=NAV_AS_OF)
+        assert _by_code(warnings, "NAV_SOURCE_DISK")["severity"] == "error"
+
+    def test_a_live_flex_fetch_emits_no_source_warning(self):
+        warnings = _freshness_warnings("flex_live", behind=1, nav_as_of=NAV_AS_OF)
+        assert _by_code(warnings, "NAV_SOURCE_DISK") is None
+        assert _by_code(warnings, "NAV_SOURCE_TURSO") is None

--- a/tests/test_perf_twr_flows.py
+++ b/tests/test_perf_twr_flows.py
@@ -382,9 +382,17 @@ def test_76c_the_thirty_day_boundary(tmp_path, monkeypatch):
         ("flex_live", 0, "ok", []),
         ("flex_live", 2, "ok", []),
         ("flex_live", 3, "stale", ["NAV_STALE"]),
-        ("disk_cache", 1, "stale", ["NAV_SOURCE_DISK"]),
+        # Re-pinned 2026-08-17: a fallback SOURCE inside the freshness budget
+        # is provenance, not staleness. These two cases pinned status="stale",
+        # and the render layer gates the TWR on "stale" exactly as on
+        # "degraded" -- so a NAV of 2026-08-14 served from cache on 2026-08-17
+        # blanked the entire page, even though a live Flex fetch would have
+        # returned that same date (IBKR is T+1). The NAV_SOURCE_* code is still
+        # emitted; only the status floor moved. Age still escalates -- see the
+        # `behind=9` rows, which are unchanged.
+        ("disk_cache", 1, "ok", ["NAV_SOURCE_DISK"]),
         ("disk_cache", 9, "degraded", ["NAV_SOURCE_DISK", "NAV_STALE"]),
-        ("turso", 1, "stale", ["NAV_SOURCE_TURSO"]),
+        ("turso", 1, "ok", ["NAV_SOURCE_TURSO"]),
         ("turso", 9, "degraded", ["NAV_SOURCE_TURSO", "NAV_STALE"]),
     ],
 )


### PR DESCRIPTION
Final defect in the "/performance is blank" chain. Complements #51 (which stops the duplicate Flex request); this one is in `_freshness_warnings` and does not overlap it.

## Symptom

After #49 gave flows a Turso fallback, a live run produced:

```
[perf_twr] Serving 21 mirrored flows from Turso after Flex failure
[perf_twr] status=stale period=2025-12-31..2026-08-14 source=disk_cache flows=ok
```

`flows=ok` — the fallback worked. But `status=stale`, and the render layer gates the TWR on `stale` **exactly as it gates on `degraded`**. So the page was still blank.

## Cause

`_freshness_warnings` emitted `NAV_SOURCE_DISK` at severity `warn`, and `_SEVERITY_FLOOR` maps `warn -> stale`. The payload was floored to "stale" because the NAV *came from a cache* — even though the cached NAV was `2026-08-14`, which is precisely what a live Flex fetch would have returned at that moment, IBKR being T+1.

Two independent things were conflated:

- **WHERE** the NAV came from (`flex` / `disk_cache` / `turso`) — provenance
- **HOW OLD** it is (`behind` vs `NAV_STALENESS_BUDGET_SESSIONS`) — freshness

Only the second should gate a number. Age is already policed twice: `_NAV_DISK_MAX_AGE_DAYS` refuses a stale disk cache, and the read layer re-derives `sessionsBehind` from `nav_as_of` against the current clock. The source-based floor added nothing and suppressed correct data.

## Change

Within the budget the source warning is `info` — provenance surfaced, number published. Past the budget it stays `error`. The `NAV_SOURCE_*` code is emitted either way.

## Re-pinned tests (called out deliberately)

`test_f4_nav_freshness_matrix` had two cases asserting the old behaviour:

```
- ("disk_cache", 1, "stale", ["NAV_SOURCE_DISK"])
+ ("disk_cache", 1, "ok",    ["NAV_SOURCE_DISK"])
- ("turso",      1, "stale", ["NAV_SOURCE_TURSO"])
+ ("turso",      1, "ok",    ["NAV_SOURCE_TURSO"])
```

Rationale is inline in the parametrize block. The `behind=9` rows are untouched — genuinely old data still escalates to `degraded`.

## Verification

- Red first (4 failed), then green
- `tests/`: 289 passed
- `scripts/tests`: 5972 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)