### PR TITLE
feat(scanner): mobile-nav overhaul — visible overflow, keyboard tabs, contained scroll

### DIFF
--- a/scripts/order_limits.py
+++ b/scripts/order_limits.py
@@ -104,6 +104,24 @@ def _combo_risk_per_unit(legs: Any) -> Optional[float]:
     return risk
 
 
+def _combo_credit_per_unit(params: dict, price: float, multiplier: int) -> float:
+    """Premium ONE combo unit collects, in dollars; 0 when the order pays.
+
+    Two credit encodings reach the funnel: the chain builder keeps a BUY
+    envelope and signs the credit negative (commit 1db9f558); the position
+    close ticket ships a SELL envelope with a positive price. Either way the
+    order receives the premium.
+    """
+    try:
+        signed_price = float(params.get("limitPrice") or 0)
+    except (TypeError, ValueError):
+        signed_price = 0.0
+    is_sell_envelope = str(params.get("action") or "").upper().startswith("SELL")
+    if signed_price < 0 or is_sell_envelope:
+        return price * multiplier
+    return 0.0
+
+
 def order_notional(params: dict) -> Optional[float]:
     """Worst-case dollar exposure of the order; None when unpriceable.
 
@@ -111,6 +129,13 @@ def order_notional(params: dict) -> Optional[float]:
     limitPrice a signed net price, so measuring the cap against |limitPrice|
     measured a short strangle's net CREDIT: 500 lots at $0.20 priced as
     $10,000 and cleared the $250k cap with room to spare (R-052).
+
+    A credit combo's worst case is the strike risk MINUS the premium it
+    collects: 100 lots of a 30-wide vertical sold at $15 risks $150k, not
+    $300k — gross width refused a legitimate close (GLD, 2026-08-19). The
+    premium term counts the same dollars the netting subtracts, so
+    max(premium, risk − credit) never falls below half the strike risk and a
+    fat-fingered credit cannot slip an undefined-risk structure past the cap.
     """
     try:
         quantity = abs(float(params.get("quantity") or 0))
@@ -128,7 +153,9 @@ def order_notional(params: dict) -> Optional[float]:
     if str(params.get("type", "")).lower() == "combo":
         risk_per_unit = _combo_risk_per_unit(params.get("legs"))
         if risk_per_unit is not None:
-            return max(premium, quantity * risk_per_unit)
+            credit_per_unit = _combo_credit_per_unit(params, price, multiplier)
+            max_loss_per_unit = max(risk_per_unit - credit_per_unit, 0.0)
+            return max(premium, quantity * max_loss_per_unit)
 
     return premium or None
 

--- a/scripts/tests/test_monitor_daemon/test_menthorq_login_probe.py
+++ b/scripts/tests/test_monitor_daemon/test_menthorq_login_probe.py
@@ -99,7 +99,12 @@ class TestLoginProbeVerdicts:
         from monitor_daemon.handlers import menthorq_login_probe as mod
 
         handler = _handler()
-        moment = NOW
+        # Midday anchor: the loop advances ~16.5 minutes and the handler keys
+        # its attempt budget to the UTC DATE — a wall-clock NOW within 16.5
+        # minutes of UTC midnight crossed the boundary, reset the counter, and
+        # turned the final attempt into a fresh day's soft failure (CI ran at
+        # 23:50 UTC and failed exactly this way, 2026-08-19).
+        moment = NOW.replace(hour=12, minute=0, second=0, microsecond=0)
         for attempt in range(mod.MAX_TRANSIENT_ATTEMPTS_PER_DAY):
             moment += timedelta(seconds=mod.RETRY_EMBARGO_SECONDS + 30)
             with _patch_get(exc=requests.ConnectionError("refused")), \

--- a/scripts/tests/test_order_limits.py
+++ b/scripts/tests/test_order_limits.py
@@ -198,13 +198,14 @@ class TestComboNotionalIsRiskNotPremium:
         assert violation["code"] == "ORDER_NOTIONAL_LIMIT"
 
     def test_short_strangle_notional_prices_the_risk(self):
-        """(700 + 600) × 100 × 500 = $65M of exposure, not $10k of credit."""
+        """(700 + 600) × 100 × 500 = $65M of exposure, less the $10k the
+        order collects — not $10k of credit."""
         notional = order_limits.order_notional({
             "type": "combo", "symbol": "SPY", "action": "SELL",
             "quantity": 500, "limitPrice": -0.20,
             "legs": [_strangle_leg(700, "C"), _strangle_leg(600, "P")],
         })
-        assert notional == pytest.approx(65_000_000.0)
+        assert notional == pytest.approx(64_990_000.0)
 
     def test_defined_risk_debit_spread_within_budget_still_places(self):
         """Control: 10 lots of a 5-wide vertical is $5,000 of risk."""
@@ -258,8 +259,9 @@ class TestComboNotionalIsRiskNotPremium:
                 {"expiry": "20260918", "strike": 6880, "right": "P", "action": "BUY", "ratio": 1},
             ],
         }
