### PR TITLE
feat(sidebar): collapsible icon rail

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -623,6 +623,186 @@ body {
   text-overflow: ellipsis;
 }
 
+/* ─── Sidebar collapse → icon rail ───────────────────────────────────────
+   The rail keeps every destination reachable: icons stay, group headers
+   become hairline dividers (the grouping survives without its labels), the
+   active item keeps its 2px bar, and a mono tooltip names each target on
+   hover / keyboard focus. Width animates only after the saved preference
+   has been applied (.sidebar--settled) so a collapsed restore snaps. */
+.sidebar {
+  position: relative;
+  --sidebar-rail-width: 56px;
+}
+
+.sidebar--settled {
+  transition: width 200ms var(--ease-out);
+}
+
+.sidebar--collapsed {
+  width: var(--sidebar-rail-width);
+}
+
+.sidebar--collapsed .sidebar-header {
+  padding: 0;
+  justify-content: center;
+}
+
+.sidebar--collapsed .logo-text,
+.sidebar--collapsed .nav-item-label,
+.sidebar--collapsed .nav-group-label-text,
+.sidebar--collapsed .nav-group-chevron,
+.sidebar--collapsed .sidebar-user-card__text {
+  display: none;
+}
+
+.sidebar--collapsed .sidebar-nav {
+  overflow: visible;
+  padding: 4px 0;
+}
+
+.sidebar--collapsed .nav-group + .nav-group {
+  margin-top: 0;
+}
+
+/* Group header → divider. Keeps the boundary, drops the label. */
+.sidebar--collapsed .nav-group-label {
+  min-height: 0;
+  height: 1px;
+  padding: 0;
+  margin: 6px 14px;
+  background: var(--border-dim);
+  pointer-events: none;
+}
+
+.sidebar--collapsed .nav-group:first-child .nav-group-label {
+  display: none;
+}
+
+.sidebar--collapsed .nav-item,
+.sidebar--collapsed .sidebar-collapse-toggle,
+.sidebar--collapsed .sidebar-user-card {
+  justify-content: center;
+  padding-left: 0;
+  padding-right: 0;
+  gap: 0;
+}
+
+.sidebar--collapsed .nav-item {
+  height: 36px;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+/* Optical: the 2px active bar sits on the left edge, so nudge the icon back
+   by half of it to keep the rail's icon column visually centred. */
+.sidebar--collapsed .nav-item .nav-icon,
+.sidebar--collapsed .sidebar-user-card__avatar {
+  margin-left: -2px;
+}
+
+/* Collapse / expand control — a nav row, not a floating chrome button. */
+.sidebar-collapse-toggle {
+  position: relative;
+  width: 100%;
+  min-height: var(--hit-min);
+  padding: 0 16px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border: none;
+  border-top: 1px solid var(--border-dim);
+  border-left: 2px solid transparent;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: var(--transition-controls);
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.sidebar-collapse-toggle:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.sidebar-collapse-toggle:focus-visible,
+.sidebar--collapsed .nav-item:focus-visible,
+.sidebar--collapsed .sidebar-user-card:focus-visible {
+  outline: 1px solid var(--signal-core-text);
+  outline-offset: -1px;
+}
+
+.sidebar-collapse-glyph__arrow {
+  transform-origin: 9.75px 7px;
+  transition: transform 150ms var(--ease-out);
+}
+
+.sidebar-collapse-glyph--collapsed .sidebar-collapse-glyph__arrow {
+  transform: scaleX(-1);
+}
+
+/* Rail tooltips — CSS only, named from data-label. Enter slides 4px from
+   the rail; exit is a plain fade (softer than the enter). */
+.sidebar--collapsed [data-label] {
+  position: relative;
+}
+
+.sidebar--collapsed [data-label]::after {
+  content: attr(data-label);
+  position: absolute;
+  left: calc(100% + 8px);
+  top: 50%;
+  translate: -4px -50%;
+  padding: 5px 8px;
+  background: var(--bg-panel-raised);
+  border: 1px solid var(--border-dim);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  line-height: 1;
+  box-shadow: 0 1px 2px oklch(0 0 0 / 0.12), 0 4px 12px oklch(0 0 0 / 0.16);
+  opacity: 0;
+  pointer-events: none;
+  z-index: 60;
+  transition: opacity 120ms var(--ease-out), translate 120ms var(--ease-out);
+}
+
+.sidebar--collapsed [data-label]:hover::after,
+.sidebar--collapsed [data-label]:focus-visible::after {
+  opacity: 1;
+  translate: 0 -50%;
+  transition-delay: 60ms, 60ms;
+}
+
+/* Short viewports: let the rail scroll instead of pushing the profile card
+   off-screen; tooltips would be clipped there, so drop them. */
+@media (max-height: 720px) {
+  .sidebar--collapsed .sidebar-nav {
+    overflow-y: auto;
+  }
+
+  .sidebar--collapsed .sidebar-nav [data-label]::after {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sidebar--settled,
+  .sidebar-collapse-glyph__arrow,
+  .sidebar--collapsed [data-label]::after {
+    transition: none;
+  }
+}
+
 /* ─── StarToggle ─── */
 .star-toggle {
   display: inline-flex;

--- a/web/components/Sidebar.tsx
+++ b/web/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import type { WorkspaceSection, NavGroupId } from "@/lib/types";
 import { navItems, NAV_GROUP_LABEL, NAV_GROUP_ORDER } from "@/lib/data";
 import { useProfile } from "@/lib/useProfile";
@@ -14,6 +14,8 @@ type SidebarProps = {
   lastSync?: string | null;
 };
 
+export const SIDEBAR_COLLAPSED_STORAGE_KEY = "radon:sidebar-collapsed";
+
 function monogramFor(name: string | null, email: string | null): string {
   const source = (name ?? email ?? "").trim();
   if (!source) return "·";
@@ -23,7 +25,52 @@ function monogramFor(name: string | null, email: string | null): string {
   return (parts[0][0] + parts[1][0]).toUpperCase();
 }
 
+function readSavedCollapsed(): boolean {
+  try {
+    return window.localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function saveCollapsed(collapsed: boolean) {
+  try {
+    window.localStorage.setItem(SIDEBAR_COLLAPSED_STORAGE_KEY, collapsed ? "1" : "0");
+  } catch {}
+}
+
+// SSR always renders expanded; the saved preference is applied post-mount
+// (same hydration contract as ThemeContext). `settled` gates the width
+// transition so restoring a collapsed rail on load snaps instead of sliding.
+function useCollapsedPreference() {
+  const [collapsed, setCollapsed] = useState(false);
+  const [settled, setSettled] = useState(false);
+  useEffect(() => {
+    setCollapsed(readSavedCollapsed());
+    const frame = window.requestAnimationFrame(() => setSettled(true));
+    return () => window.cancelAnimationFrame(frame);
+  }, []);
+  const toggle = useCallback(() => {
+    setCollapsed((prev) => {
+      saveCollapsed(!prev);
+      return !prev;
+    });
+  }, []);
+  return { collapsed, settled, toggle };
+}
+
+function CollapseGlyph({ collapsed }: { collapsed: boolean }) {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden className={`sidebar-collapse-glyph${collapsed ? " sidebar-collapse-glyph--collapsed" : ""}`}>
+      <rect x="1.5" y="2.5" width="11" height="9" stroke="currentColor" strokeWidth="1.2" />
+      <path d="M5 2.5V11.5" stroke="currentColor" strokeWidth="1.2" />
+      <path className="sidebar-collapse-glyph__arrow" d="M10.5 5.5L9 7L10.5 8.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="square" />
+    </svg>
+  );
+}
+
 export default function Sidebar({ activeSection, actionTone }: SidebarProps) {
+  const { collapsed, settled, toggle: toggleCollapsed } = useCollapsedPreference();
   const [collapsedGroups, setCollapsedGroups] = useState<Set<NavGroupId>>(() => new Set<NavGroupId>(["operations"]));
   const toggleGroup = useCallback((group: NavGroupId) => {
     setCollapsedGroups((prev) => {
@@ -43,8 +90,10 @@ export default function Sidebar({ activeSection, actionTone }: SidebarProps) {
   const monogram = monogramFor(profile?.username ?? null, null);
   const profileActive = activeSection === "profile";
 
+  const sidebarClass = `sidebar${collapsed ? " sidebar--collapsed" : ""}${settled ? " sidebar--settled" : ""}`;
+
   return (
-    <aside className="sidebar">
+    <aside className={sidebarClass} data-collapsed={collapsed ? "true" : "false"}>
       <div className="sidebar-header">
         <img
           src="/brand/radon-monogram.svg"
@@ -64,25 +113,28 @@ export default function Sidebar({ activeSection, actionTone }: SidebarProps) {
         {NAV_GROUP_ORDER.map((groupId) => {
           const items = navItems.filter((item) => !item.hidden && item.group === groupId);
           if (items.length === 0) return null;
-          const collapsed = collapsedGroups.has(groupId);
+          // The rail has no group headers to fold, so every group shows its items.
+          const groupFolded = !collapsed && collapsedGroups.has(groupId);
           const isActiveGroup = items.some((it) => it.route === activeSection);
           return (
-            <div key={groupId} className={`nav-group${collapsed ? " nav-group--collapsed" : ""}${isActiveGroup ? " nav-group--active" : ""}`}>
+            <div key={groupId} className={`nav-group${groupFolded ? " nav-group--collapsed" : ""}${isActiveGroup ? " nav-group--active" : ""}`}>
               <button
                 type="button"
                 className="nav-group-label"
                 onClick={() => toggleGroup(groupId)}
-                aria-expanded={!collapsed}
+                aria-expanded={!groupFolded}
                 aria-label={`${NAV_GROUP_LABEL[groupId]} group`}
+                tabIndex={collapsed ? -1 : undefined}
+                aria-hidden={collapsed || undefined}
               >
                 <span className="nav-group-label-text">{NAV_GROUP_LABEL[groupId]}</span>
-                <span className={`nav-group-chevron${collapsed ? "" : " nav-group-chevron--open"}`} aria-hidden>
+                <span className={`nav-group-chevron${groupFolded ? "" : " nav-group-chevron--open"}`} aria-hidden>
                   <svg width="8" height="8" viewBox="0 0 8 8" fill="none">
                     <path d="M1.5 2.5L4 5L6.5 2.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="square" strokeLinejoin="miter" />
                   </svg>
                 </span>
               </button>
-              {!collapsed && (
+              {!groupFolded && (
                 <div className="nav-group-items">
                   {items.map((item) => {
                     const Icon = item.icon;
@@ -92,11 +144,13 @@ export default function Sidebar({ activeSection, actionTone }: SidebarProps) {
                         href={item.href}
                         className={item.route === activeSection ? "nav-item active" : "nav-item"}
                         aria-current={item.route === activeSection ? "page" : undefined}
+                        aria-label={collapsed ? item.label : undefined}
+                        data-label={item.label}
                       >
                         <span className="nav-icon">
                           <Icon size={14} color={actionTone} strokeWidth={2} />
                         </span>
-                        {item.label}
+                        <span className="nav-item-label">{item.label}</span>
                       </Link>
                     );
                   })}
@@ -107,10 +161,26 @@ export default function Sidebar({ activeSection, actionTone }: SidebarProps) {
         })}
       </nav>
 
+      <button
+        type="button"
+        className="sidebar-collapse-toggle"
+        onClick={toggleCollapsed}
+        aria-expanded={!collapsed}
+        aria-label={collapsed ? "Expand navigation" : "Collapse navigation"}
+        data-label={collapsed ? "Expand" : "Collapse"}
+      >
+        <span className="nav-icon">
+          <CollapseGlyph collapsed={collapsed} />
+        </span>
+        <span className="nav-item-label">Collapse</span>
+      </button>
+
       <Link
         href="/profile"
         className={`sidebar-user-card${profileActive ? " sidebar-user-card--active" : ""}`}
         aria-current={profileActive ? "page" : undefined}
+        aria-label={collapsed ? "Profile" : undefined}
+        data-label={displayName}
       >
         <span className="sidebar-user-card__avatar">
           {avatarUrl ? (

--- a/web/tests/sidebar-collapse.test.ts
+++ b/web/tests/sidebar-collapse.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { createElement } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import Sidebar, { SIDEBAR_COLLAPSED_STORAGE_KEY } from "../components/Sidebar";
+
+function renderSidebar() {
+  return render(
+    createElement(Sidebar, {
+      activeSection: "regime",
+      actionTone: "#05AD98",
+    }),
+  );
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Sidebar collapse", () => {
+  it("starts expanded and collapses to an icon rail that keeps every link reachable", () => {
+    const { container } = renderSidebar();
+    const aside = container.querySelector("aside.sidebar")!;
+    expect(aside.getAttribute("data-collapsed")).toBe("false");
+
+    fireEvent.click(screen.getByRole("button", { name: /collapse navigation/i }));
+
+    expect(aside.getAttribute("data-collapsed")).toBe("true");
+    // Every link still has an accessible name while collapsed (icon-only rail).
+    expect(screen.getByRole("link", { name: /dashboard/i })).toBeTruthy();
+    expect(screen.getByRole("link", { name: /^regime$/i }).getAttribute("aria-current")).toBe("page");
+    expect(screen.getByRole("link", { name: /^cta$/i })).toBeTruthy();
+    // The rail surfaces items from groups the user had folded (operations folds by default).
+    expect(screen.getByRole("link", { name: /^profile$/i })).toBeTruthy();
+  });
+
+  it("expands again from the same control and persists the preference", () => {
+    renderSidebar();
+    const toggle = screen.getByRole("button", { name: /collapse navigation/i });
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+
+    fireEvent.click(toggle);
+    expect(window.localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY)).toBe("1");
+    const expand = screen.getByRole("button", { name: /expand navigation/i });
+    expect(expand.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.click(expand);
+    expect(window.localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY)).toBe("0");
+    expect(screen.getByRole("button", { name: /collapse navigation/i })).toBeTruthy();
+  });
+
+  it("restores a saved collapsed state after mount", () => {
+    window.localStorage.setItem(SIDEBAR_COLLAPSED_STORAGE_KEY, "1");
+    const { container } = renderSidebar();
+    expect(container.querySelector("aside.sidebar")!.getAttribute("data-collapsed")).toBe("true");
+  });
+});


### PR DESCRIPTION
## Summary
- Collapse/expand toggle row in the left nav (above the profile card); preference persisted in `localStorage` (`radon:sidebar-collapsed`), applied post-mount per the ThemeContext SSR contract.
- Collapsed = 56px icon rail: every link stays reachable, group headers become hairline dividers, active item keeps its bar, CSS-only mono tooltips on hover/focus. Groups the user had folded still show in the rail.
- Short viewports (<=720px tall) scroll the rail instead of pushing the profile card off-screen. Reduced motion respected.

## Verification
- `vitest`: 630 files / 6620 tests passed (3 new in `web/tests/sidebar-collapse.test.ts`).
- Playwright against `next dev`: collapsed width 56px, rail link click navigated to `/scanner`, state persisted across navigation, expanded back to 220px. Screenshots in the job scratch dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)