### PR TITLE
ci: shard pytest and vitest across GitHub runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,16 +61,26 @@ jobs:
         run: gitleaks detect --source . --config cloud/.gitleaks.toml --redact --no-banner --verbose
 
   web-tests:
-    name: Vitest (full config)
+    name: Vitest (shard ${{ matrix.shard }}/8)
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     concurrency:
-      group: ci-web-tests-${{ github.ref }}
+      group: ci-web-tests-${{ github.ref }}-${{ matrix.shard }}
       cancel-in-progress: true
     env:
       NODE_ENV: test
       ASSISTANT_MOCK: "1"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock', 'web/bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.3.14"
@@ -78,9 +88,10 @@ jobs:
       # cross-cutting vitest.config.ts (which imports `vitest/config`), and
       # web/ provides the app modules the tests import (@/lib, react, ...).
       # Install BOTH or the root config fails to load with ERR_MODULE_NOT_FOUND.
-      - run: bun install --frozen-lockfile
-      - run: bun install --frozen-lockfile
-        working-directory: web
+      - run: |
+          bun install --frozen-lockfile &
+          bun install --frozen-lockfile --cwd web &
+          wait
       # Run the FULL vitest config from the repo root (lib/tools + site/lib +
       # web/tests), NOT `bun run test` — that script restricts to web/tests and
       # silently skips ~9 files / ~68 tests (incl. site/lib/theme). vitest + the
@@ -97,38 +108,96 @@ jobs:
       # reads from resolveProjectRoot()); the test now writes under the project
       # root, so it is cwd-independent and runs in CI.
       #
-      # --coverage enforces the vitest.config.ts thresholds (lines/funcs/
-      # branches) as a non-regressing ratchet — symmetric with the pytest
-      # --cov-fail-under gate. @vitest/coverage-v8 is a declared devDep.
+      # Shards zero the per-job coverage thresholds: each shard only executes
+      # an eighth of the tests, so the ratchet would false-fail. web-coverage merges
+      # istanbul JSON and applies vitest.config.ts lines/functions/branches.
       - run: >-
           bunx vitest run --config vitest.config.ts --coverage
+          --shard=${{ matrix.shard }}/8
+          --coverage.reporter=json
+          --coverage.reportsDirectory=coverage/shard-${{ matrix.shard }}
+          --coverage.thresholds.lines=0
+          --coverage.thresholds.functions=0
+          --coverage.thresholds.branches=0
           --exclude '**/web/tests/integration.test.ts'
           --exclude '**/lib/tools/__tests__/kelly.test.ts'
           --exclude '**/lib/tools/__tests__/runner.test.ts'
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vitest-coverage-${{ matrix.shard }}
+          path: coverage/shard-${{ matrix.shard }}
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 3
 
-  py-tests:
-    name: pytest (unit, no integration)
+  web-coverage:
+    name: Vitest coverage ratchet
+    needs: [web-tests]
     runs-on: ubuntu-latest
     concurrency:
