### PR TITLE
docs: unblock main — index the vol-cone builder deep link

### DIFF
--- a/docs/indicators/README.md
+++ b/docs/indicators/README.md
@@ -14,6 +14,13 @@ Owner specs for regime tabs and the cheap-wing scanner. Add a row here when a sp
 
 `/regime/vol-cone` redirects to the scanner. Pattern for a new indicator: `.claude/skills/new-indicator/SKILL.md`.
 
+`vol-cone` is the only indicator that deep-links into the ORDER BUILDER: a
+`CHEAP_WINGS` / `CHEAP_ATM` row links to
+`/{TICKER}?deck=c&expiry=…&src=vol-cone&legs=…`, and the chain labels the
+builder `PREFILLED FROM VOL CONE` off that `src`. Any other `src` falls back to
+`PREFILLED FROM THETA HARVESTER`, so a new indicator that prefills the builder
+must add its own `src` value rather than reuse one.
+
 A derived indicator must tell an explained parent lag apart from a broken
 parent, or a spent UW daily cap fails its unit and pages a P1 every run. See
 [skew2d.md](skew2d.md) "Parent lag — stale vs embargoed".


### PR DESCRIPTION
**main is red and its deploy is SKIPPED.** Nothing can ship until this lands.

`b585f5d6` ("feat(web): vol cone analysis and recommended-trade deep link") changed `docs/indicators/vol-cone.md` without touching `docs/indicators/README.md`, which the `indicators` docs-ownership rule requires:

```
indicators: changed ['docs/indicators/vol-cone.md'] but none of ['docs/indicators/README.md']
```

Run `32090249644` on main: `pytest` failed, `Deploy to VPS` **skipped**. The same hit then failed PR #52, since CI tests the merge result.

## What this adds

Not a token touch — the README genuinely did not record what that commit introduced: vol-cone is the **only** indicator that deep-links into the order builder, and the chain picks its `PREFILLED FROM VOL CONE` label off `src=vol-cone`, falling back to theta-harvester for any other value. A future indicator that prefills the builder needs its own `src` rather than reusing one.

`docs-skip:` is deliberately **not** used — the rule caught a real omission.

## Verification

`scripts/tests/test_docs_contract.py`: 6 passed.

## Note

This is another session's change; I'm unblocking it because it gates every deploy including the `/performance` fixes (#47-#50 merged, #52 open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)