### PR TITLE
fix(edge): ride out upstream restarts instead of 502ing the browser

### DIFF
--- a/cloud/caddy/Caddyfile
+++ b/cloud/caddy/Caddyfile
@@ -29,8 +29,19 @@
         reverse_proxy localhost:8765
     }
 
+    # Ride out an upstream restart instead of forwarding it to the browser.
+    # reverse_proxy defaults to zero retries, so every request that landed in
+    # the ~7s radon-nextjs/radon-api gap of a deploy promote got a raw 502
+    # (2026-08-25: /admin, /api/ib/ws-ticket, /api/portfolio). The window
+    # outlasts the bounded 10s Next.js SIGTERM drain plus the restart, and is
+    # short enough that a genuinely dead upstream still fails the request.
+    # Do NOT add fail_duration: marking the single upstream down would take
+    # the retry loop out of the picture and 502 immediately again.
     handle_path /api/ib/* {
-        reverse_proxy localhost:8321
+        reverse_proxy localhost:8321 {
+            lb_try_duration 15s
+            lb_try_interval 250ms
+        }
     }
 
     # Tier-2 edge health surface. Reached Caddy->daemon DIRECTLY (never via
@@ -62,7 +73,10 @@
     }
 
     handle {
-        reverse_proxy localhost:3000
+        reverse_proxy localhost:3000 {
+            lb_try_duration 15s
+            lb_try_interval 250ms
+        }
     }
 }
 

--- a/cloud/tests/test_caddyfile.py
+++ b/cloud/tests/test_caddyfile.py
@@ -1,6 +1,17 @@
 """Tests for caddy/Caddyfile configuration."""
 
+import contextlib
+import http.server
+import os
 import re
+import shutil
+import socket
+import subprocess
+import threading
+import time
+import urllib.request
+
+import pytest
 
 
 def read_caddyfile(caddy_dir):
@@ -151,3 +162,167 @@ class TestReloadCompletes:
             f"grace_period {match.group(1)}s is outside the bound the publish "
             "action's reload timeout is sized for"
         )
+
+
+# The bounded Next.js SIGTERM drain (web/lib/boundedShutdown.ts
+# SHUTDOWN_GRACE_MS) caps how long radon-nextjs may take to go away, and
+# `next start` is listening ~1s later. A retry window has to outlast the whole
+# gap or a deploy restart still reaches the browser as a 502.
+SHUTDOWN_GRACE_SECONDS = 10
+MIN_RETRY_WINDOW_SECONDS = SHUTDOWN_GRACE_SECONDS + 2
+
+
+def reverse_proxy_block(content, upstream):
+    """Return the body of the `reverse_proxy <upstream>` block, '' if inline."""
+    match = re.search(
+        r"reverse_proxy\s+" + re.escape(upstream) + r"\s*(\{(?:[^{}]|\{[^{}]*\})*\})?",
+        content,
+    )
+    assert match, f"no reverse_proxy directive for {upstream}"
+    return match.group(1) or ""
+
+
+def retry_window_seconds(block):
+    match = re.search(r"lb_try_duration\s+(\d+)s", block)
+    return int(match.group(1)) if match else 0
+
+
+class TestUpstreamRestartWindow:
+    """A deploy restart of an upstream must not surface as a 502.
+
+    2026-08-25: during the #89 promote, Caddy logged `dial tcp [::1]:3000:
+    connect: connection refused` for ~7s and every request in that window --
+    /admin included -- got a raw 502. `reverse_proxy` defaults to zero retries,
+    so the edge forwards the restart gap straight to the browser instead of
+    riding over it.
+    """
+
+    def test_app_proxy_retries_across_the_restart_gap(self, caddy_dir):
+        block = reverse_proxy_block(read_caddyfile(caddy_dir), "localhost:3000")
+        assert retry_window_seconds(block) >= MIN_RETRY_WINDOW_SECONDS, (
+            "the app upstream has no retry window that outlasts a radon-nextjs "
+            "restart; every request during the deploy gap 502s"
+        )
+
+    def test_api_proxy_retries_across_the_restart_gap(self, caddy_dir):
+        block = reverse_proxy_block(read_caddyfile(caddy_dir), "localhost:8321")
+        assert retry_window_seconds(block) >= MIN_RETRY_WINDOW_SECONDS, (
+            "the /api/ib/* upstream has no retry window that outlasts a "
+            "radon-api restart; ws-ticket calls 502 through every deploy"
+        )
+
+    def test_edge_health_status_stays_fast(self, caddy_dir):
+        block = reverse_proxy_block(read_caddyfile(caddy_dir), "127.0.0.1:8330")
+        assert retry_window_seconds(block) == 0, (
+            "the edge health floor must answer immediately; a retry window "
+            "would make the probe hang instead of reporting unreachable"
+        )
+
+
+class _RestoredUpstream(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Length", "5")
+        self.end_headers()
+        self.wfile.write(b"admin")
+
+    def log_message(self, *args):
+        pass
+
+
+def free_port():
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return probe.getsockname()[1]
+
+
+def wait_for_listener(port, deadline):
+    while time.monotonic() < deadline:
+        with socket.socket() as probe:
+            probe.settimeout(0.2)
+            if probe.connect_ex(("127.0.0.1", port)) == 0:
+                return True
+        time.sleep(0.05)
+    return False
+
+
+CADDY_BIN = os.environ.get("RADON_CADDY_BIN", "caddy")
+
+
+@pytest.mark.skipif(
+    shutil.which(CADDY_BIN) is None,
+    reason="needs a caddy binary; set RADON_CADDY_BIN to run the edge mechanism test",
+)
+class TestRestartWindowMechanism:
+    """Drive the shipped proxy block with a real caddy against a real dead port.
+
+    The assertions above only prove the retry window is spelled correctly.
+    This one reproduces what production did: a request that arrives while the
+    upstream is refusing connections must still be answered once the upstream
+    is back, not turned into a 502 the instant the dial fails.
+    """
+
+    def test_request_during_an_upstream_gap_is_served_not_502ed(
+        self, caddy_dir, tmp_path
+    ):
+        upstream_port = free_port()
+        proxy_port = free_port()
+        proxied = reverse_proxy_block(read_caddyfile(caddy_dir), "localhost:3000")
+        config = tmp_path / "Caddyfile"
+        config.write_text(
+            "{\n\tadmin off\n\tgrace_period 10s\n}\n\n"
+            f"http://127.0.0.1:{proxy_port} {{\n"
+            "\thandle {\n"
+            f"\t\treverse_proxy 127.0.0.1:{upstream_port} {proxied}\n"
+            "\t}\n}\n"
+        )
+
+        caddy = subprocess.Popen(
+            [CADDY_BIN, "run", "--config", str(config), "--adapter", "caddyfile"],
+            env={
+                **os.environ,
+                "XDG_DATA_HOME": str(tmp_path / "data"),
+                "XDG_CONFIG_HOME": str(tmp_path / "config"),
+            },
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        upstream = []
+        try:
+            assert wait_for_listener(proxy_port, time.monotonic() + 10), (
+                "caddy never started listening"
+            )
+
+            # Nothing is listening on the upstream port yet -- exactly what
+            # radon-nextjs looks like between systemd's stop and `next start`.
+            def serve_after_the_gap():
+                time.sleep(1.5)
+                server = http.server.ThreadingHTTPServer(
+                    ("127.0.0.1", upstream_port), _RestoredUpstream
+                )
+                upstream.append(server)
+                server.serve_forever(poll_interval=0.05)
+
+            threading.Thread(target=serve_after_the_gap, daemon=True).start()
+
+            started = time.monotonic()
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{proxy_port}/admin", timeout=30
+            ) as response:
+                status, body = response.status, response.read()
+            waited = time.monotonic() - started
+
+            assert status == 200, f"upstream gap surfaced as HTTP {status}"
+            assert body == b"admin", body
+            assert waited >= 1.0, (
+                f"answered in {waited:.2f}s -- the request cannot have waited "
+                "out the gap, so this is not the retry path"
+            )
+        finally:
+            for server in upstream:
+                with contextlib.suppress(Exception):
+                    server.shutdown()
+            caddy.terminate()
+            caddy.wait(timeout=10)

--- a/docs/incident-runbook.md
+++ b/docs/incident-runbook.md
@@ -195,6 +195,49 @@ Incident: 2026-07-08, P1.
 
 ---
 
+## deploy-restart-window-edge-502
+
+**Every page 502s for a few seconds during a deploy promote.**
+Reported 2026-08-25 as "502 on https://app.radon.run/admin".
+
+- **Mechanism:** `restart-managed` stops `radon-nextjs` and `radon-api` before
+  the new ones listen. `reverse_proxy` defaults to zero retries, so Caddy
+  turned each `dial tcp [::1]:3000: connect: connection refused` into a raw
+  502 the instant the dial failed. Deploy #89 promoted at 12:31 UTC and the
+  edge served 502s from 12:31:29 to 12:31:36 — `/admin` and its RSC prefetches,
+  plus 64 `/api/ib/ws-ticket`, `/api/portfolio`, `/api/orders`. Nothing was
+  broken: the release was green and `/admin` answered 307 → `/sign-in` again
+  the moment `next start` bound the port.
+- **Detection:** transient — a 502 that clears on reload. `journalctl -u caddy`
+  shows `connection refused` to `:3000`/`:8321`, `/var/log/caddy/radon.log` has
+  a `"status":502` burst confined to one minute, and that minute matches the
+  deploy's `[gate] Next.js HTTP responding` line. `curl -sI` after the fact
+  returns the normal 307.
+- **Discriminating check:** compare the 502 timestamps with
+  `systemctl show radon-nextjs -p ActiveEnterTimestamp` and
+  `/home/radon/.radon-last-green-deploy`. Inside the restart window it is this
+  case. Persisting 502s after the unit is active are a different failure
+  (check `.next/BUILD_ID` and `cancelled-deploy-corrupt-next-build`).
+- **Fix (`cloud/caddy/Caddyfile`):** `lb_try_duration 15s` /
+  `lb_try_interval 250ms` on the `:3000` and `:8321` upstreams. The window
+  outlasts the bounded 10 s Next.js SIGTERM drain
+  (`web/lib/boundedShutdown.ts`) plus the restart, so requests wait out the gap
+  instead of failing. Never add `fail_duration`: marking the single upstream
+  down removes the retry loop and restores the instant 502. The edge health
+  floor (`:8330`) deliberately keeps zero retries so probes stay fast.
+- **Publishing:** the Caddyfile is NOT shipped by the CI deploy. After merge,
+  on the VPS as `radon`:
+  `sudo -n /usr/local/sbin/radon-deploy-root publish-caddy` (stages, validates,
+  installs atomically, bounded reload, rolls back on failure). Until then the
+  drift audit flags `/etc/caddy/Caddyfile`.
+- **Regression:** `cloud/tests/test_caddyfile.py::TestUpstreamRestartWindow`
+  (retry window ≥ drain + start on both app upstreams, none on the health
+  floor) and `::TestRestartWindowMechanism`, which runs a real caddy against a
+  dead port and asserts the request is served once the upstream returns
+  (`RADON_CADDY_BIN=<path>` to run it; skipped when no binary is present).
+
+---
+
 ## signals-refresh-curl-timeout-pages-p1
 
 **`radon-signals-refresh.service` oneshot pages P1 `Result=exit-code`


### PR DESCRIPTION
`https://app.radon.run/admin` returned 502. Not a broken release — the edge was forwarding the deploy's restart gap straight to the browser.

## What happened

Deploy #89 promoted at 12:31 UTC. Caddy logged `dial tcp [::1]:3000: connect: connection refused` from 12:31:29 to 12:31:36, and every request in that window got a raw 502: `/admin` plus its RSC prefetches, 64 `/api/ib/ws-ticket`, `/api/portfolio`, `/api/orders`, `/api/service-health`. `reverse_proxy` defaults to zero retries, so the gap between `restart-managed` stopping `radon-nextjs` and `next start` binding the port is user-visible. The release itself was green and `/admin` answered 307 → `/sign-in` again as soon as the port was up.

## Fix

`lb_try_duration 15s` / `lb_try_interval 250ms` on the `:3000` and `:8321` upstreams. The window outlasts the bounded 10s Next.js SIGTERM drain (`web/lib/boundedShutdown.ts`) plus the restart, so requests wait the gap out instead of failing, and it is short enough that a genuinely dead upstream still errors.

- No `fail_duration` — marking the single upstream down removes the retry loop and restores the instant 502.
- The `:8330` edge health floor deliberately keeps zero retries so probes stay fast; a test locks that in.

## Tests

`cloud/tests/test_caddyfile.py`:

- `TestUpstreamRestartWindow` — retry window ≥ drain + start on both app upstreams, none on the health floor.
- `TestRestartWindowMechanism` — starts a real caddy 2.11.2 (the production version) with the shipped proxy block pointed at a dead port, brings the upstream up 1.5s later, asserts the request is served. Red before the change with `urllib.error.HTTPError: HTTP Error 502: Bad Gateway`. Skipped when no caddy binary is present; `RADON_CADDY_BIN=<path>` to run it.

`23 passed` on `cloud/tests/test_caddyfile.py`. Full `cloud/tests`: 1046 passed, 35 pre-existing macOS shell-harness failures in `test_ib_gateway_control.py` / `test_bootstrap_control_plane.py` / `test_deploy_resilience.py` (untouched files, none mention caddy; green on the ubuntu runner).

## After merge — this does not ship itself

The Caddyfile is not published by the CI deploy. Once the deploy has fast-forwarded the VPS checkout:

```bash
ssh radon@ib-gateway sudo -n /usr/local/sbin/radon-deploy-root publish-caddy
```

That stages, `caddy validate`s, installs atomically and reloads under a bound, rolling back on failure. Until it runs, the drift audit flags `/etc/caddy/Caddyfile`.

Runbook case added: `docs/incident-runbook.md` § `deploy-restart-window-edge-502`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)