### PR TITLE
feat(newsfeed): Live Article redesign for Feed / 01

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -4518,11 +4518,30 @@ body[data-mobile="true"] .dashboard-news .news-feed-refresh--rail {
   flex-direction: column;
 }
 
+/* Live Article layout (Claude Design "Live Article Redesign", 2026-08-22):
+   editorial headline, mono meta row, chips, body copy, full-bleed chart figure
+   with a caption rail, then the source / stamp / bookmark footer. */
+.news-feed-live-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 20px;
+  padding: 0 8px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--signal-core-text);
+  background: color-mix(in srgb, var(--signal-core) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--signal-core) 40%, transparent);
+  border-radius: 4px;
+}
+
 .news-feed-item {
   display: flex;
   flex-direction: column;
-  gap: 14px;
-  padding: 24px;
+  gap: 0;
+  padding: 32px 40px 8px;
   border-bottom: 1px solid var(--border-dim);
 }
 
@@ -4541,22 +4560,80 @@ body[data-mobile="true"] .dashboard-news .news-feed-refresh--rail {
 
 .news-feed-headline {
   margin: 0;
-  font-size: 18px;
-  font-weight: 700;
-  letter-spacing: 0.01em;
-  line-height: 1.3;
+  max-inline-size: 680px;
+  font-size: 30px;
+  font-weight: 650;
+  letter-spacing: -0.015em;
+  line-height: 1.2;
   color: var(--text-primary);
   text-wrap: balance;
 }
 
-.news-feed-summary {
-  margin: 0;
-  max-inline-size: 70ch;
-  font-size: var(--text-prose);
-  line-height: 1.6;
+.news-feed-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px 18px;
+  margin-top: 12px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.news-feed-meta__source {
   color: var(--text-secondary);
+}
+
+.news-feed-item .news-feed-tags {
+  margin-top: 16px;
+}
+
+.news-feed-summary {
+  margin: 26px 0 0;
+  max-inline-size: 680px;
+  font-size: var(--text-prose);
+  line-height: 1.7;
+  color: var(--text-primary);
   white-space: pre-wrap;
   text-wrap: pretty;
+}
+
+.news-feed-figure {
+  margin: 36px -40px 0;
+  border-top: 1px solid var(--line-grid);
+  border-bottom: 1px solid var(--line-grid);
+}
+
+.news-feed-figure .news-feed-image-wrapper {
+  border: 0;
+  border-radius: 0;
+  background: var(--bg-base);
+}
+
+.news-feed-figcaption {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 8px 40px;
+  border-top: 1px solid var(--line-grid);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.news-feed-figcaption span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.news-feed-figcaption span:last-child {
+  flex: none;
 }
 
 .news-feed-image-wrapper {
@@ -5015,17 +5092,18 @@ body[data-mobile="true"] .dashboard-news .news-feed-refresh--rail {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  margin-top: 4px;
+  gap: 16px;
+  margin-top: 0;
+  padding: 14px 0 6px;
 }
 
 .news-feed-link-pill {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 10px;
-  border: 1px solid var(--border-dim);
-  border-radius: 4px;
+  padding: 4px 12px;
+  border: 1px solid var(--line-grid);
+  border-radius: 999px;
   background: transparent;
   color: var(--text-secondary);
   font-family: var(--font-mono);
@@ -5038,14 +5116,15 @@ body[data-mobile="true"] .dashboard-news .news-feed-refresh--rail {
 
 .news-feed-link-pill:hover {
   color: var(--signal-core-text);
-  border-color: var(--signal-core-text);
-  background: var(--bg-hover);
+  border-color: var(--line-grid);
+  background: var(--bg-panel-raised);
 }
 
 .news-feed-timestamp {
+  margin-left: auto;
   font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.06em;
+  font-size: 11px;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--text-muted);
 }
@@ -5192,16 +5271,16 @@ body[data-mobile="true"] .dashboard-news .news-feed-refresh--rail {
 .news-feed-tags {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: 8px;
   margin-top: 4px;
 }
 
 .news-feed-tag-chip {
   display: inline-flex;
   align-items: center;
-  padding: 3px 8px;
-  border: 1px solid var(--border-dim);
-  border-radius: 4px;
+  padding: 3px 10px;
+  border: 1px solid var(--line-grid);
+  border-radius: 999px;
   background: transparent;
   color: var(--text-secondary);
   font-family: var(--font-mono);
@@ -5220,8 +5299,8 @@ body[data-mobile="true"] .dashboard-news .news-feed-refresh--rail {
 
 .news-feed-tag-chip.is-active {
   color: var(--signal-core-text);
-  border-color: var(--signal-core-text);
-  background: var(--bg-hover);
+  border-color: var(--line-grid);
+  background: color-mix(in srgb, var(--signal-core) 10%, transparent);
 }
 
 .news-feed-empty-filtered {

--- a/web/components/DashboardNewsFeed.module.css
+++ b/web/components/DashboardNewsFeed.module.css
@@ -70,34 +70,56 @@
   scroll-margin-bottom: calc(var(--mobile-tab-bar-height) + var(--safe-bottom) + var(--nf-s3));
 }
 
+/* The design's mobile frame drops the LIVE badge: Refresh alone fits the row. */
+:global(body[data-mobile="true"]) .liveBadge.liveBadge {
+  display: none;
+}
+
 :global(body[data-mobile="true"]) .headline.headline {
-  font-size: 16px;
+  font-size: 23px;
   line-height: 1.25;
 }
 
+:global(body[data-mobile="true"]) .meta.meta {
+  gap: var(--nf-s1) 14px;
+  margin-top: var(--nf-s1);
+  font-size: 10.5px;
+}
+
+:global(body[data-mobile="true"]) .figure.figure {
+  margin: var(--nf-s2) 0 0;
+}
+
+:global(body[data-mobile="true"]) .figcaption.figcaption {
+  flex-direction: column;
+  gap: 2px;
+  padding: var(--nf-s2) 0 0;
+}
+
 :global(body[data-mobile="true"]) .summary.summary {
+  margin: var(--nf-s3) 0 0;
   max-inline-size: none;
   font-size: var(--text-body);
   line-height: 1.3846;
   white-space: pre-line;
 }
 
-/* One frame around the image: the image's own inset outline from globals.css. */
+/* One frame around the image: the image's own inset outline from globals.css.
+   Charts render uncropped (Live Article Redesign): a 16:9 cover crop cut the
+   left axis off wide Market Ear charts. */
 :global(body[data-mobile="true"]) .imageWrapper.imageWrapper {
   margin-top: var(--nf-s1);
   border: 0;
   border-radius: 4px;
   overflow: hidden;
   background: var(--bg-base);
-  aspect-ratio: 16 / 9;
   min-height: 0;
   min-width: 0;
 }
 
 :global(body[data-mobile="true"]) .image.image {
   width: 100%;
-  height: 100%;
-  object-fit: cover;
+  height: auto;
   border-radius: 4px;
 }
 

--- a/web/components/DashboardNewsFeed.tsx
+++ b/web/components/DashboardNewsFeed.tsx
@@ -2,8 +2,9 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Image from "next/image";
-import { ChevronLeft, ChevronRight, Link as LinkIcon, RefreshCw } from "lucide-react";
+import { ArrowUpRight, ChevronLeft, ChevronRight, RefreshCw } from "lucide-react";
 
+import { estimateReadMinutes } from "../lib/newsfeedReadTime";
 import { formatAbsolute, formatCompact, formatRelative, formatTime } from "../lib/newsfeedTime";
 import {
   useNewsfeedPosts,
@@ -32,6 +33,7 @@ function buildPostSnapshot(post: NormalisedPost) {
 }
 
 const PAGE_SIZE = 18;
+const SOURCE_NAME = "Market Ear";
 
 export type { MarketEarPost };
 
@@ -263,6 +265,9 @@ export default function DashboardNewsFeed() {
           <h3 className="panel-title">Live market analysis</h3>
         </div>
         <div className={`news-feed-actions ${styles.actions}`}>
+          {!loading && !error && posts.length > 0 ? (
+            <span className={`news-feed-live-badge ${styles.liveBadge}`}>LIVE</span>
+          ) : null}
           <button
             type="button"
             className={`news-feed-refresh news-feed-refresh--rail ${styles.refresh}`}
@@ -306,38 +311,18 @@ export default function DashboardNewsFeed() {
               const postTags = Array.isArray(post.tags) ? post.tags : [];
               const overflowCount = postTags.length - VISIBLE_TAG_LIMIT;
               const tagsExpanded = expandedTags.has(post.id);
+              const readMinutes = estimateReadMinutes(post.content ?? "");
 
               return (
                 <li key={post.id} data-testid="news-feed-item" className={`news-feed-item ${styles.item}`}>
                   <a className="news-feed-link" href={post.href} target="_blank" rel="noopener noreferrer">
                     <h3 className={`news-feed-headline ${styles.headline}`}>{post.title}</h3>
                   </a>
-                  {post.content ? (
-                    <p className={`news-feed-summary ${styles.summary}`}>{post.content}</p>
-                  ) : null}
-                  {firstImage ? (
-                    <button
-                      type="button"
-                      className={`news-feed-image-wrapper news-feed-image-wrapper--button ${styles.imageWrapper}`}
-                      onClick={() =>
-                        setLightboxFocus({ post, imageUrl: firstImage })
-                      }
-                      aria-label={`Open lightbox for: ${post.title}`}
-                    >
-                      <Image
-                        src={firstImage}
-                        alt={post.title}
-                        width={1200}
-                        height={675}
-                        sizes="(max-width: 1440px) 100vw, 60vw"
-                        className={`news-feed-image ${styles.image}`}
-                        priority={false}
-                      />
-                      <span className="news-feed-image-zoom" aria-hidden>
-                        ⤢
-                      </span>
-                    </button>
-                  ) : null}
+                  <div data-testid="news-feed-meta" className={`news-feed-meta ${styles.meta}`}>
+                    <span title={absolute}>{absolute}</span>
+                    <span className="news-feed-meta__source">{SOURCE_NAME}</span>
+                    <span>{readMinutes} min read</span>
+                  </div>
                   {postTags.length > 0 ? (
                     <div
                       data-testid="news-feed-tags"
@@ -377,6 +362,38 @@ export default function DashboardNewsFeed() {
                       ) : null}
                     </div>
                   ) : null}
+                  {post.content ? (
+                    <p className={`news-feed-summary ${styles.summary}`}>{post.content}</p>
+                  ) : null}
+                  {firstImage ? (
+                    <figure className={`news-feed-figure ${styles.figure}`}>
+                      <button
+                        type="button"
+                        className={`news-feed-image-wrapper news-feed-image-wrapper--button ${styles.imageWrapper}`}
+                        onClick={() =>
+                          setLightboxFocus({ post, imageUrl: firstImage })
+                        }
+                        aria-label={`Open lightbox for: ${post.title}`}
+                      >
+                        <Image
+                          src={firstImage}
+                          alt={post.title}
+                          width={1200}
+                          height={675}
+                          sizes="(max-width: 1440px) 100vw, 60vw"
+                          className={`news-feed-image ${styles.image}`}
+                          priority={false}
+                        />
+                        <span className="news-feed-image-zoom" aria-hidden>
+                          ⤢
+                        </span>
+                      </button>
+                      <figcaption className={`news-feed-figcaption ${styles.figcaption}`}>
+                        <span>Chart · {post.title}</span>
+                        <span>Source · {SOURCE_NAME}</span>
+                      </figcaption>
+                    </figure>
+                  ) : null}
                   <div data-testid="news-feed-footer" className={`news-feed-footer ${styles.footer}`}>
                     <a
                       data-testid="news-feed-link-pill"
@@ -385,8 +402,8 @@ export default function DashboardNewsFeed() {
                       target="_blank"
                       rel="noopener noreferrer"
                     >
-                      <LinkIcon size={11} />
-                      <span>Link</span>
+                      <ArrowUpRight size={11} aria-hidden />
+                      <span>Source link</span>
                     </a>
                     <span
                       data-testid="news-feed-timestamp"

--- a/web/lib/newsfeedReadTime.ts
+++ b/web/lib/newsfeedReadTime.ts
@@ -1,0 +1,10 @@
+const WORDS_PER_MINUTE = 200;
+
+function countWords(text: string): number {
+  return text.split(/\s+/).filter((word) => word.length > 0).length;
+}
+
+/** Whole-minute reading estimate, never below one minute. */
+export function estimateReadMinutes(text: string): number {
+  return Math.max(1, Math.round(countWords(text) / WORDS_PER_MINUTE));
+}

--- a/web/tests/dashboard-newsfeed-article-layout.test.tsx
+++ b/web/tests/dashboard-newsfeed-article-layout.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React from "react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import DashboardNewsFeed from "../components/DashboardNewsFeed";
+import { estimateReadMinutes } from "../lib/newsfeedReadTime";
+import { formatAbsolute } from "../lib/newsfeedTime";
+
+vi.mock("next/image", () => ({
+  default: ({ src, alt, className }: { src: string; alt: string; className?: string }) =>
+    React.createElement("img", { src, alt, className }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn(), refresh: vi.fn() }),
+  usePathname: () => "/dashboard",
+  useSearchParams: () => new URLSearchParams(""),
+}));
+
+const fetchMock = vi.fn();
+
+const POST = {
+  id: "p1",
+  title: "What to watch",
+  content: "Three things matter most from here. ".repeat(60).trim(),
+  timestamp: new Date(Date.now() - 26 * 60_000).toISOString(),
+  images: ["/media/p1-01.png"],
+  tags: ["FRANCE", "RATES"],
+};
+
+async function renderFeed(posts: unknown[]) {
+  fetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => posts } as Response);
+  render(React.createElement(DashboardNewsFeed));
+  await waitFor(() => {
+    expect(screen.queryAllByRole("listitem").length).toBeGreaterThan(0);
+  });
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  // @ts-expect-error — overriding global fetch for test
+  global.fetch = fetchMock;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("estimateReadMinutes", () => {
+  it("rounds to a one-minute floor at ~200 wpm", () => {
+    expect(estimateReadMinutes("")).toBe(1);
+    expect(estimateReadMinutes("one two three")).toBe(1);
+    expect(estimateReadMinutes("word ".repeat(420))).toBe(2);
+  });
+});
+
+describe("DashboardNewsFeed article layout", () => {
+  it("shows a LIVE badge in the panel header once posts have loaded", async () => {
+    await renderFeed([POST]);
+    expect(document.querySelector(".news-feed-live-badge")!.textContent).toBe("LIVE");
+  });
+
+  it("renders a mono meta row: stamp · Market Ear · read time", async () => {
+    await renderFeed([POST]);
+    const meta = document.querySelector("[data-testid='news-feed-meta']")!;
+    const cells = Array.from(meta.querySelectorAll("span")).map((s) => s.textContent);
+    expect(cells).toEqual([formatAbsolute(POST.timestamp), "Market Ear", "2 min read"]);
+  });
+
+  it("places the tag strip between the meta row and the body", async () => {
+    await renderFeed([POST]);
+    const item = document.querySelector("li.news-feed-item")!;
+    const order = Array.from(item.querySelectorAll(":scope > *")).map((n) =>
+      n.getAttribute("data-testid") ?? n.className.split(" ")[0],
+    );
+    expect(order.indexOf("news-feed-meta")).toBeLessThan(order.indexOf("news-feed-tags"));
+    expect(order.indexOf("news-feed-tags")).toBeLessThan(order.indexOf("news-feed-summary"));
+  });
+
+  it("wraps the chart in a figure with a caption crediting the source", async () => {
+    await renderFeed([POST]);
+    const figure = document.querySelector("figure.news-feed-figure")!;
+    expect(figure.querySelector("img.news-feed-image")).not.toBeNull();
+    const caption = figure.querySelector("figcaption")!;
+    expect(caption.textContent).toContain(POST.title);
+    expect(caption.textContent).toContain("Source · Market Ear");
+  });
+
+  it("labels the footer pill as the source link", async () => {
+    await renderFeed([POST]);
+    const pill = screen.getByTestId("news-feed-link-pill");
+    expect(pill.textContent).toBe("Source link");
+    expect(pill.getAttribute("href")).toBe("https://themarketear.com/posts/p1");
+  });
+});

--- a/web/tests/dashboard-newsfeed-mobile-item.test.tsx
+++ b/web/tests/dashboard-newsfeed-mobile-item.test.tsx
@@ -258,7 +258,8 @@ describe("DashboardNewsFeed.module.css mobile rules", () => {
 
   it("tightens the type scale", () => {
     const headline = ruleBlock(moduleCss, `:global(${mobile}) .headline.headline`);
-    expect(headline).toMatch(/font-size:\s*16px/);
+    // Live Article Redesign (2026-08-22): 23px headline on the 390 frame.
+    expect(headline).toMatch(/font-size:\s*23px/);
     expect(headline).toMatch(/line-height:\s*1\.25/);
 
     const summary = ruleBlock(moduleCss, `:global(${mobile}) .summary.summary`);
@@ -305,12 +306,13 @@ describe("DashboardNewsFeed.module.css mobile rules", () => {
     expect(refresh).toMatch(/position:\s*relative/);
   });
 
-  it("leaves one frame around the image", () => {
+  it("leaves one frame around the image and never crops the chart", () => {
     const wrapper = ruleBlock(moduleCss, `:global(${mobile}) .imageWrapper.imageWrapper`);
     expect(wrapper).toMatch(/border:\s*0/);
-    expect(wrapper).toMatch(/aspect-ratio:\s*16\s*\/\s*9/);
+    expect(wrapper).not.toMatch(/aspect-ratio/);
     const image = ruleBlock(moduleCss, `:global(${mobile}) .image.image`);
-    expect(image).toMatch(/object-fit:\s*cover/);
+    expect(image).toMatch(/height:\s*auto/);
+    expect(image).not.toMatch(/object-fit:\s*cover/);
   });
 
   it("clears the fixed tab bar without double-counting its reservation", () => {

--- a/web/tests/typography-readability-contract.test.ts
+++ b/web/tests/typography-readability-contract.test.ts
@@ -14,8 +14,8 @@ function ruleBlock(selector: string): string {
 describe("typography readability contracts", () => {
   it("gives sustained prose a readable size, rhythm, and measure", () => {
     expect(ruleBlock(".news-feed-summary")).toMatch(/font-size:\s*var\(--text-prose\)/);
-    expect(ruleBlock(".news-feed-summary")).toMatch(/line-height:\s*1\.6/);
-    expect(ruleBlock(".news-feed-summary")).toMatch(/max-inline-size:\s*70ch/);
+    expect(ruleBlock(".news-feed-summary")).toMatch(/line-height:\s*1\.7/);
+    expect(ruleBlock(".news-feed-summary")).toMatch(/max-inline-size:\s*680px/);
     expect(ruleBlock(".news-feed-summary")).toMatch(/text-wrap:\s*pretty/);
 
     expect(ruleBlock(".chat-markdown p")).toMatch(/font-size:\s*var\(--text-prose\)/);


### PR DESCRIPTION
Implements the Claude Design **Live Article Redesign** (`Live Article Redesign.dc.html`) on `DashboardNewsFeed`.

- LIVE badge in the panel header (desktop; hidden on the 390 frame per the design)
- 30px / 23px editorial headline, mono meta row: stamp · Market Ear · N min read (`lib/newsfeedReadTime.ts`)
- Pill tag chips moved above the body; 16px / 1.7 body copy, 680px measure
- Full-bleed chart figure with caption rail (`Chart · <title>` / `Source · Market Ear`)
- Footer: Source link pill (arrow icon) · stamp · bookmark star
- Mobile: drops the 16:9 cover crop so wide charts render whole

Not implemented (no data source): the mock's Key-takeaways aside, numbered 01/02/03 sections and the +2.0σ callout are content-specific; posts are free text.

Verification: vitest 6927 pass (`ib-wrappers-db-source` fails on clean main too), tsc clean, Playwright screenshots at 1440 and 393 on a worktree dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)