### PR TITLE
fix(grg): fill the divergence field cell and label a real date axis

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -14915,6 +14915,22 @@ body[data-mobile="true"] .garch-scanner__table tbody td {
 .grg-chart-wrap {
   min-height: 306px;
   padding: 12px;
+  /* The chart sits beside the SPY/TLT stack, so its grid cell is as tall as
+     that stack. Stretch the plot into the whole cell instead of letting a
+     fixed-ratio SVG letterbox and leave a dead band underneath. */
+  display: flex;
+  flex-direction: column;
+}
+
+.grg-chart-plot {
+  flex: 1;
+  /* Without this a flex child refuses to shrink below its content height and
+     the ResizeObserver never settles. */
+  min-height: 0;
+}
+
+.grg-chart-plot svg {
+  display: block;
 }
 
 .grg-chart-head {

--- a/web/components/GammaRotationPanel.tsx
+++ b/web/components/GammaRotationPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Activity, AlertTriangle, TrendingDown, TrendingUp } from "lucide-react";
 import { MarketState } from "@/lib/useMarketHours";
 import {
@@ -123,17 +124,38 @@ function AssetCard({ asset }: { asset: GammaRotationAsset }) {
   );
 }
 
-function yFor(value: number, min: number, max: number): number {
-  if (max <= min) return 120;
-  return 220 - ((value - min) / (max - min)) * 180;
+/**
+ * The plot rectangle inside the measured SVG box. Left gutter holds the sigma
+ * labels, the bottom gutter holds the date axis.
+ */
+type ChartBox = { width: number; height: number };
+type PlotRect = { left: number; right: number; top: number; bottom: number };
+
+const CHART_PAD = { left: 44, right: 24, top: 20, bottom: 34 };
+const FALLBACK_BOX: ChartBox = { width: 708, height: 306 };
+/** Below this the axis drops ticks rather than overlapping them. */
+const MIN_PX_PER_DATE_TICK = 120;
+
+function plotRect(box: ChartBox): PlotRect {
+  return {
+    left: CHART_PAD.left,
+    right: Math.max(CHART_PAD.left + 1, box.width - CHART_PAD.right),
+    top: CHART_PAD.top,
+    bottom: Math.max(CHART_PAD.top + 1, box.height - CHART_PAD.bottom),
+  };
 }
 
-function xFor(index: number, count: number): number {
-  if (count <= 1) return 44;
-  return 44 + (index / (count - 1)) * 620;
+function yFor(value: number, min: number, max: number, rect: PlotRect): number {
+  if (max <= min) return (rect.top + rect.bottom) / 2;
+  return rect.bottom - ((value - min) / (max - min)) * (rect.bottom - rect.top);
 }
 
-function linePath(history: GammaRotationHistoryEntry[], key: "grg_z" | "spy_gamma_z" | "tlt_gamma_z", min: number, max: number): string {
+function xFor(index: number, count: number, rect: PlotRect): number {
+  if (count <= 1) return rect.left;
+  return rect.left + (index / (count - 1)) * (rect.right - rect.left);
+}
+
+function linePath(history: GammaRotationHistoryEntry[], key: "grg_z" | "spy_gamma_z" | "tlt_gamma_z", min: number, max: number, rect: PlotRect): string {
   let segmentOpen = false;
   const commands: string[] = [];
   history.forEach((row, index) => {
@@ -142,10 +164,48 @@ function linePath(history: GammaRotationHistoryEntry[], key: "grg_z" | "spy_gamm
       segmentOpen = false;
       return;
     }
-    commands.push(`${segmentOpen ? "L" : "M"}${xFor(index, history.length).toFixed(1)} ${yFor(value, min, max).toFixed(1)}`);
+    commands.push(`${segmentOpen ? "L" : "M"}${xFor(index, history.length, rect).toFixed(1)} ${yFor(value, min, max, rect).toFixed(1)}`);
     segmentOpen = true;
   });
   return commands.join(" ");
+}
+
+/**
+ * Evenly spaced session indices for the date axis, always including the first
+ * and last so the axis states the range it covers. Count is driven by the
+ * measured width so labels never collide.
+ */
+function dateTickIndices(count: number, plotWidth: number): number[] {
+  if (count <= 0) return [];
+  if (count === 1) return [0];
+  const fit = Math.floor(plotWidth / MIN_PX_PER_DATE_TICK);
+  const ticks = Math.max(2, Math.min(7, fit, count));
+  const step = (count - 1) / (ticks - 1);
+  const indices = Array.from({ length: ticks }, (_, i) => Math.round(i * step));
+  return [...new Set(indices)];
+}
+
+/** Measures the chart host so the SVG can draw in pixel space and fill it. */
+function useChartBox(ref: React.RefObject<HTMLDivElement | null>): ChartBox {
+  const [box, setBox] = useState<ChartBox>(FALLBACK_BOX);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver((entries) => {
+      const rect = entries[0]?.contentRect;
+      if (!rect || rect.width <= 0 || rect.height <= 0) return;
+      setBox({ width: rect.width, height: rect.height });
+    });
+    observer.observe(el);
+    const initial = el.getBoundingClientRect();
+    if (initial.width > 0 && initial.height > 0) {
+      setBox({ width: initial.width, height: initial.height });
+    }
+    return () => observer.disconnect();
+  }, [ref]);
+
+  return box;
 }
 
 function domainLabel(value: number): string {
@@ -153,10 +213,20 @@ function domainLabel(value: number): string {
 }
 
 function GammaRotationChart({ history }: { history: GammaRotationHistoryEntry[] }) {
+  const plotRef = useRef<HTMLDivElement>(null);
+  const box = useChartBox(plotRef);
+  const rect = plotRect(box);
+
   const values = history.flatMap((row) => [row.grg_z, row.spy_gamma_z, row.tlt_gamma_z]).filter((value): value is number => value != null && Number.isFinite(value));
   const min = Math.min(-3, ...values);
   const max = Math.max(3, ...values);
-  const last = history.at(-1);
+  const zeroY = yFor(0, min, max, rect);
+
+  const gridRows = [0, 0.25, 0.5, 0.75, 1].map((t) => rect.top + t * (rect.bottom - rect.top));
+  const ticks = useMemo(
+    () => dateTickIndices(history.length, rect.right - rect.left),
+    [history.length, rect.left, rect.right],
+  );
 
   return (
     <div className="grg-chart-wrap" data-testid="grg-chart">
@@ -168,20 +238,47 @@ function GammaRotationChart({ history }: { history: GammaRotationHistoryEntry[] 
           <i style={{ background: "var(--fault)" }} /> TLT
         </span>
       </div>
-      <svg viewBox="0 0 708 260" role="img" aria-label="Gamma Rotation Gap history">
-        <g stroke="var(--chart-grid)" strokeWidth="1">
-          {[40, 85, 130, 175, 220].map((y) => <line key={y} x1="44" y1={y} x2="664" y2={y} />)}
-          {[44, 168, 292, 416, 540, 664].map((x) => <line key={x} x1={x} y1="28" x2={x} y2="226" />)}
-        </g>
-        <line x1="44" y1={yFor(0, min, max)} x2="664" y2={yFor(0, min, max)} stroke="var(--text-muted)" strokeDasharray="4 6" opacity="0.65" />
-        <path d={linePath(history, "spy_gamma_z", min, max)} fill="none" stroke="var(--signal-core)" strokeWidth="2" opacity="0.8" />
-        <path d={linePath(history, "tlt_gamma_z", min, max)} fill="none" stroke="var(--fault)" strokeWidth="2" opacity="0.8" />
-        <path d={linePath(history, "grg_z", min, max)} fill="none" stroke="var(--warning)" strokeWidth="3" />
-        <text x="8" y="43" className="grg-svg-label">{domainLabel(max)}</text>
-        <text x="20" y={yFor(0, min, max) - 4} className="grg-svg-label">0</text>
-        <text x="8" y="224" className="grg-svg-label">{domainLabel(min)}</text>
-        {last && <text x="548" y="248" className="grg-svg-label">{last.date}</text>}
-      </svg>
+      <div className="grg-chart-plot" ref={plotRef}>
+        <svg
+          width="100%"
+          height="100%"
+          viewBox={`0 0 ${Math.round(box.width)} ${Math.round(box.height)}`}
+          role="img"
+          aria-label="Gamma Rotation Gap history"
+        >
+          <g stroke="var(--chart-grid)" strokeWidth="1">
+            {gridRows.map((y) => <line key={y} x1={rect.left} y1={y} x2={rect.right} y2={y} />)}
+            {ticks.map((index) => {
+              const x = xFor(index, history.length, rect);
+              return <line key={`v${index}`} x1={x} y1={rect.top} x2={x} y2={rect.bottom} />;
+            })}
+          </g>
+          <line x1={rect.left} y1={zeroY} x2={rect.right} y2={zeroY} stroke="var(--text-muted)" strokeDasharray="4 6" opacity="0.65" />
+          <path d={linePath(history, "spy_gamma_z", min, max, rect)} fill="none" stroke="var(--signal-core)" strokeWidth="2" opacity="0.8" />
+          <path d={linePath(history, "tlt_gamma_z", min, max, rect)} fill="none" stroke="var(--fault)" strokeWidth="2" opacity="0.8" />
+          <path d={linePath(history, "grg_z", min, max, rect)} fill="none" stroke="var(--warning)" strokeWidth="3" />
+          <text x="8" y={rect.top + 8} className="grg-svg-label">{domainLabel(max)}</text>
+          <text x="20" y={zeroY - 4} className="grg-svg-label">0</text>
+          <text x="8" y={rect.bottom} className="grg-svg-label">{domainLabel(min)}</text>
+          {ticks.map((index, position) => {
+            const row = history[index];
+            if (!row) return null;
+            const anchor = position === 0 ? "start" : position === ticks.length - 1 ? "end" : "middle";
+            return (
+              <text
+                key={`t${index}`}
+                data-testid="grg-x-tick"
+                x={xFor(index, history.length, rect)}
+                y={rect.bottom + 20}
+                textAnchor={anchor}
+                className="grg-svg-label"
+              >
+                {row.date}
+              </text>
+            );
+          })}
+        </svg>
+      </div>
     </div>
   );
 }

--- a/web/tests/gamma-rotation-panel.test.tsx
+++ b/web/tests/gamma-rotation-panel.test.tsx
@@ -3,9 +3,37 @@
  */
 
 import React from "react";
-import { render } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import GammaRotationPanel from "../components/GammaRotationPanel";
+
+// jsdom doesn't ship ResizeObserver; the chart wires one up on mount to size
+// itself to its container.
+// jsdom ships no ResizeObserver and reports every rect as 0x0, so the chart
+// can never measure itself here. This stub records the observers so a test can
+// drive a resize and assert the chart redraws into the new box.
+const observers: Array<(entries: Array<{ contentRect: { width: number; height: number } }>) => void> = [];
+
+function resizeTo(rect: { width: number; height: number }) {
+  observers.forEach((cb) => cb([{ contentRect: rect }]));
+}
+
+beforeAll(() => {
+  class StubResizeObserver {
+    constructor(cb: (entries: Array<{ contentRect: { width: number; height: number } }>) => void) {
+      observers.push(cb);
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  (globalThis as unknown as { ResizeObserver: typeof StubResizeObserver }).ResizeObserver =
+    StubResizeObserver;
+});
+
+afterEach(() => {
+  observers.length = 0;
+});
 
 const mockUseGammaRotation = vi.fn();
 
@@ -128,5 +156,58 @@ describe("GammaRotationPanel", () => {
     expect(path.match(/M/g)).toHaveLength(2);
     expect(path).not.toContain("NaN");
     expect(container.textContent).toContain("+4.5σ");
+  });
+});
+
+
+/**
+ * The divergence field sat in a grid cell as tall as the SPY+TLT stack beside
+ * it but drew into a fixed 708x260 viewBox, so it letterboxed and left a large
+ * dead band under the plot. It also labelled a single date, which makes a
+ * 90-session series unreadable as a timeline.
+ *
+ * The fix measures the container and draws in pixel space, so these assert the
+ * behaviour (fills the box, tracks its height, labels a real axis) rather than
+ * any particular scaling trick.
+ */
+describe("GammaRotationPanel divergence field", () => {
+  function renderChart() {
+    mockUseGammaRotation.mockReturnValue({ data: MOCK_GRG, loading: false, error: null });
+    return render(<GammaRotationPanel />);
+  }
+
+  it("fills its container box rather than scaling to a fixed aspect ratio", () => {
+    const { container } = renderChart();
+    const svg = container.querySelector("[data-testid='grg-chart'] svg");
+    expect(svg).toBeTruthy();
+    expect(svg?.getAttribute("width")).toBe("100%");
+    expect(svg?.getAttribute("height")).toBe("100%");
+  });
+
+  it("redraws into the measured height so the plot grows with the cell", () => {
+    const { container } = renderChart();
+    const svg = container.querySelector("[data-testid='grg-chart'] svg");
+    const before = svg?.getAttribute("viewBox");
+
+    act(() => {
+      resizeTo({ width: 1200, height: 820 });
+    });
+
+    const after = svg?.getAttribute("viewBox");
+    expect(after).not.toBe(before);
+    expect(after).toBe("0 0 1200 820");
+  });
+
+  it("labels several dates across the x-axis, not just the last one", () => {
+    const { container } = renderChart();
+    act(() => {
+      resizeTo({ width: 1200, height: 820 });
+    });
+    const ticks = container.querySelectorAll("[data-testid='grg-x-tick']");
+    expect(ticks.length).toBeGreaterThanOrEqual(2);
+    const labels = [...ticks].map((t) => t.textContent);
+    // First and last session always anchor the axis.
+    expect(labels[0]).toBe("2026-05-27");
+    expect(labels[labels.length - 1]).toBe("2026-05-29");
   });
 });


### PR DESCRIPTION
The 90-session divergence field on `/regime/grg` drew into a fixed `708x260` viewBox. Its grid cell is as tall as the SPY+TLT stack beside it, so the SVG scaled to its own aspect ratio and left a large dead band underneath — and it printed exactly one date, which makes a 90-session series unreadable as a timeline.

### Fix

**Fill the cell.** Measure the host with a `ResizeObserver` and draw in pixel space: the viewBox becomes the measured box, so the plot grows into whatever height the cell has, with no distortion and no letterboxing. Geometry helpers now take the plot rect instead of hard-coded `44/220/180` offsets.

I deliberately did *not* use `preserveAspectRatio="none"` — it fills the box but stretches the axis text vertically. Measuring keeps everything crisp.

**Real date axis.** Evenly spaced ticks, always including the first and last session so the axis states the range it covers. Tick count derives from the measured width (one per ~120px, capped at 7) so labels never collide on a narrow cell, and the vertical gridlines now align with the dates instead of sitting at arbitrary offsets.

### Verification

Rendered the built page in a real browser with a stubbed 90-session payload:

- wrap **476px** / svg **427px** — the balance is the header and padding, no dead band
- viewBox `0 0 687 427` (measured pixel space)
- 5 ticks spanning `2026-06-01` → `2026-08-30`

Tests are behavioural (fills the box, redraws into a measured resize, labels a real axis) rather than pinned to any scaling trick — the ResizeObserver stub is driveable so a test can resize and assert the redraw.

- `vitest run`: **718 files / 7445 tests pass**
- `tsc --noEmit`: exit 0 · `eslint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177apGqsWaVFmiCkBvzNCSs