### PR TITLE
fix(p3): Docker cgroup-parent must be a slice

### DIFF
--- a/cloud/scripts/radon-app-runtime.sh
+++ b/cloud/scripts/radon-app-runtime.sh
@@ -106,7 +106,7 @@ cmd_run() {
     --cap-drop ALL \
     --security-opt no-new-privileges \
     --cgroupns host \
-    --cgroup-parent="system.slice/${unit}" \
+    --cgroup-parent=system.slice \
     --env-file "$ENV_FILE" \
     --env RADON_DB_NO_REPLICA=1 \
     -w "$workdir" \

--- a/cloud/tests/test_app_runtime.py
+++ b/cloud/tests/test_app_runtime.py
@@ -153,7 +153,9 @@ def test_run_allowlisted_unit_uses_host_net_and_radon_user(
     assert "--cap-drop ALL" in log
     assert "no-new-privileges" in log
     assert "--cgroupns host" in log or "--cgroupns=host" in log
-    assert f"--cgroup-parent=system.slice/{unit}" in log
+    # Docker's systemd driver accepts a slice only, not a unit path.
+    assert "--cgroup-parent=system.slice --env-file" in log
+    assert f"system.slice/{unit}" not in log
     assert "docker.sock" not in log
     assert "--privileged" not in log
     assert "ib-gateway" not in log


### PR DESCRIPTION
Fixes the live cutover failure: Docker systemd cgroup driver requires `--cgroup-parent=system.slice`, not `system.slice/<unit>.service`.

Does not install drop-ins. Host ExecStart stays. No runtime retry.