### PR TITLE
fix(web): the vol cone table's scroll wrapper was a class no stylesheet defines

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -8947,6 +8947,16 @@ body[data-mobile="true"] .orders-command-strip__jump:active {
 /* ── Table wrap for horizontal scroll ── */
 .table-wrap { overflow-x: auto; }
 
+/* Desktop-only tables that swap to cards on mobile still need containment
+   on narrow desktop panels. The mobile display:none rules still win. */
+.theta-harvester__table-wrap { overflow-x: auto; }
+
+/* On the mobile shell a wide table scrolls inside its wrapper instead of
+   two-line-wrapping every cell (same treatment as .pos-legs-table-wrap). */
+body[data-mobile="true"] .table-wrap table { min-width: max-content; }
+body[data-mobile="true"] .table-wrap th,
+body[data-mobile="true"] .table-wrap td { white-space: nowrap; }
+
 /* Horizontal-scroll affordance for wide tables inside a .modal-content
    (which clips overflow-x). Wrap the table in this so it scrolls within
    the modal body instead of overflowing the dialog. */

--- a/web/components/GarchConvergenceScanner.tsx
+++ b/web/components/GarchConvergenceScanner.tsx
@@ -236,7 +236,7 @@ export default function GarchConvergenceScanner({
             testId="garch-scanner-filter-empty"
           />
         ) : (
-          <div className="table-scroll garch-scanner__table-wrap">
+          <div className="table-wrap garch-scanner__table-wrap">
             <table className="data-table garch-scanner__table">
               <thead>
                 <tr>

--- a/web/components/LeapScanner.tsx
+++ b/web/components/LeapScanner.tsx
@@ -128,7 +128,7 @@ export default function LeapScanner({
             action={onScan ? { label: "Run scan", onClick: onScan } : undefined}
           />
         ) : (
-          <div className="table-scroll">
+          <div className="table-wrap">
             <table className="data-table">
               <thead>
                 <tr>

--- a/web/components/VolConePanel.tsx
+++ b/web/components/VolConePanel.tsx
@@ -253,7 +253,7 @@ export default function VolConePanel() {
           </nav>
         </div>
         <div className="section-body">
-          <div className="table-scroll">
+          <div className="table-wrap">
             <table className="data-table">
               <thead>
                 <tr>
@@ -394,7 +394,7 @@ export default function VolConePanel() {
             </div>
           )}
           <div className="section-body">
-            <div className="table-scroll">
+            <div className="table-wrap">
               <table className="data-table" data-sortable-exempt="chrome">
                 <tbody>
                   <tr>

--- a/web/components/equibles-ats-venue-share/AtsVenueSharePanel.tsx
+++ b/web/components/equibles-ats-venue-share/AtsVenueSharePanel.tsx
@@ -191,7 +191,7 @@ export default function AtsVenueSharePanel() {
       </div>
 
       <div className="section">
-        <div className="table-scroll">
+        <div className="table-wrap">
           <AtsVenueShareTable rows={rows} />
         </div>
 

--- a/web/components/equibles/EquiblesShortCrowdingPanel.tsx
+++ b/web/components/equibles/EquiblesShortCrowdingPanel.tsx
@@ -241,7 +241,7 @@ export default function EquiblesShortCrowdingPanel() {
       </div>
 
       <div className="section">
-        <div className="table-scroll">
+        <div className="table-wrap">
           <ShortCrowdingTable entries={entries} />
         </div>
 

--- a/web/e2e/mobile-vol-cone-table.spec.ts
+++ b/web/e2e/mobile-vol-cone-table.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * E2E: vol cone scanner table on the mobile shell (393×852).
+ *
+ * Bug (2026-08-18 screenshot): the Names table was unreadable on a phone —
+ * cell text bisected by the panel's right border, the whole page scrolling
+ * sideways, the Ticker column lost off-screen. The table's wrapper class
+ * (`table-scroll`) was defined in no stylesheet, so the 9-column table
+ * overflowed the document instead of scrolling inside its container.
+ *
+ * Invariant pinned here: the page body never scrolls horizontally; the wide
+ * table scrolls inside its own overflow-x wrapper.
+ */
+
+import { test, expect } from "@playwright/test";
+
+function point(date: string, atm: number) {
+  return {
+    date,
+    spot: 220,
+    atm_iv: atm,
+    call_10_iv: atm - 0.005,
+    put_10_iv: atm + 0.01,
+  };
+}
+
+function name(overrides: Record<string, unknown> = {}) {
+  const series = Array.from({ length: 18 }, (_, i) =>
+    point(`2026-04-${String(10 + i).padStart(2, "0")}`, 0.40 - i * 0.001),
+  );
+  return {
+    ticker: "NVDA",
+    spot: 223.95,
+    expiry: "2026-09-18",
+    dte: 37,
+    atm_iv: 0.3851329156797111,
+    call_10_iv: 0.3862120615005326,
+    put_10_iv: 0.39731998999142565,
+    call_10_strike: 246.345,
+    put_10_strike: 201.555,
+    p10: 0.3879,
+    p90: 0.443,
+    atm_percentile: 0,
+    call_10_percentile: 0.0556,
+    put_10_percentile: 0.1111,
+    wing_score: 0.0833,
+    regime: "CHEAP_WINGS",
+    series,
+    ...overrides,
+  };
+}
+
+const NVDA = name();
+const SMH = name({
+  ticker: "SMH",
+  regime: "NEUTRAL",
+  wing_score: 0.44,
+  atm_percentile: 0.4,
+  atm_iv: 0.387,
+});
+
+const VOL_CONE_MOCK = {
+  scan_time: "2026-08-12T20:45:00Z",
+  source_as_of: "2026-08-12",
+  count: 2,
+  hit_count: 1,
+  current: NVDA,
+  names: [NVDA, SMH],
+  hits: [NVDA],
+};
+
+const PORTFOLIO_EMPTY = {
+  bankroll: 100_000,
+  positions: [],
+  account_summary: {},
+  exposure: {},
+  violations: [],
+};
+
+const ORDERS_EMPTY = {
+  last_sync: new Date().toISOString(),
+  open_orders: [],
+  executed_orders: [],
+  open_count: 0,
+  executed_count: 0,
+};
+
+async function setupMocks(page: import("@playwright/test").Page) {
+  await page.unrouteAll({ behavior: "ignoreErrors" });
+  await page.route("**/api/vol-cone", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(VOL_CONE_MOCK) }),
+  );
+  await page.route("**/api/portfolio", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(PORTFOLIO_EMPTY) }),
+  );
+  await page.route("**/api/orders", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(ORDERS_EMPTY) }),
+  );
+  await page.route("**/api/prices", (route) => route.abort());
+  await page.route("**/api/ib-status", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ connected: false }) }),
+  );
+}
+
+test.describe("vol cone scanner table — mobile shell", () => {
+  test("the wide Names table scrolls in its wrapper, never the page", async ({ page }) => {
+    await setupMocks(page);
+    await page.goto("/scanner?mode=vol-cone");
+
+    const row = page.getByTestId("vol-cone-row-NVDA-2026-09-18");
+    await expect(row).toBeVisible();
+
+    // The page body must not scroll horizontally.
+    const overflow = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      innerWidth: window.innerWidth,
+    }));
+    expect(
+      overflow.scrollWidth,
+      `document scrolls sideways (${overflow.scrollWidth}px > ${overflow.innerWidth}px viewport)`,
+    ).toBeLessThanOrEqual(overflow.innerWidth + 1);
+
+    // The wide table's own wrapper is the scroll container.
+    const wrapper = page
+      .getByTestId("vol-cone-table-section")
+      .locator(".table-wrap")
+      .first();
+    const wrapperState = await wrapper.evaluate((el) => ({
+      overflowX: window.getComputedStyle(el).overflowX,
+      clientWidth: el.clientWidth,
+      scrollWidth: el.scrollWidth,
+    }));
+    expect(wrapperState.overflowX).toBe("auto");
+    // 9 columns cannot fit 393px — the wrapper, not the page, absorbs it.
+    expect(wrapperState.scrollWidth).toBeGreaterThan(wrapperState.clientWidth);
+  });
+
+  test("the Ticker column is visible at rest on a phone", async ({ page }) => {
+    await setupMocks(page);
+    await page.goto("/scanner?mode=vol-cone");
+
+    const row = page.getByTestId("vol-cone-row-NVDA-2026-09-18");
+    await expect(row).toBeVisible();
+
+    // At scrollLeft 0 the first (Ticker) cell must be inside the viewport —
+    // the screenshot showed expiry groups with no way to tell which ticker
+    // they belonged to.
+    const tickerCell = row.locator("td").first();
+    await expect(tickerCell).toContainText("NVDA");
+    const box = await tickerCell.boundingBox();
+    expect(box, "ticker cell has no box").not.toBeNull();
+    expect(box!.x).toBeGreaterThanOrEqual(0);
+    expect(box!.x).toBeLessThan(393);
+  });
+});

