### PR TITLE
fix(web): staleness is session-independent and self-ticking

### DIFF
--- a/web/components/WorkspaceShell.tsx
+++ b/web/components/WorkspaceShell.tsx
@@ -11,6 +11,7 @@ import { usePortfolio } from "@/lib/usePortfolio";
 import { useOrders } from "@/lib/useOrders";
 import { useMarketHours, MarketState } from "@/lib/useMarketHours";
 import { useAutoSyncOnStale } from "@/lib/useAutoSyncOnStale";
+import { useSnapshotStaleness } from "@/lib/useSnapshotStaleness";
 import { useToast } from "@/lib/useToast";
 import { useOrderActions } from "@/lib/OrderActionsContext";
 import { usePrices } from "@/lib/usePrices";
@@ -472,21 +473,13 @@ export default function WorkspaceShell({ section, tickerParam }: WorkspaceShellP
       ? "Sync failed. Reconstruction incomplete."
       : "Awaiting first sample";
 
-  const isStale = useMemo(() => {
-    if (!lastSync) return false;
-    if (marketState !== MarketState.OPEN) return false;
-    const ageMs = Date.now() - new Date(lastSync).getTime();
-    return ageMs > 60_000;
-  }, [lastSync, marketState]);
-  const staleAgeMinutes = useMemo(() => {
-    if (!lastSync) return null;
-    const ageMs = Date.now() - new Date(lastSync).getTime();
-    return Math.max(1, Math.floor(ageMs / 60_000));
-  }, [lastSync]);
+  // Staleness is session-independent (after-hours/overnight fills exist)
+  // and re-evaluated on its own clock, so an idle page cannot rot silently.
+  const { isStale, staleAgeMinutes, tick: stalenessTick } = useSnapshotStaleness(lastSync);
 
   // A render that surfaces a stale snapshot triggers the producer sync
   // itself — the stale pill's Sync button remains the manual fallback.
-  useAutoSyncOnStale(isStale, syncNow, syncTarget, !isDemoMode);
+  useAutoSyncOnStale(isStale, syncNow, syncTarget, !isDemoMode, stalenessTick);
 
   // Sections that render live marks from the prices map. Scanner/discover (and
   // other non-price modules) must not receive a new `prices` identity on every

--- a/web/components/WorkspaceShell.tsx
+++ b/web/components/WorkspaceShell.tsx
@@ -10,6 +10,7 @@ import { resolveSectionFromPath } from "@/lib/chat";
 import { usePortfolio } from "@/lib/usePortfolio";
 import { useOrders } from "@/lib/useOrders";
 import { useMarketHours, MarketState } from "@/lib/useMarketHours";
+import { useAutoSyncOnStale } from "@/lib/useAutoSyncOnStale";
 import { useToast } from "@/lib/useToast";
 import { useOrderActions } from "@/lib/OrderActionsContext";
 import { usePrices } from "@/lib/usePrices";
@@ -482,6 +483,10 @@ export default function WorkspaceShell({ section, tickerParam }: WorkspaceShellP
     const ageMs = Date.now() - new Date(lastSync).getTime();
     return Math.max(1, Math.floor(ageMs / 60_000));
   }, [lastSync]);
+
+  // A render that surfaces a stale snapshot triggers the producer sync
+  // itself — the stale pill's Sync button remains the manual fallback.
+  useAutoSyncOnStale(isStale, syncNow, syncTarget, !isDemoMode);
 
   // Sections that render live marks from the prices map. Scanner/discover (and
   // other non-price modules) must not receive a new `prices` identity on every

--- a/web/lib/useAutoSyncOnStale.ts
+++ b/web/lib/useAutoSyncOnStale.ts
@@ -13,13 +13,16 @@ const AUTO_SYNC_COOLDOWN_MS = 60_000;
  *
  * Cooldown is per sync target so rapid route flips cannot hammer the
  * rate-limited refresh routes, and a failing producer is retried at most
- * once per window.
+ * once per window. `tick` (from useSnapshotStaleness) re-arms the effect
+ * while the snapshot stays stale, so a failing sync keeps retrying on the
+ * staleness cadence instead of firing once and going quiet.
  */
 export function useAutoSyncOnStale(
   stale: boolean,
   syncNow: () => void,
   target: string,
   enabled: boolean,
+  tick = 0,
 ): void {
   const lastFiredAtByTargetRef = useRef<Map<string, number>>(new Map());
 
@@ -30,5 +33,5 @@ export function useAutoSyncOnStale(
     if (now - lastFiredAt < AUTO_SYNC_COOLDOWN_MS) return;
     lastFiredAtByTargetRef.current.set(target, now);
     syncNow();
-  }, [stale, enabled, target, syncNow]);
+  }, [stale, enabled, target, syncNow, tick]);
 }

