### PR TITLE
feat(order): full nine-field quote telemetry on every order surface

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -7868,6 +7868,11 @@ body[data-mobile="true"] .orders-command-strip__jump:active {
 .price-bar-value { font-family: var(--font-mono); font-size: 12px; font-weight: 500; }
 .price-bar-value.positive { color: var(--positive); }
 .price-bar-value.negative { color: var(--negative); }
+/* Tight density: same nine fields, smaller spacing + type so the panel fits a
+   narrow inline order ticket or a mobile bottom sheet. Never drops a field. */
+.price-bar--tight { gap: 4px 8px; padding: 6px 0; }
+.price-bar--tight .price-bar-label { font-size: 8px; }
+.price-bar--tight .price-bar-value { font-size: 11px; }
 
 /* Price chart */
 .price-chart-panel { border-top: none; }

--- a/web/components/ChatLauncher.tsx
+++ b/web/components/ChatLauncher.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import ChatPanel from "@/components/ChatPanel";
 import { subscribeAsk } from "@/lib/agent/askBus";
+import type { PriceData } from "@/lib/pricesProtocol";
 import type { WorkspaceSection } from "@/lib/types";
 import type { PortfolioData } from "@/lib/types";
 
@@ -16,9 +17,11 @@ import type { PortfolioData } from "@/lib/types";
 type ChatLauncherProps = {
   activeSection: WorkspaceSection;
   portfolio: PortfolioData | null | undefined;
+  /** Live quotes from the shell's single relay subscription, for the approval gate. */
+  prices?: Record<string, PriceData>;
 };
 
-export default function ChatLauncher({ activeSection, portfolio }: ChatLauncherProps) {
+export default function ChatLauncher({ activeSection, portfolio, prices }: ChatLauncherProps) {
   const [open, setOpen] = useState(false);
   // A prompt handed over from another surface (newsfeed follow-up chips).
   // Consumed once by ChatPanel, then cleared so it can't re-fire on re-render.
@@ -74,6 +77,7 @@ export default function ChatLauncher({ activeSection, portfolio }: ChatLauncherP
           isOpen={open}
           seedPrompt={seedPrompt}
           onSeedConsumed={() => setSeedPrompt(null)}
+          prices={prices}
         />
       </div>
     </div>

--- a/web/components/ChatPanel.tsx
+++ b/web/components/ChatPanel.tsx
@@ -6,6 +6,7 @@ import { ApprovalGate, AskComposer, EngineTrace } from "@/components/agent";
 import { buildTurnSteps, describeEngines } from "@/lib/agent/turnSteps";
 import type {
   ApiMessage,
+  AssistantOrderInput,
   AssistantOrderProposal,
   AssistantToolEvent,
   Message,
@@ -23,8 +24,16 @@ import {
   streamMessage,
 } from "@/lib/chat";
 import MarkdownRenderer from "./MarkdownRenderer";
+import { OrderQuoteTelemetry } from "@/components/QuoteTelemetry";
 import { OrderRiskGate } from "@/lib/order/risk/OrderRiskGate";
 import type { OrderRiskInput, OrderRiskState } from "@/lib/order/risk/useOrderRisk";
+import { computeNetOptionQuote, formatExpiry, type OrderLeg } from "@/lib/optionsChainUtils";
+import { optionKey, type PriceData } from "@/lib/pricesProtocol";
+import {
+  buildQuoteTelemetryModel,
+  comboQuotePriceData,
+  type QuoteTelemetryModel,
+} from "@/lib/quoteTelemetry";
 
 type ChatPanelProps = {
   activeSection: WorkspaceSection;
@@ -40,7 +49,15 @@ type ChatPanelProps = {
    */
   seedPrompt?: string | null;
   onSeedConsumed?: () => void;
+  /**
+   * Live quotes, keyed the way `usePrices` keys them (ticker for a stock,
+   * `optionKey()` for a contract). The proposal gate reads the one instrument
+   * it is about to route out of this map.
+   */
+  prices?: Record<string, PriceData>;
 };
+
+const NO_PRICES: Record<string, PriceData> = {};
 
 /**
  * Request lifecycle as a named union, not scattered booleans. Each state maps
@@ -96,12 +113,81 @@ function proposalRiskInput(proposal: AssistantOrderProposal | null): OrderRiskIn
   };
 }
 
+/** Names the instrument the way its ticket names it, e.g. "MU 2026-09-18 $120 C". */
+function proposalQuoteLabel(input: AssistantOrderInput): string {
+  if (input.type === "option") {
+    return `${input.ticker} ${formatExpiry(input.expiry)} $${input.strike} ${input.right}`;
+  }
+  if (input.type === "combo") {
+    return `${input.ticker} ${input.structure ?? "Combo"}`;
+  }
+  return input.ticker;
+}
+
+/**
+ * A BAG is not a quoted instrument: net the legs with the shared combo
+ * calculation, then hand that net quote to the SAME model builder every
+ * single-leg surface uses.
+ */
+function comboQuoteModel(
+  input: Extract<AssistantOrderInput, { type: "combo" }>,
+  prices: Record<string, PriceData>,
+): QuoteTelemetryModel | null {
+  const legs: OrderLeg[] = input.legs.map((leg, index) => ({
+    id: `${input.ticker}-${index}`,
+    action: leg.action,
+    right: leg.right,
+    strike: leg.strike,
+    expiry: leg.expiry,
+    quantity: leg.ratio,
+    limitPrice: null,
+  }));
+  const net = computeNetOptionQuote(legs, prices, input.ticker);
+  if (net.bid == null && net.ask == null) return null;
+  return buildQuoteTelemetryModel(
+    comboQuotePriceData({ symbol: input.ticker, bid: net.bid, ask: net.ask, last: net.mid }),
+  );
+}
+
+type ProposalQuote = {
+  label: string;
+  priceData: PriceData | null;
+  model: QuoteTelemetryModel | null;
+};
+
+/**
+ * The proposal's own quote: the underlying for a stock, the contract for a
+ * single-leg option, the net market for a combo.
+ */
+function proposalQuote(
+  proposal: AssistantOrderProposal | null,
+  prices: Record<string, PriceData>,
+): ProposalQuote | null {
+  if (!proposal) return null;
+  const input = proposal.input;
+  const label = proposalQuoteLabel(input);
+  if (input.type === "combo") {
+    return { label, priceData: null, model: comboQuoteModel(input, prices) };
+  }
+  const key =
+    input.type === "option"
+      ? optionKey({
+          symbol: input.ticker,
+          expiry: input.expiry,
+          strike: input.strike,
+          right: input.right,
+        })
+      : input.ticker;
+  return { label, priceData: prices[key] ?? null, model: null };
+}
+
 export default function ChatPanel({
   activeSection,
   portfolio,
   isOpen = true,
   seedPrompt = null,
   onSeedConsumed,
+  prices = NO_PRICES,
 }: ChatPanelProps) {
   const [messages, setMessages] = useState<Message[]>([]);
   const [status, setStatus] = useState<ChatStatus>("idle");
@@ -114,6 +200,7 @@ export default function ChatPanel({
   const [isPlacing, setPlacing] = useState(false);
   const [riskState, setRiskState] = useState<OrderRiskState | null>(null);
   const riskInput = useMemo(() => proposalRiskInput(proposal), [proposal]);
+  const quote = useMemo(() => proposalQuote(proposal, prices), [proposal, prices]);
   const [showJump, setShowJump] = useState(false);
 
   const messagesRef = useRef<HTMLDivElement | null>(null);
@@ -383,6 +470,16 @@ export default function ChatPanel({
               <ApprovalGate
                 title="Confirmation required"
                 body={proposal.summary}
+                quote={
+                  quote ? (
+                    <OrderQuoteTelemetry
+                      priceData={quote.priceData}
+                      model={quote.model}
+                      label={quote.label}
+                      density="tight"
+                    />
+                  ) : null
+                }
                 options={[{ id: "route", label: "Route as proposed", meta: "AS PROPOSED" }]}
                 busy={isPlacing}
                 confirmDisabled={riskState?.okToSubmit !== true}

--- a/web/components/InstrumentDetailModal.tsx
+++ b/web/components/InstrumentDetailModal.tsx
@@ -244,6 +244,7 @@ function LegOrderForm({
       bid={bid}
       mid={mid}
       ask={ask}
+      priceData={priceData}
       showQuickButtonPrices={true}
       isValid={isValid}
       limitPrice={limitPrice}

--- a/web/components/ModifyOrderModal.tsx
+++ b/web/components/ModifyOrderModal.tsx
@@ -17,9 +17,8 @@ import {
 } from "@/lib/order/positionTrade";
 import { computeLegImpliedValue } from "@/lib/impliedValue";
 import { useRiskFreeRate } from "@/lib/useRiskFreeRate";
-import { ModifyOrderQuoteTelemetry } from "./QuoteTelemetry";
+import { OrderQuoteTelemetry } from "./QuoteTelemetry";
 import {
-  OrderPriceStrip,
   OrderLegPills,
   OrderRiskGate,
   type OrderLeg as UnifiedOrderLeg,
@@ -626,22 +625,7 @@ export default function ModifyOrderModal({ order, loading, prices, portfolio, op
 
         <div className={`modify-layout${isComboOrder ? " modify-layout-combo" : ""}`}>
           <div className="modify-primary-panel">
-            <ModifyOrderQuoteTelemetry priceData={priceData} />
-
-            {/* Price strip for combo orders */}
-            {isComboOrder && hasPriceData && bid != null && ask != null && mid != null && (
-              <OrderPriceStrip
-                prices={{
-                  bid,
-                  mid,
-                  ask,
-                  spread: ask - bid,
-                  spreadPct: Math.abs(mid) > 0 ? ((ask - bid) / Math.abs(mid)) * 100 : null,
-                  available: true,
-                }}
-                compact
-              />
-            )}
+            <OrderQuoteTelemetry priceData={priceData} label={order.symbol} density="tight" />
 
             {order.orderType === "STP LMT" && order.auxPrice != null && (
               <div className="modify-stop-row">

--- a/web/components/QuoteTelemetry.tsx
+++ b/web/components/QuoteTelemetry.tsx
@@ -11,6 +11,12 @@ import {
 
 type QuoteTelemetryVariant = "bar" | "compact";
 
+/**
+ * Spacing/type-scale only. `tight` exists so the same nine fields fit a narrow
+ * inline ticket or a mobile bottom sheet; it never changes WHICH fields render.
+ */
+export type QuoteTelemetryDensity = "default" | "tight";
+
 const BAR_FIELDS: QuoteTelemetryFieldKey[] = ["bid", "mid", "ask", "spread", "last", "volume", "high", "low", "day"];
 const COMPACT_FIELDS: QuoteTelemetryFieldKey[] = ["bid", "mid", "ask", "spread"];
 
@@ -38,19 +44,25 @@ function QuoteTelemetryPanel({
   label,
   fields,
   variant,
+  density = "default",
 }: {
   model: QuoteTelemetryModel | null;
   label?: string;
   fields: QuoteTelemetryFieldKey[];
   variant: QuoteTelemetryVariant;
+  density?: QuoteTelemetryDensity;
 }) {
   const classes = VARIANT_CLASSES[variant];
   if (!model) {
     return <div className={classes.empty}>{classes.emptyText}</div>;
   }
 
+  const containerClass = density === "tight"
+    ? `${classes.container} ${classes.container}--tight`
+    : classes.container;
+
   return (
-    <div className={classes.container}>
+    <div className={containerClass}>
       {variant === "bar" && label && (
         <div className={classes.row} style={{ gridColumn: "1 / -1" }}>
           <span className={classes.label}>{label}</span>
@@ -74,41 +86,52 @@ function QuoteTelemetryPanel({
   );
 }
 
-export function TickerQuoteTelemetry({
-  priceData,
+export type OrderQuoteTelemetryProps = {
+  /** The traded instrument's live quote. Omit (or pass null) on a combo and hand `model` instead. */
+  priceData?: PriceData | null;
+  /**
+   * Escape hatch for surfaces that have no single PriceData (BAG / combo
+   * tickets). Build it with `comboQuotePriceData()` + `buildQuoteTelemetryModel()`
+   * so the spread math and the closed-market fallback stay in one place.
+   * Takes precedence over `priceData`.
+   */
+  model?: QuoteTelemetryModel | null;
+  /** e.g. "META 2026-08-28 $550 P". Rendered as a full-width row above the fields. */
+  label?: string;
+  /** Prior-session OHLV (UW stock-state) so a closed market shows CLOSE instead of an empty panel. */
+  fallback?: QuoteFallback | null;
+  /** Spacing and type scale only. `tight` for inline tickets and mobile sheets. */
+  density?: QuoteTelemetryDensity;
+};
+
+/**
+ * The one nine-field quote panel every order surface renders: BID MID ASK /
+ * SPREAD LAST VOLUME / HIGH LOW DAY. Same model, same formatter, and the same
+ * closed-market fallback the portfolio position drawer gets.
+ */
+export function OrderQuoteTelemetry({
+  priceData = null,
+  model,
   label,
   fallback,
-}: {
-  priceData: PriceData | null;
-  label?: string;
-  fallback?: QuoteFallback | null;
-}) {
+  density = "default",
+}: OrderQuoteTelemetryProps) {
   return (
     <QuoteTelemetryPanel
-      model={buildQuoteTelemetryModel(priceData, fallback ?? null)}
+      model={model ?? buildQuoteTelemetryModel(priceData ?? null, fallback ?? null)}
       label={label}
       fields={BAR_FIELDS}
       variant="bar"
+      density={density}
     />
   );
 }
 
-export function InstrumentOrderQuoteTelemetry({
-  priceData,
-  label,
-}: {
-  priceData: PriceData | null;
-  label?: string;
-}) {
-  return (
-    <QuoteTelemetryPanel
-      model={buildQuoteTelemetryModel(priceData)}
-      label={label}
-      fields={BAR_FIELDS}
-      variant="bar"
-    />
-  );
-}
+/** Thin alias. The ticker hero bar is the same nine-field panel. */
+export const TickerQuoteTelemetry = OrderQuoteTelemetry;
+
+/** Thin alias kept for existing order call sites. Prefer `OrderQuoteTelemetry`. */
+export const InstrumentOrderQuoteTelemetry = OrderQuoteTelemetry;
 
 export function ModifyOrderQuoteTelemetry({ priceData }: { priceData: PriceData | null }) {
   return (

--- a/web/components/SingleLegOrderTicket.tsx
+++ b/web/components/SingleLegOrderTicket.tsx
@@ -11,6 +11,8 @@ import {
 } from "@/lib/order";
 import OrderErrorBanner from "./OrderErrorBanner";
 import OrderTypeToggle from "./OrderTypeToggle";
+import { OrderQuoteTelemetry } from "./QuoteTelemetry";
+import type { PriceData } from "@/lib/pricesProtocol";
 import {
   type IbOrderType,
   isStopOrderType,
@@ -60,6 +62,14 @@ export type SingleLegOrderTicketProps = {
   bid: number | null;
   mid: number | null;
   ask: number | null;
+  /**
+   * Full live quote for the instrument being traded. When present the ticket
+   * renders the shared nine-field `<OrderQuoteTelemetry>` block above the
+   * Action field; omitted, no quote block is rendered at all.
+   */
+  priceData?: PriceData | null;
+  /** Instrument caption for the telemetry block (e.g. "AAPL $170 Call 2026-08-28"). */
+  quoteLabel?: string;
   /** When true the quick buttons append the price (e.g. "BID 1.23"). */
   showQuickButtonPrices?: boolean;
   /** Whether the current form state is submittable. */
@@ -132,6 +142,8 @@ export default function SingleLegOrderTicket({
   bid,
   mid,
   ask,
+  priceData,
+  quoteLabel,
   showQuickButtonPrices = false,
   isValid,
   limitPrice,
@@ -299,6 +311,10 @@ export default function SingleLegOrderTicket({
   return (
     <div className={className ? `order-form ${className}` : "order-form"} style={style}>
       {header}
+
+      {priceData != null && (
+        <OrderQuoteTelemetry priceData={priceData} label={quoteLabel} density="tight" />
+      )}
 
       <div className="order-field">
         <label className="order-label">Action</label>

--- a/web/components/WorkspaceShell.tsx
+++ b/web/components/WorkspaceShell.tsx
@@ -580,7 +580,7 @@ export default function WorkspaceShell({ section, tickerParam }: WorkspaceShellP
       </main>
 
       <ToastContainer toasts={toasts} exitingIds={exitingIds} onDismiss={dismissToast} />
-      <ChatLauncher activeSection={activeSection} portfolio={portfolio} />
+      <ChatLauncher activeSection={activeSection} portfolio={portfolio} prices={prices} />
       <DemoWelcomeModal />
       <CommandPalette
         open={paletteOpen}

--- a/web/components/agent/ApprovalGate.tsx
+++ b/web/components/agent/ApprovalGate.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 
 /**
  * ApprovalGate — structured human-in-the-loop confirmation. Adopted from
@@ -20,6 +20,12 @@ type ApprovalGateProps = {
   title?: string;
   /** Declarative condition statement, e.g. the order summary + why gated. */
   body: string;
+  /**
+   * Telemetry rendered above the handling options, e.g. the nine-field
+   * <OrderQuoteTelemetry> block for the instrument being routed. The gate stays
+   * presentational: the caller owns the quote, the gate owns the layout.
+   */
+  quote?: ReactNode;
   options: GateOption[];
   defaultOptionId?: string;
   /** Mono expiry telemetry, e.g. "EXPIRES 09:32:00 ET". */
@@ -38,6 +44,7 @@ type ApprovalGateProps = {
 export default function ApprovalGate({
   title = "Confirmation required",
   body,
+  quote,
   options,
   defaultOptionId,
   expiry,
@@ -56,6 +63,7 @@ export default function ApprovalGate({
       </div>
       <div className="approval-gate__body">
         <p className="approval-gate__statement">{body}</p>
+        {quote}
         <div className="approval-gate__options" role="radiogroup" aria-label="Handling options">
           {options.map((opt) => (
             <button

--- a/web/components/mobile/MobileChainLadder.tsx
+++ b/web/components/mobile/MobileChainLadder.tsx
@@ -25,6 +25,7 @@ import type { SideFilter } from "@/lib/useChainUrlState";
 import BottomSheet from "./BottomSheet";
 import MobileOrderTicket from "./MobileOrderTicket";
 import SpectralLoader from "@/components/SpectralLoader";
+import { OrderQuoteTelemetry } from "@/components/QuoteTelemetry";
 
 type Strike = {
   strike: number;
@@ -630,17 +631,11 @@ export default function MobileChainLadder({
           }
         >
           <div className="mobile-chain__detail">
-            <div className="mobile-chain__detail-row">
-              <span className="mobile-chain__detail-label">Last</span>
-              <span className="mobile-chain__detail-value">{fmtLast(selected.data?.last)}</span>
-            </div>
-            <div className="mobile-chain__detail-row">
-              <span className="mobile-chain__detail-label">Bid / Ask</span>
-              <span className="mobile-chain__detail-value">
-                {selected.data?.bid != null ? fmtPrice(selected.data.bid) : "—"} /{" "}
-                {selected.data?.ask != null ? fmtPrice(selected.data.ask) : "—"}
-              </span>
-            </div>
+            <OrderQuoteTelemetry
+              priceData={selected.data}
+              label={`${ticker.toUpperCase()} ${selected.strike} ${selected.right === "C" ? "Call" : "Put"}`}
+              density="tight"
+            />
             <div className="mobile-chain__detail-row">
               <span className="mobile-chain__detail-label">Bid Size / Ask Size</span>
               <span className="mobile-chain__detail-value">
@@ -666,10 +661,6 @@ export default function MobileChainLadder({
             <div className="mobile-chain__detail-row">
               <span className="mobile-chain__detail-label">Vega</span>
               <span className="mobile-chain__detail-value">{fmtGreek(selected.data?.vega)}</span>
-            </div>
-            <div className="mobile-chain__detail-row">
-              <span className="mobile-chain__detail-label">Volume</span>
-              <span className="mobile-chain__detail-value">{fmtOi(selected.data?.volume)}</span>
             </div>
             <div className="mobile-chain__detail-row">
               <span className="mobile-chain__detail-label">Avg Volume</span>

--- a/web/components/mobile/MobileOrderTicket.tsx
+++ b/web/components/mobile/MobileOrderTicket.tsx
@@ -11,8 +11,10 @@ import {
   normalizeComboOrder,
   formatExpiry,
 } from "@/lib/optionsChainUtils";
-import { normalizeOptionExpiry } from "@/lib/pricesProtocol";
+import { normalizeOptionExpiry, optionKey } from "@/lib/pricesProtocol";
 import type { PriceData } from "@/lib/pricesProtocol";
+import { OrderQuoteTelemetry } from "@/components/QuoteTelemetry";
+import { buildQuoteTelemetryModel, comboQuotePriceData } from "@/lib/quoteTelemetry";
 import type { PortfolioData } from "@/lib/types";
 import { fmtPrice } from "@/lib/positionUtils";
 import {
@@ -196,6 +198,40 @@ export default function MobileOrderTicket({
     }),
     [netQuote.bid, netQuote.mid, netQuote.ask, isCombo],
   );
+
+  // The same nine-field telemetry the position drawer renders, for the exact
+  // instrument being traded: the leg's own live quote when single-leg, the
+  // signed net quote wrapped as a PriceData when it is a combo (no exchange
+  // publishes a BAG's session OHLV, so those fields read "---").
+  const quoteTelemetryModel = useMemo(() => {
+    const soleLeg = !isCombo && legs.length === 1 ? legs[0] : null;
+    if (soleLeg) {
+      const key = optionKey({
+        symbol: ticker,
+        expiry: soleLeg.expiry,
+        strike: soleLeg.strike,
+        right: soleLeg.right,
+      });
+      return buildQuoteTelemetryModel(prices[key] ?? null);
+    }
+    if (signedQuote.bid == null && signedQuote.ask == null) return null;
+    return buildQuoteTelemetryModel(
+      comboQuotePriceData({
+        symbol: ticker,
+        bid: signedQuote.bid,
+        ask: signedQuote.ask,
+        last: signedQuote.mid,
+      }),
+    );
+  }, [isCombo, legs, prices, ticker, signedQuote.bid, signedQuote.ask, signedQuote.mid]);
+
+  const quoteTelemetryLabel = useMemo(() => {
+    const soleLeg = !isCombo && legs.length === 1 ? legs[0] : null;
+    if (soleLeg) {
+      return `${ticker} ${formatExpiry(soleLeg.expiry)} $${soleLeg.strike} ${soleLeg.right}`;
+    }
+    return `${ticker} ${structure || "Combo"} NET`;
+  }, [isCombo, legs, ticker, structure]);
 
   // Auto-populate to mid on first availability + on structure changes.
   useEffect(() => {
@@ -708,6 +744,12 @@ export default function MobileOrderTicket({
 
           {/* 2. Price stepper — after legs */}
           <div className="mobile-ticket__price-section">
+            <OrderQuoteTelemetry
+              model={quoteTelemetryModel}
+              label={quoteTelemetryLabel}
+              density="tight"
+            />
+
             {/* F3: Bid/Mid/Ask are tappable quick-set chips — one tap fills the
                 limit input from the live combo quote. */}
             <div className="mobile-ticket__quote">

--- a/web/components/ticker-detail/BookTab.tsx
+++ b/web/components/ticker-detail/BookTab.tsx
@@ -317,6 +317,7 @@ function StockOrderForm({
   bid,
   ask,
   mid,
+  priceData,
 }: {
   ticker: string;
   position: PortfolioPosition | null;
@@ -324,6 +325,7 @@ function StockOrderForm({
   bid: number | null;
   ask: number | null;
   mid: number | null;
+  priceData: PriceData | null;
 }) {
   const orderActions = useOrderActionsOptional();
   const defaultAction: SingleLegOrderAction = position != null ? "SELL" : "BUY";
@@ -403,6 +405,8 @@ function StockOrderForm({
       bid={bid}
       mid={mid}
       ask={ask}
+      priceData={priceData}
+      quoteLabel={ticker}
       showQuickButtonPrices={false}
       isValid={isValid}
       limitPrice={limitPrice}
@@ -511,6 +515,9 @@ export default function BookTab({
   const spread = bid != null && ask != null ? ask - bid : null;
   const last = priceData?.last ?? null;
   const lastLabel = priceData?.lastIsCalculated ? "MARK" : "LAST";
+  // The stock ticket always trades the UNDERLYING, so its quote telemetry must
+  // read the stock's own quote even while the book is focused on an option leg.
+  const stockPriceData = resolvedBookKey === ticker ? priceData : prices[ticker] ?? null;
   const isIndex = isIndexSymbol(ticker);
 
   const selectedOptionLeg = optionLegBooks.find((leg) => leg.key === resolvedBookKey) ?? null;
@@ -665,7 +672,9 @@ export default function BookTab({
 
       {isIndex ? (
         <>
-          {hasFuturesSupport(ticker) && <FuturesOrderForm ticker={ticker} />}
+          {hasFuturesSupport(ticker) && (
+            <FuturesOrderForm ticker={ticker} priceData={tickerPriceData ?? prices[ticker] ?? null} />
+          )}
           {hasIndexOptionsSupport(ticker) && (
             <div style={{ marginTop: hasFuturesSupport(ticker) ? "24px" : "0" }}>
               <IndexOptionOrderForm ticker={ticker} />
@@ -683,6 +692,7 @@ export default function BookTab({
           bid={bid}
           ask={ask}
           mid={mid}
+          priceData={stockPriceData}
         />
       )}
 

--- a/web/components/ticker-detail/FuturesOrderForm.tsx
+++ b/web/components/ticker-detail/FuturesOrderForm.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useTickerDetailOptional } from "@/lib/TickerDetailContext";
 import { useFuturesChain, type FuturesChainContract } from "@/lib/useFuturesChain";
 import { type LinearOrderRiskInput } from "@/lib/order";
+import type { PriceData } from "@/lib/pricesProtocol";
 import type { PortfolioData } from "@/lib/types";
 import {
   ListedContractOrderForm,
@@ -18,6 +19,15 @@ interface FuturesOrderFormProps {
    * branch (added 2026-05-26 via OrderRiskInput discriminated union).
    */
   portfolio?: PortfolioData | null;
+  /**
+   * Live quote for the INDEX the futures chain is listed against (VIX), which
+   * is the only feed keyed for this surface — no PriceData is keyed by a
+   * future's conId anywhere in the app. Threaded from the parent so the
+   * telemetry panel re-renders on tick; the panel is labelled with the index
+   * symbol so the operator never reads it as the front-month contract's own
+   * book.
+   */
+  priceData?: PriceData | null;
 }
 
 function formatExpiry(date: string): string {
@@ -45,7 +55,7 @@ function formatExpiry(date: string): string {
  * sees the actual exposure (1 VIX future at 19 = $19,000 notional,
  * ~$5,500 initial margin).
  */
-export function FuturesOrderForm({ ticker, portfolio }: FuturesOrderFormProps) {
+export function FuturesOrderForm({ ticker, portfolio, priceData }: FuturesOrderFormProps) {
   const symbol = ticker.toUpperCase();
   const tickerDetail = useTickerDetailOptional();
   const { data, loading, error } = useFuturesChain(symbol);
@@ -209,6 +219,8 @@ export function FuturesOrderForm({ ticker, portfolio }: FuturesOrderFormProps) {
       notionalLabel="Notional"
       limitPriceLabel="Limit Price"
       limitPriceStep={selectedContract?.minTick ?? 0.05}
+      priceData={priceData ?? null}
+      quoteLabel={`${symbol} Index`}
       buildRiskInput={buildRiskInput}
       portfolio={portfolio}
       surface="futures-form"

--- a/web/components/ticker-detail/IndexOptionOrderForm.tsx
+++ b/web/components/ticker-detail/IndexOptionOrderForm.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useIndexOptionsChain } from "@/lib/useIndexOptionsChain";
+import { useTickerDetailOptional } from "@/lib/TickerDetailContext";
+import { optionKey } from "@/lib/pricesProtocol";
 import { type OrderRiskInput } from "@/lib/order";
 import type { PortfolioData } from "@/lib/types";
 import {
@@ -92,6 +94,26 @@ export function IndexOptionOrderForm({ ticker, portfolio }: IndexOptionOrderForm
     () => expiryContracts.find((c) => c.conId === selectedConId) ?? null,
     [expiryContracts, selectedConId],
   );
+
+  // Quote telemetry for the STRIKE the operator is about to trade. Keyed on the
+  // selected contract so the panel never falls back to the cash index, whose
+  // bid/ask/high/low describe a different instrument. No quote for that key
+  // (relay not subscribed to it) → the shared panel renders its empty state.
+  const tickerDetail = useTickerDetailOptional();
+  const prices = tickerDetail?.getPrices();
+  const quote = useMemo(() => {
+    if (!selectedContract) return { priceData: null, label: undefined as string | undefined };
+    const key = optionKey({
+      symbol,
+      expiry: selectedContract.lastTradeDateOrContractMonth,
+      strike: selectedContract.strike,
+      right: selectedContract.right === "P" ? "P" : "C",
+    });
+    return {
+      priceData: prices?.[key] ?? null,
+      label: `${symbol} ${formatExpiry(selectedContract.lastTradeDateOrContractMonth)} $${selectedContract.strike} ${selectedContract.right}`,
+    };
+  }, [prices, selectedContract, symbol]);
 
   // Build the chokepoint input. Index options (SPX/NDX/VIX) are cash-settled
   // but the risk model is identical to equity options for the structures the
@@ -241,6 +263,8 @@ export function IndexOptionOrderForm({ ticker, portfolio }: IndexOptionOrderForm
       notionalLabel="Notional (limit × qty × 100)"
       limitPriceLabel="Limit Price (per share, x100 = contract)"
       limitPriceStep={selectedContract?.minTick ?? 0.05}
+      priceData={quote.priceData}
+      quoteLabel={quote.label}
       buildRiskInput={buildRiskInput}
       portfolio={portfolio}
       surface="index-option-form"

--- a/web/components/ticker-detail/ListedContractOrderForm.tsx
+++ b/web/components/ticker-detail/ListedContractOrderForm.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useCallback, useMemo, useState, type ReactNode } from "react";
+import { OrderQuoteTelemetry } from "@/components/QuoteTelemetry";
 import { OrderRiskGate, type OrderRiskInput, type OrderRiskState } from "@/lib/order";
+import type { PriceData } from "@/lib/pricesProtocol";
 import { placeOrderFeedback, type PlaceOrderFeedback } from "@/lib/orders/placeOrderFeedback";
 import type { PortfolioData } from "@/lib/types";
 
@@ -46,6 +48,15 @@ export interface ListedContractOrderFormProps {
    * price-or-qty); the gate then renders nothing.
    */
   buildRiskInput: (values: ListedOrderFormValues) => OrderRiskInput | null;
+  /**
+   * Live quote for the contract being traded — the SELECTED future / index
+   * option, never the cash underlying. Adapters that cannot name a price key
+   * for the listed contract omit it and the panel says "No real-time data"
+   * rather than quoting a different instrument.
+   */
+  priceData?: PriceData | null;
+  /** Instrument label rendered above the quote fields (e.g. "VIX 2026-09-16 $20 C"). */
+  quoteLabel?: string;
   /** Live portfolio snapshot routed into `<OrderRiskGate>`. */
   portfolio: PortfolioData | null | undefined;
   /** Telemetry surface tag for `<OrderRiskGate>`. */
@@ -91,6 +102,8 @@ export function ListedContractOrderForm({
   notionalLabel,
   limitPriceLabel,
   limitPriceStep,
+  priceData,
+  quoteLabel,
   buildRiskInput,
   portfolio,
   surface,
@@ -182,6 +195,8 @@ export function ListedContractOrderForm({
       >
         {eyebrow}
       </div>
+
+      <OrderQuoteTelemetry priceData={priceData ?? null} label={quoteLabel} density="tight" />
 
       {contractSelector}
 

--- a/web/components/ticker-detail/OptionsChainTab.tsx
+++ b/web/components/ticker-detail/OptionsChainTab.tsx
@@ -36,6 +36,8 @@ import {
   type OrderQuoteSide,
   type OrderRiskInput,
 } from "@/lib/order";
+import { OrderQuoteTelemetry } from "@/components/QuoteTelemetry";
+import { comboQuotePriceData } from "@/lib/quoteTelemetry";
 import { useViewport } from "@/lib/useViewport";
 import MobileChainLadder from "@/components/mobile/MobileChainLadder";
 import ComboSkewPanel from "@/components/ComboSkewPanel";
@@ -325,6 +327,32 @@ function OrderBuilder({
     };
   }, [netPrices.bid, netPrices.mid, netPrices.ask, signedNetPrice]);
 
+  // One quote for whatever is being ticketed: the contract's own book for a
+  // single leg, the net combo book wrapped as a PriceData for a spread. Both
+  // feed the same shared quote-telemetry model.
+  const quotePriceData = useMemo((): PriceData | null => {
+    if (legs.length === 0) return null;
+    if (isCombo) {
+      const { bid, ask, mid } = signedNetPrices;
+      if (bid == null || ask == null) return null;
+      return comboQuotePriceData({ symbol: ticker, bid, ask, last: mid });
+    }
+    const leg = legs[0];
+    return prices[optionKey({
+      symbol: ticker,
+      expiry: leg.expiry,
+      strike: leg.strike,
+      right: leg.right,
+    })] ?? null;
+  }, [legs, isCombo, signedNetPrices, prices, ticker]);
+
+  const quoteLabel = useMemo(() => {
+    if (legs.length === 0) return "";
+    if (isCombo) return `${ticker}${structure ? ` ${structure}` : ""} NET`;
+    const leg = legs[0];
+    return `${ticker} ${formatExpiry(leg.expiry)} $${leg.strike} ${leg.right === "C" ? "Call" : "Put"}`;
+  }, [legs, isCombo, ticker, structure]);
+
   useEffect(() => {
     if (structureKey === lastStructureKeyRef.current) return;
     lastStructureKeyRef.current = structureKey;
@@ -600,14 +628,21 @@ function OrderBuilder({
         )}
       </div>
 
-      {/* Market: single tappable quote surface */}
-      {isCombo && stripPrices.available && (
+      {/* Market: full quote telemetry above the tappable quote surface */}
+      {(quotePriceData != null || (isCombo && stripPrices.available)) && (
         <div className="order-builder-section order-builder-section--market">
-          <OrderPriceStrip
-            prices={stripPrices}
-            selected={selectedQuoteSide}
-            onSelect={applyQuoteSide}
+          <OrderQuoteTelemetry
+            priceData={quotePriceData}
+            label={quoteLabel}
+            density="tight"
           />
+          {isCombo && stripPrices.available && (
+            <OrderPriceStrip
+              prices={stripPrices}
+              selected={selectedQuoteSide}
+              onSelect={applyQuoteSide}
+            />
+          )}
         </div>
       )}
 

--- a/web/components/ticker-detail/OrderTab.tsx
+++ b/web/components/ticker-detail/OrderTab.tsx
@@ -11,6 +11,7 @@ import { fmtPrice, legPriceKey, resolveEntryCost, resolveNaturalSpreadQuote } fr
 import { computeLegImpliedValue } from "@/lib/impliedValue";
 import { useRiskFreeRate } from "@/lib/useRiskFreeRate";
 import ModifyOrderModal from "@/components/ModifyOrderModal";
+import { OrderQuoteTelemetry } from "@/components/QuoteTelemetry";
 import OrderErrorBanner from "@/components/OrderErrorBanner";
 import type { ModifyOrderRequest } from "@/lib/orderModify";
 import { checkNakedShortRisk, type NakedShortPortfolio, type OrderPayload } from "@/lib/nakedShortGuard";
@@ -576,6 +577,8 @@ function NewOrderForm({
 
   return (
     <div className="order-form">
+      <OrderQuoteTelemetry priceData={tickerPriceData ?? null} label={ticker} />
+
       <div className="order-field">
         <label className="order-label">Action</label>
         <div className="order-action-buttons">
@@ -1121,7 +1124,13 @@ export default function OrderTab({ ticker, position, portfolio, prices, openOrde
         {isIndex ? (
           <div className="new-order-section-top">
             <div className="existing-orders-title">New Order</div>
-            {hasFuturesSupport(ticker) && <FuturesOrderForm ticker={ticker} portfolio={portfolio} />}
+            {hasFuturesSupport(ticker) && (
+              <FuturesOrderForm
+                ticker={ticker}
+                portfolio={portfolio}
+                priceData={tickerPriceData ?? prices[ticker] ?? null}
+              />
+            )}
             {hasIndexOptionsSupport(ticker) && (
               <div style={{ marginTop: hasFuturesSupport(ticker) ? "24px" : "0" }}>
                 <IndexOptionOrderForm ticker={ticker} portfolio={portfolio} />

--- a/web/components/ticker-detail/PositionTradeTicket.tsx
+++ b/web/components/ticker-detail/PositionTradeTicket.tsx
@@ -27,6 +27,8 @@ import {
   riskPriceForOrderType,
 } from "@/lib/order/stopOrder";
 import OrderTypeToggle from "@/components/OrderTypeToggle";
+import { OrderQuoteTelemetry } from "@/components/QuoteTelemetry";
+import { buildQuoteTelemetryModel, comboQuotePriceData } from "@/lib/quoteTelemetry";
 
 function toNakedShortPortfolio(portfolio: PortfolioData | null | undefined): NakedShortPortfolio {
   if (!portfolio) return { positions: [] };
@@ -42,20 +44,24 @@ function toNakedShortPortfolio(portfolio: PortfolioData | null | undefined): Nak
   };
 }
 
-/** Net BID/ASK/MID for the combo (signed sum of leg quotes), or one leg's quote. */
+/**
+ * Net BID/ASK/MID for the combo (signed sum of leg quotes), or one leg's quote.
+ * `priceData` is the leg's own live quote (null on a combo, which has no single
+ * PriceData) so the telemetry panel reads the traded instrument's session stats.
+ */
 function useTargetQuote(
   position: PortfolioPosition,
   prices: Record<string, PriceData>,
   target: TradeTarget,
-): { bid: number | null; ask: number | null; mid: number | null } {
+): { bid: number | null; ask: number | null; mid: number | null; priceData: PriceData | null } {
   return useMemo(() => {
     if (target.kind === "leg") {
       const leg = position.legs[target.index];
       const key = leg ? legPriceKey(position.ticker, position.expiry, leg) : null;
-      const lp = key ? prices[key] : null;
+      const lp = (key ? prices[key] : null) ?? null;
       const bid = lp?.bid ?? null;
       const ask = lp?.ask ?? null;
-      return { bid, ask, mid: bid != null && ask != null ? (bid + ask) / 2 : null };
+      return { bid, ask, mid: bid != null && ask != null ? (bid + ask) / 2 : null, priceData: lp };
     }
     let netBid = 0;
     let netAsk = 0;
@@ -68,10 +74,10 @@ function useTargetQuote(
       netBid += sign * lp.bid;
       netAsk += sign * lp.ask;
     }
-    if (!ok) return { bid: null, ask: null, mid: null };
+    if (!ok) return { bid: null, ask: null, mid: null, priceData: null };
     const bid = Math.min(netBid, netAsk);
     const ask = Math.max(netBid, netAsk);
-    return { bid, ask, mid: (bid + ask) / 2 };
+    return { bid, ask, mid: (bid + ask) / 2, priceData: null };
   }, [position, prices, target]);
 }
 
@@ -114,7 +120,15 @@ export default function PositionTradeTicket({
 
   const reset = () => setConfirmStep(false);
 
-  const { bid, ask, mid } = useTargetQuote(position, prices, target);
+  const { bid, ask, mid, priceData: legPriceData } = useTargetQuote(position, prices, target);
+
+  const comboQuoteModel = useMemo(() => {
+    if (target.kind !== "combo") return null;
+    if (bid == null && ask == null) return null;
+    return buildQuoteTelemetryModel(
+      comboQuotePriceData({ symbol: position.ticker, bid, ask, last: mid }),
+    );
+  }, [target.kind, position.ticker, bid, ask, mid]);
 
   const parsedQty = parseInt(quantity, 10);
   const parsedPrice = parseFloat(limitPrice);
@@ -212,6 +226,12 @@ export default function PositionTradeTicket({
           esc ✕
         </button>
       </div>
+
+      <OrderQuoteTelemetry
+        priceData={legPriceData}
+        model={comboQuoteModel}
+        label={subjectLabel}
+      />
 
       <div className="order-field">
         <label className="order-label">Action</label>

--- a/web/e2e/modify-order-correlation-risk.spec.ts
+++ b/web/e2e/modify-order-correlation-risk.spec.ts
@@ -89,6 +89,31 @@ async function stubApis(page: import("@playwright/test").Page) {
   );
 }
 
+/**
+ * Measure the header's title and gate in a SINGLE evaluate.
+ *
+ * Two sequential `boundingBox()` calls are two round-trips, and the modal
+ * reflows once shortly after it opens (the mono webfont swaps in and every
+ * row above the banner re-measures). Straddling that reflow compares a
+ * pre-shift `title.y` against a post-shift `gate.y` and reports a gap no
+ * single frame ever had - main measured 5.85 against this 6px tolerance
+ * purely by luck. Reading both rects in one frame, after fonts settle, is
+ * what "on one row" actually means, and it is stricter than the old form:
+ * a genuine wrap puts the gap at a full row height (~24px), not 4px.
+ */
+async function headerGeometry(banner: import("@playwright/test").Locator) {
+  await banner.page().evaluate(() => document.fonts?.ready);
+  return banner.evaluate((el) => {
+    const rect = (selector: string) => {
+      const node = el.querySelector(selector);
+      if (!node) return null;
+      const { x, y, width } = node.getBoundingClientRect();
+      return { x, y, width };
+    };
+    return { title: rect(".crb-title"), gate: rect(".crb-gate") };
+  });
+}
+
 test("modify modal keeps correlation risk header on one row with ticker chips", async ({ page }) => {
   await page.emulateMedia({ colorScheme: "dark" });
   await page.addInitScript(() => {
@@ -105,10 +130,7 @@ test("modify modal keeps correlation risk header on one row with ticker chips", 
   await expect(banner).toBeVisible();
   await expect(banner).toContainText("Gate 3: correlation measurement unavailable");
 
-  const title = banner.locator(".crb-title");
-  const gate = banner.locator(".crb-gate");
-  const titleBox = await title.boundingBox();
-  const gateBox = await gate.boundingBox();
+  const { title: titleBox, gate: gateBox } = await headerGeometry(banner);
   expect(titleBox).toBeTruthy();
   expect(gateBox).toBeTruthy();
   expect(Math.abs((titleBox?.y ?? 0) - (gateBox?.y ?? 0))).toBeLessThan(6);
@@ -120,8 +142,7 @@ test("modify modal keeps correlation risk header on one row with ticker chips", 
   await expect(dialog.getByRole("button", { name: "Modify Order" })).toBeVisible();
 
   await page.setViewportSize({ width: 393, height: 852 });
-  const titleMobile = await title.boundingBox();
-  const gateMobile = await gate.boundingBox();
+  const { title: titleMobile, gate: gateMobile } = await headerGeometry(banner);
   expect(titleMobile).toBeTruthy();
   expect(gateMobile).toBeTruthy();
   expect(Math.abs((titleMobile?.y ?? 0) - (gateMobile?.y ?? 0))).toBeLessThan(6);

--- a/web/lib/quoteTelemetry.ts
+++ b/web/lib/quoteTelemetry.ts
@@ -72,6 +72,49 @@ export function formatSpreadTelemetry(
   return `${fmtPrice(spread)} / ${((spread / midMagnitude) * 100).toFixed(2)}%`;
 }
 
+export type ComboNetQuote = {
+  symbol: string;
+  bid: number | null;
+  ask: number | null;
+  last?: number | null;
+};
+
+/**
+ * A BAG/combo is not a quoted instrument: every combo surface holds only a
+ * signed per-leg sum (`computeNetOptionQuote`, `ComboOrderForm.netPrices`,
+ * `useTargetQuote`). Wrap that net quote in a PriceData so a combo ticket feeds
+ * the SAME `buildQuoteTelemetryModel` every single-leg surface uses instead of
+ * hand-rolling a second model. Session OHLV stays null because no exchange
+ * publishes a combo's high/low/volume — those fields render "---" honestly.
+ */
+export function comboQuotePriceData({ symbol, bid, ask, last }: ComboNetQuote): PriceData {
+  const { mid } = getQuoteMetrics({ bid, ask });
+  return {
+    symbol,
+    last: last ?? mid,
+    lastIsCalculated: true,
+    bid,
+    ask,
+    bidSize: null,
+    askSize: null,
+    volume: null,
+    high: null,
+    low: null,
+    open: null,
+    close: null,
+    week52High: null,
+    week52Low: null,
+    avgVolume: null,
+    delta: null,
+    gamma: null,
+    theta: null,
+    vega: null,
+    impliedVol: null,
+    undPrice: null,
+    timestamp: new Date().toISOString(),
+  };
+}
+
 function formatMetricValue(value: number | null): string {
   return value != null ? fmtPrice(value) : "---";
 }

--- a/web/tests/book-tab-order-quote-telemetry.test.tsx
+++ b/web/tests/book-tab-order-quote-telemetry.test.tsx
@@ -1,0 +1,151 @@
+/** @vitest-environment jsdom */
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import BookTab from "@/components/ticker-detail/BookTab";
+import type { PriceData } from "@/lib/pricesProtocol";
+
+vi.mock("@/lib/useViewport", () => ({
+  useViewport: () => ({ isMobile: false, hasMounted: true }),
+}));
+
+// The telemetry model only treats a quote as live within 5 minutes of now, so
+// the fixture timestamp must be resolved at call time, never hardcoded.
+function stockPrice(overrides: Partial<PriceData> = {}): PriceData {
+  return {
+    symbol: "NVDA",
+    last: 182.5,
+    lastIsCalculated: false,
+    bid: 182.4,
+    ask: 182.6,
+    bidSize: 400,
+    askSize: 300,
+    volume: 12_500_000,
+    high: 184.2,
+    low: 180.1,
+    open: 181,
+    close: 180.5,
+    week52High: null,
+    week52Low: null,
+    avgVolume: null,
+    delta: null,
+    gamma: null,
+    theta: null,
+    vega: null,
+    impliedVol: null,
+    undPrice: null,
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function telemetryLabels(): string[] {
+  const panel = document.querySelector(".price-bar");
+  if (!panel) return [];
+  return [...panel.querySelectorAll(".price-bar-label")].map((n) => n.textContent ?? "");
+}
+
+afterEach(cleanup);
+
+describe("BookTab stock ticket quote telemetry", () => {
+  it("renders the full nine-field telemetry block above the stock order ticket", () => {
+    const price = stockPrice();
+    render(
+      <BookTab
+        ticker="NVDA"
+        position={null}
+        prices={{ NVDA: price }}
+        openOrders={[]}
+        tickerPriceData={price}
+        depths={{}}
+        tape={{}}
+        bookKey="NVDA"
+        bookKind="stock"
+      />,
+    );
+
+    expect(telemetryLabels()).toEqual([
+      "NVDA",
+      "BID",
+      "MID",
+      "ASK",
+      "SPREAD",
+      "LAST",
+      "VOLUME",
+      "HIGH",
+      "LOW",
+      "DAY",
+    ]);
+    expect(document.querySelector(".price-bar--tight")).toBeTruthy();
+    // The telemetry sits inside the ticket, above the Action field.
+    expect(document.querySelector(".order-form .price-bar")).toBeTruthy();
+  });
+
+  it("labels a calculated last as MARK", () => {
+    const price = stockPrice({ lastIsCalculated: true });
+    render(
+      <BookTab
+        ticker="NVDA"
+        position={null}
+        prices={{ NVDA: price }}
+        openOrders={[]}
+        tickerPriceData={price}
+        depths={{}}
+        tape={{}}
+        bookKey="NVDA"
+        bookKind="stock"
+      />,
+    );
+    expect(telemetryLabels()).toContain("MARK");
+  });
+
+  it("keeps the ticket's tap-to-fill BID / MID / ASK quick buttons", () => {
+    const price = stockPrice();
+    render(
+      <BookTab
+        ticker="NVDA"
+        position={null}
+        prices={{ NVDA: price }}
+        openOrders={[]}
+        tickerPriceData={price}
+        depths={{}}
+        tape={{}}
+        bookKey="NVDA"
+        bookKind="stock"
+      />,
+    );
+    const quick = [...document.querySelectorAll(".btn-quick")].map((b) => b.textContent ?? "");
+    expect(quick).toEqual(expect.arrayContaining(["BID", "MID", "ASK"]));
+  });
+
+  it("uses the underlying stock quote, not the focused option leg quote", () => {
+    const stock = stockPrice();
+    const optionQuote = stockPrice({
+      symbol: "NVDA 20260918 C 200",
+      bid: 4.1,
+      ask: 4.3,
+      last: 4.2,
+      high: 4.9,
+      low: 3.8,
+      volume: 1200,
+      close: 4,
+    });
+    render(
+      <BookTab
+        ticker="NVDA"
+        position={null}
+        prices={{ NVDA: stock }}
+        openOrders={[]}
+        tickerPriceData={optionQuote}
+        depths={{}}
+        tape={{}}
+        bookKey="NVDA 20260918 C 200"
+        bookKind="option"
+      />,
+    );
+    const values = [...document.querySelectorAll(".price-bar .price-bar-value")].map(
+      (n) => n.textContent ?? "",
+    );
+    expect(values.join(" ")).toContain("182.40");
+    expect(values.join(" ")).not.toContain("4.10");
+  });
+});

--- a/web/tests/chain-atm-scroll-isolation.test.tsx
+++ b/web/tests/chain-atm-scroll-isolation.test.tsx
@@ -28,6 +28,7 @@ vi.mock("../components/PriceChart", () => ({
 
 vi.mock("../components/QuoteTelemetry", () => ({
   TickerQuoteTelemetry: () => React.createElement("div", { "data-testid": "quote-telemetry" }),
+  OrderQuoteTelemetry: () => React.createElement("div", { "data-testid": "order-quote-telemetry" }),
 }));
 
 const PRICE: PriceData = {

--- a/web/tests/chain-expiry-preserves-legs.test.tsx
+++ b/web/tests/chain-expiry-preserves-legs.test.tsx
@@ -39,6 +39,7 @@ vi.mock("../components/PriceChart", () => ({
 }));
 vi.mock("../components/QuoteTelemetry", () => ({
   TickerQuoteTelemetry: () => React.createElement("div", { "data-testid": "quote-telemetry" }),
+  OrderQuoteTelemetry: () => React.createElement("div", { "data-testid": "order-quote-telemetry" }),
 }));
 
 const MU_PRICE: PriceData = {

--- a/web/tests/chain-order-builder-quote-telemetry.test.tsx
+++ b/web/tests/chain-order-builder-quote-telemetry.test.tsx
@@ -1,0 +1,246 @@
+// @vitest-environment jsdom
+//
+// The options-chain ORDER BUILDER is an order-entry surface, so it must show
+// the same nine-field quote telemetry the portfolio position drawer shows:
+// BID MID ASK / SPREAD LAST / VOLUME HIGH LOW DAY.
+//
+// Single leg  -> the contract's own live quote.
+// Combo       -> the net combo quote, alongside the interactive OrderPriceStrip
+//                (tap-to-fill bid/mid/ask must keep working).
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+
+import TickerDetailContent from "../components/TickerDetailContent";
+import { TickerDetailProvider } from "../lib/TickerDetailContext";
+import { OrderActionsProvider } from "../lib/OrderActionsContext";
+import type { OrdersData, PortfolioData } from "../lib/types";
+import type { PriceData } from "../lib/pricesProtocol";
+
+let searchParamsString = "";
+const replaceMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(searchParamsString),
+  usePathname: () => "/MU",
+  useRouter: () => ({
+    replace: replaceMock,
+    push: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/useWatchlist", () => ({
+  useWatchlist: () => ({ isWatched: () => false, toggleWatch: vi.fn() }),
+}));
+
+vi.mock("../components/PriceChart", () => ({
+  default: () => React.createElement("div", { "data-testid": "price-chart" }),
+}));
+
+function futureExpiry(days: number) {
+  const date = new Date();
+  date.setUTCHours(0, 0, 0, 0);
+  date.setUTCDate(date.getUTCDate() + days);
+  const dashed = date.toISOString().slice(0, 10);
+  return { dashed, compact: dashed.replaceAll("-", "") };
+}
+
+const EXPIRY = futureExpiry(21);
+
+function optionQuote(
+  symbolKey: string,
+  bid: number,
+  ask: number,
+  extra: Partial<PriceData> = {},
+): PriceData {
+  return {
+    symbol: symbolKey,
+    last: (bid + ask) / 2,
+    lastIsCalculated: false,
+    bid,
+    ask,
+    bidSize: 10,
+    askSize: 10,
+    volume: 4321,
+    high: ask + 1,
+    low: bid - 1,
+    open: bid,
+    close: bid,
+    week52High: null,
+    week52Low: null,
+    avgVolume: null,
+    delta: null,
+    gamma: null,
+    theta: null,
+    vega: null,
+    impliedVol: null,
+    undPrice: null,
+    timestamp: new Date().toISOString(),
+    ...extra,
+  };
+}
+
+const MU_PRICE: PriceData = optionQuote("MU", 967.5, 968.0, {
+  last: 967.78,
+  volume: 1_000,
+  high: 970,
+  low: 960,
+  close: 960,
+});
+
+const CALL_970_KEY = `MU_${EXPIRY.compact}_970_C`;
+const CALL_960_KEY = `MU_${EXPIRY.compact}_960_C`;
+
+const PRICES: Record<string, PriceData> = {
+  MU: MU_PRICE,
+  [CALL_970_KEY]: optionQuote(CALL_970_KEY, 12.1, 12.9),
+  [CALL_960_KEY]: optionQuote(CALL_960_KEY, 18.4, 19.2),
+};
+
+const PORTFOLIO: PortfolioData = {
+  bankroll: 100_000, peak_value: 100_000, last_sync: new Date().toISOString(),
+  total_deployed_pct: 0, total_deployed_dollars: 0, remaining_capacity_pct: 100,
+  position_count: 0, defined_risk_count: 0, undefined_risk_count: 0,
+  avg_kelly_optimal: null, positions: [],
+};
+const ORDERS: OrdersData = {
+  last_sync: new Date().toISOString(), open_orders: [], executed_orders: [],
+  open_count: 0, executed_count: 0,
+};
+
+const fetchMock = vi.fn<typeof fetch>();
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve(
+    new Response(JSON.stringify(body), { status: 200, headers: { "Content-Type": "application/json" } }),
+  );
+}
+
+function renderChain() {
+  return render(
+    React.createElement(
+      OrderActionsProvider,
+      null,
+      React.createElement(
+        TickerDetailProvider,
+        null,
+        React.createElement(TickerDetailContent, {
+          ticker: "MU",
+          activeTab: "c",
+          onTabChange: vi.fn(),
+          prices: PRICES,
+          fundamentals: {},
+          portfolio: PORTFOLIO,
+          orders: ORDERS,
+          theme: "dark",
+        }),
+      ),
+    ),
+  );
+}
+
+function findStrikeRow(strike: number) {
+  const strikeCell = Array.from(document.querySelectorAll("td.chain-strike")).find(
+    (cell) => Number((cell.textContent ?? "").replace(/[^0-9.]/g, "")) === strike,
+  );
+  if (!strikeCell) throw new Error(`No chain row for strike ${strike}`);
+  return strikeCell.closest("tr")!;
+}
+
+/** Call side renders bid (SELL), mid (BUY), ask (BUY). */
+function clickCallCell(strike: number, index: number) {
+  fireEvent.click(findStrikeRow(strike).querySelectorAll("td.chain-clickable")[index]);
+}
+
+async function builderAfter(clicks: () => void) {
+  renderChain();
+  const expirySelect = (await screen.findAllByRole("combobox"))[0] as HTMLSelectElement;
+  await waitFor(() => expect(expirySelect.value).toBe(EXPIRY.compact));
+  await waitFor(() => findStrikeRow(970));
+  clicks();
+  return waitFor(() => {
+    const el = document.querySelector(".order-builder");
+    if (!el) throw new Error("order builder not rendered");
+    return el as HTMLElement;
+  });
+}
+
+function telemetryLabels(scope: HTMLElement): string[] {
+  return Array.from(scope.querySelectorAll(".price-bar-label")).map(
+    (el) => (el.textContent ?? "").trim(),
+  );
+}
+
+const NINE_FIELDS = ["BID", "MID", "ASK", "SPREAD", "VOLUME", "HIGH", "LOW", "DAY"];
+
+describe("Options chain order builder quote telemetry", () => {
+  beforeEach(() => {
+    searchParamsString = "tab=chain";
+    replaceMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+    Object.defineProperty(Element.prototype, "scrollTo", { configurable: true, value: vi.fn() });
+    if (!("scrollIntoView" in HTMLElement.prototype)) {
+      Object.defineProperty(HTMLElement.prototype, "scrollIntoView", { configurable: true, value: vi.fn() });
+    } else {
+      vi.spyOn(HTMLElement.prototype, "scrollIntoView").mockImplementation(() => {});
+    }
+    fetchMock.mockImplementation((input) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : String(input.url);
+      if (url.includes("/api/options/expirations")) {
+        return jsonResponse({ symbol: "MU", expirations: [EXPIRY.compact] });
+      }
+      if (url.includes("/api/options/chain")) {
+        return jsonResponse({ symbol: "MU", expiry: EXPIRY.compact, strikes: [950, 960, 970] });
+      }
+      if (url.includes("/api/risk-free-rate")) return jsonResponse({ rate: 0 });
+      if (url.includes("/api/ticker/info")) return jsonResponse({ stock_state: {}, uw_info: {}, profile: {}, stats: {} });
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("shows the full nine-field telemetry for a single-leg ticket", async () => {
+    const builder = await builderAfter(() => clickCallCell(970, 2));
+
+    const panel = builder.querySelector(".order-builder-section--market") as HTMLElement | null;
+    expect(panel).not.toBeNull();
+
+    const labels = telemetryLabels(panel!);
+    for (const field of NINE_FIELDS) expect(labels).toContain(field);
+    expect(labels).toContain("LAST");
+
+    // The contract's own quote, not the underlying's.
+    expect(panel!.textContent).toContain("$12.10");
+    expect(panel!.textContent).toContain("$12.90");
+    expect(panel!.textContent).toContain("4,321");
+    expect(panel!.textContent ?? "").not.toMatch(/—/);
+  });
+
+  it("shows the net combo telemetry without regressing the tappable price strip", async () => {
+    const builder = await builderAfter(() => {
+      clickCallCell(970, 2); // BUY 970 call
+      clickCallCell(960, 0); // SELL 960 call
+    });
+
+    await waitFor(() => expect(within(builder).getAllByTestId("order-builder-leg").length).toBe(2));
+
+    const panel = builder.querySelector(".order-builder-section--market") as HTMLElement;
+    const labels = telemetryLabels(panel);
+    for (const field of NINE_FIELDS) expect(labels).toContain(field);
+
+    // Tap-to-fill must survive.
+    const strip = within(panel).getByTestId("order-price-strip");
+    expect(strip).toBeTruthy();
+    fireEvent.click(within(panel).getByTestId("order-price-select-bid"));
+    const limitInput = builder.querySelector(".modify-price-input") as HTMLInputElement;
+    await waitFor(() => expect(limitInput.value).not.toBe(""));
+  });
+});

--- a/web/tests/chain-url-deeplink.test.tsx
+++ b/web/tests/chain-url-deeplink.test.tsx
@@ -36,6 +36,7 @@ vi.mock("../components/PriceChart", () => ({
 }));
 vi.mock("../components/QuoteTelemetry", () => ({
   TickerQuoteTelemetry: () => React.createElement("div", { "data-testid": "quote-telemetry" }),
+  OrderQuoteTelemetry: () => React.createElement("div", { "data-testid": "order-quote-telemetry" }),
 }));
 
 const MU_PRICE: PriceData = {

--- a/web/tests/chat-approval-gate-quote-telemetry.test.tsx
+++ b/web/tests/chat-approval-gate-quote-telemetry.test.tsx
@@ -1,0 +1,280 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Assistant order surface — full nine-field quote telemetry.
+ *
+ * ChatPanel routes an assistant order proposal through <ApprovalGate>, which is
+ * the operator's LAST look before the order is placed. Until now the gate
+ * showed prose only: the operator confirmed a live order with no bid/ask in
+ * front of them. The gate now carries the same nine-field block the portfolio
+ * position drawer renders (BID MID ASK / SPREAD LAST / VOLUME HIGH LOW DAY),
+ * built by the shared OrderQuoteTelemetry component.
+ *
+ * Pinned here:
+ *   1. ApprovalGate renders an optional `quote` slot, and stays unchanged when
+ *      no caller passes one (it is a shared primitive with other callers).
+ *   2. ChatPanel resolves the proposal's own instrument out of `prices`:
+ *      stock -> ticker, single-leg option -> optionKey, combo -> the net quote.
+ *   3. A combo reads MARK (a BAG is not a quoted instrument) and never borrows
+ *      the underlying's session OHLV.
+ */
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import ApprovalGate from "@/components/agent/ApprovalGate";
+import ChatPanel from "@/components/ChatPanel";
+import type { PriceData } from "@/lib/pricesProtocol";
+
+afterEach(cleanup);
+
+const NINE_LABELS = ["BID", "MID", "ASK", "SPREAD", "VOLUME", "HIGH", "LOW", "DAY"];
+
+function makePriceData(overrides: Partial<PriceData> & { symbol: string }): PriceData {
+  return {
+    last: null,
+    lastIsCalculated: false,
+    bid: null,
+    ask: null,
+    bidSize: null,
+    askSize: null,
+    volume: null,
+    high: null,
+    low: null,
+    open: null,
+    close: null,
+    week52High: null,
+    week52Low: null,
+    avgVolume: null,
+    delta: null,
+    gamma: null,
+    theta: null,
+    vega: null,
+    impliedVol: null,
+    undPrice: null,
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+const OPTION_PROPOSAL = {
+  tool: "place_order",
+  destructive: true as const,
+  input: {
+    type: "option" as const,
+    ticker: "WULF",
+    action: "BUY" as const,
+    quantity: 10,
+    limit_price: 5.6,
+    expiry: "20260918",
+    strike: 6,
+    right: "C" as const,
+    conId: 12345,
+    exchange: "SMART",
+  },
+  summary: "BUY 10 WULF long call @ 5.6",
+  toolUseId: "tu-1",
+};
+
+const STOCK_PROPOSAL = {
+  tool: "place_order",
+  destructive: true as const,
+  input: {
+    type: "stock" as const,
+    ticker: "MU",
+    action: "BUY" as const,
+    quantity: 100,
+    limit_price: 120,
+  },
+  summary: "BUY 100 MU @ 120",
+  toolUseId: "tu-2",
+};
+
+const COMBO_PROPOSAL = {
+  tool: "place_order",
+  destructive: true as const,
+  input: {
+    type: "combo" as const,
+    ticker: "MU",
+    action: "BUY" as const,
+    quantity: 5,
+    limit_price: 2.1,
+    structure: "Bull Call Spread",
+    legs: [
+      { expiry: "20260918", strike: 120, right: "C" as const, action: "BUY" as const, ratio: 1 },
+      { expiry: "20260918", strike: 130, right: "C" as const, action: "SELL" as const, ratio: 1 },
+    ],
+  },
+  summary: "BUY 5 MU bull call spread @ 2.10 debit",
+  toolUseId: "tu-3",
+};
+
+const PRICES: Record<string, PriceData> = {
+  WULF_20260918_6_C: makePriceData({
+    symbol: "WULF_20260918_6_C",
+    bid: 5.4,
+    ask: 5.8,
+    last: 5.6,
+    close: 5.1,
+    volume: 1420,
+    high: 6.05,
+    low: 5.2,
+  }),
+  MU: makePriceData({
+    symbol: "MU",
+    bid: 119.9,
+    ask: 120.1,
+    last: 120.05,
+    close: 118.4,
+    volume: 8_120_000,
+    high: 121.2,
+    low: 118.1,
+  }),
+  MU_20260918_120_C: makePriceData({
+    symbol: "MU_20260918_120_C",
+    bid: 8.0,
+    ask: 8.4,
+    last: 8.2,
+  }),
+  MU_20260918_130_C: makePriceData({
+    symbol: "MU_20260918_130_C",
+    bid: 5.9,
+    ask: 6.3,
+    last: 6.1,
+  }),
+};
+
+function mockAssistantProposal(proposal: unknown) {
+  const fetchMock = vi.fn(async (url: string) => {
+    const body = url.includes("/api/assistant")
+      ? { content: "Proposing an order.", proposal }
+      : { content: "ok" };
+    return { ok: true, status: 200, json: async () => body } as Response;
+  });
+  // @ts-expect-error test stub
+  global.fetch = fetchMock;
+}
+
+async function sendPrompt(text: string) {
+  const textarea = screen.getByLabelText("Ask Radon");
+  fireEvent.change(textarea, { target: { value: text } });
+  fireEvent.submit(textarea.closest("form")!);
+}
+
+function priceBarLabels(): string[] {
+  return Array.from(document.querySelectorAll(".price-bar-label")).map(
+    (el) => el.textContent ?? "",
+  );
+}
+
+describe("ApprovalGate — quote slot", () => {
+  it("renders the telemetry node handed to it, above the handling options", () => {
+    render(
+      <ApprovalGate
+        body="BUY 10 WULF 2026-09-18 $6 C @ 5.60 debit."
+        options={[{ id: "route", label: "Route as proposed" }]}
+        quote={<div className="price-bar"><span className="price-bar-label">BID</span></div>}
+        onConfirm={() => {}}
+        onDismiss={() => {}}
+      />,
+    );
+    const gateBody = document.querySelector(".approval-gate__body")!;
+    const nodes = Array.from(gateBody.children);
+    const quoteIndex = nodes.findIndex((n) => n.classList.contains("price-bar"));
+    const optionsIndex = nodes.findIndex((n) => n.classList.contains("approval-gate__options"));
+    expect(quoteIndex).toBeGreaterThan(-1);
+    expect(quoteIndex).toBeLessThan(optionsIndex);
+  });
+
+  it("renders no quote block for callers that pass none", () => {
+    render(
+      <ApprovalGate
+        body="Nothing to quote."
+        options={[{ id: "route", label: "Route as proposed" }]}
+        onConfirm={() => {}}
+        onDismiss={() => {}}
+      />,
+    );
+    expect(priceBarLabels()).toHaveLength(0);
+    expect(screen.getByText("Route as proposed")).toBeTruthy();
+  });
+});
+
+describe("ChatPanel proposal gate — nine-field telemetry", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows the full nine fields for a single-leg option proposal", async () => {
+    mockAssistantProposal(OPTION_PROPOSAL);
+    render(
+      <ChatPanel
+        activeSection="dashboard"
+        portfolio={{ positions: [] } as never}
+        prices={PRICES}
+      />,
+    );
+    await sendPrompt("buy me some wulf calls");
+
+    await screen.findByRole("button", { name: /confirm/i }, { timeout: 8000 });
+    const labels = priceBarLabels();
+    for (const label of NINE_LABELS) expect(labels).toContain(label);
+    expect(labels).toContain("LAST");
+    expect(labels).toContain("WULF 2026-09-18 $6 C");
+    expect(screen.getByText("$5.40")).toBeTruthy();
+    expect(screen.getByText("$5.80")).toBeTruthy();
+    expect(screen.getByText("1,420")).toBeTruthy();
+  });
+
+  it("quotes the underlying for a stock proposal", async () => {
+    mockAssistantProposal(STOCK_PROPOSAL);
+    render(
+      <ChatPanel
+        activeSection="dashboard"
+        portfolio={{ positions: [] } as never}
+        prices={PRICES}
+      />,
+    );
+    await sendPrompt("buy me 100 mu");
+
+    await screen.findByRole("button", { name: /confirm/i }, { timeout: 8000 });
+    const labels = priceBarLabels();
+    for (const label of NINE_LABELS) expect(labels).toContain(label);
+    expect(labels).toContain("MU");
+    expect(screen.getByText("$119.90")).toBeTruthy();
+    expect(screen.getByText("$120.10")).toBeTruthy();
+  });
+
+  it("quotes the net combo as MARK and leaves session OHLV empty", async () => {
+    mockAssistantProposal(COMBO_PROPOSAL);
+    render(
+      <ChatPanel
+        activeSection="dashboard"
+        portfolio={{ positions: [] } as never}
+        prices={PRICES}
+      />,
+    );
+    await sendPrompt("put on a mu bull call spread");
+
+    await screen.findByRole("button", { name: /confirm/i }, { timeout: 8000 });
+    const labels = priceBarLabels();
+    for (const label of NINE_LABELS) expect(labels).toContain(label);
+    expect(labels).toContain("MARK");
+    expect(labels).not.toContain("LAST");
+    expect(labels).toContain("MU Bull Call Spread");
+    // net bid = 8.00 - 6.30, net ask = 8.40 - 5.90, mid = 2.10
+    expect(screen.getByText("$1.70")).toBeTruthy();
+    expect(screen.getByText("$2.50")).toBeTruthy();
+    expect(screen.getAllByText("$2.10").length).toBeGreaterThan(0);
+  });
+
+  it("renders an honest empty panel when no quote has arrived", async () => {
+    mockAssistantProposal(OPTION_PROPOSAL);
+    render(<ChatPanel activeSection="dashboard" portfolio={{ positions: [] } as never} />);
+    await sendPrompt("buy me some wulf calls");
+
+    await screen.findByRole("button", { name: /confirm/i }, { timeout: 8000 });
+    expect(priceBarLabels()).toHaveLength(0);
+    expect(screen.getByText("No real-time data")).toBeTruthy();
+  });
+});

--- a/web/tests/chat-launcher-prices-threading.test.tsx
+++ b/web/tests/chat-launcher-prices-threading.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Assistant order surface — the quote map actually reaches the gate.
+ *
+ * chat-approval-gate-quote-telemetry.test.tsx proves ChatPanel renders the
+ * shared nine-field block once it HAS a `prices` map. That is only half the
+ * story: ChatPanel does not own quotes and never opens its own relay socket,
+ * so if nothing hands it the map the gate silently renders the empty
+ * "No real-time data" panel in the running app and the operator confirms a
+ * live order with no bid/ask in front of them.
+ *
+ * The map already exists exactly once, in WorkspaceShell (`usePrices` plus the
+ * previous-close backfill). Pinned here is the path from that single owner to
+ * the gate: WorkspaceShell -> ChatLauncher -> ChatPanel.
+ */
+import React from "react";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import type { PriceData } from "@/lib/pricesProtocol";
+
+const chatPanelProps = vi.hoisted(() => ({ current: null as Record<string, unknown> | null }));
+
+vi.mock("@/components/ChatPanel", () => ({
+  default: (props: Record<string, unknown>) => {
+    chatPanelProps.current = props;
+    return <div data-testid="chat-panel" />;
+  },
+}));
+
+import ChatLauncher from "@/components/ChatLauncher";
+
+afterEach(() => {
+  cleanup();
+  chatPanelProps.current = null;
+});
+
+const projectRoot = resolve(__dirname, "..");
+
+const MU: PriceData = {
+  symbol: "MU",
+  last: 121.5,
+  lastIsCalculated: false,
+  bid: 121.4,
+  ask: 121.6,
+  bidSize: 4,
+  askSize: 7,
+  volume: 8_100_000,
+  high: 123.1,
+  low: 119.8,
+  open: 120.2,
+  close: 120.0,
+  week52High: null,
+  week52Low: null,
+  avgVolume: null,
+  delta: null,
+  gamma: null,
+  theta: null,
+  vega: null,
+  impliedVol: null,
+  undPrice: null,
+  timestamp: new Date().toISOString(),
+} as PriceData;
+
+describe("assistant gate quote plumbing", () => {
+  it("ChatLauncher forwards the live quote map to ChatPanel", () => {
+    render(
+      <ChatLauncher
+        activeSection="dashboard"
+        portfolio={{ positions: [] } as never}
+        prices={{ MU }}
+      />,
+    );
+
+    fireEvent.keyDown(document, { key: "j", ctrlKey: true });
+
+    expect(chatPanelProps.current).not.toBeNull();
+    expect(chatPanelProps.current?.prices).toEqual({ MU });
+  });
+
+  it("WorkspaceShell hands ChatLauncher the one price map it already owns", () => {
+    const source = readFileSync(resolve(projectRoot, "components", "WorkspaceShell.tsx"), "utf8");
+
+    const launcher = source.match(/<ChatLauncher[\s\S]*?\/>/);
+    expect(launcher).not.toBeNull();
+    // The backfilled map (`const prices = usePreviousClose(...)`), not the raw
+    // socket map — the gate's DAY row needs the previous close.
+    expect(launcher?.[0]).toContain("prices={prices}");
+    expect(source).toContain("const prices = usePreviousClose(");
+  });
+});

--- a/web/tests/futures-order-quote-telemetry.test.tsx
+++ b/web/tests/futures-order-quote-telemetry.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * FuturesOrderForm renders the shared nine-field quote panel so the operator
+ * placing a futures order sees the same telemetry the portfolio position
+ * drawer gives them: BID MID ASK / SPREAD LAST / VOLUME HIGH LOW DAY.
+ *
+ * The only quote reachable for a listed future today is the INDEX quote
+ * (prices["VIX"]), not the front-month contract's own feed, so the panel is
+ * labelled with the index symbol.
+ */
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import type { PriceData } from "@/lib/pricesProtocol";
+
+const mocks = vi.hoisted(() => ({
+  futuresState: null as unknown,
+}));
+
+vi.mock("@/lib/TickerDetailContext", () => ({ useTickerDetailOptional: () => null }));
+vi.mock("@/lib/useFuturesChain", () => ({
+  useFuturesChain: () => mocks.futuresState,
+}));
+
+import { FuturesOrderForm } from "../components/ticker-detail/FuturesOrderForm";
+
+afterEach(cleanup);
+
+const future = {
+  conId: 9001,
+  symbol: "VIX",
+  localSymbol: "VIXU6",
+  exchange: "CFE",
+  currency: "USD",
+  lastTradeDateOrContractMonth: "20260916",
+  multiplier: "1000",
+  tradingClass: "VX",
+  marketName: "VIX",
+  minTick: 0.05,
+};
+
+function chainLoaded() {
+  return {
+    data: { symbol: "VIX", exchange: "CFE", contracts: [future], count: 1 },
+    loading: false,
+    error: null,
+  };
+}
+
+function vixQuote(): PriceData {
+  return {
+    symbol: "VIX",
+    last: 19.4,
+    lastIsCalculated: false,
+    bid: 19.3,
+    ask: 19.5,
+    bidSize: 12,
+    askSize: 8,
+    volume: 84_120,
+    high: 20.1,
+    low: 18.9,
+    open: 19.0,
+    close: 18.8,
+    week52High: null,
+    week52Low: null,
+    avgVolume: null,
+    delta: null,
+    gamma: null,
+    theta: null,
+    vega: null,
+    impliedVol: null,
+    undPrice: null,
+    timestamp: new Date().toISOString(),
+  } as unknown as PriceData;
+}
+
+describe("FuturesOrderForm quote telemetry", () => {
+  it("renders the full nine-field panel for the supplied quote", async () => {
+    mocks.futuresState = chainLoaded();
+    const { container } = render(<FuturesOrderForm ticker="VIX" priceData={vixQuote()} />);
+
+    await waitFor(() => expect(container.querySelector(".price-bar")).toBeTruthy());
+    const panel = within(container.querySelector(".price-bar") as HTMLElement);
+    for (const label of ["BID", "MID", "ASK", "SPREAD", "LAST", "VOLUME", "HIGH", "LOW", "DAY"]) {
+      expect(panel.getByText(label)).toBeTruthy();
+    }
+    expect(panel.getByText("$19.30")).toBeTruthy();
+    expect(panel.getByText("$19.50")).toBeTruthy();
+    expect(panel.getByText("84,120")).toBeTruthy();
+  });
+
+  it("labels the panel with the index symbol, not the listed contract", async () => {
+    mocks.futuresState = chainLoaded();
+    render(<FuturesOrderForm ticker="VIX" priceData={vixQuote()} />);
+
+    await waitFor(() => expect(screen.getByText("VIX Index")).toBeTruthy());
+    expect(screen.queryByText("VIXU6 Index")).toBeNull();
+  });
+
+  it("falls back to the empty panel when no quote is threaded", async () => {
+    mocks.futuresState = chainLoaded();
+    const { container } = render(<FuturesOrderForm ticker="VIX" />);
+
+    await waitFor(() => expect(container.querySelector(".price-bar-empty")).toBeTruthy());
+    expect(container.querySelectorAll(".price-bar-label").length).toBe(0);
+  });
+});

--- a/web/tests/listed-contract-order-quote.test.tsx
+++ b/web/tests/listed-contract-order-quote.test.tsx
@@ -1,0 +1,248 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Listed-contract order surfaces (futures + index options) must show the same
+ * nine-field quote telemetry the portfolio position drawer shows, so the
+ * operator never enters an order against less information than they get when
+ * reviewing a held position.
+ *
+ * `ListedContractOrderForm` is the single chokepoint both adapters render
+ * through, so the panel is wired once there and threaded from the adapter that
+ * can name the traded contract's price key.
+ */
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { PriceData } from "@/lib/pricesProtocol";
+
+const mocks = vi.hoisted(() => ({
+  prices: {} as Record<string, PriceData>,
+  indexHook: vi.fn(),
+}));
+
+vi.mock("@/lib/TickerDetailContext", () => ({
+  useTickerDetailOptional: () => ({ getPrices: () => mocks.prices }),
+}));
+vi.mock("@/lib/useIndexOptionsChain", () => ({
+  useIndexOptionsChain: (symbol: string, expiry: string | null) => mocks.indexHook(symbol, expiry),
+}));
+vi.mock("@/lib/useFuturesChain", () => ({
+  useFuturesChain: () => ({
+    data: {
+      symbol: "VIX",
+      exchange: "CFE",
+      count: 1,
+      contracts: [
+        {
+          conId: 9001,
+          symbol: "VIX",
+          localSymbol: "VIXU6",
+          exchange: "CFE",
+          currency: "USD",
+          lastTradeDateOrContractMonth: "20260916",
+          multiplier: "1000",
+          tradingClass: "VX",
+          marketName: "VIX",
+          minTick: 0.05,
+        },
+      ],
+    },
+    loading: false,
+    error: null,
+  }),
+}));
+
+import { ListedContractOrderForm } from "../components/ticker-detail/ListedContractOrderForm";
+import { IndexOptionOrderForm } from "../components/ticker-detail/IndexOptionOrderForm";
+import { FuturesOrderForm } from "../components/ticker-detail/FuturesOrderForm";
+
+const NINE_LABELS = ["BID", "MID", "ASK", "SPREAD", "VOLUME", "HIGH", "LOW", "DAY"];
+
+function makePriceData(overrides: Partial<PriceData> & { symbol: string }): PriceData {
+  return {
+    last: null,
+    lastIsCalculated: false,
+    bid: null,
+    ask: null,
+    bidSize: null,
+    askSize: null,
+    volume: null,
+    high: null,
+    low: null,
+    open: null,
+    close: null,
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  } as PriceData;
+}
+
+function labelsIn(container: HTMLElement): string[] {
+  return [...container.querySelectorAll(".price-bar-label")].map((n) => n.textContent ?? "");
+}
+
+function renderChokepoint(props: Partial<React.ComponentProps<typeof ListedContractOrderForm>> = {}) {
+  return render(
+    <ListedContractOrderForm
+      eyebrow={<>VIX Options</>}
+      contractSelector={null}
+      multiplier={100}
+      multiplierDisplay="100"
+      notionalLabel="Notional"
+      limitPriceLabel="Limit Price"
+      limitPriceStep={0.05}
+      buildRiskInput={() => null}
+      portfolio={null}
+      surface="test-surface"
+      buildSubmit={() => ({ error: "not submittable" })}
+      submitLabel="BUY"
+      submitDisabled
+      {...props}
+    />,
+  );
+}
+
+const VIX_CALL_QUOTE = makePriceData({
+  symbol: "VIX_20260916_20_C",
+  bid: 1.85,
+  ask: 2.05,
+  last: 1.95,
+  close: 1.7,
+  volume: 812,
+  high: 2.2,
+  low: 1.6,
+});
+
+afterEach(() => {
+  cleanup();
+  mocks.indexHook.mockReset();
+  mocks.prices = {};
+});
+
+describe("listed-contract order quote telemetry", () => {
+  it("renders all nine fields plus the instrument label on the shared chokepoint", () => {
+    const { container } = renderChokepoint({
+      priceData: VIX_CALL_QUOTE,
+      quoteLabel: "VIX 2026-09-16 $20 C",
+    });
+
+    const labels = labelsIn(container);
+    for (const label of NINE_LABELS) {
+      expect(labels).toContain(label);
+    }
+    expect(labels).toContain("LAST");
+    expect(labels).toContain("VIX 2026-09-16 $20 C");
+    expect(container.querySelectorAll(".price-bar-item").length).toBe(10);
+  });
+
+  it("renders the honest empty state when the surface has no quote for the contract", () => {
+    const { container } = renderChokepoint();
+
+    expect(container.querySelector(".price-bar-empty")?.textContent).toBe("No real-time data");
+    expect(labelsIn(container)).toHaveLength(0);
+  });
+
+  it("keeps the quote block above the contract selector and the order inputs", () => {
+    const { container } = renderChokepoint({
+      priceData: VIX_CALL_QUOTE,
+      contractSelector: <div data-testid="contract-selector" />,
+    });
+
+    const form = container.querySelector("form.futures-order-form") as HTMLElement;
+    const bar = form.querySelector(".price-bar") as HTMLElement;
+    const selector = form.querySelector("[data-testid='contract-selector']") as HTMLElement;
+    expect(bar.compareDocumentPosition(selector) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});
+
+function strikeSelect(): HTMLSelectElement {
+  const selects = screen.getAllByRole("combobox") as HTMLSelectElement[];
+  const strike = selects.find((s) => [...s.options].some((o) => o.value === "7001"));
+  if (!strike) throw new Error("strike select not found");
+  return strike;
+}
+
+describe("IndexOptionOrderForm quote threading", () => {
+  beforeEach(() => {
+    mocks.indexHook.mockImplementation((symbol: string, expiry: string | null) =>
+      expiry == null
+        ? {
+            data: {
+              symbol,
+              exchange: "CBOE",
+              tradingClass: "VIX",
+              expirations: ["20260916"],
+              contracts: [],
+              count: 0,
+            },
+            loading: false,
+            error: null,
+          }
+        : {
+            data: {
+              symbol,
+              contracts: [
+                {
+                  conId: 7001,
+                  symbol,
+                  localSymbol: "VIX   260916C00020000",
+                  exchange: "CBOE",
+                  currency: "USD",
+                  lastTradeDateOrContractMonth: "20260916",
+                  strike: 20,
+                  right: "C",
+                  multiplier: "100",
+                  tradingClass: "VIX",
+                  minTick: 0.05,
+                },
+              ],
+              count: 1,
+            },
+            loading: false,
+            error: null,
+          },
+    );
+  });
+
+  it("shows the selected strike's own quote, not the cash index", async () => {
+    mocks.prices = {
+      VIX: makePriceData({ symbol: "VIX", bid: 15.1, ask: 15.3, last: 15.2 }),
+      VIX_20260916_20_C: VIX_CALL_QUOTE,
+    };
+
+    const { container } = render(<IndexOptionOrderForm ticker="VIX" portfolio={null} />);
+    fireEvent.change(strikeSelect(), { target: { value: "7001" } });
+
+    await waitFor(() => {
+      expect(labelsIn(container)).toContain("VIX 2026-09-16 $20 C");
+    });
+    const values = [...container.querySelectorAll(".price-bar-value")].map((n) => n.textContent ?? "");
+    expect(values).toContain("$1.85");
+    expect(values).not.toContain("$15.10");
+  });
+
+  it("falls back to the empty state while no strike is selected", () => {
+    mocks.prices = { VIX_20260916_20_C: VIX_CALL_QUOTE };
+
+    const { container } = render(<IndexOptionOrderForm ticker="VIX" portfolio={null} />);
+
+    expect(container.querySelector(".price-bar-empty")?.textContent).toBe("No real-time data");
+  });
+});
+
+describe("FuturesOrderForm quote threading", () => {
+  it("renders exactly one quote panel, labelled as the index the chain is listed against", () => {
+    const { container } = render(
+      <FuturesOrderForm
+        ticker="VIX"
+        portfolio={null}
+        priceData={makePriceData({ symbol: "VIX", bid: 15.1, ask: 15.3, last: 15.2, close: 14.9 })}
+      />,
+    );
+
+    expect(container.querySelectorAll(".price-bar").length).toBe(1);
+    expect(labelsIn(container)).toContain("VIX Index");
+    for (const label of NINE_LABELS) {
+      expect(labelsIn(container)).toContain(label);
+    }
+  });
+});

--- a/web/tests/mobile-chain-detail-quote-telemetry.test.tsx
+++ b/web/tests/mobile-chain-detail-quote-telemetry.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+//
+// The mobile ladder's detail sheet is the per-contract order-entry step (its
+// footer places the BUY / SELL leg), so it must show the SAME nine-field quote
+// telemetry the portfolio position drawer gives the operator, not a hand-rolled
+// Last / Bid-Ask / Volume subset.
+
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+
+import MobileChainLadder from "../components/mobile/MobileChainLadder";
+import { optionKey } from "../lib/pricesProtocol";
+import type { PriceData } from "../lib/pricesProtocol";
+
+const EXPIRY = "20260821";
+const TICKER = "MU";
+const STRIKE = 970;
+
+const CALL_KEY = optionKey({ symbol: TICKER, expiry: EXPIRY, strike: STRIKE, right: "C" });
+
+function strikeRow(strike: number) {
+  return {
+    strike,
+    callKey: optionKey({ symbol: TICKER, expiry: EXPIRY, strike, right: "C" }),
+    putKey: optionKey({ symbol: TICKER, expiry: EXPIRY, strike, right: "P" }),
+  };
+}
+
+function callQuote(): PriceData {
+  return {
+    symbol: CALL_KEY,
+    last: 12.5,
+    lastIsCalculated: false,
+    bid: 12.3,
+    ask: 12.7,
+    bidSize: 14,
+    askSize: 9,
+    volume: 4210,
+    high: 13.4,
+    low: 11.2,
+    open: 11.9,
+    close: 11.5,
+    week52High: null,
+    week52Low: null,
+    avgVolume: 12_345,
+    delta: 0.55,
+    gamma: 0.012,
+    theta: -0.44,
+    vega: 0.31,
+    impliedVol: 0.42,
+    undPrice: 967.78,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function renderLadder(prices: Record<string, PriceData>) {
+  Object.defineProperty(Element.prototype, "scrollTo", { configurable: true, value: vi.fn() });
+  return render(
+    React.createElement(MobileChainLadder, {
+      ticker: TICKER,
+      expirations: [EXPIRY],
+      selectedExpiry: EXPIRY,
+      onSelectExpiry: vi.fn(),
+      visibleStrikes: [strikeRow(960), strikeRow(STRIKE)],
+      atmStrike: STRIKE,
+      prices,
+      currentPrice: 967.78,
+      sideFilter: "both" as const,
+      onSideFilterChange: vi.fn(),
+      strikesPerSide: 15,
+      onStrikesPerSideChange: vi.fn(),
+      orderLegs: [],
+      onAddLeg: vi.fn(),
+      portfolio: null,
+    }),
+  );
+}
+
+function openDetailSheet() {
+  fireEvent.click(screen.getByTestId(`mobile-chain-call-${STRIKE}`));
+  return screen.getByTestId("mobile-chain-detail-sheet");
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("Mobile chain detail sheet quote telemetry", () => {
+  it("renders the full nine-field telemetry block for the tapped contract", () => {
+    renderLadder({ [CALL_KEY]: callQuote() });
+    const sheet = openDetailSheet();
+
+    const labels = within(sheet)
+      .getAllByText(/^(BID|MID|ASK|SPREAD|LAST|MARK|CLOSE|VOLUME|HIGH|LOW|DAY)$/)
+      .map((node) => node.textContent);
+
+    expect(labels).toEqual(["BID", "MID", "ASK", "SPREAD", "LAST", "VOLUME", "HIGH", "LOW", "DAY"]);
+  });
+
+  it("labels the panel with the tapped contract and uses the tight density", () => {
+    renderLadder({ [CALL_KEY]: callQuote() });
+    const sheet = openDetailSheet();
+
+    const panel = sheet.querySelector(".price-bar--tight");
+    expect(panel).toBeTruthy();
+    expect(within(panel as HTMLElement).getByText(`${TICKER} ${STRIKE} Call`)).toBeTruthy();
+  });
+
+  it("keeps the option-specific rows the shared model does not cover", () => {
+    renderLadder({ [CALL_KEY]: callQuote() });
+    const sheet = openDetailSheet();
+
+    for (const label of ["Bid Size / Ask Size", "IV", "Delta", "Gamma", "Theta", "Vega", "Avg Volume"]) {
+      expect(within(sheet).getByText(label)).toBeTruthy();
+    }
+  });
+
+  it("renders the empty telemetry state when the contract has no quote", () => {
+    renderLadder({});
+    const sheet = openDetailSheet();
+
+    expect(within(sheet).getByText("No real-time data")).toBeTruthy();
+    expect(sheet.querySelectorAll(".price-bar-label").length).toBe(0);
+  });
+});

--- a/web/tests/mobile-order-ticket-quote-telemetry.test.tsx
+++ b/web/tests/mobile-order-ticket-quote-telemetry.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The mobile order ticket must show the operator the SAME nine-field quote
+ * telemetry the portfolio position drawer gives them: BID MID ASK / SPREAD
+ * LAST(or MARK) VOLUME / HIGH LOW DAY — for the exact instrument they are
+ * about to trade.
+ *
+ * Single leg  -> the leg's real PriceData out of the `prices` map.
+ * Combo       -> the signed net quote wrapped by `comboQuotePriceData`, so the
+ *                spread math stays in `buildQuoteTelemetryModel`.
+ *
+ * The Bid/Mid/Ask quick-set chips are a real feature (one tap fills the limit
+ * input) and must survive the addition of the panel.
+ */
+
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import MobileOrderTicket from "../components/mobile/MobileOrderTicket";
+import type { OrderLeg } from "@/lib/optionsChainUtils";
+import type { PortfolioData } from "@/lib/types";
+import type { PriceData } from "@/lib/pricesProtocol";
+
+vi.mock("@/components/ComboSkewPanel", () => ({ default: () => null }));
+
+const TICKER = "AAPL";
+const EXPIRY = "20260320";
+
+const NINE_FIELDS = ["BID", "MID", "ASK", "SPREAD", "VOLUME", "HIGH", "LOW", "DAY"];
+
+function makePrice(
+  symbol: string,
+  bid: number,
+  ask: number,
+  session: Partial<PriceData> = {},
+): PriceData {
+  return {
+    symbol,
+    last: (bid + ask) / 2,
+    lastIsCalculated: false,
+    bid,
+    ask,
+    bidSize: 1,
+    askSize: 1,
+    volume: 1234,
+    high: 4.1,
+    low: 2.6,
+    open: 3.0,
+    close: 3.0,
+    week52High: null,
+    week52Low: null,
+    avgVolume: null,
+    delta: null,
+    gamma: null,
+    theta: null,
+    vega: null,
+    impliedVol: null,
+    undPrice: null,
+    timestamp: new Date().toISOString(),
+    ...session,
+  };
+}
+
+const CALL_KEY = `${TICKER}_${EXPIRY}_200_C`;
+const PUT_KEY = `${TICKER}_${EXPIRY}_190_P`;
+
+const PRICES: Record<string, PriceData> = {
+  [CALL_KEY]: makePrice(CALL_KEY, 3.0, 3.4),
+  [PUT_KEY]: makePrice(PUT_KEY, 1.0, 1.2),
+};
+
+const EMPTY_PORTFOLIO = { positions: [] } as unknown as PortfolioData;
+
+function makeLeg(overrides: Partial<OrderLeg> = {}): OrderLeg {
+  return {
+    id: CALL_KEY,
+    action: "BUY",
+    right: "C",
+    strike: 200,
+    expiry: EXPIRY,
+    quantity: 1,
+    limitPrice: null,
+    ...overrides,
+  };
+}
+
+function renderTicket(legs: OrderLeg[]) {
+  return render(
+    <MobileOrderTicket
+      open
+      ticker={TICKER}
+      legs={legs}
+      prices={PRICES}
+      spot={210}
+      portfolio={EMPTY_PORTFOLIO}
+      onClose={() => {}}
+      onRemoveLeg={() => {}}
+      onUpdateLeg={() => {}}
+      onClearLegs={() => {}}
+    />,
+  );
+}
+
+// BottomSheet portals to document.body, so the sheet body is NOT inside the
+// render container.
+function labelTexts(): string[] {
+  return Array.from(document.body.querySelectorAll(".price-bar-label")).map(
+    (node) => node.textContent ?? "",
+  );
+}
+
+function valueFor(label: string): string {
+  const row = Array.from(document.body.querySelectorAll(".price-bar-item")).find(
+    (node) => node.querySelector(".price-bar-label")?.textContent === label,
+  );
+  return row?.querySelector(".price-bar-value")?.textContent ?? "";
+}
+
+afterEach(() => cleanup());
+
+describe("MobileOrderTicket quote telemetry", () => {
+  it("renders the full nine-field telemetry for a single-leg ticket", () => {
+    renderTicket([makeLeg()]);
+
+    const labels = labelTexts();
+    for (const field of NINE_FIELDS) {
+      expect(labels).toContain(field);
+    }
+    expect(labels).toContain("LAST");
+
+    expect(valueFor("BID")).toBe("$3.00");
+    expect(valueFor("MID")).toBe("$3.20");
+    expect(valueFor("ASK")).toBe("$3.40");
+    expect(valueFor("VOLUME")).toBe("1,234");
+    expect(valueFor("HIGH")).toBe("$4.10");
+    expect(valueFor("LOW")).toBe("$2.60");
+  });
+
+  it("uses the tight density inside the bottom sheet", () => {
+    renderTicket([makeLeg()]);
+    expect(document.body.querySelector(".price-bar--tight")).not.toBeNull();
+  });
+
+  it("renders the nine fields off the signed net quote on a combo ticket", () => {
+    renderTicket([
+      makeLeg(),
+      makeLeg({ id: PUT_KEY, action: "SELL", right: "P", strike: 190 }),
+    ]);
+
+    const labels = labelTexts();
+    for (const field of NINE_FIELDS) {
+      expect(labels).toContain(field);
+    }
+    // A combo has no traded print, so the panel reads MARK, not LAST.
+    expect(labels).toContain("MARK");
+
+    // BUY call ask 3.40 - SELL put bid 1.00 = 2.40 net ask;
+    // BUY call bid 3.00 - SELL put ask 1.20 = 1.80 net bid.
+    expect(valueFor("BID")).toBe("$1.80");
+    expect(valueFor("ASK")).toBe("$2.40");
+    expect(valueFor("MID")).toBe("$2.10");
+    // No exchange publishes a combo's session OHLV.
+    expect(valueFor("VOLUME")).toBe("---");
+    expect(valueFor("HIGH")).toBe("---");
+  });
+
+  it("keeps the Bid/Mid/Ask chips tappable so one tap still fills the limit", () => {
+    renderTicket([makeLeg()]);
+
+    fireEvent.click(screen.getByTestId("mobile-order-ticket-quote-ask"));
+
+    expect(
+      (screen.getByTestId("mobile-order-ticket-price-input") as HTMLInputElement).value,
+    ).toBe("3.40");
+  });
+});

--- a/web/tests/modify-order-full-telemetry.test.tsx
+++ b/web/tests/modify-order-full-telemetry.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * ModifyOrderModal renders the same nine-field quote telemetry the portfolio
+ * position drawer gives the operator: BID MID ASK / SPREAD LAST VOLUME /
+ * HIGH LOW DAY.
+ */
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { OpenOrder } from "@/lib/types";
+import type { PriceData } from "@/lib/pricesProtocol";
+import { optionKey } from "@/lib/pricesProtocol";
+import ModifyOrderModal from "@/components/ModifyOrderModal";
+
+vi.mock("@/lib/useRiskFreeRate", () => ({
+  useRiskFreeRate: () => 0,
+}));
+
+vi.mock("@/components/Modal", () => ({
+  default: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? React.createElement("div", { className: "mock-modal" }, children) : null,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const NINE_LABELS = ["BID", "MID", "ASK", "SPREAD", "LAST", "VOLUME", "HIGH", "LOW", "DAY"];
+
+function makePriceData(overrides: Partial<PriceData> & { symbol: string }): PriceData {
+  return {
+    last: null,
+    lastIsCalculated: false,
+    bid: null,
+    ask: null,
+    bidSize: null,
+    askSize: null,
+    volume: null,
+    high: null,
+    low: null,
+    open: null,
+    close: null,
+    week52High: null,
+    week52Low: null,
+    avgVolume: null,
+    delta: null,
+    gamma: null,
+    theta: null,
+    vega: null,
+    impliedVol: null,
+    undPrice: null,
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+const OPTION_KEY = optionKey({ symbol: "SNDK", expiry: "20260717", strike: 1570, right: "C" });
+
+function optionOrder(): OpenOrder {
+  return {
+    orderId: 95,
+    permId: 653624857,
+    symbol: "SNDK C1570",
+    contract: {
+      conId: 987654,
+      symbol: "SNDK",
+      secType: "OPT",
+      strike: 1570,
+      right: "C",
+      expiry: "2026-07-17",
+    },
+    action: "SELL",
+    orderType: "LMT",
+    totalQuantity: 4,
+    limitPrice: 100,
+    auxPrice: null,
+    status: "Submitted",
+    filled: 0,
+    remaining: 4,
+    avgFillPrice: null,
+    tif: "DAY",
+  };
+}
+
+function optionPrices(): Record<string, PriceData> {
+  return {
+    [OPTION_KEY]: makePriceData({
+      symbol: OPTION_KEY,
+      bid: 93.5,
+      ask: 96.5,
+      last: 95,
+      close: 90,
+      volume: 812,
+      high: 99.4,
+      low: 88.2,
+    }),
+  };
+}
+
+function renderModal(order: OpenOrder, prices?: Record<string, PriceData>) {
+  return render(
+    <ModifyOrderModal
+      order={order}
+      loading={false}
+      prices={prices}
+      onConfirm={vi.fn()}
+      onClose={() => {}}
+    />,
+  );
+}
+
+function telemetryLabels(container: HTMLElement): string[] {
+  return [...container.querySelectorAll(".price-bar-label")].map((node) => node.textContent ?? "");
+}
+
+describe("ModifyOrderModal quote telemetry", () => {
+  it("renders the full nine-field telemetry for the order being modified", () => {
+    const { container } = renderModal(optionOrder(), optionPrices());
+    const labels = telemetryLabels(container);
+    for (const label of NINE_LABELS) {
+      expect(labels).toContain(label);
+    }
+    expect(labels[0]).toBe("SNDK C1570");
+  });
+
+  it("uses the tight density inside the modify primary panel", () => {
+    const { container } = renderModal(optionOrder(), optionPrices());
+    const bar = container.querySelector(".price-bar");
+    expect(bar?.classList.contains("price-bar--tight")).toBe(true);
+  });
+
+  it("keeps the BID/MID/ASK reference buttons that fill the limit price", () => {
+    renderModal(optionOrder(), optionPrices());
+    expect(screen.getByRole("button", { name: /^BID/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /^MID/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /^ASK/ })).toBeTruthy();
+  });
+
+  it("renders no duplicate informational price strip", () => {
+    const { container } = renderModal(optionOrder(), optionPrices());
+    expect(container.querySelector('[data-testid="order-price-strip"]')).toBeNull();
+  });
+
+  it("falls back to the empty telemetry state when no quote is reachable", () => {
+    const { container } = renderModal(optionOrder(), undefined);
+    expect(container.querySelector(".price-bar-empty")).toBeTruthy();
+    expect(container.querySelectorAll(".price-bar-label")).toHaveLength(0);
+  });
+});

--- a/web/tests/order-quote-telemetry.test.tsx
+++ b/web/tests/order-quote-telemetry.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * OrderQuoteTelemetry — the single nine-field quote panel every order surface
+ * renders (new order entry, order modification, chain tickets, mobile tickets).
+ * Same model, same formatter, same closed-market fallback as the portfolio
+ * position drawer.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { OrderQuoteTelemetry } from "@/components/QuoteTelemetry";
+import type { PriceData } from "@/lib/pricesProtocol";
+import {
+  buildQuoteTelemetryModel,
+  comboQuotePriceData,
+  type QuoteFallback,
+} from "@/lib/quoteTelemetry";
+
+afterEach(cleanup);
+
+const NINE_LABELS = ["BID", "MID", "ASK", "SPREAD", "VOLUME", "HIGH", "LOW", "DAY"];
+
+function makePriceData(overrides: Partial<PriceData> & { symbol: string }): PriceData {
+  return {
+    last: null,
+    lastIsCalculated: false,
+    bid: null,
+    ask: null,
+    bidSize: null,
+    askSize: null,
+    volume: null,
+    high: null,
+    low: null,
+    open: null,
+    close: null,
+    week52High: null,
+    week52Low: null,
+    avgVolume: null,
+    delta: null,
+    gamma: null,
+    theta: null,
+    vega: null,
+    impliedVol: null,
+    undPrice: null,
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+const LIVE_QUOTE = makePriceData({
+  symbol: "META_20260828_550_P",
+  bid: 12.8,
+  ask: 13.2,
+  last: 13.0,
+  close: 12.5,
+  volume: 4231,
+  high: 14.1,
+  low: 12.4,
+});
+
+function labelsIn(container: HTMLElement): string[] {
+  return [...container.querySelectorAll(".price-bar-label")].map((n) => n.textContent ?? "");
+}
+
+describe("OrderQuoteTelemetry", () => {
+  it("renders all nine telemetry fields", () => {
+    const { container } = render(<OrderQuoteTelemetry priceData={LIVE_QUOTE} />);
+    const labels = labelsIn(container);
+    for (const label of NINE_LABELS) {
+      expect(labels).toContain(label);
+    }
+    expect(labels).toContain("LAST");
+    expect(labels).toHaveLength(9);
+  });
+
+  it("renders the optional instrument label above the fields", () => {
+    const { container } = render(
+      <OrderQuoteTelemetry priceData={LIVE_QUOTE} label="META 2026-08-28 $550 P" />,
+    );
+    expect(labelsIn(container)[0]).toBe("META 2026-08-28 $550 P");
+    expect(labelsIn(container)).toHaveLength(10);
+  });
+
+  it("renders all nine fields at tight density and tags the container", () => {
+    const { container } = render(<OrderQuoteTelemetry priceData={LIVE_QUOTE} density="tight" />);
+    const bar = container.querySelector(".price-bar");
+    expect(bar).not.toBeNull();
+    expect(bar?.classList.contains("price-bar--tight")).toBe(true);
+    expect(labelsIn(container)).toHaveLength(9);
+    for (const label of NINE_LABELS) {
+      expect(labelsIn(container)).toContain(label);
+    }
+  });
+
+  it("renders the no-real-time-data empty state instead of a grid of dashes", () => {
+    const { container } = render(<OrderQuoteTelemetry priceData={null} />);
+    expect(screen.getByText("No real-time data")).toBeTruthy();
+    expect(container.querySelectorAll(".price-bar-label")).toHaveLength(0);
+  });
+
+  it("tones DAY positive when the quote is above the prior close", () => {
+    const { container } = render(<OrderQuoteTelemetry priceData={LIVE_QUOTE} />);
+    const dayValue = [...container.querySelectorAll(".price-bar-item")]
+      .find((item) => item.querySelector(".price-bar-label")?.textContent === "DAY")
+      ?.querySelector(".price-bar-value");
+    expect(dayValue?.className).toContain("positive");
+    expect(dayValue?.textContent).toContain("+4.00%");
+  });
+
+  it("tones DAY negative when the quote is below the prior close", () => {
+    const { container } = render(
+      <OrderQuoteTelemetry priceData={makePriceData({ ...LIVE_QUOTE, last: 11.0 })} />,
+    );
+    const dayValue = [...container.querySelectorAll(".price-bar-item")]
+      .find((item) => item.querySelector(".price-bar-label")?.textContent === "DAY")
+      ?.querySelector(".price-bar-value");
+    expect(dayValue?.className).toContain("negative");
+    expect(dayValue?.textContent).toContain("-12.00%");
+  });
+
+  it("labels LAST as CLOSE on the closed-market fallback path", () => {
+    const fallback: QuoteFallback = {
+      open: 610,
+      high: 618.4,
+      low: 604.2,
+      close: 615.5,
+      volume: 12_400_000,
+      prevClose: 600,
+    };
+    const { container } = render(<OrderQuoteTelemetry priceData={null} fallback={fallback} />);
+    const labels = labelsIn(container);
+    expect(labels).toContain("CLOSE");
+    expect(labels).not.toContain("LAST");
+    expect(labels).toHaveLength(9);
+    expect(screen.getByText("$615.50")).toBeTruthy();
+  });
+
+  it("accepts a pre-built model so combo tickets with no single PriceData can render", () => {
+    const netQuote = comboQuotePriceData({ symbol: "AAOI", bid: -1.2, ask: -0.8, last: -1.0 });
+    const model = buildQuoteTelemetryModel(netQuote);
+    const { container } = render(<OrderQuoteTelemetry model={model} label="AAOI RR" />);
+    expect(labelsIn(container)).toContain("SPREAD");
+    expect(labelsIn(container)).toHaveLength(10);
+  });
+});

--- a/web/tests/order-tab-quote-telemetry.test.tsx
+++ b/web/tests/order-tab-quote-telemetry.test.tsx
@@ -1,0 +1,218 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The Order tab is an order-entry surface, so it must show the operator the
+ * same nine-field quote telemetry the portfolio position drawer shows:
+ * BID MID ASK / SPREAD LAST VOLUME / HIGH LOW DAY. Before this it rendered
+ * only the four BID/MID/ASK quick-fill buttons, which are inputs and not
+ * telemetry.
+ */
+
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import OrderTab from "@/components/ticker-detail/OrderTab";
+import type { PriceData } from "@/lib/pricesProtocol";
+import type { PortfolioPosition } from "@/lib/types";
+
+vi.mock("@/lib/OrderActionsContext", () => ({
+  useOrderActions: () => ({
+    pendingCancels: new Map(),
+    pendingModifies: new Map(),
+    cancelledOrders: [],
+    requestCancel: vi.fn(),
+    requestModify: vi.fn(),
+    pushNotification: vi.fn(),
+    drainNotifications: vi.fn(() => []),
+    setOrdersUpdater: vi.fn(),
+  }),
+  useOrderActionsOptional: () => ({ pushNotification: vi.fn() }),
+}));
+
+vi.mock("@/components/ModifyOrderModal", () => ({ default: () => null }));
+
+const NINE_FIELDS = ["BID", "MID", "ASK", "SPREAD", "LAST", "VOLUME", "HIGH", "LOW", "DAY"];
+
+function stockPrice(overrides: Partial<PriceData> = {}): PriceData {
+  return {
+    symbol: "NVDA",
+    last: 182.5,
+    lastIsCalculated: false,
+    bid: 182.4,
+    ask: 182.6,
+    bidSize: 400,
+    askSize: 300,
+    volume: 12_500_000,
+    high: 184.2,
+    low: 180.1,
+    open: 181,
+    close: 180.5,
+    week52High: null,
+    week52Low: null,
+    avgVolume: null,
+    delta: null,
+    gamma: null,
+    theta: null,
+    vega: null,
+    impliedVol: null,
+    undPrice: null,
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+const HELD_CALL: PortfolioPosition = {
+  id: 7,
+  ticker: "NVDA",
+  structure: "Long Call $190.0",
+  structure_type: "Long Call",
+  risk_profile: "defined",
+  expiry: "2026-09-18",
+  contracts: 4,
+  direction: "LONG",
+  entry_cost: 2000,
+  max_risk: 2000,
+  market_value: 2400,
+  kelly_optimal: null,
+  target: null,
+  stop: null,
+  entry_date: "2026-07-01",
+  legs: [
+    {
+      direction: "LONG",
+      contracts: 4,
+      type: "Call",
+      strike: 190,
+      entry_cost: 2000,
+      avg_cost: 500,
+      market_price: 6,
+      market_value: 2400,
+      market_price_is_calculated: false,
+    },
+  ],
+};
+
+function telemetryPanel(container: HTMLElement): HTMLElement | null {
+  return container.querySelector(".order-form .price-bar");
+}
+
+function telemetryLabels(container: HTMLElement): string[] {
+  const panel = telemetryPanel(container);
+  if (!panel) return [];
+  return [...panel.querySelectorAll(".price-bar-label")].map((n) => n.textContent ?? "");
+}
+
+function telemetryValues(container: HTMLElement): Record<string, string> {
+  const panel = telemetryPanel(container);
+  const values: Record<string, string> = {};
+  panel?.querySelectorAll(".price-bar-item").forEach((row) => {
+    const label = row.querySelector(".price-bar-label")?.textContent ?? "";
+    const value = row.querySelector(".price-bar-value")?.textContent ?? "";
+    if (label && value) values[label] = value;
+  });
+  return values;
+}
+
+afterEach(cleanup);
+
+describe("OrderTab new-order quote telemetry", () => {
+  it("renders the full nine-field telemetry block on a fresh stock order", () => {
+    const price = stockPrice();
+    const { container } = render(
+      <OrderTab
+        ticker="NVDA"
+        position={null}
+        portfolio={null}
+        prices={{ NVDA: price }}
+        openOrders={[]}
+        tickerPriceData={price}
+      />,
+    );
+
+    expect(telemetryLabels(container)).toEqual(["NVDA", ...NINE_FIELDS]);
+    expect(telemetryValues(container)).toMatchObject({
+      BID: "$182.40",
+      MID: "$182.50",
+      ASK: "$182.60",
+      SPREAD: "$0.20 / 0.11%",
+      LAST: "$182.50",
+      VOLUME: "12,500,000",
+      HIGH: "$184.20",
+      LOW: "$180.10",
+      DAY: "+1.11%",
+    });
+  });
+
+  it("keeps the bid/mid/ask quick-fill buttons alongside the telemetry", () => {
+    const price = stockPrice();
+    const { container } = render(
+      <OrderTab
+        ticker="NVDA"
+        position={null}
+        portfolio={null}
+        prices={{ NVDA: price }}
+        openOrders={[]}
+        tickerPriceData={price}
+      />,
+    );
+
+    const quickFills = [...container.querySelectorAll(".modify-quick-buttons .btn-quick")].map(
+      (n) => n.textContent ?? "",
+    );
+    expect(quickFills).toEqual(["BID", "MID", "ASK"]);
+  });
+
+  it("labels the option quote MARK when the close-position ticket has a calculated last", () => {
+    const optionQuote = stockPrice({
+      symbol: "NVDA_20260918_190_C",
+      last: 6.1,
+      lastIsCalculated: true,
+      bid: 6,
+      ask: 6.2,
+      volume: 1200,
+      high: 6.4,
+      low: 5.7,
+      close: 5.9,
+    });
+    const { container } = render(
+      <OrderTab
+        ticker="NVDA"
+        position={HELD_CALL}
+        portfolio={null}
+        prices={{ NVDA: stockPrice(), NVDA_20260918_190_C: optionQuote }}
+        openOrders={[]}
+        tickerPriceData={optionQuote}
+      />,
+    );
+
+    expect(telemetryLabels(container)).toEqual([
+      "NVDA",
+      "BID",
+      "MID",
+      "ASK",
+      "SPREAD",
+      "MARK",
+      "VOLUME",
+      "HIGH",
+      "LOW",
+      "DAY",
+    ]);
+    expect(telemetryValues(container).MARK).toBe("$6.10");
+  });
+
+  it("renders the honest empty state when no quote has arrived", () => {
+    const { container } = render(
+      <OrderTab
+        ticker="NVDA"
+        position={null}
+        portfolio={null}
+        prices={{}}
+        openOrders={[]}
+        tickerPriceData={null}
+      />,
+    );
+
+    expect(container.querySelectorAll(".price-bar-label")).toHaveLength(0);
+    expect(container.querySelector(".order-form .price-bar-empty")?.textContent).toBe("No real-time data");
+  });
+});

--- a/web/tests/position-trade-ticket-quote-telemetry.test.tsx
+++ b/web/tests/position-trade-ticket-quote-telemetry.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * PositionTradeTicket must render the same nine-field quote telemetry block the
+ * portfolio position drawer gives the operator: BID MID ASK / SPREAD LAST
+ * VOLUME / HIGH LOW DAY — for a single leg AND for the combo net quote — while
+ * keeping the BID/MID/ASK quick-fill buttons that set the limit price.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import PositionTradeTicket from "@/components/ticker-detail/PositionTradeTicket";
+import { legPriceKey } from "@/lib/positionUtils";
+import type { PriceData } from "@/lib/pricesProtocol";
+import type { PortfolioPosition } from "@/lib/types";
+import type { TradeTarget } from "@/lib/order/positionTrade";
+
+afterEach(cleanup);
+
+const NINE_LABELS = ["BID", "MID", "ASK", "SPREAD", "VOLUME", "HIGH", "LOW", "DAY"];
+
+function makePriceData(overrides: Partial<PriceData> & { symbol: string }): PriceData {
+  return {
+    last: null,
+    lastIsCalculated: false,
+    bid: null,
+    ask: null,
+    bidSize: null,
+    askSize: null,
+    volume: null,
+    high: null,
+    low: null,
+    open: null,
+    close: null,
+    week52High: null,
+    week52Low: null,
+    avgVolume: null,
+    delta: null,
+    gamma: null,
+    theta: null,
+    vega: null,
+    impliedVol: null,
+    undPrice: null,
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function riskReversal(): PortfolioPosition {
+  return {
+    id: 7,
+    ticker: "MU",
+    structure: "Risk Reversal (P$800.0/C$1050.0)",
+    structure_type: "Risk Reversal",
+    direction: "COMBO",
+    contracts: 5,
+    expiry: "2026-07-17",
+    entry_date: "2026-05-29",
+    entry_cost: -3495,
+    market_value: -46290,
+    market_price_is_calculated: false,
+    legs: [
+      {
+        direction: "SHORT",
+        type: "Call",
+        strike: 1050,
+        contracts: 3,
+        avg_cost: 10999,
+        entry_cost: -32997,
+        market_price: 133.93,
+        market_price_is_calculated: false,
+      },
+      {
+        direction: "LONG",
+        type: "Put",
+        strike: 800,
+        contracts: 5,
+        avg_cost: 5900,
+        entry_cost: 29500,
+        market_price: 41.0,
+        market_price_is_calculated: false,
+      },
+    ],
+  } as unknown as PortfolioPosition;
+}
+
+function pricesFor(position: PortfolioPosition): Record<string, PriceData> {
+  const callKey = legPriceKey(position.ticker, position.expiry, position.legs[0])!;
+  const putKey = legPriceKey(position.ticker, position.expiry, position.legs[1])!;
+  return {
+    [callKey]: makePriceData({
+      symbol: callKey,
+      bid: 132.0,
+      ask: 136.0,
+      last: 133.93,
+      close: 130.0,
+      volume: 812,
+      high: 138.5,
+      low: 129.75,
+    }),
+    [putKey]: makePriceData({
+      symbol: putKey,
+      bid: 40.5,
+      ask: 41.5,
+      last: 41.0,
+      close: 43.25,
+      volume: 4231,
+      high: 44.1,
+      low: 40.2,
+    }),
+  };
+}
+
+function renderTicket(target: TradeTarget) {
+  const position = riskReversal();
+  return render(
+    <PositionTradeTicket
+      position={position}
+      prices={pricesFor(position)}
+      portfolio={null}
+      target={target}
+      onClose={() => {}}
+    />,
+  );
+}
+
+function labelsIn(container: HTMLElement): string[] {
+  return [...container.querySelectorAll(".price-bar-label")].map((n) => n.textContent ?? "");
+}
+
+describe("PositionTradeTicket quote telemetry", () => {
+  it("renders the nine-field telemetry block for a leg target", () => {
+    const { container } = renderTicket({ kind: "leg", index: 1 });
+    const labels = labelsIn(container);
+    for (const label of NINE_LABELS) {
+      expect(labels).toContain(label);
+    }
+    expect(labels).toContain("LAST");
+    expect(container.querySelector(".price-bar")).not.toBeNull();
+  });
+
+  it("shows the leg's own session stats, not the underlying's", () => {
+    const { container } = renderTicket({ kind: "leg", index: 1 });
+    const values = [...container.querySelectorAll(".price-bar-value")].map((n) => n.textContent ?? "");
+    expect(values.some((v) => v.includes("4,231") || v.includes("4231"))).toBe(true);
+    expect(values.some((v) => v.includes("44.10"))).toBe(true);
+    expect(values.some((v) => v.includes("40.20"))).toBe(true);
+  });
+
+  it("renders the nine-field telemetry block for a combo target from the net quote", () => {
+    const { container } = renderTicket({ kind: "combo" });
+    const labels = labelsIn(container);
+    for (const label of NINE_LABELS) {
+      expect(labels).toContain(label);
+    }
+    // A combo has no exchange-published last, so the panel reads MARK.
+    expect(labels).toContain("MARK");
+  });
+
+  it("keeps the BID/MID/ASK quick-fill buttons wired to the limit price", () => {
+    renderTicket({ kind: "leg", index: 1 });
+    const limit = screen.getByTestId("position-trade-limit") as HTMLInputElement;
+    fireEvent.click(screen.getByRole("button", { name: /^BID/ }));
+    expect(limit.value).toBe("40.50");
+    fireEvent.click(screen.getByRole("button", { name: /^ASK/ }));
+    expect(limit.value).toBe("41.50");
+  });
+});

--- a/web/tests/single-leg-ticket-quote-telemetry.test.tsx
+++ b/web/tests/single-leg-ticket-quote-telemetry.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * SingleLegOrderTicket renders the shared nine-field quote telemetry block so
+ * the operator entering an order sees the same information the portfolio
+ * position drawer gives them.
+ */
+import React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import SingleLegOrderTicket from "../components/SingleLegOrderTicket";
+import type { PortfolioData } from "@/lib/types";
+import type { PriceData } from "@/lib/pricesProtocol";
+
+afterEach(cleanup);
+
+const emptyPortfolio = { positions: [], account_summary: null } as unknown as PortfolioData;
+
+const NINE_LABELS = ["BID", "MID", "ASK", "SPREAD", "LAST", "VOLUME", "HIGH", "LOW", "DAY"];
+
+const LIVE_QUOTE: PriceData = {
+  symbol: "AAPL",
+  last: 171.5,
+  lastIsCalculated: false,
+  bid: 171.0,
+  ask: 172.0,
+  bidSize: 3,
+  askSize: 5,
+  volume: 41_230_000,
+  high: 173.4,
+  low: 169.8,
+  open: 170.2,
+  close: 168.9,
+  week52High: null,
+  week52Low: null,
+  avgVolume: null,
+  delta: null,
+  gamma: null,
+  theta: null,
+  vega: null,
+  impliedVol: null,
+  undPrice: null,
+  timestamp: new Date().toISOString(),
+} as unknown as PriceData;
+
+function renderTicket(
+  overrides: Partial<React.ComponentProps<typeof SingleLegOrderTicket>> = {},
+) {
+  const props: React.ComponentProps<typeof SingleLegOrderTicket> = {
+    defaultAction: "BUY",
+    defaultTif: "DAY",
+    quantity: "100",
+    onQuantityChange: () => {},
+    quantityPlaceholder: "Shares",
+    bid: 171,
+    mid: 171.5,
+    ask: 172,
+    isValid: true,
+    limitPrice: "171.50",
+    onLimitPriceChange: () => {},
+    riskInput: null,
+    portfolio: emptyPortfolio,
+    riskSurface: "single-leg-telemetry-test",
+    buildPayload: () => ({}),
+    buildSuccessMessage: () => "ok",
+    ...overrides,
+  };
+  return render(<SingleLegOrderTicket {...props} />);
+}
+
+function labelsIn(container: HTMLElement): string[] {
+  return [...container.querySelectorAll(".price-bar-label")].map((n) => n.textContent ?? "");
+}
+
+describe("SingleLegOrderTicket quote telemetry", () => {
+  it("renders the nine shared telemetry fields when priceData is threaded", () => {
+    const { container } = renderTicket({ priceData: LIVE_QUOTE, quoteLabel: "AAPL" });
+    const labels = labelsIn(container);
+    for (const label of NINE_LABELS) {
+      expect(labels).toContain(label);
+    }
+  });
+
+  it("renders the instrument label above the fields", () => {
+    const { container } = renderTicket({ priceData: LIVE_QUOTE, quoteLabel: "AAPL" });
+    expect(labelsIn(container)[0]).toBe("AAPL");
+  });
+
+  it("uses the tight density so the block fits a narrow ticket column", () => {
+    const { container } = renderTicket({ priceData: LIVE_QUOTE });
+    expect(container.querySelector(".price-bar--tight")).not.toBeNull();
+  });
+
+  it("renders no telemetry block at all when priceData is omitted", () => {
+    const { container } = renderTicket();
+    expect(container.querySelector(".price-bar")).toBeNull();
+    expect(labelsIn(container)).toHaveLength(0);
+  });
+
+  it("keeps the BID/MID/ASK quick buttons alongside the telemetry block", () => {
+    const { getByRole } = renderTicket({ priceData: LIVE_QUOTE });
+    expect(getByRole("button", { name: "BID" })).toBeTruthy();
+    expect(getByRole("button", { name: "MID" })).toBeTruthy();
+    expect(getByRole("button", { name: "ASK" })).toBeTruthy();
+  });
+});

--- a/web/tests/ticker-chain-position-focus.test.tsx
+++ b/web/tests/ticker-chain-position-focus.test.tsx
@@ -29,6 +29,7 @@ vi.mock("../components/PriceChart", () => ({
 
 vi.mock("../components/QuoteTelemetry", () => ({
   TickerQuoteTelemetry: () => React.createElement("div", { "data-testid": "quote-telemetry" }),
+  OrderQuoteTelemetry: () => React.createElement("div", { "data-testid": "order-quote-telemetry" }),
 }));
 
 const PLTR_PRICE: PriceData = {

--- a/web/tests/ticker-detail-content-focused-book-key-clears.test.tsx
+++ b/web/tests/ticker-detail-content-focused-book-key-clears.test.tsx
@@ -26,6 +26,7 @@ vi.mock("../components/PriceChart", () => ({
 }));
 vi.mock("../components/QuoteTelemetry", () => ({
   TickerQuoteTelemetry: () => React.createElement("div", { "data-testid": "quote-telemetry" }),
+  OrderQuoteTelemetry: () => React.createElement("div", { "data-testid": "order-quote-telemetry" }),
 }));
 
 const PORTFOLIO: PortfolioData = {


### PR DESCRIPTION
## What

The portfolio position drawer showed nine quote fields for the instrument being traded. Every other order-entry / order-modification surface showed only the four-field strip (BID/MID/ASK/SPREAD). This brings all of them to parity.

**BID · MID · ASK / SPREAD · LAST-or-MARK · VOLUME / HIGH · LOW · DAY** now renders on:

| Surface | File |
|---|---|
| Modify order modal | `ModifyOrderModal.tsx` |
| Single-leg ticket | `SingleLegOrderTicket.tsx` |
| Ticker order tab | `ticker-detail/OrderTab.tsx` |
| Position trade ticket | `ticker-detail/PositionTradeTicket.tsx` |
| Options chain builder | `ticker-detail/OptionsChainTab.tsx` |
| Futures / index / listed contract | `ListedContractOrderForm.tsx` (chokepoint) |
| Book tab stock ticket | `ticker-detail/BookTab.tsx` |
| Mobile order ticket | `mobile/MobileOrderTicket.tsx` |
| Mobile chain detail sheet | `mobile/MobileChainLadder.tsx` |
| Agent approval gate | `agent/ApprovalGate.tsx` |

## How

- **One implementation.** `OrderQuoteTelemetry` is the single component; `InstrumentOrderQuoteTelemetry` and `TickerQuoteTelemetry` become aliases. The model, spread math and closed-market fallback exist exactly once.
- **Combos reuse the same model.** `comboQuotePriceData()` wraps a BAG's existing signed net quote so combo tickets get the panel with no second net-quote calculation. Session OHLV stays `---` for a combo, which is honest: no exchange publishes a combo's high/low/volume.
- **`density="tight"`** changes spacing and type scale only, never which fields render. Verified at 320px with no overflow.
- **Tap-to-fill preserved.** Every interactive BID/MID/ASK limit-fill control is untouched and pinned by regression tests.
- **Approval gate got a real producer.** `prices` threaded ChatLauncher → ChatPanel, so the gate's panel isn't dead code.

## Verification

- `vitest run` from repo root: **696 files / 7222 tests pass**, 0 failures
- `tsc --noEmit`: exit 0 · `eslint`: 0 errors (13 pre-existing warnings, unchanged count)
- Playwright render of the real component against `globals.css`: field-for-field match with the position drawer in **both light and dark themes**, tight density clean at 320px
- 13 new test files, red-verified before green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177apGqsWaVFmiCkBvzNCSs