### PR TITLE
fix(signals-refresh): stop hourly oneshot P1 from curl aborting live scans

### DIFF
--- a/cloud/config/drift-allowlist.conf
+++ b/cloud/config/drift-allowlist.conf
@@ -68,3 +68,7 @@ not-installed:radon-llm-index.timer expires=2026-12-31 gated on Artificial Analy
 # unit reinstall (setup-vps.sh SERVICE_FILES already lists them).
 not-installed:radon-credit-spread.service expires=2026-12-31 new CREDIT indicator; root install-copy owed after merge
 not-installed:radon-credit-spread.timer expires=2026-12-31 new CREDIT indicator; root install-copy owed after merge
+
+# TimeoutStartSec 450 -> 1050 so sequential curl -m 490s POSTs can finish.
+# CI deploy does not install this unit; root install-copy still owed.
+unit-mismatch:radon-signals-refresh.service expires=2026-09-15 curl deadline now covers FastAPI 420/480s children; root install-copy owed

--- a/cloud/services/radon-signals-refresh.service
+++ b/cloud/services/radon-signals-refresh.service
@@ -16,13 +16,14 @@ Type=oneshot
 User=radon
 WorkingDirectory=/home/radon/radon
 EnvironmentFile=/home/radon/radon-cloud/.env
+Environment=RADON_SIGNALS_SCAN_TIMEOUT=490
 ExecStart=/usr/bin/bash /home/radon/radon/scripts/run_signals_refresh.sh
 StandardOutput=journal
 StandardError=journal
-# Two sequential scans, each bounded at 200s by the wrapper's curl deadline.
-# Releases the unit well before the next slot of radon-signals-refresh.timer
-# (the cadence SoT).
-TimeoutStartSec=450
+# Sequential POSTs: wrapper curl -m is 490s (FastAPI strength child 480s
+# + slack). Two scans plus the calendar probe fit in 1050s; the hourly
+# timer gap is 3600s. A 450s cap SIGTERMed a live first scan.
+TimeoutStartSec=1050
 
 [Install]
 WantedBy=multi-user.target

--- a/cloud/tests/test_systemd_services.py
+++ b/cloud/tests/test_systemd_services.py
@@ -355,9 +355,13 @@ class TestSignalsRefresh:
         assert svc["environmentfile"] == ENV_FILE_PATH
         assert svc["workingdirectory"] == "/home/radon/radon"
         assert "run_signals_refresh.sh" in svc["execstart"]
-        # Both scans run ~8s each; the budget must still release the unit
-        # well before the next slot.
-        assert int(svc["timeoutstartsec"]) <= 600
+        assert "RADON_SIGNALS_SCAN_TIMEOUT=490" in svc.get("environment", "")
+        # Sequential POSTs must outlive FastAPI's theta 420s + strength 480s
+        # children (curl -m 490 each). A 450s unit cap SIGTERMs a live
+        # first scan and pages; the hourly timer gap is 3600s.
+        budget = int(svc["timeoutstartsec"])
+        assert budget >= 980
+        assert budget <= 1800
 
     def test_timer_covers_et_trading_hours_only(self, unit, services_dir):
         timer = unit("radon-signals-refresh.timer")["Timer"]

--- a/docs/incident-runbook.md
+++ b/docs/incident-runbook.md
@@ -194,6 +194,46 @@ Incident: 2026-07-08, P1.
 
 ---
 