--- a/web/lib/useAutoSyncOnStale.ts
+++ b/web/lib/useAutoSyncOnStale.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+const AUTO_SYNC_COOLDOWN_MS = 60_000;
+
+/**
+ * Fires the page's producer sync when a render surfaces a stale snapshot,
+ * so freshness never waits on the operator pressing SYNC. The backend
+ * orders/portfolio loops run on a 5-minute cadence; landing on a page
+ * between ticks used to serve a snapshot up to that old with nothing
+ * refreshing it (the client-side auto-POST was removed in 43a02eff).
+ *
+ * Cooldown is per sync target so rapid route flips cannot hammer the
+ * rate-limited refresh routes, and a failing producer is retried at most
+ * once per window.
+ */
+export function useAutoSyncOnStale(
+  stale: boolean,
+  syncNow: () => void,
+  target: string,
+  enabled: boolean,
+): void {
+  const lastFiredAtByTargetRef = useRef<Map<string, number>>(new Map());
+
+  useEffect(() => {
+    if (!stale || !enabled) return;
+    const now = Date.now();
+    const lastFiredAt = lastFiredAtByTargetRef.current.get(target) ?? 0;
+    if (now - lastFiredAt < AUTO_SYNC_COOLDOWN_MS) return;
+    lastFiredAtByTargetRef.current.set(target, now);
+    syncNow();
+  }, [stale, enabled, target, syncNow]);
+}

--- a/web/lib/useSnapshotStaleness.ts
+++ b/web/lib/useSnapshotStaleness.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+export const SNAPSHOT_STALE_THRESHOLD_MS = 60_000;
+const STALENESS_TICK_MS = 30_000;
+
+export type SnapshotStaleness = {
+  isStale: boolean;
+  staleAgeMinutes: number | null;
+  /** Advances on every re-evaluation. Pass into stale-driven effects
+   *  (useAutoSyncOnStale) so retries share this cadence instead of dying
+   *  after the first attempt when the stale boolean never transitions. */
+  tick: number;
+};
+
+/**
+ * Session-independent snapshot staleness. After-hours, overnight and
+ * weekend fills exist, so freshness is never gated on market state —
+ * a snapshot older than the threshold is stale whenever it renders.
+ *
+ * Re-evaluates on an internal clock: without the tick, staleness was
+ * only recomputed when lastSync changed, so a page left open went
+ * silently stale once the backend producer's cadence lapsed.
+ */
+export function useSnapshotStaleness(lastSync: string | null): SnapshotStaleness {
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), STALENESS_TICK_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  return useMemo(() => {
+    if (!lastSync) return { isStale: false, staleAgeMinutes: null, tick };
+    const syncedAt = new Date(lastSync).getTime();
+    if (Number.isNaN(syncedAt)) return { isStale: false, staleAgeMinutes: null, tick };
+    const ageMs = Date.now() - syncedAt;
+    return {
+      isStale: ageMs > SNAPSHOT_STALE_THRESHOLD_MS,
+      staleAgeMinutes: Math.max(1, Math.floor(ageMs / 60_000)),
+      tick,
+    };
+  }, [lastSync, tick]);
+}

