### PR TITLE
fix(order): combo ticket telemetry, and stop the drawer printing it twice

### DIFF
--- a/web/components/InstrumentDetailModal.tsx
+++ b/web/components/InstrumentDetailModal.tsx
@@ -234,6 +234,9 @@ function LegOrderForm({
     };
   }, [isValid, parsedQty, parsedPrice, parsedStop, orderType, action, ticker, strikeStr, right, isStock, leg.strike, leg.direction, leg.contracts, leg.avg_cost, expiry, bid, ask]);
 
+  // Deliberately no `priceData` below: the modal already renders the telemetry
+  // block above this form, and handing it to the ticket as well prints the
+  // same nine fields twice.
   return (
     <SingleLegOrderTicket
       defaultAction={defaultAction}
@@ -244,7 +247,6 @@ function LegOrderForm({
       bid={bid}
       mid={mid}
       ask={ask}
-      priceData={priceData}
       showQuickButtonPrices={true}
       isValid={isValid}
       limitPrice={limitPrice}

--- a/web/components/ticker-detail/OrderTab.tsx
+++ b/web/components/ticker-detail/OrderTab.tsx
@@ -12,6 +12,7 @@ import { computeLegImpliedValue } from "@/lib/impliedValue";
 import { useRiskFreeRate } from "@/lib/useRiskFreeRate";
 import ModifyOrderModal from "@/components/ModifyOrderModal";
 import { OrderQuoteTelemetry } from "@/components/QuoteTelemetry";
+import { buildQuoteTelemetryModel, comboQuotePriceData } from "@/lib/quoteTelemetry";
 import OrderErrorBanner from "@/components/OrderErrorBanner";
 import type { ModifyOrderRequest } from "@/lib/orderModify";
 import { checkNakedShortRisk, type NakedShortPortfolio, type OrderPayload } from "@/lib/nakedShortGuard";
@@ -780,6 +781,22 @@ function ComboOrderForm({
       ?? { bid: null, ask: null, mid: null };
   }, [position, prices, ticker]);
 
+  // A BAG has no quote of its own, so feed the net through the same model
+  // every single-leg surface uses rather than hand-building a second one.
+  // Session OHLV stays null on purpose: no exchange publishes a combo's
+  // high, low or volume, so those render "---" instead of a borrowed number.
+  const comboQuoteModel = useMemo(() => {
+    if (netPrices.bid == null && netPrices.ask == null) return null;
+    return buildQuoteTelemetryModel(
+      comboQuotePriceData({
+        symbol: ticker,
+        bid: netPrices.bid,
+        ask: netPrices.ask,
+        last: netPrices.mid,
+      }),
+    );
+  }, [ticker, netPrices.bid, netPrices.ask, netPrices.mid]);
+
   const parsedQty = parseInt(quantity, 10);
   const parsedPrice = parseFloat(limitPrice);
   const isValid = !isNaN(parsedQty) && parsedQty > 0 && Number.isFinite(parsedPrice) && parsedPrice !== 0;
@@ -932,6 +949,8 @@ function ComboOrderForm({
 
   return (
     <div className="order-form">
+      <OrderQuoteTelemetry model={comboQuoteModel} label={position.structure} />
+
       {/* Spread price strip — always visible at top */}
       <div className="spread-price-strip">
         <div className="spread-price-item">

--- a/web/tests/order-tab-quote-telemetry.test.tsx
+++ b/web/tests/order-tab-quote-telemetry.test.tsx
@@ -216,3 +216,99 @@ describe("OrderTab new-order quote telemetry", () => {
     expect(container.querySelector(".order-form .price-bar-empty")?.textContent).toBe("No real-time data");
   });
 });
+
+const HELD_SPREAD: PortfolioPosition = {
+  id: 8,
+  ticker: "NVDA",
+  structure: "Bull Call Spread $190.0/$200.0",
+  structure_type: "Bull Call Spread",
+  risk_profile: "defined",
+  expiry: "2026-09-18",
+  contracts: 4,
+  direction: "COMBO",
+  entry_cost: 1600,
+  max_risk: 1600,
+  market_value: 2000,
+  kelly_optimal: null,
+  target: null,
+  stop: null,
+  entry_date: "2026-07-01",
+  legs: [
+    {
+      direction: "LONG", contracts: 4, type: "Call", strike: 190,
+      entry_cost: 2400, avg_cost: 600, market_price: 7, market_value: 2800,
+      market_price_is_calculated: false,
+    },
+    {
+      direction: "SHORT", contracts: 4, type: "Call", strike: 200,
+      entry_cost: 800, avg_cost: 200, market_price: 2, market_value: 800,
+      market_price_is_calculated: false,
+    },
+  ],
+};
+
+function legPrice(symbol: string, bid: number, ask: number): PriceData {
+  return { ...stockPrice(), symbol, bid, ask, last: (bid + ask) / 2, volume: null, high: null, low: null, open: null, close: null };
+}
+
+/**
+ * The combo branch of the Order tab is its own order-entry surface ("Place
+ * Combo Order") and was shipped without the telemetry block that the
+ * single-leg branch got - it showed only its three-field net BID/MID/ASK
+ * strip. Caught on production after the first rollout.
+ */
+describe("OrderTab combo quote telemetry", () => {
+  it("renders the nine-field telemetry block on the combo order form", () => {
+    const prices = {
+      NVDA: stockPrice(),
+      NVDA_20260918_190_C: legPrice("NVDA_20260918_190_C", 7.0, 7.4),
+      NVDA_20260918_200_C: legPrice("NVDA_20260918_200_C", 2.0, 2.2),
+    };
+    const { container } = render(
+      <OrderTab
+        ticker="NVDA"
+        position={HELD_SPREAD}
+        portfolio={null}
+        prices={prices}
+        openOrders={[]}
+        tickerPriceData={prices.NVDA}
+      />,
+    );
+
+    expect(telemetryLabels(container)).toEqual(
+      expect.arrayContaining(["BID", "MID", "ASK", "SPREAD", "VOLUME", "HIGH", "LOW", "DAY"]),
+    );
+    const values = telemetryValues(container);
+    // Natural spread: BUY leg pays ask, SELL leg receives bid -> 7.4 - 2.0 = 5.40 ask,
+    // 7.0 - 2.2 = 4.80 bid. A combo has no session OHLV, so those read "---".
+    expect(values.BID).toBe("$4.80");
+    expect(values.ASK).toBe("$5.40");
+    expect(values.VOLUME).toBe("---");
+    expect(values.HIGH).toBe("---");
+    expect(values.DAY).toBe("---");
+    // MARK, not LAST: the net is calculated, never a printed trade.
+    expect(values.MARK).toBe("$5.10");
+  });
+
+  it("keeps the combo net BID/MID/ASK quick-fill buttons", () => {
+    const prices = {
+      NVDA: stockPrice(),
+      NVDA_20260918_190_C: legPrice("NVDA_20260918_190_C", 7.0, 7.4),
+      NVDA_20260918_200_C: legPrice("NVDA_20260918_200_C", 2.0, 2.2),
+    };
+    const { container } = render(
+      <OrderTab
+        ticker="NVDA"
+        position={HELD_SPREAD}
+        portfolio={null}
+        prices={prices}
+        openOrders={[]}
+        tickerPriceData={prices.NVDA}
+      />,
+    );
+    const quick = [...container.querySelectorAll("button.btn-quick")].map((b) => b.textContent ?? "");
+    expect(quick.some((t) => t.startsWith("BID"))).toBe(true);
+    expect(quick.some((t) => t.startsWith("MID"))).toBe(true);
+    expect(quick.some((t) => t.startsWith("ASK"))).toBe(true);
+  });
+});

--- a/web/tests/single-leg-ticket-quote-telemetry.test.tsx
+++ b/web/tests/single-leg-ticket-quote-telemetry.test.tsx
@@ -104,3 +104,65 @@ describe("SingleLegOrderTicket quote telemetry", () => {
     expect(getByRole("button", { name: "ASK" })).toBeTruthy();
   });
 });
+
+/**
+ * The position drawer renders the telemetry block itself, ABOVE the order
+ * form. Threading `priceData` into the nested ticket as well made the drawer
+ * print the same nine fields twice, stacked - caught on production. The
+ * drawer must show exactly one.
+ */
+describe("InstrumentDetailModal renders exactly one telemetry block", () => {
+  it("does not duplicate the quote panel inside the nested order ticket", async () => {
+    const { default: InstrumentDetailModal } = await import("@/components/InstrumentDetailModal");
+    const leg = {
+      direction: "LONG" as const,
+      contracts: 50,
+      type: "Call" as const,
+      strike: 575,
+      entry_cost: 21250,
+      avg_cost: 425,
+      market_price: 4.35,
+      market_value: 21750,
+      market_price_is_calculated: false,
+    };
+    const price: PriceData = {
+      symbol: "META_20260828_575_C",
+      last: 4.35,
+      lastIsCalculated: false,
+      bid: 4.2,
+      ask: 4.45,
+      bidSize: 10,
+      askSize: 12,
+      volume: 1060,
+      high: 6.4,
+      low: 3.55,
+      open: 5.0,
+      close: 3.65,
+      week52High: null,
+      week52Low: null,
+      avgVolume: null,
+      delta: null,
+      gamma: null,
+      theta: null,
+      vega: null,
+      impliedVol: null,
+      undPrice: null,
+      timestamp: new Date().toISOString(),
+    };
+
+    render(
+      <InstrumentDetailModal
+        leg={leg}
+        ticker="META"
+        expiry="2026-08-28"
+        prices={{ META_20260828_575_C: price }}
+        onClose={() => {}}
+        portfolio={null}
+      />,
+    );
+
+    // Modal portals to document.body, so scope the count to the whole document.
+    const panels = document.querySelectorAll(".price-bar");
+    expect(panels.length).toBe(1);
+  });
+});


### PR DESCRIPTION
Found by walking every order surface on **production** after #94 deployed. Two real gaps.

### 1. Order tab's combo branch never got the block

Only the single-leg branch (`NewOrderForm`) was wired in #94. The combo branch — the "Place Combo Order" form — still showed just its three-field net BID/MID/ASK strip.

It now feeds its existing `netPrices` through `comboQuotePriceData` into the same model every other surface uses, so no second net-quote or spread calculation is introduced. Session OHLV stays `---` because no exchange publishes a combo's high, low, or volume.

### 2. The position drawer printed the nine fields twice

The drawer already renders the block above its order form, and the nested `SingleLegOrderTicket` was *also* handed `priceData` — so the identical panel appeared twice, stacked, on the very surface that was the design reference.

Dropped the prop at that call site, with a comment so it doesn't come back.

### Red/green

- Combo test asserts the nine labels plus the derived net (`$4.80` bid / `$5.40` ask from `7.00 − 2.20` and `7.40 − 2.00`), that OHLV reads `---`, that the net is labelled MARK, and that the quick-fill buttons survive. Verified RED first.
- Drawer test pins exactly one panel, and was confirmed to report `2` with the prop restored — so it genuinely catches the regression rather than passing vacuously.

### Verification

- `vitest run`: **718 files / 7442 tests pass**
- `tsc --noEmit`: exit 0
- Live on production (market open) across modify modal (single-leg + combo), chain builder (single-leg + combo), BookTab stock ticket, position trade ticket, VIX futures form, and the position drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177apGqsWaVFmiCkBvzNCSs