--- a/web/tests/table-scroll-wrapper-contract.test.ts
+++ b/web/tests/table-scroll-wrapper-contract.test.ts
@@ -1,0 +1,83 @@
+/**
+ * A table's scroll wrapper must be a class that actually exists.
+ *
+ * Bug (2026-08-18 screenshot): the vol cone scanner table was unreadable on
+ * mobile — content bisected by the panel border, page scrolling sideways.
+ * `VolConePanel` (and `LeapScanner`, `GarchConvergenceScanner`) wrapped their
+ * 9-column tables in `<div className="table-scroll">`, a class defined in NO
+ * stylesheet. The wrapper was an unstyled div, so on a 390px viewport the
+ * table overflowed the document instead of scrolling inside its container —
+ * violating the "wide content scrolls in its own overflow-x container, the
+ * page never scrolls horizontally" rule.
+ *
+ * Contract: every `*table-scroll*` / `*table-wrap*` class token used in a
+ * component's className must have a stylesheet definition that sets
+ * `overflow-x`. A typo'd or phantom wrapper class fails here instead of
+ * shipping as an invisible no-op.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const WEB_ROOT = join(__dirname, "..");
+const TSX_ROOTS = [join(WEB_ROOT, "components"), join(WEB_ROOT, "app")];
+
+function walk(dir: string, ext: string): string[] {
+  const out: string[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const name of entries) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) out.push(...walk(p, ext));
+    else if (p.endsWith(ext)) out.push(p);
+  }
+  return out;
+}
+
+/** Class-token lists for every className attribute that names a table wrapper.
+ *  Template-literal interpolations (`${...}`) split like whitespace, so
+ *  `table-wrap${density}` yields the checkable "table-wrap" token. */
+function wrapperElementsIn(src: string): string[][] {
+  const out: string[][] = [];
+  for (const attr of src.matchAll(/className=\{?["'`]([^"'`]+)["'`]/g)) {
+    const tokens = attr[1].split(/\s+|\$\{[^}]*\}|\$\{/).filter(Boolean);
+    if (tokens.some((t) => /table-(scroll|wrap)/.test(t))) out.push(tokens);
+  }
+  return out;
+}
+
+describe("table scroll wrapper contract", () => {
+  it("every table-scroll/table-wrap class used in TSX has an overflow-x stylesheet definition", () => {
+    const stylesheets = [
+      join(WEB_ROOT, "app", "globals.css"),
+      ...walk(join(WEB_ROOT, "components"), ".css"),
+      ...walk(join(WEB_ROOT, "app"), ".css"),
+    ];
+    const css = [...new Set(stylesheets)].map((p) => readFileSync(p, "utf8")).join("\n");
+
+    const definesWithOverflow = (token: string): boolean => {
+      // Any rule block whose selector names the class and whose body sets overflow-x.
+      const rule = new RegExp(`\\.${token}[^{}]*\\{[^}]*overflow-x`, "s");
+      return rule.test(css);
+    };
+
+    const violations: string[] = [];
+    for (const file of TSX_ROOTS.flatMap((r) => walk(r, ".tsx"))) {
+      const src = readFileSync(file, "utf8");
+      for (const tokens of wrapperElementsIn(src)) {
+        if (!tokens.some(definesWithOverflow)) {
+          violations.push(
+            `${relative(WEB_ROOT, file)}: wrapper "${tokens.join(" ")}" — no class carries an overflow-x rule`,
+          );
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
The vol cone scanner Names table was unreadable on a phone: cell text bisected by the panel border, the page scrolling sideways, the Ticker column lost off-screen so three tickers' expiry groups ran together unlabeled.

## Root cause

`VolConePanel` wrapped its 9-column table in `<div className="table-scroll">` — a class defined in **no stylesheet**. The wrapper was an unstyled div, so the table overflowed the document instead of scrolling inside its container. The same phantom class shipped in five more panels (LeapScanner, GarchConvergenceScanner, EquiblesShortCrowdingPanel, AtsVenueSharePanel) with the same latent blowout. The defined convention is `.table-wrap { overflow-x: auto; }`.

## Changes

- All six sites now use `table-wrap`
- `.theta-harvester__table-wrap` (desktop-only table, cards on mobile) gets its own `overflow-x` rule
- Mobile shell: `.table-wrap` tables get `min-width: max-content` + nowrap cells (the `.pos-legs-table-wrap` treatment) — a wide table scrolls in its wrapper instead of two-line-wrapping every cell
- **Contract test**: every className naming a `table-(scroll|wrap)` class must have at least one class on that element carrying an `overflow-x` stylesheet rule — a typo'd wrapper class can no longer ship as an invisible no-op (red: 7 violations across 6 files)
- **Mobile e2e** (393×852, stubbed payload): document never scrolls horizontally, the wrapper is the scroll container, the Ticker column visible at rest — red pre-fix, green after

## Verification

- Contract test red→green; e2e red→green (both specs failed against the pre-fix tree, pass after)
- Full web gate: 6492 unit tests green; tsc + ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)