### PR TITLE
ci: path-filter gates, split slow shards, skip idle restarts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,29 @@ jobs:
       - name: Scan repo history for committed secrets
         run: gitleaks detect --source . --config cloud/.gitleaks.toml --redact --no-banner --verbose
 
+  changes:
+    name: Path filter
+    runs-on: ubuntu-latest
+    outputs:
+      python: ${{ steps.filter.outputs.python }}
+      web: ${{ steps.filter.outputs.web }}
+    concurrency:
+      group: ci-changes-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: python3 scripts/ci/path_filter.py
+
   web-tests:
     name: Vitest (shard ${{ matrix.shard }}/8)
+    needs: [changes]
+    if: needs.changes.outputs.web == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -133,6 +154,7 @@ jobs:
   web-coverage:
     name: Vitest coverage ratchet
     needs: [web-tests]
+    if: needs.web-tests.result == 'success'
     runs-on: ubuntu-latest
     concurrency:
       group: ci-web-coverage-${{ github.ref }}
@@ -152,17 +174,19 @@ jobs:
 
   py-tests:
     name: pytest (${{ matrix.shard }})
+    needs: [changes]
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        # Isolate test_i* and scripts/api/tests; those two buckets dominated
-        # wall-clock under the previous a-c / d-g / h-i / rest split.
+        # Isolate test_i* and scripts/api/tests. Split g-h / j-m because the
+        # combined ghjm bucket was the pytest wall (~82s).
         # scripts-daemons: the test_*.py globs match FILES only, so the
         # monitor_daemon/ and watchdog/ subdirectories need their own shard
         # (TEST_AUDIT T-122 — 752 tests left CI unnoticed without it).
         # test_ci_deploy_concurrency.py asserts shard-union == recursive.
-        shard: [scripts-ac, scripts-df, scripts-i, scripts-ghjm, scripts-npsz, scripts-rs, scripts-daemons, rest-api, rest]
+        shard: [scripts-ac, scripts-df, scripts-i, scripts-gh, scripts-jm, scripts-npsz, scripts-rs, scripts-daemons, rest-api, rest]
         include:
           - shard: scripts-ac
             paths: "scripts/tests/test_[a-c]*.py"
@@ -170,8 +194,10 @@ jobs:
             paths: "scripts/tests/test_[d-f]*.py"
           - shard: scripts-i
             paths: "scripts/tests/test_i*.py"
-          - shard: scripts-ghjm
-            paths: "scripts/tests/test_[g-h]*.py scripts/tests/test_[j-m]*.py"
+          - shard: scripts-gh
+            paths: "scripts/tests/test_[g-h]*.py"
+          - shard: scripts-jm
+            paths: "scripts/tests/test_[j-m]*.py"
           - shard: scripts-npsz
             paths: "scripts/tests/test_[n-p]*.py scripts/tests/test_[t-z]*.py"
           - shard: scripts-rs
@@ -238,6 +264,7 @@ jobs:
   py-coverage:
     name: pytest coverage ratchet
     needs: [py-tests]
+    if: needs.py-tests.result == 'success'
     runs-on: ubuntu-latest
     concurrency:
       group: ci-py-coverage-${{ github.ref }}
@@ -298,10 +325,21 @@ jobs:
           python3 scripts/ci/check_demo_isolation.py
 
   cloud-tests:
-    name: pytest (cloud infra)
+    name: pytest (cloud ${{ matrix.shard }})
+    needs: [changes]
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [al, mz]
+        include:
+          - shard: al
+            paths: "cloud/tests/test_[a-l]*.py"
+          - shard: mz
+            paths: "cloud/tests/test_[m-z]*.py"
     concurrency:
-      group: ci-cloud-tests-${{ github.ref }}
+      group: ci-cloud-tests-${{ github.ref }}-${{ matrix.shard }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -323,10 +361,12 @@ jobs:
       # cloud/tests/conftest.py collides with scripts/tests/conftest.py on the
       # import path `tests.conftest`. Running it after unit pytest serialized
       # ~60s onto the deploy critical path.
-      - run: python -m pytest cloud/tests -q
+      - run: python -m pytest ${{ matrix.paths }} -q
 
   perimeter-smoke:
     name: Perimeter smoke (next start + curl)
+    needs: [changes]
+    if: needs.changes.outputs.web == 'true'
     runs-on: ubuntu-latest
     concurrency:
       group: ci-perimeter-smoke-${{ github.ref }}
@@ -421,6 +461,8 @@ jobs:
 
   e2e-financial-smoke:
     name: Playwright P0-financial smoke (non-gating)
+    needs: [changes]
+    if: needs.changes.outputs.web == 'true'
     runs-on: ubuntu-latest
     # The earlier "chromium can't reach loopback" reading (2026-06-13) was a
     # misdiagnosis: the navigation actually failed because a Clerk DEVELOPMENT
@@ -568,8 +610,19 @@ jobs:
 
   deploy:
     name: Deploy to VPS
-    needs: [secret-scan, web-tests, web-coverage, py-tests, py-coverage, cloud-tests, perimeter-smoke, stage-release]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    # Coverage merge stays a required workflow job but is omitted here so
+    # deploy starts when shards pass. Combine needs a barrier VM; putting it
+    # on a matrix shard cannot wait for siblings.
+    needs: [secret-scan, changes, web-tests, py-tests, cloud-tests, perimeter-smoke, stage-release]
+    if: >-
+      github.ref == 'refs/heads/main' && github.event_name == 'push' && !cancelled()
+      && needs.secret-scan.result == 'success'
+      && needs.changes.result == 'success'
+      && (needs.web-tests.result == 'success' || needs.web-tests.result == 'skipped')
+      && (needs.py-tests.result == 'success' || needs.py-tests.result == 'skipped')
+      && (needs.cloud-tests.result == 'success' || needs.cloud-tests.result == 'skipped')
+      && (needs.perimeter-smoke.result == 'success' || needs.perimeter-smoke.result == 'skipped')
+      && (needs.stage-release.result == 'success' || needs.stage-release.result == 'failure' || needs.stage-release.result == 'skipped')
     runs-on: ubuntu-latest
     # Outer budget: deploy.sh gets 15m, then 30s to kill descendants. A root
     # action can hold its lifecycle lock for 180s. Worst-case durable recovery

--- a/cloud/scripts/deploy.sh
+++ b/cloud/scripts/deploy.sh
@@ -94,6 +94,7 @@ readonly DEPLOY_KILL_AFTER="${DEPLOY_KILL_AFTER:-30}"
 readonly BUN_VERSION="1.3.14"
 
 readonly SERVICES=(radon-nextjs radon-api radon-relay radon-monitor radon-newsfeed)
+UNITS_RESTARTED=1
 
 # Required env vars that MUST be present before a deploy touches services.
 # Prefer /etc/radon/env when that regular file exists; else ~/radon-cloud/.env.
@@ -1097,13 +1098,49 @@ start_services_after_transition() {
   DEPLOY_TEARDOWN_STARTED=0
 }
 
+payload_paths_changed() {
+  local prev="$1"
+  local new="$2"
+  local path
+  if [[ -z "$prev" || -z "$new" || "$prev" == "$new" || "$prev" =~ ^0+$ ]]; then
+    return 0
+  fi
+  while IFS= read -r path; do
+    [[ -z "$path" ]] && continue
+    case "$path" in
+      docs/*|tasks/*|.claude/*|.agents/*|notebooks/*|.github/*|*.md)
+        continue
+        ;;
+      scripts/tests/*|cloud/tests/*|web/tests/*|web/e2e/*|site/*)
+        continue
+        ;;
+      web/*|lib/*|scripts/*|cloud/services/*|cloud/scripts/*|cloud/config/*| \
+      requirements*|pyproject.toml|bun.lock|package.json|*.service)
+        return 0
+        ;;
+    esac
+    return 0
+  done < <(git -C "$RADON_DIR" diff --name-only "$prev" "$new")
+  return 1
+}
+
 restart_services() {
   local requested_sha="${1:-}"
   local previous_sha="${2:-}"
   local status=0
+  UNITS_RESTARTED=1
 
   if [[ -n "$requested_sha" ]]; then
     prepare_release_transition "$requested_sha" "$previous_sha" || return $?
+  fi
+  if [[ -n "$requested_sha" && -n "$previous_sha" ]] \
+    && ! payload_paths_changed "$previous_sha" "$requested_sha"; then
+    log_info "No runtime payload changes; promoting without unit restart"
+    activate_staged_release "$requested_sha" "$previous_sha" || return $?
+    refresh_control_plane || return 1
+    install_release_units
+    UNITS_RESTARTED=0
+    return 0
   fi
   stop_services_for_transition
   if [[ -n "$requested_sha" ]]; then
@@ -1212,6 +1249,9 @@ check_units_stable() {
   fi
   elapsed=$((SECONDS - STABILITY_STARTED_AT))
   remaining=$((UNIT_STABILITY_SECONDS - elapsed))
+  if [[ "${UNITS_RESTARTED:-1}" != "1" ]]; then
+    remaining=0
+  fi
   if (( remaining > 0 )); then
     sleep "$remaining"
   fi

--- a/cloud/scripts/deploy.sh
+++ b/cloud/scripts/deploy.sh
@@ -1102,7 +1102,12 @@ payload_paths_changed() {
   local prev="$1"
   local new="$2"
   local path
+  local paths
   if [[ -z "$prev" || -z "$new" || "$prev" == "$new" || "$prev" =~ ^0+$ ]]; then
+    return 0
+  fi
+  # Fail open: unknown git state must restart, not skip the fleet.
+  if ! paths="$(git -C "$RADON_DIR" diff --name-only "$prev" "$new" 2>/dev/null)"; then
     return 0
   fi
   while IFS= read -r path; do
@@ -1120,7 +1125,7 @@ payload_paths_changed() {
         ;;
     esac
     return 0
-  done < <(git -C "$RADON_DIR" diff --name-only "$prev" "$new")
+  done <<< "$paths"
   return 1
 }
 

--- a/cloud/tests/test_deploy_corrections.py
+++ b/cloud/tests/test_deploy_corrections.py
@@ -1926,6 +1926,111 @@ check_units_stable
         assert result.returncode == 0, result.stdout + result.stderr
         assert slept.read_text(encoding="utf-8").strip() == "3"
 
+    def test_check_units_stable_skips_sleep_when_units_were_not_restarted(
+        self, tmp_path: Path
+    ) -> None:
+        fake_bin = tmp_path / "bin"
+        fake_bin.mkdir()
+        slept = tmp_path / "slept"
+        _write_executable(
+            fake_bin / "systemctl",
+            f"""#!{sys.executable}
+import sys
+if sys.argv[1] == "is-active":
+    raise SystemExit(0)
+if sys.argv[1] == "show":
+    print(0)
+    raise SystemExit(0)
+raise SystemExit(2)
+""",
+        )
+        _write_executable(
+            fake_bin / "sleep",
+            f"""#!{sys.executable}
+from pathlib import Path
+import sys
+Path({str(slept)!r}).write_text(sys.argv[1], encoding="utf-8")
+""",
+        )
+        shell = f"""
+set -euo pipefail
+source {DEPLOY!s}
+PATH={fake_bin!s}:$PATH
+UNITS_RESTARTED=0
+snapshot_unit_restarts
+STABILITY_STARTED_AT=$((SECONDS - 1))
+check_units_stable
+"""
+        result = subprocess.run(
+            ["bash", "-c", shell],
+            env={
+                **os.environ,
+                "PATH": f"{fake_bin}:{os.environ['PATH']}",
+                "RADON_DEPLOY_UNIT_STABILITY_SECONDS": "40",
+            },
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert not slept.exists()
+
+    def test_payload_paths_changed_ignores_docs_and_tests(self, tmp_path: Path) -> None:
+        fake_bin = tmp_path / "bin"
+        fake_bin.mkdir()
+        _write_executable(
+            fake_bin / "git",
+            f"""#!{sys.executable}
+import sys
+if sys.argv[1] == "-C":
+    sys.argv = sys.argv[3:]
+if sys.argv[:2] == ["diff", "--name-only"]:
+    print("docs/cloud-services.md")
+    print("scripts/tests/test_foo.py")
+    print(".github/workflows/ci.yml")
+    raise SystemExit(0)
+raise SystemExit(2)
+""",
+        )
+        result = subprocess.run(
+            ["bash", "-c", f"source {DEPLOY!s}; payload_paths_changed a b"],
+            env={**os.environ, "PATH": f"{fake_bin}:{os.environ['PATH']}"},
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 1, result.stdout + result.stderr
+
+    def test_payload_paths_changed_detects_web_runtime(self, tmp_path: Path) -> None:
+        fake_bin = tmp_path / "bin"
+        fake_bin.mkdir()
+        _write_executable(
+            fake_bin / "git",
+            f"""#!{sys.executable}
+import sys
+if sys.argv[1] == "-C":
+    sys.argv = sys.argv[3:]
+if sys.argv[:2] == ["diff", "--name-only"]:
+    print("web/app/page.tsx")
+    raise SystemExit(0)
+raise SystemExit(2)
+""",
+        )
+        result = subprocess.run(
+            ["bash", "-c", f"source {DEPLOY!s}; payload_paths_changed a b"],
+            env={**os.environ, "PATH": f"{fake_bin}:{os.environ['PATH']}"},
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_restart_services_skips_helper_when_payloads_match(
+        self, deploy_text: str
+    ) -> None:
+        body = function_body(deploy_text, "restart_services")
+        assert "payload_paths_changed" in body
+        assert "UNITS_RESTARTED=0" in body
+        assert "stop_services_for_transition" in body
+        assert "start_services_after_transition" in body
+
     def test_topology_is_reverified_after_core_stability_hold(self, deploy_text: str) -> None:
         gate = function_body(deploy_text, "deploy_gate")
         stability = gate.index("check_units_stable")
@@ -2117,8 +2222,10 @@ class TestFrozenArtifacts:
         assert "&" in staged
         assert main.find("build_staged_release") < main.find("restart_services")
         restart = function_body(deploy_text, "restart_services")
-        assert restart.find("stop_services_for_transition") < restart.find(
-            "activate_staged_release"
+        stop_at = restart.find("stop_services_for_transition")
+        assert stop_at >= 0
+        assert stop_at < restart.find(
+            "activate_staged_release", stop_at
         ) < restart.find("start_services_after_transition")
 
     def test_seed_staged_node_modules_reuses_live_tree_when_lockfiles_match(
@@ -2996,7 +3103,9 @@ class TestCloudSecretScan:
             "\n".join(str(step.get("run", "")) for step in job["steps"])
             for job in pytest_jobs
         ]
-        assert any("pytest cloud/tests" in commands for commands in commands_by_job)
+        cloud = jobs["cloud-tests"]
+        assert "cloud/tests/test_" in str(cloud["strategy"]["matrix"]["include"])
+        assert "matrix.paths" in "\n".join(str(step.get("run", "")) for step in cloud["steps"])
         all_commands = [
             "\n".join(str(step.get("run", "")) for step in job["steps"])
             for job in jobs.values()

--- a/cloud/tests/test_deploy_corrections.py
+++ b/cloud/tests/test_deploy_corrections.py
@@ -2022,6 +2022,24 @@ raise SystemExit(2)
         )
         assert result.returncode == 0, result.stdout + result.stderr
 
+    def test_payload_paths_changed_fail_open_when_git_fails(self, tmp_path: Path) -> None:
+        fake_bin = tmp_path / "bin"
+        fake_bin.mkdir()
+        _write_executable(
+            fake_bin / "git",
+            f"""#!{sys.executable}
+import sys
+raise SystemExit(128)
+""",
+        )
+        result = subprocess.run(
+            ["bash", "-c", f"source {DEPLOY!s}; payload_paths_changed a b"],
+            env={**os.environ, "PATH": f"{fake_bin}:{os.environ['PATH']}"},
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+
     def test_restart_services_skips_helper_when_payloads_match(
         self, deploy_text: str
     ) -> None:

--- a/cloud/tests/test_refresh_control_plane.py
+++ b/cloud/tests/test_refresh_control_plane.py
@@ -431,9 +431,12 @@ def test_restart_services_refreshes_before_restart_and_installs_units_after() ->
     deploy = DEPLOY.read_text(encoding="utf-8")
     restart = function_body(deploy, "restart_services")
     assert "refresh_control_plane" in restart
-    assert restart.index("activate_staged_release") < restart.index("refresh_control_plane")
-    assert restart.index("refresh_control_plane") < restart.index("start_services_after_transition")
-    assert restart.index("start_services_after_transition") < restart.index("install_release_units")
+    stop_at = restart.index("stop_services_for_transition")
+    activate_at = restart.index("activate_staged_release", stop_at)
+    refresh_at = restart.index("refresh_control_plane", stop_at)
+    start_at = restart.index("start_services_after_transition")
+    install_at = restart.index("install_release_units", start_at)
+    assert activate_at < refresh_at < start_at < install_at
     refresh = function_body(deploy, "refresh_control_plane")
     assert "refresh-control-plane" in refresh
     assert "refresh-control-plane-privileged" not in refresh

--- a/scripts/ci/path_filter.py
+++ b/scripts/ci/path_filter.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Classify a SHA range as python-gate, web-gate, both, or neither.
+
+Used by .github/workflows/ci.yml so a web/-only push skips pytest and a
+scripts/-only push skips vitest. Shared files (CI yaml, lockfiles that both
+gates consume) run both. Docs-only ranges skip both test gates.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+WEB_PREFIXES = (
+    "web/",
+    "site/",
+    "lib/",
+    "brand/",
+    "vitest.config.ts",
+    "package.json",
+    "bun.lock",
+)
+PYTHON_PREFIXES = (
+    "scripts/",
+    "cloud/",
+    "tests/",
+    "pyproject.toml",
+    "requirements.txt",
+    "requirements-dev.txt",
+)
+SHARED_PREFIXES = (".github/",)
+SKIP_PREFIXES = (
+    "docs/",
+    "tasks/",
+    ".claude/",
+    ".agents/",
+    "notebooks/",
+)
+
+
+def _matches(path: str, prefixes: tuple[str, ...]) -> bool:
+    return any(path == prefix.rstrip("/") or path.startswith(prefix) for prefix in prefixes)
+
+
+def classify(paths: list[str]) -> tuple[bool, bool]:
+    """Return (python, web). Unknown runtime paths force both gates on."""
+    if not paths:
+        return True, True
+    python = False
+    web = False
+    saw_runtime = False
+    for path in paths:
+        if _matches(path, SKIP_PREFIXES) or path.endswith(".md"):
+            continue
+        saw_runtime = True
+        if _matches(path, SHARED_PREFIXES):
+            python = True
+            web = True
+            continue
+        if _matches(path, WEB_PREFIXES):
+            web = True
+        if _matches(path, PYTHON_PREFIXES):
+            python = True
+        if not _matches(path, WEB_PREFIXES + PYTHON_PREFIXES + SHARED_PREFIXES):
+            python = True
+            web = True
+    if not saw_runtime:
+        return False, False
+    return python, web
+
+
+def changed_paths(base: str, head: str, cwd: Path | None = None) -> list[str]:
+    if not base or set(base) <= {"0"}:
+        return []
+    result = subprocess.run(
+        ["git", "diff", "--name-only", f"{base}...{head}"],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def write_output(python: bool, web: bool, output_path: Path) -> None:
+    line = f"python={'true' if python else 'false'}\nweb={'true' if web else 'false'}\n"
+    with output_path.open("a", encoding="utf-8") as handle:
+        handle.write(line)
+
+
+def main(argv: list[str] | None = None) -> int:
+    del argv
+    base = os.environ.get("BASE_SHA", "")
+    head = os.environ.get("HEAD_SHA", "") or "HEAD"
+    output = os.environ.get("GITHUB_OUTPUT")
+    if not output:
+        print("GITHUB_OUTPUT is required", file=sys.stderr)
+        return 2
+    paths = changed_paths(base, head)
+    python, web = classify(paths)
+    write_output(python, web, Path(output))
+    print(f"python={python} web={web} files={len(paths)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_ci_deploy_concurrency.py
+++ b/scripts/tests/test_ci_deploy_concurrency.py
@@ -18,6 +18,7 @@ import yaml
 WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "ci.yml"
 TEST_JOBS = (
     "secret-scan",
+    "changes",
     "web-tests",
     "web-coverage",
     "py-tests",
@@ -97,7 +98,9 @@ def test_stage_release_overlaps_gating_jobs_and_is_cancelable() -> None:
     jobs = _workflow()["jobs"]
     stage = jobs["stage-release"]
     assert "needs" not in stage or stage.get("needs") in (None, [], "")
-    assert stage["if"] == jobs["deploy"]["if"]
+    assert "refs/heads/main" in stage["if"]
+    assert "push" in stage["if"]
+    assert "refs/heads/main" in jobs["deploy"]["if"]
     concurrency = stage.get("concurrency", {})
     assert concurrency.get("cancel-in-progress") == "true"
     assert "github.ref" in concurrency.get("group", "")
@@ -119,7 +122,8 @@ def _job_commands(job: dict) -> str:
 def test_ci_runs_cloud_infra_pytest() -> None:
     jobs = _workflow()["jobs"]
     cloud = jobs["cloud-tests"]
-    assert "pytest cloud/tests" in _job_commands(cloud)
+    assert "matrix.paths" in _job_commands(cloud)
+    assert "cloud/tests" in str(cloud["strategy"]["matrix"]["include"])
     assert "pytest cloud/tests" not in _job_commands(jobs["py-tests"]), (
         "cloud infra tests must run as their own job so they leave the unit "
         "pytest critical path"
@@ -206,7 +210,8 @@ def test_pytest_shards_then_combines_coverage_ratchet() -> None:
         "scripts-ac",
         "scripts-df",
         "scripts-i",
-        "scripts-ghjm",
+        "scripts-gh",
+        "scripts-jm",
         "scripts-npsz",
         "scripts-rs",
         "scripts-daemons",
@@ -282,17 +287,58 @@ def test_pytest_filename_shards_partition_scripts_tests() -> None:
     assert "tests" in other_paths
 
 
-def test_coverage_ratchets_gate_deploy() -> None:
+def test_coverage_ratchets_do_not_serialize_deploy() -> None:
     jobs = _workflow()["jobs"]
     needs = jobs["deploy"]["needs"]
-    assert "web-coverage" in needs
-    assert "py-coverage" in needs
+    assert "web-coverage" not in needs
+    assert "py-coverage" not in needs
     assert "web-tests" in needs
     assert "py-tests" in needs
     assert "cloud-tests" in needs
     assert "stage-release" in needs
     assert "merge_vitest_coverage" in _job_commands(jobs["web-coverage"])
     assert "fail-under=56" in _job_commands(jobs["py-coverage"])
+
+
+def test_path_filter_skips_the_other_gate() -> None:
+    jobs = _workflow()["jobs"]
+    assert jobs["changes"]["outputs"]["python"]
+    assert jobs["changes"]["outputs"]["web"]
+    assert "path_filter.py" in _job_commands(jobs["changes"])
+    assert jobs["web-tests"]["needs"] == ["changes"]
+    assert "web" in jobs["web-tests"]["if"]
+    assert jobs["py-tests"]["needs"] == ["changes"]
+    assert "python" in jobs["py-tests"]["if"]
+    assert jobs["cloud-tests"]["needs"] == ["changes"]
+    assert jobs["perimeter-smoke"]["needs"] == ["changes"]
+
+
+def test_deploy_accepts_skipped_test_jobs() -> None:
+    deploy_if = _workflow()["jobs"]["deploy"]["if"]
+    for job in ("web-tests", "py-tests", "cloud-tests", "perimeter-smoke"):
+        assert f"needs.{job}.result == 'skipped'" in deploy_if
+    assert "needs.changes.result == 'success'" in deploy_if
+    assert "web-coverage" not in deploy_if
+
+
+def test_cloud_infra_shards_partition_cloud_tests() -> None:
+    cloud = _workflow()["jobs"]["cloud-tests"]
+    include = cloud["strategy"]["matrix"]["include"]
+    files = [
+        path.name
+        for path in (WORKFLOW.parents[2] / "cloud" / "tests").glob("test_*.py")
+    ]
+    assigned = {name: [] for name in files}
+    for row in include:
+        for token in str(row["paths"]).split():
+            pattern = Path(token.strip('"')).name
+            for name in files:
+                if fnmatch.fnmatch(name, pattern):
+                    assigned[name].append(pattern)
+    overlap = {name: hits for name, hits in assigned.items() if len(hits) > 1}
+    missing = [name for name, hits in assigned.items() if not hits]
+    assert overlap == {}
+    assert missing == []
 
 
 def test_py_coverage_installs_coverage_only() -> None:

--- a/scripts/tests/test_path_filter.py
+++ b/scripts/tests/test_path_filter.py
@@ -1,0 +1,48 @@
+"""Path-filter classification for CI test gates."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ci.path_filter import classify, write_output
+
+
+def test_web_only_skips_python() -> None:
+    python, web = classify(["web/lib/foo.ts", "web/tests/bar.test.tsx"])
+    assert (python, web) == (False, True)
+
+
+def test_scripts_only_skips_web() -> None:
+    python, web = classify(["scripts/ib_sync.py", "cloud/scripts/deploy.sh"])
+    assert (python, web) == (True, False)
+
+
+def test_shared_ci_yaml_runs_both() -> None:
+    python, web = classify([".github/workflows/ci.yml"])
+    assert (python, web) == (True, True)
+
+
+def test_docs_only_skips_both_gates() -> None:
+    python, web = classify(["docs/cloud-services.md", "tasks/todo.md", "README.md"])
+    assert (python, web) == (False, False)
+
+
+def test_mixed_web_and_python_runs_both() -> None:
+    python, web = classify(["web/app/page.tsx", "scripts/ib_sync.py"])
+    assert (python, web) == (True, True)
+
+
+def test_unknown_runtime_path_runs_both() -> None:
+    python, web = classify(["config/sudoers.d/radon-deploy"])
+    assert (python, web) == (True, True)
+
+
+def test_empty_range_runs_both() -> None:
+    python, web = classify([])
+    assert (python, web) == (True, True)
+
+
+def test_write_output_appends_github_output(tmp_path: Path) -> None:
+    target = tmp_path / "github_output"
+    write_output(False, True, target)
+    assert target.read_text(encoding="utf-8") == "python=false\nweb=true\n"


### PR DESCRIPTION
Post-#89 healthy e2e is ~3m (pytest ~82s + deploy ~75s). This cuts the remaining wall.

**CI**
- `changes` job classifies the SHA range. web-only skips pytest/cloud; scripts-only skips vitest/perimeter/Playwright. Docs-only skips both test gates. `.github/` still runs both.
- Split `scripts-ghjm` into `scripts-gh` and `scripts-jm`.
- Shard `cloud-tests` a-l / m-z.
- Deploy no longer `needs` coverage merge. Ratchets still run and fail the workflow. Deploy treats skipped test jobs as OK so a web-only push can still ship.

**VPS**
- If `git diff` has no runtime payload, promote without `stop-clean` / `restart-managed`.
- `check_units_stable` sleeps 0 when nothing was restarted.

Verify: 31 CI contract + 43 deploy contract tests passed locally.