### PR TITLE
fix(deploy): finish verified journals when unit sync lags GitHub tip

### DIFF
--- a/cloud/tests/test_deploy_corrections.py
+++ b/cloud/tests/test_deploy_corrections.py
@@ -855,6 +855,53 @@ recover_pending_transition
             "/usr/local/sbin/radon-deploy-root sync-scheduled-units",
         ]
 
+    def test_verified_journal_finalizes_when_unit_sync_refuses_stale_head(
+        self, tmp_path: Path
+    ) -> None:
+        releases = tmp_path / "releases"
+        live = tmp_path / "live"
+        stage = releases / "stage.target"
+        backup = releases / "backup.previous"
+        journal = tmp_path / "transition.json"
+        marker = tmp_path / "green-marker"
+        calls = tmp_path / "sudo.log"
+        releases.mkdir()
+        stage.mkdir()
+        backup.mkdir()
+        target = _create_release_artifacts(live, "target")
+        _create_release_artifacts(backup, "old")
+        _write_transition_journal(
+            journal, self.REQUESTED, self.PREVIOUS, stage, backup, "verified"
+        )
+        shell = f"""
+set -euo pipefail
+source {DEPLOY!s}
+current_commit() {{ printf '%s\\n' {self.REQUESTED}; }}
+deploy_gate() {{ return 0; }}
+record_deploy_marker() {{ return 0; }}
+log_warn() {{ :; }}
+sudo() {{
+  printf '%s\\n' "$*" >> {calls!s}
+  [[ "$*" == "/usr/local/sbin/radon-deploy-root sync-scheduled-units" ]] && return 76
+  return 0
+}}
+recover_pending_transition
+"""
+        result = subprocess.run(
+            ["bash", "-c", shell],
+            env={
+                **_transition_env(live, releases, journal),
+                "RADON_DEPLOY_GREEN_MARKER": str(marker),
+            },
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        for relative, expected in target.items():
+            assert (live / relative).read_bytes() == expected
+        assert marker.read_text(encoding="utf-8") == f"{self.REQUESTED}\n"
+        assert not journal.exists()
+
     def test_verified_journal_with_missing_venv_rolls_back_instead_of_finalizing(
         self, tmp_path: Path
     ) -> None:

--- a/cloud/tests/test_sync_scheduled_units.py
+++ b/cloud/tests/test_sync_scheduled_units.py
@@ -218,6 +218,7 @@ def test_deploy_syncs_after_green_gate_and_skips_when_ungranted():
     assert main.index("sync_scheduled_units") < main.index("write_green_marker")
     assert main.index("commit-transition") < main.rindex("sync_scheduled_units")
     assert "sync_scheduled_units" in recover
+    assert "sync_scheduled_units || return 1" not in recover
     assert "sudo -n -l --" in grant
     assert "bootstrap-control-plane.sh" in sync
     assert "return 0" in sync

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -14,6 +14,10 @@
 - Do not SendRequest to "check". Recover with `--from-file`. Do not heartbeat
   `cash-flow-sync` on reconstruct (that would stamp `last_attempt` as now and
   slide the 7-day clock).
+## 2026-08-23 — Verified-journal recover must not die on unit sync
+
+- `sync-scheduled-units` requires HEAD == GitHub main tip. A verified journal is often one SHA behind a tip that moved during the 40s gate. Fatal sync left the journal in place and the next deploy exited 76 (`Unfinished transition recovery failed`).
+- Recover: `sync_scheduled_units || log_warn`. Do not `return 1`. The gate already passed; finish the journal.
 
 ## 2026-08-21 — Scheduled units sync through a fixed helper, not a radon install
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`e32a0833` deploy aborted with:

```
HEAD is not the GitHub main tip; refusing unit install
Scheduled unit sync failed
Unfinished transition recovery failed; refusing a new deploy
```

Recover was finalizing verified `8c192a0c` after the gate. GitHub `main` had already moved, so `sync-scheduled-units` exited 76 and left the journal. Every later deploy dies before promote.

Recover now warns and finalizes. Helper is unchanged, so this does not need another bootstrap.

## Checklist

- [x] Red/green TDD (failing test, then fix)
- [x] Staged only the files this change owns (no `git add -A`)
- [x] Owner doc updated, or the commit message has `docs-skip: <reason>`
- [x] Previous `main` deploy finished before this push

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a024cd-ac4a-7743-8296-c9d67f6a038e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a024cd-ac4a-7743-8296-c9d67f6a038e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