+## signals-refresh-curl-timeout-pages-p1
+
+**`radon-signals-refresh.service` oneshot pages P1 `Result=exit-code`
+(`NRestarts=0`) on the hourly ET timer.** Recurs every RTH hour while
+the unit stays failed.
+
+- **Mechanism:** `run_signals_refresh.sh` POSTs `/theta-harvester/scan`
+  then `/strength-confirmation/scan`. FastAPI `run_script` budgets are
+  420s / 480s. BUG-013 set curl `-m 200` and treated any non-connect
+  failure (curl 28, HTTP 502) as `return 1` with no fallback. Curl abort
+  disconnects the request; Starlette cancels it; `run_script` SIGKILLs
+  the scanner. The wrapper then starts the second scan. `Type=oneshot`
+  has no `Restart=`, so `NRestarts=0` and `ActiveState=failed` until
+  the next timer. Unit watchdog pages P1. Next hourly fire repeats.
+- **Detection:** journal `FastAPI outcome indeterminate (curl=28, http=000)`
+  then `Signals refresh finished with N failed scan(s)`;
+  `systemctl show radon-signals-refresh.service -p Result,NRestarts`
+  → `exit-code` / `0`. Edge and `:8321/health/lite` stay up.
+- **Discriminating check:** curl 28 with http 000 (this case). Instant
+  HTTP 502 with `Subprocess capacity exhausted` is
+  `signals-refresh-capacity-502` (retry, `6093c087`). HTTP 502 with a
+  scanner traceback is a real scan failure, still P1. `Result=signal`
+  is deploy stop-clean. 09:00 ET skip (`Market closed`) is exit 0.
+- **Remediation (code):** the 1050s unit exports `RADON_SIGNALS_SCAN_TIMEOUT=490`
+  (curl `-m` >= max FastAPI child). Wrapper default stays 200 so an
+  un-upgraded `TimeoutStartSec=450` host does not SIGTERM a live scan.
+  CI deploy does not install the unit — root install-copy:
+  `install -m 0644 cloud/services/radon-signals-refresh.service /etc/systemd/system/ && systemctl daemon-reload`.
+  Then `systemctl reset-failed radon-signals-refresh.service`.
+  Do not restart-flap; next timer after the install-copy.
+- **Regression:**
+  `test_run_signals_refresh_wrapper.py::test_wrapper_curl_deadline_covers_fastapi_scan_children`,
+  `test_systemd_services.py::TestSignalsRefresh::test_oneshot_with_timeout`.
+- **Code:** `scripts/run_signals_refresh.sh`
+  (`RADON_SIGNALS_SCAN_TIMEOUT`, default 200),
+  `cloud/services/radon-signals-refresh.service` (`TimeoutStartSec=1050`,
+  `Environment=RADON_SIGNALS_SCAN_TIMEOUT=490`).
+
+---
+
 ## leap-partial-ticker-exit-pages-p1
 
 **`radon-leap.service` oneshot pages P1 `Result=exit-code` after a successful

--- a/scripts/run_signals_refresh.sh
+++ b/scripts/run_signals_refresh.sh
@@ -105,10 +105,13 @@ fi
 PRESET="${RADON_SIGNALS_REFRESH_PRESET:-ndx100}"
 FASTAPI_HOST="${RADON_SIGNALS_REFRESH_FASTAPI_HOST:-127.0.0.1}"
 FASTAPI_PORT="${RADON_SIGNALS_REFRESH_FASTAPI_PORT:-8321}"
-# FastAPI caps the theta child at 420s and the strength child at 480s; a full
-# NDX100 pass measures ~8s. 200s covers a badly degraded UW without holding
-# the unit past its next slot.
-SCAN_TIMEOUT=200
+# FastAPI caps the theta child at 420s and the strength child at 480s.
+# Curl -m must outlive both: a shorter abort disconnects, Starlette
+# cancels the request, run_script kills the scanner, and the oneshot
+# pages P1 (Result=exit-code, NRestarts=0) on every hourly fire.
+# Default 200 stays under TimeoutStartSec=450 on hosts that have not
+# yet installed the 1050s unit (which exports RADON_SIGNALS_SCAN_TIMEOUT=490).
+SCAN_TIMEOUT="${RADON_SIGNALS_SCAN_TIMEOUT:-200}"
 # Retry transient FastAPI shedding a bounded number of times:
 #   502/503 — API up but subprocess slot-cap full (2026-08-21 14:00Z:
 #             both signals POSTs 502 while /health 200; capacity exhausted)

--- a/scripts/tests/test_run_signals_refresh_wrapper.py
+++ b/scripts/tests/test_run_signals_refresh_wrapper.py
@@ -22,6 +22,7 @@ Responsibilities:
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import socket
 import stat
@@ -368,3 +369,45 @@ def test_persistent_502_still_fails_without_direct_fallback(tmp_path: Path) -> N
     assert "fallback" not in combined
     assert "theta-direct" not in combined
     assert stub.hits.get(THETA_PATH, 0) >= 3, stub.hits