-        # 10-wide call wing + 20-wide put wing = $3,000 per unit.
-        assert order_limits.order_notional(params) == pytest.approx(3_000.0)
+        # 10-wide call wing + 20-wide put wing = $3,000 per unit, less the
+        # $400 credit the condor collects.
+        assert order_limits.order_notional(params) == pytest.approx(2_600.0)
 
     def test_ratio_spread_leaves_the_uncovered_short_uncovered(self):
         """Buy 1 / sell 2: one short is paired against the long, the other is
@@ -272,8 +274,66 @@ class TestComboNotionalIsRiskNotPremium:
                 {"expiry": "20260918", "strike": 7050, "right": "C", "action": "SELL", "ratio": 2},
             ],
         }
-        # 50-wide covered pair + one naked 7050 short = (50 + 7050) × 100.
-        assert order_limits.order_notional(params) == pytest.approx(710_000.0)
+        # 50-wide covered pair + one naked 7050 short = (50 + 7050) × 100,
+        # less the $100 credit collected.
+        assert order_limits.order_notional(params) == pytest.approx(709_900.0)
+
+    def test_gld_spread_close_nets_the_credit_against_the_width(self):
+        """Production repro 2026-08-19: SELL 100x GLD 420/450 bull call spread
+        @ $15 credit (a close of a held position). Gross width is $300k, but
+        the order COLLECTS $150k — worst-case exposure is width − credit =
+        $150k, under the $250k cap. Measuring gross width refused a
+        legitimate close."""
+        params = {
+            "type": "combo", "symbol": "GLD", "action": "SELL",
+            "quantity": 100, "limitPrice": 15.0,
+            "legs": [
+                {"expiry": "20260828", "strike": 420, "right": "C", "action": "BUY", "ratio": 1},
+                {"expiry": "20260828", "strike": 450, "right": "C", "action": "SELL", "ratio": 1},
+            ],
+        }
+        assert order_limits.order_notional(params) == pytest.approx(150_000.0)
+        assert order_limits.check_order_limits(params) is None
+
+    def test_chain_builder_credit_spread_nets_the_signed_credit(self):
+        """Chain-builder convention: BUY envelope, negative limitPrice = net
+        credit (commit 1db9f558). Same structure as the SELL-envelope close
+        must measure the same."""
+        params = {
+            "type": "combo", "symbol": "GLD", "action": "BUY",
+            "quantity": 100, "limitPrice": -15.0,
+            "legs": [
+                {"expiry": "20260828", "strike": 420, "right": "C", "action": "SELL", "ratio": 1},
+                {"expiry": "20260828", "strike": 450, "right": "C", "action": "BUY", "ratio": 1},
+            ],
+        }
+        assert order_limits.order_notional(params) == pytest.approx(150_000.0)
+        assert order_limits.check_order_limits(params) is None
+
+    def test_absurd_credit_cannot_zero_out_the_risk_measure(self):
+        """Fat-fingered credit large enough to swallow the strike risk must
+        not slip the cap: the premium term counts the same dollars, so
+        max(premium, risk − credit) never drops below half the strike risk."""
+        violation = order_limits.check_order_limits({
+            "type": "combo", "symbol": "SPY", "action": "SELL",
+            "quantity": 500, "limitPrice": -1500.0,
+            "legs": [_strangle_leg(700, "C"), _strangle_leg(600, "P")],
+        })
+        assert violation is not None
+        assert violation["code"] == "ORDER_NOTIONAL_LIMIT"
+
+    def test_debit_combos_do_not_net(self):
+        """A debit pays premium on top of carrying the structure — netting
+        applies only when the order collects premium."""
+        notional = order_limits.order_notional({
+            "type": "combo", "symbol": "SPX", "action": "BUY",
+            "quantity": 100, "limitPrice": 2.0,
+            "legs": [
+                {"expiry": "20260918", "strike": 7000, "right": "C", "action": "BUY", "ratio": 1},
+                {"expiry": "20260918", "strike": 7050, "right": "C", "action": "SELL", "ratio": 1},
+            ],
+        })
+        assert notional == pytest.approx(500_000.0)
 
     def test_unpriceable_legs_fall_back_to_premium(self):
         """Missing strikes must not silently produce a zero risk number."""

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -12853,10 +12853,58 @@ body[data-mobile="true"] .vol-cone-analysis .vol-cone-analysis-metrics {
   gap: 12px;
 }
 
+/* Shell owns layout position + the edge-fade overflow affordance; the inner
+   tablist owns scrolling. Fades appear only when the strip actually overflows
+   (data attrs set from scroll state) — a strip ending flush at the viewport
+   edge otherwise reads as complete and hides the off-screen modes. */
+.scanner-mode-tabs-shell {
+  position: relative;
+  align-self: flex-start;
+  max-width: 100%;
+}
+
+.scanner-mode-tabs-shell::before,
+.scanner-mode-tabs-shell::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 1px;
+  width: 28px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 120ms ease;
+  z-index: 1;
+}
+
+.scanner-mode-tabs-shell::before {
+  left: 0;
+  background: linear-gradient(
+    to right,
+    var(--bg-base),
+    color-mix(in srgb, var(--bg-base) 0%, transparent)
+  );
+}
+
+.scanner-mode-tabs-shell::after {
+  right: 0;
+  background: linear-gradient(
+    to left,
+    var(--bg-base),
+    color-mix(in srgb, var(--bg-base) 0%, transparent)
+  );
+}
+
+.scanner-mode-tabs-shell[data-overflow-left="true"]::before {
+  opacity: 1;
+}
+
+.scanner-mode-tabs-shell[data-overflow-right="true"]::after {
+  opacity: 1;
+}
+
 .scanner-mode-tabs {
   display: flex;
   align-items: center;
-  align-self: flex-start;
   gap: 6px;
   padding: 0;
   border-bottom: 1px solid var(--line-grid);
@@ -19030,18 +19078,28 @@ body[data-mobile="true"] .scanner-page-shell {
   gap: 8px;
 }
 
-/* Six tabs never fit a phone's width, so they scroll horizontally rather than
-   squeezing to fit — squeezing wrapped the multi-word labels ("THETA
+/* Seven tabs never fit a phone's width, so they scroll horizontally rather
+   than squeezing to fit — squeezing wrapped the multi-word labels ("THETA
    HARVESTER", "7-STEP STRENGTH") onto two lines and overlapped them. Natural
    width + single line + scroll keeps every label and count chip intact; the
-   partial tab at the trailing edge signals there is more to scroll. */
-body[data-mobile="true"] .scanner-mode-tabs {
+   shell's edge fades (scroll-state driven) signal there is more to scroll —
+   a partial trailing tab alone proved unreliable (the strip can end flush at
+   the viewport edge and read as three-tabs-total). overscroll containment
+   keeps an edge swipe from turning into browser back-navigation. */
+body[data-mobile="true"] .scanner-mode-tabs-shell {
   width: calc(100% - 32px);
   margin: 8px 16px 0;
+  align-self: auto;
+}
+
+body[data-mobile="true"] .scanner-mode-tabs {
+  width: 100%;
   flex-wrap: nowrap;
   overflow-x: auto;
+  overscroll-behavior-x: contain;
   -webkit-overflow-scrolling: touch;
   scroll-snap-type: x proximity;
+  scroll-padding-inline: 12px;
   scrollbar-width: none;
 }
 

--- a/web/components/ScannerModeTabs.tsx
+++ b/web/components/ScannerModeTabs.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { computeScrollAffordance, type ScrollAffordance } from "@/lib/scrollAffordance";
 
 export type ScannerMode = "flow" | "discover" | "theta" | "strength" | "leap" | "garch" | "vol-cone";
 
@@ -26,13 +27,47 @@ const TABS: { mode: ScannerMode; label: string }[] = [
   { mode: "vol-cone", label: "VOL CONE" },
 ];
 
+const ROVING_KEYS = ["ArrowLeft", "ArrowRight", "Home", "End"];
+
 /**
  * The scanner mode tab strip. Each tab carries a small count chip when
  * its scan has a known result count, so signal presence reads across modes
  * without clicking through them.
+ *
+ * On phones the strip scrolls horizontally; the shell's data-overflow-left /
+ * data-overflow-right attributes drive edge fades so off-screen modes are
+ * visible as such — the strip used to end flush at the viewport edge and
+ * read as three-tabs-total. Arrow keys rove focus (WAI-ARIA tabs, manual
+ * activation: Enter/Space selects, so arrowing across seven modes does not
+ * fire seven scans).
  */
 export function ScannerModeTabs({ mode, onModeChange, counts }: ScannerModeTabsProps) {
   const activeRef = useRef<HTMLButtonElement | null>(null);
+  const stripRef = useRef<HTMLDivElement | null>(null);
+  const [overflow, setOverflow] = useState<ScrollAffordance>({ left: false, right: false });
+
+  const syncOverflow = useCallback(() => {
+    const strip = stripRef.current;
+    if (!strip) return;
+    setOverflow((prev) => {
+      const next = computeScrollAffordance(strip.scrollLeft, strip.scrollWidth, strip.clientWidth);
+      return prev.left === next.left && prev.right === next.right ? prev : next;
+    });
+  }, []);
+
+  useEffect(() => {
+    const strip = stripRef.current;
+    if (!strip) return;
+    syncOverflow();
+    strip.addEventListener("scroll", syncOverflow, { passive: true });
+    const resizeObserver =
+      typeof ResizeObserver !== "undefined" ? new ResizeObserver(syncOverflow) : null;
+    resizeObserver?.observe(strip);
+    return () => {
+      strip.removeEventListener("scroll", syncOverflow);
+      resizeObserver?.disconnect();
+    };
+  }, [syncOverflow]);
 
   // When the strip scrolls horizontally (phone), keep the selected tab in view
   // so arriving on e.g. ?mode=garch does not leave the active tab off-screen.
@@ -41,35 +76,69 @@ export function ScannerModeTabs({ mode, onModeChange, counts }: ScannerModeTabsP
     activeRef.current?.scrollIntoView?.({ inline: "center", block: "nearest" });
   }, [mode]);
 
+  const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!ROVING_KEYS.includes(event.key)) return;
+    const tabs = Array.from(
+      event.currentTarget.querySelectorAll<HTMLButtonElement>('[role="tab"]'),
+    );
+    if (tabs.length === 0) return;
+    event.preventDefault();
+    const focused = tabs.indexOf(document.activeElement as HTMLButtonElement);
+    const from = focused >= 0 ? focused : tabs.findIndex((tab) => tab.tabIndex === 0);
+    const target =
+      event.key === "Home"
+        ? 0
+        : event.key === "End"
+          ? tabs.length - 1
+          : event.key === "ArrowRight"
+            ? (from + 1) % tabs.length
+            : (from - 1 + tabs.length) % tabs.length;
+    tabs[target].focus();
+    tabs[target].scrollIntoView?.({ inline: "nearest", block: "nearest" });
+  }, []);
+
   return (
-    <div className="scanner-mode-tabs" role="tablist" aria-label="Scanner mode">
-      {TABS.map((tab) => {
-        const count = counts[tab.mode];
-        const isActive = mode === tab.mode;
-        return (
-          <button
-            key={tab.mode}
-            ref={isActive ? activeRef : undefined}
-            type="button"
-            role="tab"
-            aria-selected={isActive}
-            className={`scanner-mode-tab${isActive ? " scanner-mode-tab--active" : ""}`}
-            onClick={() => onModeChange(tab.mode)}
-          >
-            {tab.label}
-            {count != null && (
-              <span
-                className="scanner-mode-tab__count"
-                aria-hidden="true"
-                data-hot={count > 0 ? "true" : "false"}
-                data-testid={`scanner-tab-count-${tab.mode}`}
-              >
-                {count}
-              </span>
-            )}
-          </button>
-        );
-      })}
+    <div
+      className="scanner-mode-tabs-shell"
+      data-overflow-left={overflow.left ? "true" : "false"}
+      data-overflow-right={overflow.right ? "true" : "false"}
+    >
+      <div
+        className="scanner-mode-tabs"
+        role="tablist"
+        aria-label="Scanner mode"
+        ref={stripRef}
+        onKeyDown={handleKeyDown}
+      >
+        {TABS.map((tab) => {
+          const count = counts[tab.mode];
+          const isActive = mode === tab.mode;
+          return (
+            <button
+              key={tab.mode}
+              ref={isActive ? activeRef : undefined}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              tabIndex={isActive ? 0 : -1}
+              className={`scanner-mode-tab${isActive ? " scanner-mode-tab--active" : ""}`}
+              onClick={() => onModeChange(tab.mode)}
+            >
+              {tab.label}
+              {count != null && (
+                <span
+                  className="scanner-mode-tab__count"
+                  aria-hidden="true"
+                  data-hot={count > 0 ? "true" : "false"}
+                  data-testid={`scanner-tab-count-${tab.mode}`}
+                >
+                  {count}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/web/components/WorkspaceShell.tsx
+++ b/web/components/WorkspaceShell.tsx
@@ -11,6 +11,7 @@ import { usePortfolio } from "@/lib/usePortfolio";
 import { useOrders } from "@/lib/useOrders";
 import { useMarketHours, MarketState } from "@/lib/useMarketHours";
 import { useAutoSyncOnStale } from "@/lib/useAutoSyncOnStale";
+import { useSnapshotStaleness } from "@/lib/useSnapshotStaleness";
 import { useToast } from "@/lib/useToast";
 import { useOrderActions } from "@/lib/OrderActionsContext";
 import { usePrices } from "@/lib/usePrices";
@@ -472,21 +473,13 @@ export default function WorkspaceShell({ section, tickerParam }: WorkspaceShellP
       ? "Sync failed. Reconstruction incomplete."
       : "Awaiting first sample";
 
-  const isStale = useMemo(() => {
-    if (!lastSync) return false;
-    if (marketState !== MarketState.OPEN) return false;
-    const ageMs = Date.now() - new Date(lastSync).getTime();
-    return ageMs > 60_000;
-  }, [lastSync, marketState]);
-  const staleAgeMinutes = useMemo(() => {
-    if (!lastSync) return null;
-    const ageMs = Date.now() - new Date(lastSync).getTime();
-    return Math.max(1, Math.floor(ageMs / 60_000));
-  }, [lastSync]);
+  // Staleness is session-independent (after-hours/overnight fills exist)
+  // and re-evaluated on its own clock, so an idle page cannot rot silently.
+  const { isStale, staleAgeMinutes, tick: stalenessTick } = useSnapshotStaleness(lastSync);
 
   // A render that surfaces a stale snapshot triggers the producer sync
   // itself — the stale pill's Sync button remains the manual fallback.
-  useAutoSyncOnStale(isStale, syncNow, syncTarget, !isDemoMode);
+  useAutoSyncOnStale(isStale, syncNow, syncTarget, !isDemoMode, stalenessTick);
 
   // Sections that render live marks from the prices map. Scanner/discover (and
   // other non-price modules) must not receive a new `prices` identity on every

--- a/web/components/WorkspaceShell.tsx
+++ b/web/components/WorkspaceShell.tsx
@@ -10,6 +10,7 @@ import { resolveSectionFromPath } from "@/lib/chat";
 import { usePortfolio } from "@/lib/usePortfolio";
 import { useOrders } from "@/lib/useOrders";
 import { useMarketHours, MarketState } from "@/lib/useMarketHours";
+import { useAutoSyncOnStale } from "@/lib/useAutoSyncOnStale";
 import { useToast } from "@/lib/useToast";
 import { useOrderActions } from "@/lib/OrderActionsContext";
 import { usePrices } from "@/lib/usePrices";
@@ -482,6 +483,10 @@ export default function WorkspaceShell({ section, tickerParam }: WorkspaceShellP
     const ageMs = Date.now() - new Date(lastSync).getTime();
     return Math.max(1, Math.floor(ageMs / 60_000));
   }, [lastSync]);
+
+  // A render that surfaces a stale snapshot triggers the producer sync
+  // itself — the stale pill's Sync button remains the manual fallback.
+  useAutoSyncOnStale(isStale, syncNow, syncTarget, !isDemoMode);
 
   // Sections that render live marks from the prices map. Scanner/discover (and
   // other non-price modules) must not receive a new `prices` identity on every

--- a/web/lib/scrollAffordance.ts
+++ b/web/lib/scrollAffordance.ts
@@ -1,0 +1,23 @@
+export type ScrollAffordance = { left: boolean; right: boolean };
+
+/** Sub-pixel scroll residue that still counts as "at the edge". */
+const EDGE_EPSILON_PX = 2;
+
+/**
+ * Which edges of a horizontal scroller have off-screen content. Drives the
+ * edge-fade affordance so overflow is visible without a scrollbar — a strip
+ * whose last visible item ends flush at the viewport edge otherwise reads
+ * as complete.
+ */
+export function computeScrollAffordance(
+  scrollLeft: number,
+  scrollWidth: number,
+  clientWidth: number,
+): ScrollAffordance {
+  const maxScroll = scrollWidth - clientWidth;
+  if (maxScroll <= EDGE_EPSILON_PX) return { left: false, right: false };
+  return {
+    left: scrollLeft > EDGE_EPSILON_PX,
+    right: scrollLeft < maxScroll - EDGE_EPSILON_PX,
+  };
+}

--- a/web/lib/useAutoSyncOnStale.ts
+++ b/web/lib/useAutoSyncOnStale.ts
@@ -13,13 +13,16 @@ const AUTO_SYNC_COOLDOWN_MS = 60_000;
  *
  * Cooldown is per sync target so rapid route flips cannot hammer the
  * rate-limited refresh routes, and a failing producer is retried at most
- * once per window.
+ * once per window. `tick` (from useSnapshotStaleness) re-arms the effect
+ * while the snapshot stays stale, so a failing sync keeps retrying on the
+ * staleness cadence instead of firing once and going quiet.
  */
 export function useAutoSyncOnStale(
   stale: boolean,
   syncNow: () => void,
   target: string,
   enabled: boolean,
+  tick = 0,
 ): void {
   const lastFiredAtByTargetRef = useRef<Map<string, number>>(new Map());
 
@@ -30,5 +33,5 @@ export function useAutoSyncOnStale(
     if (now - lastFiredAt < AUTO_SYNC_COOLDOWN_MS) return;
     lastFiredAtByTargetRef.current.set(target, now);
     syncNow();
-  }, [stale, enabled, target, syncNow]);
+  }, [stale, enabled, target, syncNow, tick]);
 }

--- a/web/lib/useAutoSyncOnStale.ts
+++ b/web/lib/useAutoSyncOnStale.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+const AUTO_SYNC_COOLDOWN_MS = 60_000;
+
+/**
+ * Fires the page's producer sync when a render surfaces a stale snapshot,
+ * so freshness never waits on the operator pressing SYNC. The backend
+ * orders/portfolio loops run on a 5-minute cadence; landing on a page
+ * between ticks used to serve a snapshot up to that old with nothing
+ * refreshing it (the client-side auto-POST was removed in 43a02eff).
+ *
+ * Cooldown is per sync target so rapid route flips cannot hammer the
+ * rate-limited refresh routes, and a failing producer is retried at most
+ * once per window.
+ */
+export function useAutoSyncOnStale(
+  stale: boolean,
+  syncNow: () => void,
+  target: string,
+  enabled: boolean,
+): void {
+  const lastFiredAtByTargetRef = useRef<Map<string, number>>(new Map());
+
+  useEffect(() => {
+    if (!stale || !enabled) return;
+    const now = Date.now();
+    const lastFiredAt = lastFiredAtByTargetRef.current.get(target) ?? 0;
+    if (now - lastFiredAt < AUTO_SYNC_COOLDOWN_MS) return;
+    lastFiredAtByTargetRef.current.set(target, now);
+    syncNow();
+  }, [stale, enabled, target, syncNow]);
+}

--- a/web/lib/useSnapshotStaleness.ts
+++ b/web/lib/useSnapshotStaleness.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+export const SNAPSHOT_STALE_THRESHOLD_MS = 60_000;
+const STALENESS_TICK_MS = 30_000;
+
+export type SnapshotStaleness = {
+  isStale: boolean;
+  staleAgeMinutes: number | null;
+  /** Advances on every re-evaluation. Pass into stale-driven effects
+   *  (useAutoSyncOnStale) so retries share this cadence instead of dying
+   *  after the first attempt when the stale boolean never transitions. */
+  tick: number;
+};
+
+/**
+ * Session-independent snapshot staleness. After-hours, overnight and
+ * weekend fills exist, so freshness is never gated on market state —
+ * a snapshot older than the threshold is stale whenever it renders.
+ *
+ * Re-evaluates on an internal clock: without the tick, staleness was
+ * only recomputed when lastSync changed, so a page left open went
+ * silently stale once the backend producer's cadence lapsed.
+ */
+export function useSnapshotStaleness(lastSync: string | null): SnapshotStaleness {
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), STALENESS_TICK_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  return useMemo(() => {
+    if (!lastSync) return { isStale: false, staleAgeMinutes: null, tick };
+    const syncedAt = new Date(lastSync).getTime();
+    if (Number.isNaN(syncedAt)) return { isStale: false, staleAgeMinutes: null, tick };
+    const ageMs = Date.now() - syncedAt;
+    return {
+      isStale: ageMs > SNAPSHOT_STALE_THRESHOLD_MS,
+      staleAgeMinutes: Math.max(1, Math.floor(ageMs / 60_000)),
+      tick,
+    };
+  }, [lastSync, tick]);
+}

--- a/web/tests/scanner-mode-tabs.test.tsx
+++ b/web/tests/scanner-mode-tabs.test.tsx
@@ -52,6 +52,81 @@ describe("ScannerModeTabs", () => {
   });
 });
 
+describe("ScannerModeTabs mobile navigation", () => {
+  function stripAndShell() {
+    const strip = screen.getByRole("tablist");
+    const shell = strip.parentElement as HTMLElement;
+    return { strip, shell };
+  }
+
+  it("exposes overflow affordance state on the shell as data attributes", () => {
+    render(<ScannerModeTabs mode="flow" onModeChange={() => {}} counts={{}} />);
+    const { strip, shell } = stripAndShell();
+    expect(shell.className).toContain("scanner-mode-tabs-shell");
+
+    Object.defineProperty(strip, "scrollWidth", { configurable: true, value: 900 });
+    Object.defineProperty(strip, "clientWidth", { configurable: true, value: 393 });
+    strip.scrollLeft = 0;
+    fireEvent.scroll(strip);
+    expect(shell.getAttribute("data-overflow-left")).toBe("false");
+    expect(shell.getAttribute("data-overflow-right")).toBe("true");
+
+    strip.scrollLeft = 200;
+    fireEvent.scroll(strip);
+    expect(shell.getAttribute("data-overflow-left")).toBe("true");
+    expect(shell.getAttribute("data-overflow-right")).toBe("true");
+
+    strip.scrollLeft = 507;
+    fireEvent.scroll(strip);
+    expect(shell.getAttribute("data-overflow-left")).toBe("true");
+    expect(shell.getAttribute("data-overflow-right")).toBe("false");
+  });
+
+  it("uses a roving tabindex: only the selected tab is in the tab order", () => {
+    render(<ScannerModeTabs mode="theta" onModeChange={() => {}} counts={{}} />);
+    for (const tab of screen.getAllByRole("tab")) {
+      const selected = tab.getAttribute("aria-selected") === "true";
+      expect(tab.tabIndex).toBe(selected ? 0 : -1);
+    }
+  });
+
+  it("moves focus with arrow keys, wrapping at both ends", () => {
+    render(<ScannerModeTabs mode="flow" onModeChange={() => {}} counts={{}} />);
+    const tabs = screen.getAllByRole("tab");
+    tabs[0].focus();
+
+    fireEvent.keyDown(screen.getByRole("tablist"), { key: "ArrowRight" });
+    expect(document.activeElement).toBe(tabs[1]);
+
+    fireEvent.keyDown(screen.getByRole("tablist"), { key: "ArrowLeft" });
+    fireEvent.keyDown(screen.getByRole("tablist"), { key: "ArrowLeft" });
+    expect(document.activeElement).toBe(tabs[tabs.length - 1]);
+
+    fireEvent.keyDown(screen.getByRole("tablist"), { key: "ArrowRight" });
+    expect(document.activeElement).toBe(tabs[0]);
+  });
+
+  it("Home and End jump to the first and last tab", () => {
+    render(<ScannerModeTabs mode="flow" onModeChange={() => {}} counts={{}} />);
+    const tabs = screen.getAllByRole("tab");
+    tabs[0].focus();
+
+    fireEvent.keyDown(screen.getByRole("tablist"), { key: "End" });
+    expect(document.activeElement).toBe(tabs[tabs.length - 1]);
+
+    fireEvent.keyDown(screen.getByRole("tablist"), { key: "Home" });
+    expect(document.activeElement).toBe(tabs[0]);
+  });
+
+  it("arrow navigation does not fire onModeChange (manual activation)", () => {
+    const onModeChange = vi.fn();
+    render(<ScannerModeTabs mode="flow" onModeChange={onModeChange} counts={{}} />);
+    screen.getAllByRole("tab")[0].focus();
+    fireEvent.keyDown(screen.getByRole("tablist"), { key: "ArrowRight" });
+    expect(onModeChange).not.toHaveBeenCalled();
+  });
+});
+
 describe("SigMeter", () => {
   it("renders a clamped fill width with the tone class", () => {
     render(<SigMeter value={95} tone="pos" />);

--- a/web/tests/scroll-affordance.test.ts
+++ b/web/tests/scroll-affordance.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { computeScrollAffordance } from "../lib/scrollAffordance";
+
+describe("computeScrollAffordance", () => {
+  it("no overflow: neither side scrollable", () => {
+    expect(computeScrollAffordance(0, 300, 300)).toEqual({ left: false, right: false });
+  });
+
+  it("overflow at start: right only", () => {
+    expect(computeScrollAffordance(0, 900, 393)).toEqual({ left: false, right: true });
+  });
+
+  it("mid-scroll: both sides", () => {
+    expect(computeScrollAffordance(200, 900, 393)).toEqual({ left: true, right: true });
+  });
+
+  it("scrolled to end: left only", () => {
+    expect(computeScrollAffordance(507, 900, 393)).toEqual({ left: true, right: false });
+  });
+
+  it("sub-pixel residue at the end still reads as end", () => {
+    expect(computeScrollAffordance(506.4, 900, 393)).toEqual({ left: true, right: false });
+  });
+});

--- a/web/tests/use-auto-sync-on-stale.test.ts
+++ b/web/tests/use-auto-sync-on-stale.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useAutoSyncOnStale } from "../lib/useAutoSyncOnStale";
+
+describe("useAutoSyncOnStale", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-18T15:52:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fires syncNow once when the rendered snapshot is stale", () => {
+    const syncNow = vi.fn();
+    const { rerender } = renderHook(
+      ({ stale }) => useAutoSyncOnStale(stale, syncNow, "orders", true),
+      { initialProps: { stale: false } },
+    );
+    expect(syncNow).not.toHaveBeenCalled();
+
+    rerender({ stale: true });
+    expect(syncNow).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not refire while the snapshot stays stale across re-renders", () => {
+    const syncNow = vi.fn();
+    const { rerender } = renderHook(
+      ({ stale }) => useAutoSyncOnStale(stale, syncNow, "orders", true),
+      { initialProps: { stale: true } },
+    );
+    expect(syncNow).toHaveBeenCalledTimes(1);
+
+    rerender({ stale: true });
+    rerender({ stale: true });
+    expect(syncNow).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire when disabled (demo mode)", () => {
+    const syncNow = vi.fn();
+    renderHook(() => useAutoSyncOnStale(true, syncNow, "orders", false));
+    expect(syncNow).not.toHaveBeenCalled();
+  });
+
+  it("cooldown bounds repeat fires within 60s of the same target", () => {
+    const syncNow = vi.fn();
+    const { rerender } = renderHook(
+      ({ stale }) => useAutoSyncOnStale(stale, syncNow, "orders", true),
+      { initialProps: { stale: true } },
+    );
+    expect(syncNow).toHaveBeenCalledTimes(1);
+
+    rerender({ stale: false });
+    rerender({ stale: true });
+    expect(syncNow).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(61_000);
+    rerender({ stale: false });
+    rerender({ stale: true });
+    expect(syncNow).toHaveBeenCalledTimes(2);
+  });
+
+  it("tracks cooldown per target so a route change still syncs the new page", () => {
+    const portfolioSync = vi.fn();
+    const ordersSync = vi.fn();
+    const { rerender } = renderHook(
+      ({ stale, syncNow, target }: { stale: boolean; syncNow: () => void; target: string }) =>
+        useAutoSyncOnStale(stale, syncNow, target, true),
+      { initialProps: { stale: true, syncNow: portfolioSync, target: "portfolio" } },
+    );
+    expect(portfolioSync).toHaveBeenCalledTimes(1);
+
+    rerender({ stale: true, syncNow: ordersSync, target: "orders" });
+    expect(ordersSync).toHaveBeenCalledTimes(1);
+    expect(portfolioSync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/tests/use-auto-sync-on-stale.test.ts
+++ b/web/tests/use-auto-sync-on-stale.test.ts
@@ -62,6 +62,23 @@ describe("useAutoSyncOnStale", () => {
     expect(syncNow).toHaveBeenCalledTimes(2);
   });
 
+  it("retries on the staleness tick while the snapshot stays stale, cooldown-bounded", () => {
+    const syncNow = vi.fn();
+    const { rerender } = renderHook(
+      ({ tick }) => useAutoSyncOnStale(true, syncNow, "orders", true, tick),
+      { initialProps: { tick: 0 } },
+    );
+    expect(syncNow).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(30_000);
+    rerender({ tick: 1 });
+    expect(syncNow).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(31_000);
+    rerender({ tick: 2 });
+    expect(syncNow).toHaveBeenCalledTimes(2);
+  });
+
   it("tracks cooldown per target so a route change still syncs the new page", () => {
     const portfolioSync = vi.fn();
     const ordersSync = vi.fn();

--- a/web/tests/use-snapshot-staleness.test.ts
+++ b/web/tests/use-snapshot-staleness.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useSnapshotStaleness } from "../lib/useSnapshotStaleness";
+
+// Saturday 03:00 ET — deep outside any equities session. Staleness is
+// session-independent by design: after-hours and overnight fills exist,
+// so a snapshot is never allowed to rot just because RTH ended.
+const OVERNIGHT_NOW = new Date("2026-08-22T07:00:00Z");
+
+describe("useSnapshotStaleness", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(OVERNIGHT_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fresh snapshot is not stale", () => {
+    const lastSync = new Date(OVERNIGHT_NOW.getTime() - 10_000).toISOString();
+    const { result } = renderHook(() => useSnapshotStaleness(lastSync));
+    expect(result.current.isStale).toBe(false);
+  });
+
+  it("a >60s-old snapshot is stale even outside market hours", () => {
+    const lastSync = new Date(OVERNIGHT_NOW.getTime() - 3 * 60_000).toISOString();
+    const { result } = renderHook(() => useSnapshotStaleness(lastSync));
+    expect(result.current.isStale).toBe(true);
+    expect(result.current.staleAgeMinutes).toBe(3);
+  });
+
+  it("re-evaluates on its own clock — a snapshot goes stale while the page sits idle", () => {
+    const lastSync = new Date(OVERNIGHT_NOW.getTime() - 10_000).toISOString();
+    const { result } = renderHook(() => useSnapshotStaleness(lastSync));
+    expect(result.current.isStale).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(91_000);
+    });
+    expect(result.current.isStale).toBe(true);
+  });
+
+  it("null or unparseable lastSync is not stale", () => {
+    const { result: nullResult } = renderHook(() => useSnapshotStaleness(null));
+    expect(nullResult.current.isStale).toBe(false);
+    expect(nullResult.current.staleAgeMinutes).toBeNull();
+
+    const { result: badResult } = renderHook(() => useSnapshotStaleness("not-a-date"));
+    expect(badResult.current.isStale).toBe(false);
+  });
+
+  it("exposes a tick that advances with each re-evaluation", () => {
+    const { result } = renderHook(() => useSnapshotStaleness(null));
+    const initialTick = result.current.tick;
+    act(() => {
+      vi.advanceTimersByTime(61_000);
+    });
+    expect(result.current.tick).toBeGreaterThan(initialTick);
+  });
+});


### PR DESCRIPTION
Operator report: the scanner's mobile navigation needed an overhaul per mobile best practices.

## What was wrong

- The mode strip's only overflow cue was a partial trailing tab — and at 393px THETA HARVESTER ends flush at the viewport edge, so **four of seven modes were invisible with no cue they exist**.
- `role=tablist` with no keyboard pattern (no roving tabindex, no arrow keys).
- Edge swipes on the strip could leak into browser back-navigation.

## Changes

- **Edge-fade overflow affordance**: new `.scanner-mode-tabs-shell` exposes `data-overflow-left/right` from live scroll state (`computeScrollAffordance`, 2px epsilon, scroll listener + ResizeObserver) and paints token-based gradient fades only on sides with off-screen content.
- **WAI-ARIA tabs keyboard pattern**: roving tabindex (selected tab only in tab order), ArrowLeft/ArrowRight with wrap, Home/End, manual activation — arrowing across modes fires no scans.
- **`overscroll-behavior-x: contain`** + `scroll-padding-inline` on the strip.
- Touch targets were already ≥44px via the existing mobile design-system floor — untouched.

Desktop unaffected (no overflow → no fades; e2e selectors unchanged).

## Verification

- Red first: 6 new component/helper tests failed, now 17/17 in the two files.
- `tsc` clean; full web vitest 6878/6878 (one cwd-dependent suite passes from repo root, pre-existing).
- Live mobile-width verification on production after deploy (screenshot to follow in session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)