### PR TITLE
docs: register CREDIT timer so #63 can deploy

### DIFF
--- a/docs/cloud-services.md
+++ b/docs/cloud-services.md
@@ -503,6 +503,14 @@ Re-check with `turso plan show` after any plan change. Nightly dumps remain mand
 | `radon-db-backup.timer` | **09:00** | Full Turso dump after archive + retention. |
 | `radon-media-backup.timer` | **10:15** | Mirror `media.radon.run` tree (`/home/radon/radon-cloud/media`) → B2 prefix `media/`. Heartbeat: `media-backup`. `TimeoutStartSec=3600`. |
 
+### CREDIT spread (`radon-credit-spread.timer`)
+
+Daily `21:45 UTC` (`RandomizedDelaySec=300`), oneshot
+`scripts/fetch_credit_spread.py`. IB daily closes for HYG + SPX, then UW, then
+Yahoo. Heartbeat `credit-spread`. Units are listed in `setup-vps.sh`
+`SERVICE_FILES`; root install-copy is still owed (`not-installed` allowlist
+expires 2026-12-31). Spec: [`indicators/credit.md`](indicators/credit.md).
+
 ### TWR performance builder (`radon-perf-twr.timer`)
 
 `Tue..Sat 07:30 ET` (`RandomizedDelaySec=300`), oneshot

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -142,6 +142,7 @@ Hetzner host systemd is the production surface. Laptop dev uses launchd plists i
 | `radon-vol-cone.timer` | Mon-Fri 20:45 UTC | Completed-session cheap-wing cone (16:45 ET, after the close grace). Spec: [`indicators/vol-cone.md`](indicators/vol-cone.md) |
 | `radon-vol-cone-intraday.timer` | Mon-Fri 09-16 ET every 15 min | Live sample ranked against that stored cone, so the tab is tradeable during the session instead of a day stale. Holds without spending a UW request outside market hours or under a nearly-spent daily budget. |
 | `radon-vixcor.timer` | daily 02:35 UTC | VIX x COR3M 20-session correlation, 15 min behind `radon-cor`. Spec: [`indicators/vixcor.md`](indicators/vixcor.md) |
+| `radon-credit-spread.timer` | daily 21:45 UTC | HYG vs SPX credit-equity series. IB first, then UW, then Yahoo. Spec: [`indicators/credit.md`](indicators/credit.md). Units are in `setup-vps.sh`; root install-copy still owed. |
 | `radon-incident-watchdog.timer` | every 5 min | Writes `data/incidents/`. Cases: [`incident-runbook.md`](incident-runbook.md) |
 | `radon-grok-page-responder.timer` | 30s after last cycle | Headless Grok auto-fix from dedicated clone. Spec: [`grok-page-responder.md`](grok-page-responder.md) |
 

--- a/scripts/tests/test_docs_contract.py
+++ b/scripts/tests/test_docs_contract.py
@@ -180,6 +180,12 @@ class TestThinIndex:
         assert "SECURITY.md" in text
         assert "SUPPORT.md" in text
 
+    def test_owner_docs_list_credit_spread_timer(self):
+        operations = (_ROOT / "docs" / "operations.md").read_text(encoding="utf-8")
+        cloud = (_ROOT / "docs" / "cloud-services.md").read_text(encoding="utf-8")
+        assert "radon-credit-spread.timer" in operations
+        assert "radon-credit-spread.timer" in cloud
+
     def test_docs_index_exists_and_lists_owners(self):
         index = (_ROOT / "docs" / "README.md").read_text(encoding="utf-8")
         for required in (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- [x] Red/green TDD (failing test, then fix)
- [x] Staged only the files this change owns (no `git add -A`)
- [x] Owner doc updated, or the commit message has `docs-skip: <reason>`
- [x] Previous `main` deploy finished before this push

## What

#63 merged CREDIT to `main` but pytest failed the docs-contract (`radon-credit-spread.timer` with no owner-doc update). Deploy to VPS skipped. `app.radon.run/regime/credit` is 404.

This registers the timer in both owner docs and pins it.

## Evidence

- Red: `test_owner_docs_list_credit_spread_timer` missing the timer name
- Green: `test_docs_contract.py` 12 passed

## After merge

CI on `main` can deploy Next.js. `radon-credit-spread.{service,timer}` still need a root install-copy (`not-installed` allowlist expires 2026-12-31).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a021a4-d715-72bc-be42-134cb3a28446?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a021a4-d715-72bc-be42-134cb3a28446&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

