### PR TITLE
fix(web): auto-fire the producer sync when a render surfaces a stale snapshot

### DIFF
--- a/web/components/WorkspaceShell.tsx
+++ b/web/components/WorkspaceShell.tsx
@@ -10,6 +10,7 @@ import { resolveSectionFromPath } from "@/lib/chat";
 import { usePortfolio } from "@/lib/usePortfolio";
 import { useOrders } from "@/lib/useOrders";
 import { useMarketHours, MarketState } from "@/lib/useMarketHours";
+import { useAutoSyncOnStale } from "@/lib/useAutoSyncOnStale";
 import { useToast } from "@/lib/useToast";
 import { useOrderActions } from "@/lib/OrderActionsContext";
 import { usePrices } from "@/lib/usePrices";
@@ -482,6 +483,10 @@ export default function WorkspaceShell({ section, tickerParam }: WorkspaceShellP
     const ageMs = Date.now() - new Date(lastSync).getTime();
     return Math.max(1, Math.floor(ageMs / 60_000));
   }, [lastSync]);
+
+  // A render that surfaces a stale snapshot triggers the producer sync
+  // itself — the stale pill's Sync button remains the manual fallback.
+  useAutoSyncOnStale(isStale, syncNow, syncTarget, !isDemoMode);
 
   // Sections that render live marks from the prices map. Scanner/discover (and
   // other non-price modules) must not receive a new `prices` identity on every

--- a/web/lib/useAutoSyncOnStale.ts
+++ b/web/lib/useAutoSyncOnStale.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+const AUTO_SYNC_COOLDOWN_MS = 60_000;
+
+/**
+ * Fires the page's producer sync when a render surfaces a stale snapshot,
+ * so freshness never waits on the operator pressing SYNC. The backend
+ * orders/portfolio loops run on a 5-minute cadence; landing on a page
+ * between ticks used to serve a snapshot up to that old with nothing
+ * refreshing it (the client-side auto-POST was removed in 43a02eff).
+ *
+ * Cooldown is per sync target so rapid route flips cannot hammer the
+ * rate-limited refresh routes, and a failing producer is retried at most
+ * once per window.
+ */
+export function useAutoSyncOnStale(
+  stale: boolean,
+  syncNow: () => void,
+  target: string,
+  enabled: boolean,
+): void {
+  const lastFiredAtByTargetRef = useRef<Map<string, number>>(new Map());
+
+  useEffect(() => {
+    if (!stale || !enabled) return;
+    const now = Date.now();
+    const lastFiredAt = lastFiredAtByTargetRef.current.get(target) ?? 0;
+    if (now - lastFiredAt < AUTO_SYNC_COOLDOWN_MS) return;
+    lastFiredAtByTargetRef.current.set(target, now);
+    syncNow();
+  }, [stale, enabled, target, syncNow]);
+}

--- a/web/tests/use-auto-sync-on-stale.test.ts
+++ b/web/tests/use-auto-sync-on-stale.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useAutoSyncOnStale } from "../lib/useAutoSyncOnStale";
+
+describe("useAutoSyncOnStale", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-18T15:52:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fires syncNow once when the rendered snapshot is stale", () => {
+    const syncNow = vi.fn();
+    const { rerender } = renderHook(
+      ({ stale }) => useAutoSyncOnStale(stale, syncNow, "orders", true),
+      { initialProps: { stale: false } },
+    );
+    expect(syncNow).not.toHaveBeenCalled();
+
+    rerender({ stale: true });
+    expect(syncNow).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not refire while the snapshot stays stale across re-renders", () => {
+    const syncNow = vi.fn();
+    const { rerender } = renderHook(
+      ({ stale }) => useAutoSyncOnStale(stale, syncNow, "orders", true),
+      { initialProps: { stale: true } },
+    );
+    expect(syncNow).toHaveBeenCalledTimes(1);
+
+    rerender({ stale: true });
+    rerender({ stale: true });
+    expect(syncNow).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire when disabled (demo mode)", () => {
+    const syncNow = vi.fn();
+    renderHook(() => useAutoSyncOnStale(true, syncNow, "orders", false));
+    expect(syncNow).not.toHaveBeenCalled();
+  });
+
+  it("cooldown bounds repeat fires within 60s of the same target", () => {
+    const syncNow = vi.fn();
+    const { rerender } = renderHook(
+      ({ stale }) => useAutoSyncOnStale(stale, syncNow, "orders", true),
+      { initialProps: { stale: true } },
+    );
+    expect(syncNow).toHaveBeenCalledTimes(1);
+
+    rerender({ stale: false });
+    rerender({ stale: true });
+    expect(syncNow).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(61_000);
+    rerender({ stale: false });
+    rerender({ stale: true });
+    expect(syncNow).toHaveBeenCalledTimes(2);
+  });
+
+  it("tracks cooldown per target so a route change still syncs the new page", () => {
+    const portfolioSync = vi.fn();
+    const ordersSync = vi.fn();
+    const { rerender } = renderHook(
+      ({ stale, syncNow, target }: { stale: boolean; syncNow: () => void; target: string }) =>
+        useAutoSyncOnStale(stale, syncNow, target, true),
+      { initialProps: { stale: true, syncNow: portfolioSync, target: "portfolio" } },
+    );
+    expect(portfolioSync).toHaveBeenCalledTimes(1);
+
+    rerender({ stale: true, syncNow: ordersSync, target: "orders" });
+    expect(ordersSync).toHaveBeenCalledTimes(1);
+    expect(portfolioSync).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Problem

/orders (and any page reading the header stale pill) kept showing `STALE Nm SYNC` during market hours.

- 43a02eff removed `useOrders`' client auto-POST (page-load sync + 30s sync interval), leaving GET-only cache polling.
- The FastAPI `_orders_sync_loop` refreshes the snapshot every 5 minutes — its docstring still assumes the Next.js page fires `/orders/refresh` on load, which stopped being true.
- Yesterday's bb000186 re-GETs the cache on route change, but never touches the producer — it re-reads the same stale snapshot faster.

Net: landing on /orders between backend ticks served a snapshot up to 5 minutes old with nothing refreshing it.

## Fix

`useAutoSyncOnStale` (new hook, wired in `WorkspaceShell`) fires the page's existing `syncNow` — the same POST the stale pill's Sync button triggers — when the stale condition trips: market open, snapshot older than 60s, non-demo. Cooldown-bounded per sync target (60s) so route flips cannot hammer the rate-limited refresh routes, and a failing producer is retried at most once per window.

## Verification

- New `web/tests/use-auto-sync-on-stale.test.ts`: 5/5 (red first — hook absent).
- `tsc --noEmit` clean.
- Full web vitest suite: 6852/6852 (one cwd-dependent suite, `lib/tools/__tests__/ib-wrappers-db-source.test.ts`, fails when run from `web/` and passes from repo root — pre-existing, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)