+
+
+def test_wrapper_curl_deadline_covers_fastapi_scan_children() -> None:
+    """BUG-013 left deadlines unaligned: curl -m 200 abort disconnects while
+    FastAPI's theta/strength children still run (420s / 480s). Starlette
+    cancels the request, run_script kills the scanner, the oneshot exits 1,
+    and the unit watchdog pages P1 (Result=exit-code, NRestarts=0) every
+    hourly fire.
+
+    The 490s budget is exported by the 1050s unit so an un-upgraded
+    TimeoutStartSec=450 host keeps the 200s default (2x200 < 450) instead
+    of SIGTERM-ing a live first scan.
+    """
+    scripts = Path(__file__).resolve().parents[1]
+    repo = scripts.parent
+    wrapper = (scripts / "run_signals_refresh.sh").read_text()
+    server = (scripts / "api" / "server.py").read_text()
+    unit = (repo / "cloud" / "services" / "radon-signals-refresh.service").read_text()
+    env_timeout = int(re.search(r"RADON_SIGNALS_SCAN_TIMEOUT=(\d+)", unit).group(1))
+    default_timeout = int(
+        re.search(r"RADON_SIGNALS_SCAN_TIMEOUT:-(\d+)", wrapper).group(1)
+    )
+    theta = int(
+        re.search(
+            r'run_script\("theta_harvester_scanner\.py", args, timeout=(\d+)',
+            server,
+        ).group(1)
+    )
+    strength = int(
+        re.search(
+            r'run_script\("strength_confirmation_scanner\.py", args, timeout=(\d+)',
+            server,
+        ).group(1)
+    )
+    assert env_timeout >= max(theta, strength), (
+        f"unit RADON_SIGNALS_SCAN_TIMEOUT={env_timeout} < FastAPI children "
+        f"{theta}/{strength}: curl abort cancels the accepted scan and pages"
+    )
+    assert default_timeout <= 200, (
+        f"wrapper default {default_timeout} exceeds the live 450s unit cap"
+    )
+    assert int(re.search(r"^TimeoutStartSec=(\d+)", unit, re.M).group(1)) >= 2 * env_timeout

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,12 @@
 # Lessons
 
+## 2026-08-21 — Wrapper curl -m must outlive the FastAPI scan child
+
+- `radon-signals-refresh` paged P1 `Result=exit-code, NRestarts=0` every RTH hour. Curl `-m 200` aborted while FastAPI's theta/strength children still had 420s/480s. Client disconnect cancelled the request and `run_script` killed the scanner; the oneshot exited 1. NRestarts=0 is normal for `Type=oneshot`.
+- BUG-013 correctly stopped the duplicate fallback on timeout. It did not align deadlines. A shorter curl budget is not a bound — it is a self-kill.
+- Curl `-m` >= FastAPI `run_script` timeout. `TimeoutStartSec` >= the sequential POSTs. Discriminating log: `curl=28, http=000`.
+- 502/503 slot-cap is a different class (`6093c087`): retry, do not treat as a curl-28 timeout.
+
 ## 2026-08-21 — MenthorQ dashboard remint is the OIDC Authorize click
 
 - `client_id=aws_cognito_client_id` on `wp-login.php` is the OpenID consent page, not proof remint is impossible. The form is `input[name=authorize]`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- [x] Red/green TDD (failing test, then fix)
- [x] Staged only the files this change owns (no `git add -A`)
- [x] Owner doc updated (`docs/incident-runbook.md` case `signals-refresh-curl-timeout-pages-p1`)
- [x] Rebased onto `main` (`624dfbd1`). Keeps grok's 502/503 slot-cap retry (`6093c087`).

## Why this pages every hour

`radon-signals-refresh.service` is `Type=oneshot`. A non-zero wrapper exit leaves `ActiveState=failed`, `Result=exit-code`, `NRestarts=0`. The unit watchdog pages that as P1. The unit stays failed until the next timer, so the next RTH hour repeats.

Two production classes, same page text:

1. Curl `-m 200` vs FastAPI children 420s/480s. Abort disconnects; Starlette cancels; `run_script` kills the scanner. Log: `curl=28, http=000`.
2. Instant HTTP 502 `Subprocess capacity exhausted` at top of hour. Already on `main` (`6093c087`).

This PR fixes (1). It keeps (2).

## Fix

- Unit exports `RADON_SIGNALS_SCAN_TIMEOUT=490` and `TimeoutStartSec=1050`.
- Wrapper default stays 200 so an un-upgraded `TimeoutStartSec=450` host does not SIGTERM a live first scan.
- 502/503 retry from `6093c087` is unchanged.
- Drift allowlist `unit-mismatch:radon-signals-refresh.service` until the root install-copy.

## Tests

- wrapper file 10 passed (includes grok 502/503 retry cases)
- cloud signals + install-ack + allowlist expiry 5 passed

## After merge (required)

CI deploy updates the wrapper. It does **not** install the unit. Until the install-copy, curl stays `-m 200`.

```
install -m 0644 cloud/services/radon-signals-refresh.service /etc/systemd/system/
systemctl daemon-reload
systemctl reset-failed radon-signals-refresh.service
```

Then drop the allowlist entry and bump `cloud/config/installed-units.sha256`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a024cd-ac4a-7743-8296-c9d67f6a038e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a024cd-ac4a-7743-8296-c9d67f6a038e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