--- a/web/tests/use-auto-sync-on-stale.test.ts
+++ b/web/tests/use-auto-sync-on-stale.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useAutoSyncOnStale } from "../lib/useAutoSyncOnStale";
+
+describe("useAutoSyncOnStale", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-18T15:52:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fires syncNow once when the rendered snapshot is stale", () => {
+    const syncNow = vi.fn();
+    const { rerender } = renderHook(
+      ({ stale }) => useAutoSyncOnStale(stale, syncNow, "orders", true),
+      { initialProps: { stale: false } },
+    );
+    expect(syncNow).not.toHaveBeenCalled();
+
+    rerender({ stale: true });
+    expect(syncNow).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not refire while the snapshot stays stale across re-renders", () => {
+    const syncNow = vi.fn();
+    const { rerender } = renderHook(
+      ({ stale }) => useAutoSyncOnStale(stale, syncNow, "orders", true),
+      { initialProps: { stale: true } },
+    );
+    expect(syncNow).toHaveBeenCalledTimes(1);
+
+    rerender({ stale: true });
+    rerender({ stale: true });
+    expect(syncNow).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire when disabled (demo mode)", () => {
+    const syncNow = vi.fn();
+    renderHook(() => useAutoSyncOnStale(true, syncNow, "orders", false));
+    expect(syncNow).not.toHaveBeenCalled();
+  });
+
+  it("cooldown bounds repeat fires within 60s of the same target", () => {
+    const syncNow = vi.fn();
+    const { rerender } = renderHook(
+      ({ stale }) => useAutoSyncOnStale(stale, syncNow, "orders", true),
+      { initialProps: { stale: true } },
+    );
+    expect(syncNow).toHaveBeenCalledTimes(1);
+
+    rerender({ stale: false });
+    rerender({ stale: true });
+    expect(syncNow).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(61_000);
+    rerender({ stale: false });
+    rerender({ stale: true });
+    expect(syncNow).toHaveBeenCalledTimes(2);
+  });
+
+  it("tracks cooldown per target so a route change still syncs the new page", () => {
+    const portfolioSync = vi.fn();
+    const ordersSync = vi.fn();
+    const { rerender } = renderHook(
+      ({ stale, syncNow, target }: { stale: boolean; syncNow: () => void; target: string }) =>
+        useAutoSyncOnStale(stale, syncNow, target, true),
+      { initialProps: { stale: true, syncNow: portfolioSync, target: "portfolio" } },
+    );
+    expect(portfolioSync).toHaveBeenCalledTimes(1);
+
+    rerender({ stale: true, syncNow: ordersSync, target: "orders" });
+    expect(ordersSync).toHaveBeenCalledTimes(1);
+    expect(portfolioSync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/tests/use-auto-sync-on-stale.test.ts
+++ b/web/tests/use-auto-sync-on-stale.test.ts
@@ -62,6 +62,23 @@ describe("useAutoSyncOnStale", () => {
     expect(syncNow).toHaveBeenCalledTimes(2);
   });
 
+  it("retries on the staleness tick while the snapshot stays stale, cooldown-bounded", () => {
+    const syncNow = vi.fn();
+    const { rerender } = renderHook(
+      ({ tick }) => useAutoSyncOnStale(true, syncNow, "orders", true, tick),
+      { initialProps: { tick: 0 } },
+    );
+    expect(syncNow).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(30_000);
+    rerender({ tick: 1 });
+    expect(syncNow).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(31_000);
+    rerender({ tick: 2 });
+    expect(syncNow).toHaveBeenCalledTimes(2);
+  });
+
   it("tracks cooldown per target so a route change still syncs the new page", () => {
     const portfolioSync = vi.fn();
     const ordersSync = vi.fn();

--- a/web/tests/use-snapshot-staleness.test.ts
+++ b/web/tests/use-snapshot-staleness.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useSnapshotStaleness } from "../lib/useSnapshotStaleness";
+
+// Saturday 03:00 ET — deep outside any equities session. Staleness is
+// session-independent by design: after-hours and overnight fills exist,
+// so a snapshot is never allowed to rot just because RTH ended.
+const OVERNIGHT_NOW = new Date("2026-08-22T07:00:00Z");
+
+describe("useSnapshotStaleness", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(OVERNIGHT_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fresh snapshot is not stale", () => {
+    const lastSync = new Date(OVERNIGHT_NOW.getTime() - 10_000).toISOString();
+    const { result } = renderHook(() => useSnapshotStaleness(lastSync));
+    expect(result.current.isStale).toBe(false);
+  });
+
+  it("a >60s-old snapshot is stale even outside market hours", () => {
+    const lastSync = new Date(OVERNIGHT_NOW.getTime() - 3 * 60_000).toISOString();
+    const { result } = renderHook(() => useSnapshotStaleness(lastSync));
+    expect(result.current.isStale).toBe(true);
+    expect(result.current.staleAgeMinutes).toBe(3);
+  });
+
+  it("re-evaluates on its own clock — a snapshot goes stale while the page sits idle", () => {
+    const lastSync = new Date(OVERNIGHT_NOW.getTime() - 10_000).toISOString();
+    const { result } = renderHook(() => useSnapshotStaleness(lastSync));
+    expect(result.current.isStale).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(91_000);
+    });
+    expect(result.current.isStale).toBe(true);
+  });
+
+  it("null or unparseable lastSync is not stale", () => {
+    const { result: nullResult } = renderHook(() => useSnapshotStaleness(null));
+    expect(nullResult.current.isStale).toBe(false);
+    expect(nullResult.current.staleAgeMinutes).toBeNull();
+
+    const { result: badResult } = renderHook(() => useSnapshotStaleness("not-a-date"));
+    expect(badResult.current.isStale).toBe(false);
+  });
+
+  it("exposes a tick that advances with each re-evaluation", () => {
+    const { result } = renderHook(() => useSnapshotStaleness(null));
+    const initialTick = result.current.tick;
+    act(() => {
+      vi.advanceTimersByTime(61_000);
+    });
+    expect(result.current.tick).toBeGreaterThan(initialTick);
+  });
+});


### PR DESCRIPTION
Follow-up to #56, per operator: after-hours/overnight/weekend fills exist, so a snapshot is **never** allowed to be stale — market state must not exempt it.

## Two defects fixed

1. `isStale` gated on `marketState === MarketState.OPEN` — off-session snapshots were never marked stale and the auto-sync from #56 never fired for them.
2. `isStale` only recomputed when `lastSync` changed — a page left open went silently stale once the producer cadence lapsed (off-hours the backend loop stops entirely), so after one sync, detection went dead.

## Fix

New `useSnapshotStaleness`: no market-state input, re-evaluated on a 30s internal clock. Its `tick` re-arms `useAutoSyncOnStale`, so a stale or failing snapshot keeps retrying on that cadence — still cooldown-bounded to one producer POST per 60s per target, demo-gated as before.

Net behavior: any open Radon page keeps its orders/portfolio snapshot within ~60s of fresh, around the clock.

## Verification

- New `use-snapshot-staleness.test.ts` 5/5 + tick-retry case in `use-auto-sync-on-stale.test.ts` (red first).
- `tsc --noEmit` clean.
- Full vitest suite from repo root: **6858/6858**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)