-      group: ci-py-tests-${{ github.ref }}
+      group: ci-web-coverage-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: |
+            scripts/ci/merge_vitest_coverage.py
+            vitest.config.ts
+          sparse-checkout-cone-mode: false
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: vitest-coverage-*
+          path: coverage-artifacts
+      - run: python3 scripts/ci/merge_vitest_coverage.py --root coverage-artifacts
+
+  py-tests:
+    name: pytest (${{ matrix.shard }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Isolate test_i* and scripts/api/tests; those two buckets dominated
+        # wall-clock under the previous a-c / d-g / h-i / rest split.
+        shard: [scripts-ac, scripts-df, scripts-i, scripts-ghjm, scripts-npsz, scripts-rs, rest-api, rest]
+        include:
+          - shard: scripts-ac
+            paths: "scripts/tests/test_[a-c]*.py"
+          - shard: scripts-df
+            paths: "scripts/tests/test_[d-f]*.py"
+          - shard: scripts-i
+            paths: "scripts/tests/test_i*.py"
+          - shard: scripts-ghjm
+            paths: "scripts/tests/test_[g-h]*.py scripts/tests/test_[j-m]*.py"
+          - shard: scripts-npsz
+            paths: "scripts/tests/test_[n-p]*.py scripts/tests/test_[t-z]*.py"
+          - shard: scripts-rs
+            paths: "scripts/tests/test_[r-s]*.py"
+          - shard: rest-api
+            paths: scripts/api/tests
+          - shard: rest
+            paths: scripts/trade_blotter tests
+    concurrency:
+      group: ci-py-tests-${{ github.ref }}-${{ matrix.shard }}
       cancel-in-progress: true
     env:
       DOCS_CONTRACT_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+          # docs contract (test_docs_contract.py) diffs against DOCS_CONTRACT_BASE.
+          fetch-depth: ${{ matrix.shard == 'scripts-df' && 0 || 1 }}
+      - uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
         with:
           python-version: "3.13"
+          enable-cache: true
+          cache-dependency-glob: |
+            requirements.txt
+            scripts/requirements-api.txt
+            requirements-dev.txt
+            cloud/requirements-test.txt
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt -r scripts/requirements-api.txt
-          pip install pytest pytest-asyncio pytest-cov
-          if [ -f cloud/requirements-test.txt ]; then
-            pip install -r cloud/requirements-test.txt
-          fi
+          uv pip install --system -r requirements.txt -r scripts/requirements-api.txt -r requirements-dev.txt
       # Run from the repo ROOT — pyproject.toml pins pythonpath so `import
       # ib_sync` / `from api.*` / trade_blotter all resolve. addopts already
       # applies `-m 'not integration'`, so the live MenthorQ suite is skipped.
@@ -136,29 +205,53 @@ jobs:
       # tests (29 collected) are orphaned — pythonpath includes the dir, but it
       # is not a collection target unless named.
       #
-      # --cov-fail-under is a non-regressing RATCHET, not a vanity target.
-      # 2026-08-08 (TEST_AUDIT T-050): rebased onto an HONEST metric. The
-      # prior 64 gate counted test files as covered surface area — test
-      # modules self-cover ~99% just by being collected/executed, which
-      # inflated the combined statement+branch figure to 73.01% (climbing to
-      # 74.88% by the end of the T-001..T-052 remediation pass). pyproject.toml
-      # now carries `[tool.coverage.run] omit` for scripts/tests,
-      # scripts/api/tests, scripts/trade_blotter/test_*.py, and tests/, so
-      # this number measures PRODUCT code only. Measured honest coverage on
-      # this branch: 58.85%. The gate dropping from 64 to 56 is the metric
-      # excluding test files from the numerator, not a coverage regression —
-      # product coverage was unchanged (in fact still rising) at rebase time.
-      # 56 sits ~2.5pts below the measured honest figure, preserving the
-      # original ratchet design. Raise it over time as coverage climbs; never
-      # lower it to make a red build pass.
-      # `tests` (repo root) carries the TWR money-math suite (20 cases) —
-      # it passed locally for months while gating nothing (TEST_AUDIT T-051).
+      # Shards zero --cov-fail-under: each machine only executes part of the
+      # suite. py-coverage combines the data files and applies the 56 ratchet.
+      # `tests` (repo root) carries the TWR money-math suite (TEST_AUDIT T-051).
+      #
+      # -n auto --dist loadfile: GitHub-hosted runners have multiple cores;
+      # loadfile keeps each test module on one worker so autouse fixtures and
+      # module-level stubs do not race. pytest-cov combines worker coverage.
       - run: >-
-          python -m pytest scripts/tests scripts/api/tests scripts/trade_blotter tests
-          --cov=scripts --cov=api --cov-branch --cov-report=term-missing
-          --cov-fail-under=56
-      - name: Cloud infra pytest
-        run: python -m pytest cloud/tests -q
+          python -m pytest ${{ matrix.paths }}
+          -n auto --dist loadfile
+          --cov=scripts --cov=api
+          --cov-fail-under=0
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pytest-coverage-${{ matrix.shard }}
+          path: .coverage
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 3
+
+  py-coverage:
+    name: pytest coverage ratchet
+    needs: [py-tests]
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ci-py-coverage-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: |
+            pyproject.toml
+            scripts
+            tests
+      - name: Install dependencies
+        run: python3 -m pip install --user --break-system-packages pytest-cov==7.1.0
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: pytest-coverage-*
+          path: coverage-artifacts
+      # --cov-fail-under is a non-regressing RATCHET, not a vanity target.
+      # 2026-08-08 (TEST_AUDIT T-050): honest product-only coverage; 56 sits
+      # ~2.5pts below the measured figure. Never lower it to make a red build
+      # pass.
+      - run: |
+          python3 -m coverage combine coverage-artifacts/*
+          python3 -m coverage report --fail-under=56 --show-missing
       # REL-065 / R-156: docs/demo-environment.md has claimed since phase 0
       # that a "CI isolation guard rejects any demo deploy whose env carries a
       # prod TURSO_DB_URL". Nothing invoked it. On demo.radon.run
@@ -177,7 +270,34 @@ jobs:
             echo "no demo env configured on this runner — nothing to check"
             exit 0
           fi
-          python scripts/ci/check_demo_isolation.py
+          python3 scripts/ci/check_demo_isolation.py
+
+  cloud-tests:
+    name: pytest (cloud infra)
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ci-cloud-tests-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
+        with:
+          python-version: "3.13"
+          enable-cache: true
+          cache-dependency-glob: |
+            requirements-dev.txt
+            cloud/requirements-test.txt
+      - name: Install dependencies
+        run: |
+          uv pip install --system -r requirements-dev.txt
+          if [ -f cloud/requirements-test.txt ]; then
+            uv pip install --system -r cloud/requirements-test.txt
+          fi
+      # Separate job: pyproject.toml norecursedirs includes cloud/ because
+      # cloud/tests/conftest.py collides with scripts/tests/conftest.py on the
+      # import path `tests.conftest`. Running it after unit pytest serialized
+      # ~60s onto the deploy critical path.
+      - run: python -m pytest cloud/tests -q
 
   perimeter-smoke:
     name: Perimeter smoke (next start + curl)
@@ -201,14 +321,21 @@ jobs:
       RADON_PROBE_FRESHNESS_TOKEN: rpf_ci_perimeter_smoke_dummy
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock', 'web/bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.3.14"
       # Both bun projects, same as web-tests: next.config aliases @tools to
       # the root lib/tools, so the build resolves modules from BOTH trees.
-      - run: bun install --frozen-lockfile
-      - run: bun install --frozen-lockfile
-        working-directory: web
+      - run: |
+          bun install --frozen-lockfile &
+          bun install --frozen-lockfile --cwd web &
+          wait
       # Static half of the Edge-runtime guard: the no-restricted-syntax
       # node:* ban on the middleware import graph (web/eslint.config.mjs).
       # Scoped to the perimeter files so unrelated lint warnings can't block
@@ -348,7 +475,7 @@ jobs:
 
   deploy:
     name: Deploy to VPS
-    needs: [secret-scan, web-tests, py-tests, perimeter-smoke]
+    needs: [secret-scan, web-tests, web-coverage, py-tests, py-coverage, cloud-tests, perimeter-smoke]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     # Outer budget: deploy.sh gets 15m, then 30s to kill descendants. A root

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,9 @@ jobs:
         with:
           python-version: "3.13"
           enable-cache: true
+          # ubuntu-latest has no system 3.13. --system fails with
+          # "No system Python installation found for Python 3.13".
+          activate-environment: true
           cache-dependency-glob: |
             requirements.txt
             scripts/requirements-api.txt
@@ -197,7 +200,7 @@ jobs:
             cloud/requirements-test.txt
       - name: Install dependencies
         run: |
-          uv pip install --system -r requirements.txt -r scripts/requirements-api.txt -r requirements-dev.txt
+          uv pip install -r requirements.txt -r scripts/requirements-api.txt -r requirements-dev.txt
       # Run from the repo ROOT — pyproject.toml pins pythonpath so `import
       # ib_sync` / `from api.*` / trade_blotter all resolve. addopts already
       # applies `-m 'not integration'`, so the live MenthorQ suite is skipped.
@@ -284,14 +287,15 @@ jobs:
         with:
           python-version: "3.13"
           enable-cache: true
+          activate-environment: true
           cache-dependency-glob: |
             requirements-dev.txt
             cloud/requirements-test.txt
       - name: Install dependencies
         run: |
-          uv pip install --system -r requirements-dev.txt
+          uv pip install -r requirements-dev.txt
           if [ -f cloud/requirements-test.txt ]; then
-            uv pip install --system -r cloud/requirements-test.txt
+            uv pip install -r cloud/requirements-test.txt
           fi
       # Separate job: pyproject.toml norecursedirs includes cloud/ because
       # cloud/tests/conftest.py collides with scripts/tests/conftest.py on the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,7 @@ jobs:
         with:
           name: pytest-coverage-${{ matrix.shard }}
           path: .coverage
+          include-hidden-files: true
           if-no-files-found: error
           compression-level: 0
           retention-days: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,8 +243,13 @@ jobs:
             pyproject.toml
             scripts
             tests
+      - uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
+        with:
+          python-version: "3.13"
+          enable-cache: true
+          activate-environment: true
       - name: Install dependencies
-        run: python3 -m pip install --user --break-system-packages pytest-cov==7.1.0
+        run: uv pip install pytest-cov==7.1.0
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           pattern: pytest-coverage-*
@@ -254,8 +259,14 @@ jobs:
       # ~2.5pts below the measured figure. Never lower it to make a red build
       # pass.
       - run: |
-          python3 -m coverage combine coverage-artifacts/*
-          python3 -m coverage report --fail-under=56 --show-missing
+          mapfile -d '' files < <(find coverage-artifacts -name '.coverage' -print0)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "no .coverage files under coverage-artifacts" >&2
+            find coverage-artifacts -print >&2
+            exit 1
+          fi
+          python -m coverage combine "${files[@]}"
+          python -m coverage report --fail-under=56 --show-missing
       # REL-065 / R-156: docs/demo-environment.md has claimed since phase 0
       # that a "CI isolation guard rejects any demo deploy whose env carries a
       # prod TURSO_DB_URL". Nothing invoked it. On demo.radon.run

--- a/cloud/tests/test_actions_node24.py
+++ b/cloud/tests/test_actions_node24.py
@@ -3,6 +3,7 @@
 The runner warning names checkout / setup-python / upload-artifact pinned
 to Node-20 action.yml. Official majors that switched to ``using: node24``
 are the fix. setup-bun v2.2.0 is already node24 at the existing pin.
+CI Python now uses astral-sh/setup-uv (node24) instead of setup-python.
 """
 
 from __future__ import annotations
@@ -24,6 +25,9 @@ NODE24_PINS = {
     ),
     "actions/upload-artifact": (
         "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",  # v7.0.1
+    ),
+    "astral-sh/setup-uv": (
+        "803947b9bd8e9f986429fa0c5a41c367cd732b41",  # v7.2.1
     ),
 }
 

--- a/cloud/tests/test_deploy_corrections.py
+++ b/cloud/tests/test_deploy_corrections.py
@@ -2377,21 +2377,18 @@ class TestCloudSecretScan:
 
     def test_root_ci_runs_full_python313_cloud_suite(self) -> None:
         workflow = yaml.safe_load(ROOT_CI.read_text(encoding="utf-8"))
-        jobs = workflow["jobs"]
-        pytest_jobs = [
-            job
-            for job in jobs.values()
-            if "pytest" in "\n".join(str(step.get("run", "")) for step in job["steps"])
-        ]
-        assert len(pytest_jobs) == 1
-        job = pytest_jobs[0]
-        setup_python = next(
-            step for step in job["steps"] if "actions/setup-python" in step.get("uses", "")
+        job = workflow["jobs"]["cloud-tests"]
+        setup_uv = next(
+            step for step in job["steps"] if "astral-sh/setup-uv" in step.get("uses", "")
         )
-        assert setup_python["with"]["python-version"] == "3.13"
+        assert setup_uv["with"]["python-version"] == "3.13"
         commands = "\n".join(str(step.get("run", "")) for step in job["steps"])
         assert "requirements-test.txt" in commands
-        assert re.search(r"python\s+-m\s+pytest(?:\s|$)", commands)
+        assert "pytest cloud/tests" in commands
+        unit_commands = "\n".join(
+            str(step.get("run", "")) for step in workflow["jobs"]["py-tests"]["steps"]
+        )
+        assert "pytest cloud/tests" not in unit_commands
 
     def test_custom_rules_reject_literal_tws_assignments_and_examples(self) -> None:
         config = tomllib.loads(GITLEAKS_CONFIG.read_text(encoding="utf-8"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ known-first-party = ["utils", "trade_blotter"]
 # was inflating the CI coverage gate ~15pts (73.01% inflated vs 58.00%
 # honest product-only) — TEST_AUDIT T-050.
 omit = ["scripts/tests/*", "scripts/api/tests/*", "scripts/trade_blotter/test_*.py", "tests/*"]
+# CI shards pytest; combine needs repo-relative paths so
+# /home/runner/work/... does not fork the same file into two rows.
+relative_files = true
 
 [tool.pytest.ini_options]
 # Pin import roots so collection is cwd-independent. Without this, running

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,10 @@
+# Pinned CI/dev test toolchain. Installed by ci.yml py-tests and cloud-tests.
+# Keep versions here, not as unpinned `pip install pytest ...` in the workflow
+# (T-119). pytest-xdist is the unit-job wall-clock cut; --dist loadfile keeps
+# each test file on one worker so shared-module fixtures stay isolated.
+pytest==9.0.2
+pytest-asyncio==1.3.0
+pytest-cov==7.1.0
+pytest-xdist==3.8.0
+PyYAML==6.0.3
+python-dotenv==1.2.2

--- a/scripts/ci/merge_vitest_coverage.py
+++ b/scripts/ci/merge_vitest_coverage.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Merge sharded Vitest v8/istanbul JSON and enforce vitest.config.ts thresholds.
+
+Shard jobs cannot apply the ratchet: each shard only executes a subset of
+tests, so per-shard line/function/branch percentages would fail the gate.
+This combiner is the only coverage ratchet in CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+VITEST_CONFIG = REPO / "vitest.config.ts"
+THRESHOLD_KEYS = ("lines", "functions", "branches")
+
+
+def load_thresholds(config_text: str) -> dict[str, int]:
+    block = re.search(r"thresholds:\s*\{([^}]+)\}", config_text)
+    if not block:
+        raise SystemExit("vitest.config.ts is missing a thresholds block")
+    body = block.group(1)
+    out: dict[str, int] = {}
+    for key in THRESHOLD_KEYS:
+        match = re.search(rf"{key}:\s*(\d+)", body)
+        if not match:
+            raise SystemExit(f"vitest.config.ts thresholds missing {key}")
+        out[key] = int(match.group(1))
+    return out
+
+
+def _add_counts(left: dict, right: dict) -> dict:
+    keys = set(left) | set(right)
+    merged = {}
+    for key in keys:
+        a = left.get(key, 0)
+        b = right.get(key, 0)
+        if isinstance(a, list) or isinstance(b, list):
+            a = a if isinstance(a, list) else []
+            b = b if isinstance(b, list) else []
+            n = max(len(a), len(b))
+            merged[key] = [
+                (a[i] if i < len(a) else 0) + (b[i] if i < len(b) else 0) for i in range(n)
+            ]
+        else:
+            merged[key] = int(a or 0) + int(b or 0)
+    return merged
+
+
+def merge_coverage_maps(maps: list[dict]) -> dict:
+    merged: dict = {}
+    for payload in maps:
+        for path, file_cov in payload.items():
+            if path not in merged:
+                merged[path] = {
+                    "path": file_cov.get("path", path),
+                    "statementMap": dict(file_cov.get("statementMap") or {}),
+                    "s": dict(file_cov.get("s") or {}),
+                    "f": dict(file_cov.get("f") or {}),
+                    "b": {k: list(v) for k, v in (file_cov.get("b") or {}).items()},
+                }
+                continue
+            existing = merged[path]
+            existing["statementMap"].update(file_cov.get("statementMap") or {})
+            existing["s"] = _add_counts(existing["s"], file_cov.get("s") or {})
+            existing["f"] = _add_counts(existing["f"], file_cov.get("f") or {})
+            existing["b"] = _add_counts(existing["b"], file_cov.get("b") or {})
+    return merged
+
+
+def _pct(covered: int, total: int) -> float:
+    if total <= 0:
+        return 100.0
+    return 100.0 * covered / total
+
+
+def summarize(merged: dict) -> dict[str, float]:
+    line_total = line_hit = 0
+    fn_total = fn_hit = 0
+    br_total = br_hit = 0
+    for file_cov in merged.values():
+        statement_map = file_cov.get("statementMap") or {}
+        hits = file_cov.get("s") or {}
+        lines: dict[int, int] = {}
+        for sid, stmt in statement_map.items():
+            try:
+                line = int(stmt["start"]["line"])
+            except (KeyError, TypeError, ValueError):
+                continue
+            lines[line] = lines.get(line, 0) + int(hits.get(str(sid), hits.get(sid, 0)) or 0)
+        line_total += len(lines)
+        line_hit += sum(1 for n in lines.values() if n > 0)
+        for count in (file_cov.get("f") or {}).values():
+            fn_total += 1
+            if int(count or 0) > 0:
+                fn_hit += 1
+        for counts in (file_cov.get("b") or {}).values():
+            for count in counts:
+                br_total += 1
+                if int(count or 0) > 0:
+                    br_hit += 1
+    return {
+        "lines": _pct(line_hit, line_total),
+        "functions": _pct(fn_hit, fn_total),
+        "branches": _pct(br_hit, br_total),
+    }
+
+
+def find_coverage_json(root: Path) -> list[Path]:
+    return sorted(root.rglob("coverage-final.json"))
+
+
+def evaluate(maps: list[dict], thresholds: dict[str, int]) -> tuple[dict[str, float], list[str]]:
+    summary = summarize(merge_coverage_maps(maps))
+    failures = [
+        f"{key} {summary[key]:.2f}% < {thresholds[key]}%"
+        for key in THRESHOLD_KEYS
+        if summary[key] + 1e-9 < thresholds[key]
+    ]
+    return summary, failures
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--config", type=Path, default=VITEST_CONFIG)
+    args = parser.parse_args(argv)
+    files = find_coverage_json(args.root)
+    if not files:
+        print(f"no coverage-final.json under {args.root}", file=sys.stderr)
+        return 1
+    maps = [json.loads(path.read_text(encoding="utf-8")) for path in files]
+    thresholds = load_thresholds(args.config.read_text(encoding="utf-8"))
+    summary, failures = evaluate(maps, thresholds)
+    for key in THRESHOLD_KEYS:
+        print(f"{key}: {summary[key]:.2f}% (gate {thresholds[key]}%)")
+    if failures:
+        print("coverage ratchet failed: " + "; ".join(failures), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_ci_deploy_concurrency.py
+++ b/scripts/tests/test_ci_deploy_concurrency.py
@@ -220,7 +220,9 @@ def test_pytest_shards_then_combines_coverage_ratchet() -> None:
     coverage = jobs["py-coverage"]
     assert "py-tests" in coverage["needs"]
     cov_commands = _job_commands(coverage)
-    assert "coverage combine coverage-artifacts/" in cov_commands
+    assert "find coverage-artifacts" in cov_commands
+    assert "name '.coverage'" in cov_commands
+    assert "coverage combine" in cov_commands
     assert "fail-under=56" in cov_commands
     cov_checkout = next(
         step for step in coverage["steps"] if "actions/checkout" in step.get("uses", "")
@@ -278,8 +280,12 @@ def test_py_coverage_installs_coverage_only() -> None:
     commands = _job_commands(job)
     assert "pytest-cov==7.1.0" in commands
     assert "pip install -r requirements-dev.txt" not in commands
-    assert not any("astral-sh/setup-uv@" in step.get("uses", "") for step in job["steps"])
-    assert "python3 -m pip" in commands or "python3 -m coverage" in commands
+    setup_uv = next(
+        step for step in job["steps"] if "astral-sh/setup-uv@" in step.get("uses", "")
+    )
+    assert setup_uv["with"]["python-version"] == "3.13"
+    assert str(setup_uv["with"].get("activate-environment", "")).lower() in ("true", "True")
+    assert "python -m coverage combine" in commands
 
 
 def test_bun_jobs_cache_the_install_store() -> None:

--- a/scripts/tests/test_ci_deploy_concurrency.py
+++ b/scripts/tests/test_ci_deploy_concurrency.py
@@ -8,13 +8,23 @@ finish and every deploy must name the exact commit it intends to release.
 
 from __future__ import annotations
 
+import fnmatch
+import re
 from pathlib import Path
 
 import yaml
 
 
 WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "ci.yml"
-TEST_JOBS = ("secret-scan", "web-tests", "py-tests", "perimeter-smoke")
+TEST_JOBS = (
+    "secret-scan",
+    "web-tests",
+    "web-coverage",
+    "py-tests",
+    "py-coverage",
+    "cloud-tests",
+    "perimeter-smoke",
+)
 
 
 def _workflow() -> dict:
@@ -83,10 +93,198 @@ def test_deploy_passes_the_explicit_workflow_sha() -> None:
     assert "RADON_DEPLOY_ENV_FILE" in script
 
 
+def _job_commands(job: dict) -> str:
+    return "\n".join(str(step.get("run", "")) for step in job.get("steps", []))
+
+
 def test_ci_runs_cloud_infra_pytest() -> None:
+    jobs = _workflow()["jobs"]
+    cloud = jobs["cloud-tests"]
+    assert "pytest cloud/tests" in _job_commands(cloud)
+    assert "pytest cloud/tests" not in _job_commands(jobs["py-tests"]), (
+        "cloud infra tests must run as their own job so they leave the unit "
+        "pytest critical path"
+    )
+    deploy_needs = jobs["deploy"]["needs"]
+    assert "cloud-tests" in deploy_needs
+    assert "py-tests" in deploy_needs
+
+
+def test_python_ci_jobs_cache_pip_and_pin_the_test_toolchain() -> None:
+    jobs = _workflow()["jobs"]
+    uv_pin = "803947b9bd8e9f986429fa0c5a41c367cd732b41"
+    for name in ("py-tests", "cloud-tests"):
+        setup_uv = next(
+            step
+            for step in jobs[name]["steps"]
+            if "astral-sh/setup-uv@" in step.get("uses", "")
+        )
+        assert uv_pin in setup_uv["uses"]
+        assert setup_uv["with"]["python-version"] == "3.13"
+        assert str(setup_uv["with"].get("enable-cache", "")).lower() in ("true", "True")
+        cache_paths = str(setup_uv["with"].get("cache-dependency-glob", ""))
+        assert "requirements-dev.txt" in cache_paths
+        commands = _job_commands(jobs[name])
+        assert "uv pip install --system" in commands
+        assert "requirements-dev.txt" in commands
+        assert "pip install --upgrade pip" not in commands
+        assert "pip install pytest pytest-asyncio pytest-cov" not in commands
+
+
+def test_vitest_uses_all_ci_workers() -> None:
+    config = (WORKFLOW.parents[2] / "vitest.config.ts").read_text(encoding="utf-8")
+    assert re.search(r'maxWorkers:\s*["\']100%["\']', config)
+    assert re.search(r"fileParallelism:\s*true", config)
+
+
+def test_vitest_shards_then_merges_coverage_ratchet() -> None:
+    jobs = _workflow()["jobs"]
+    web = jobs["web-tests"]
+    shards = web["strategy"]["matrix"]["shard"]
+    assert [str(item) for item in shards] == ["1", "2", "3", "4", "5", "6", "7", "8"]
+    assert "matrix.shard" in web["concurrency"]["group"]
+    commands = _job_commands(web)
+    assert "--shard=${{ matrix.shard }}/8" in commands
+    assert "coverage.thresholds.lines=0" in commands
+    assert "coverage.thresholds.functions=0" in commands
+    assert "coverage.thresholds.branches=0" in commands
+    coverage = jobs["web-coverage"]
+    assert "web-tests" in coverage["needs"]
+    assert "merge_vitest_coverage" in _job_commands(coverage)
+    web_checkout = next(
+        step for step in coverage["steps"] if "actions/checkout" in step.get("uses", "")
+    )
+    sparse = str(web_checkout.get("with", {}).get("sparse-checkout", ""))
+    assert "merge_vitest_coverage.py" in sparse
+    assert "vitest.config.ts" in sparse
+
+
+def test_vitest_coverage_uses_text_reporter_only() -> None:
+    config = (WORKFLOW.parents[2] / "vitest.config.ts").read_text(encoding="utf-8")
+    assert re.search(r'reporter:\s*\[\s*["\']text["\']\s*\]', config), (
+        "html/clover/json coverage reports inflate the 307s vitest gate; "
+        "the ratchet is thresholds, not artifacts"
+    )
+    assert "--coverage" in _job_commands(_workflow()["jobs"]["web-tests"])
+
+
+def test_unit_pytest_uses_xdist_loadfile() -> None:
+    commands = _job_commands(_workflow()["jobs"]["py-tests"])
+    assert "-n auto" in commands
+    assert "--dist loadfile" in commands
+    assert "--cov-fail-under=0" in commands
+    assert "--cov-branch" not in commands
+    assert "term-missing" not in commands
+
+
+def test_pytest_shards_then_combines_coverage_ratchet() -> None:
+    jobs = _workflow()["jobs"]
+    py_tests = jobs["py-tests"]
+    shards = [str(item) for item in py_tests["strategy"]["matrix"]["shard"]]
+    assert shards == [
+        "scripts-ac",
+        "scripts-df",
+        "scripts-i",
+        "scripts-ghjm",
+        "scripts-npsz",
+        "scripts-rs",
+        "rest-api",
+        "rest",
+    ]
+    assert "matrix.shard" in py_tests["concurrency"]["group"]
+    commands = _job_commands(py_tests)
+    assert "matrix.paths" in commands
+    include = str(py_tests["strategy"]["matrix"]["include"])
+    assert "test_[a-c]" in include
+    assert "test_[d-f]" in include
+    assert "test_i*" in include
+    assert "--cov-fail-under=0" in commands
+    checkout = next(
+        step
+        for step in py_tests["steps"]
+        if "actions/checkout" in step.get("uses", "")
+    )
+    fetch_depth = str(checkout.get("with", {}).get("fetch-depth", ""))
+    assert "scripts-df" in fetch_depth
+    coverage = jobs["py-coverage"]
+    assert "py-tests" in coverage["needs"]
+    cov_commands = _job_commands(coverage)
+    assert "coverage combine coverage-artifacts/" in cov_commands
+    assert "fail-under=56" in cov_commands
+    cov_checkout = next(
+        step for step in coverage["steps"] if "actions/checkout" in step.get("uses", "")
+    )
+    sparse = str(cov_checkout.get("with", {}).get("sparse-checkout", ""))
+    assert "pyproject.toml" in sparse
+    assert "scripts" in sparse
+
+
+def test_pytest_filename_shards_partition_scripts_tests() -> None:
     py_tests = _workflow()["jobs"]["py-tests"]
-    commands = "\n".join(str(step.get("run", "")) for step in py_tests["steps"])
-    assert "pytest cloud/tests" in commands
+    include = py_tests["strategy"]["matrix"]["include"]
+    filename_globs: list[str] = []
+    other_paths: list[str] = []
+    for row in include:
+        for token in str(row["paths"]).split():
+            token = token.strip('"')
+            if token.startswith("scripts/tests/"):
+                filename_globs.append(Path(token).name)
+            else:
+                other_paths.append(token)
+    files = [
+        path.name
+        for path in (WORKFLOW.parents[2] / "scripts" / "tests").glob("test_*.py")
+    ]
+    assigned = {name: [] for name in files}
+    for pattern in filename_globs:
+        for name in files:
+            if fnmatch.fnmatch(name, pattern):
+                assigned[name].append(pattern)
+    overlap = {name: hits for name, hits in assigned.items() if len(hits) > 1}
+    missing = [name for name, hits in assigned.items() if not hits]
+    assert overlap == {}
+    assert missing == []
+    assert "scripts/api/tests" in other_paths
+    assert "scripts/trade_blotter" in other_paths
+    assert "tests" in other_paths
+
+
+def test_coverage_ratchets_gate_deploy() -> None:
+    jobs = _workflow()["jobs"]
+    needs = jobs["deploy"]["needs"]
+    assert "web-coverage" in needs
+    assert "py-coverage" in needs
+    assert "web-tests" in needs
+    assert "py-tests" in needs
+    assert "cloud-tests" in needs
+    assert "stage-release" not in jobs
+    assert "merge_vitest_coverage" in _job_commands(jobs["web-coverage"])
+    assert "fail-under=56" in _job_commands(jobs["py-coverage"])
+
+
+def test_py_coverage_installs_coverage_only() -> None:
+    job = _workflow()["jobs"]["py-coverage"]
+    commands = _job_commands(job)
+    assert "pytest-cov==7.1.0" in commands
+    assert "pip install -r requirements-dev.txt" not in commands
+    assert not any("astral-sh/setup-uv@" in step.get("uses", "") for step in job["steps"])
+    assert "python3 -m pip" in commands or "python3 -m coverage" in commands
+
+
+def test_bun_jobs_cache_the_install_store() -> None:
+    jobs = _workflow()["jobs"]
+    pin = "5a3ec84eff668545956fd18022155c47e93e2684"
+    for name in ("web-tests", "perimeter-smoke"):
+        cache = next(
+            step
+            for step in jobs[name]["steps"]
+            if "actions/cache@" in step.get("uses", "")
+        )
+        assert pin in cache["uses"]
+        assert "~/.bun/install/cache" in str(cache["with"]["path"])
+        key = str(cache["with"]["key"])
+        assert "bun.lock" in key
+        assert "web/bun.lock" in key
 
 
 def test_ci_uses_frozen_bun_lockfile_contract_for_both_workspaces() -> None:
@@ -100,8 +298,5 @@ def test_ci_uses_frozen_bun_lockfile_contract_for_both_workspaces() -> None:
         steps = workflow["jobs"][job_name]["steps"]
         commands = "\n".join(str(step.get("run", "")) for step in steps)
         assert commands.count("bun install --frozen-lockfile") == 2
-        install_lines = [line.strip() for line in commands.splitlines() if "bun install" in line]
-        assert install_lines == [
-            "bun install --frozen-lockfile",
-            "bun install --frozen-lockfile",
-        ]
+        assert "&" in commands
+        assert "wait" in commands

--- a/scripts/tests/test_ci_deploy_concurrency.py
+++ b/scripts/tests/test_ci_deploy_concurrency.py
@@ -122,10 +122,12 @@ def test_python_ci_jobs_cache_pip_and_pin_the_test_toolchain() -> None:
         assert uv_pin in setup_uv["uses"]
         assert setup_uv["with"]["python-version"] == "3.13"
         assert str(setup_uv["with"].get("enable-cache", "")).lower() in ("true", "True")
+        assert str(setup_uv["with"].get("activate-environment", "")).lower() in ("true", "True")
         cache_paths = str(setup_uv["with"].get("cache-dependency-glob", ""))
         assert "requirements-dev.txt" in cache_paths
         commands = _job_commands(jobs[name])
-        assert "uv pip install --system" in commands
+        assert "uv pip install" in commands
+        assert "uv pip install --system" not in commands
         assert "requirements-dev.txt" in commands
         assert "pip install --upgrade pip" not in commands
         assert "pip install pytest pytest-asyncio pytest-cov" not in commands

--- a/scripts/tests/test_ci_deploy_concurrency.py
+++ b/scripts/tests/test_ci_deploy_concurrency.py
@@ -208,6 +208,15 @@ def test_pytest_shards_then_combines_coverage_ratchet() -> None:
     )
     fetch_depth = str(checkout.get("with", {}).get("fetch-depth", ""))
     assert "scripts-df" in fetch_depth
+    upload = next(
+        step
+        for step in py_tests["steps"]
+        if "upload-artifact" in step.get("uses", "")
+    )
+    assert upload["with"]["path"] == ".coverage"
+    # upload-artifact v4+ skips dotfiles unless this is set (PR 88 first green
+    # pytest run: 1586 passed, then "No files were found ... path: .coverage").
+    assert str(upload["with"].get("include-hidden-files", "")).lower() in ("true", "True")
     coverage = jobs["py-coverage"]
     assert "py-tests" in coverage["needs"]
     cov_commands = _job_commands(coverage)

--- a/scripts/tests/test_merge_vitest_coverage.py
+++ b/scripts/tests/test_merge_vitest_coverage.py
@@ -1,0 +1,102 @@
+"""Merge sharded Vitest coverage and keep the vitest.config.ts ratchet."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ci.merge_vitest_coverage import (
+    evaluate,
+    find_coverage_json,
+    load_thresholds,
+    main,
+    merge_coverage_maps,
+    summarize,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _file_cov(*, statements: dict, functions: dict, branches: dict) -> dict:
+    statement_map = {
+        sid: {"start": {"line": int(sid) + 1, "column": 0}, "end": {"line": int(sid) + 1, "column": 1}}
+        for sid in statements
+    }
+    return {
+        "path": "web/lib/example.ts",
+        "statementMap": statement_map,
+        "s": statements,
+        "f": functions,
+        "b": branches,
+    }
+
+
+def test_load_thresholds_matches_vitest_config() -> None:
+    text = (REPO / "vitest.config.ts").read_text(encoding="utf-8")
+    assert load_thresholds(text) == {"lines": 75, "functions": 71, "branches": 65}
+
+
+def test_complementary_shards_meet_the_ratchet() -> None:
+    shard_a = {
+        "web/lib/example.ts": _file_cov(
+            statements={"0": 1, "1": 0},
+            functions={"0": 1, "1": 0},
+            branches={"0": [1, 0]},
+        )
+    }
+    shard_b = {
+        "web/lib/example.ts": _file_cov(
+            statements={"0": 0, "1": 1},
+            functions={"0": 0, "1": 1},
+            branches={"0": [0, 1]},
+        )
+    }
+    merged = merge_coverage_maps([shard_a, shard_b])
+    summary = summarize(merged)
+    assert summary["lines"] == 100.0
+    assert summary["functions"] == 100.0
+    assert summary["branches"] == 100.0
+    _, failures = evaluate([shard_a, shard_b], {"lines": 75, "functions": 71, "branches": 65})
+    assert failures == []
+
+
+def test_a_single_shard_fails_the_ratchet() -> None:
+    shard = {
+        "web/lib/example.ts": _file_cov(
+            statements={"0": 1, "1": 0, "2": 0, "3": 0},
+            functions={"0": 1, "1": 0, "2": 0, "3": 0},
+            branches={"0": [1, 0, 0, 0]},
+        )
+    }
+    _, failures = evaluate([shard], {"lines": 75, "functions": 71, "branches": 65})
+    assert failures
+    assert any(item.startswith("lines ") for item in failures)
+
+
+def test_main_merges_shard_json_and_exits_nonzero_when_short(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = tmp_path / "vitest.config.ts"
+    config.write_text(
+        "export default { test: { coverage: { thresholds: { lines: 75, functions: 71, branches: 65 } } } }\n",
+        encoding="utf-8",
+    )
+    root = tmp_path / "artifacts"
+    shard = root / "vitest-coverage-1"
+    shard.mkdir(parents=True)
+    (shard / "coverage-final.json").write_text(
+        json.dumps(
+            {
+                "web/lib/example.ts": _file_cov(
+                    statements={"0": 1, "1": 0, "2": 0, "3": 0},
+                    functions={"0": 1, "1": 0},
+                    branches={"0": [1, 0]},
+                )
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert find_coverage_json(root) == [shard / "coverage-final.json"]
+    assert main(["--root", str(root), "--config", str(config)]) == 1

--- a/scripts/tests/test_replica_watchdog.py
+++ b/scripts/tests/test_replica_watchdog.py
@@ -25,11 +25,10 @@ if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
 
-def _install_fake_db_writer() -> tuple[MagicMock, MagicMock]:
-    """Stub `db.writer` so the handler's lazy import works in tests.
-
-    Returns the (record_service_health, _now_iso) MagicMocks so callers
-    can assert against them.
+@pytest.fixture(autouse=True)
+def fake_db_writer(monkeypatch: pytest.MonkeyPatch):
+    """Stub db.writer for this module; restore so later files on the same
+    xdist worker still import the real writer (test_skew2d in the r-s shard).
     """
     record_mock = MagicMock(name="record_service_health")
     now_iso_mock = MagicMock(name="_now_iso", return_value="2026-05-09T09:00:00Z")
@@ -38,18 +37,12 @@ def _install_fake_db_writer() -> tuple[MagicMock, MagicMock]:
     fake_writer.record_service_health = record_mock  # type: ignore[attr-defined]
     fake_writer._now_iso = now_iso_mock  # type: ignore[attr-defined]
 
-    fake_db_pkg = sys.modules.get("db") or types.ModuleType("db")
-    fake_db_pkg.writer = fake_writer  # type: ignore[attr-defined]
-
-    sys.modules["db"] = fake_db_pkg
-    sys.modules["db.writer"] = fake_writer
-    return record_mock, now_iso_mock
-
-
-@pytest.fixture(autouse=True)
-def fake_db_writer():
-    """Reset db.writer mocks for every test."""
-    record_mock, now_iso_mock = _install_fake_db_writer()
+    monkeypatch.setitem(sys.modules, "db.writer", fake_writer)
+    db_pkg = sys.modules.get("db")
+    if db_pkg is None:
+        db_pkg = types.ModuleType("db")
+        monkeypatch.setitem(sys.modules, "db", db_pkg)
+    monkeypatch.setattr(db_pkg, "writer", fake_writer, raising=False)
     yield record_mock, now_iso_mock
 
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,6 +24,8 @@ export default defineConfig({
       ".pi/tests/**/*.test.ts",
     ],
     environment: "node",
+    fileParallelism: true,
+    maxWorkers: "100%",
     // Pin NODE_ENV=test for every run. Vitest defaults to "test", but an ambient
     // shell `NODE_ENV=development` (common in a dev session) leaks through and
     // overrides it — silently flipping code paths that branch on NODE_ENV (e.g.
@@ -38,6 +40,10 @@ export default defineConfig({
     setupFiles: ["./vitest.setup.ts"],
     coverage: {
       provider: "v8",
+      // Default v8 reporters include html/clover/json. Writing those artifacts
+      // for the 25k-line include set is a large fraction of the 307s CI job.
+      // The ratchet is thresholds, not report files.
+      reporter: ["text"],
       // Non-regressing RATCHET, not a vanity target. Each threshold sits ~2%
       // below current measured coverage so the suite passes today while
       // catching a regression. Raise these over time as coverage climbs;


### PR DESCRIPTION
Pytest is the ~7 minute critical path on main (unit 310s + cloud 62s in one job). This PR shards the test gates. It does not change production `deploy.sh`.

**Pytest**
- 8 filename shards + `scripts/api/tests` and `trade_blotter`/`tests` as their own jobs
- `-n auto --dist loadfile` inside each shard
- `cloud-tests` is its own job (was serial after unit pytest)
- `py-coverage` combines shards and keeps `--fail-under=56`

**Vitest**
- 8 `--shard` jobs; per-shard thresholds zeroed
- `web-coverage` merges istanbul JSON and applies vitest.config.ts 75/71/65

**Install**
- pinned `uv` + `requirements-dev.txt` (pytest-xdist)
- bun install cache on web-tests and perimeter-smoke

Deploy still `needs` both coverage ratchets plus `cloud-tests`.

Measure on this PR: wall clock of the slowest pytest shard vs main's 412s pytest job. Target e2e is 120s; this is the test-gate half.