### PR TITLE
fix(newsfeed): inset chart to text column; drop lightbox sources

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -4772,9 +4772,10 @@ body[data-mobile="true"] .dashboard-news .news-feed-refresh--rail {
 }
 
 .news-feed-figure {
-  margin: 36px -40px 0;
-  border-top: 1px solid var(--line-grid);
-  border-bottom: 1px solid var(--line-grid);
+  margin: 36px 0 0;
+  border: 1px solid var(--line-grid);
+  border-radius: 4px;
+  overflow: hidden;
 }
 
 .news-feed-figure .news-feed-image-wrapper {
@@ -4787,7 +4788,7 @@ body[data-mobile="true"] .dashboard-news .news-feed-refresh--rail {
   display: flex;
   justify-content: space-between;
   gap: 16px;
-  padding: 8px 40px;
+  padding: 8px 16px;
   border-top: 1px solid var(--line-grid);
   font-family: var(--font-mono);
   font-size: 10.5px;

--- a/web/components/DashboardNewsFeed.module.css
+++ b/web/components/DashboardNewsFeed.module.css
@@ -93,7 +93,7 @@
 :global(body[data-mobile="true"]) .figcaption.figcaption {
   flex-direction: column;
   gap: 2px;
-  padding: var(--nf-s2) 0 0;
+  padding: var(--nf-s2) var(--nf-s3);
 }
 
 :global(body[data-mobile="true"]) .summary.summary {

--- a/web/components/NewsfeedLightbox.tsx
+++ b/web/components/NewsfeedLightbox.tsx
@@ -9,9 +9,6 @@ import { formatAbsolute, formatRelative, formatTime } from "@/lib/newsfeedTime";
 import { useDialogChrome } from "@/lib/useDialogChrome";
 import { useBookmarks } from "@/lib/useBookmarks";
 import StarToggle from "@/components/StarToggle";
-import { AnalysisSources } from "@/components/agent";
-import { buildAnalysisSources, buildFollowUps } from "@/lib/agent/analysisSources";
-import { emitAsk } from "@/lib/agent/askBus";
 
 export type NewsfeedLightboxFocus = {
   post: MarketEarPost & { href: string; isoTimestamp: string };
@@ -213,12 +210,6 @@ export default function NewsfeedLightbox({
             {post.content ? (
               <p className="newsfeed-lightbox__body">{post.content}</p>
             ) : null}
-
-            <AnalysisSources
-              sources={buildAnalysisSources(post)}
-              followUps={buildFollowUps(post)}
-              onFollowUp={emitAsk}
-            />
 
             {tags.length > 0 ? (
               <div className="newsfeed-lightbox__tags">

--- a/web/tests/dashboard-newsfeed-article-layout.test.tsx
+++ b/web/tests/dashboard-newsfeed-article-layout.test.tsx
@@ -2,6 +2,8 @@
  * @vitest-environment jsdom
  */
 
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import React from "react";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -95,5 +97,16 @@ describe("DashboardNewsFeed article layout", () => {
     const pill = screen.getByTestId("news-feed-link-pill");
     expect(pill.textContent).toBe("Source link");
     expect(pill.getAttribute("href")).toBe("https://themarketear.com/posts/p1");
+  });
+});
+
+describe("figure column alignment", () => {
+  const css = readFileSync(join(__dirname, "..", "app", "globals.css"), "utf8");
+  const rule = (selector: string) =>
+    css.match(new RegExp(`${selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*\\{([^}]*)\\}`))![1];
+
+  it("keeps the chart inside the same column as the headline and copy", () => {
+    expect(rule(".news-feed-figure")).toMatch(/margin:\s*36px\s+0\s+0/);
+    expect(rule(".news-feed-figure")).not.toMatch(/-40px/);
   });
 });


### PR DESCRIPTION
- Chart figure now aligns with the headline/copy column (no -40px bleed), bordered frame, inset caption on desktop + mobile
- Lightbox no longer renders the SOURCES / tagger provenance block

Verification: vitest 7007 pass (one pre-existing unrelated failure), tsc clean, Playwright screenshots at 1440/393 + lightbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)