### PR TITLE
perf: restore fast portfolio page loads

### DIFF
--- a/scripts/clients/journal_basis.py
+++ b/scripts/clients/journal_basis.py
@@ -5,16 +5,20 @@ from __future__ import annotations
 import json
 import logging
 import re
-from typing import Any, Optional
+from typing import Any, Iterable, Optional
 
 logger = logging.getLogger(__name__)
 
 
-# Both journal queries below SELECT exactly these columns, in this order.
+# Rows passed to the derivation layer use exactly these columns, in this order.
 # Real libsql_experimental cursors return plain tuples, so name-based access
 # must fall back to position or every row silently reads as empty (CTA-01,
-# layer 2 — the .rows AttributeError was masking this).
+# layer 2 — the .rows AttributeError was masking this). The paginated DB reader
+# selects trade_id as a fourth cursor column and normalizes it back to this
+# stable row shape before derivation.
 _JOURNAL_COLUMNS = ("payload", "filled_at", "written_at")
+_PAGED_JOURNAL_COLUMNS = ("trade_id", *_JOURNAL_COLUMNS)
+_JOURNAL_PAGE_SIZE = 200
 
 
 def _row_value(row: Any, key: str) -> Any:
@@ -23,6 +27,17 @@ def _row_value(row: Any, key: str) -> Any:
     if isinstance(row, (tuple, list)):
         try:
             return row[_JOURNAL_COLUMNS.index(key)]
+        except (ValueError, IndexError):
+            return None
+    return getattr(row, key, None)
+
+
+def _paged_row_value(row: Any, key: str) -> Any:
+    if isinstance(row, dict):
+        return row.get(key)
+    if isinstance(row, (tuple, list)):
+        try:
+            return row[_PAGED_JOURNAL_COLUMNS.index(key)]
         except (ValueError, IndexError):
             return None
     return getattr(row, key, None)
@@ -193,6 +208,234 @@ def _row_is_before_cutoff(row: Any, before: str) -> bool:
     return str(timestamp)[:10] < str(before)[:10]
 
 
+def _fetch_journal_rows_for_tickers(db, tickers: Iterable[str]) -> list[Any]:
+    """Fetch ticker history in bounded Hrana pages, then restore legacy order."""
+    normalized_tickers = tuple(
+        sorted({_normalize_ticker(ticker) for ticker in tickers if _normalize_ticker(ticker)})
+    )
+    if not normalized_tickers:
+        return []
+
+    placeholders = ", ".join("?" for _ in normalized_tickers)
+    cursor = ""
+    accumulated: list[tuple[str, tuple[Any, Any, Any]]] = []
+
+    while True:
+        result = db.execute(
+            f"""
+            SELECT trade_id, payload, filled_at, written_at
+            FROM journal
+            WHERE trade_id > ?
+              AND UPPER(COALESCE(
+                  json_extract(payload, '$.ticker'),
+                  json_extract(payload, '$.symbol'),
+                  ''
+              )) IN ({placeholders})
+            ORDER BY trade_id ASC
+            LIMIT ?
+            """,
+            (cursor, *normalized_tickers, _JOURNAL_PAGE_SIZE),
+        )
+        page = list(result.fetchall())
+        if not page:
+            break
+
+        for row in page:
+            trade_id = str(_paged_row_value(row, "trade_id") or "")
+            if not trade_id or trade_id <= cursor:
+                raise RuntimeError("journal basis pagination returned a non-advancing trade_id")
+            accumulated.append(
+                (
+                    trade_id,
+                    (
+                        _paged_row_value(row, "payload"),
+                        _paged_row_value(row, "filled_at"),
+                        _paged_row_value(row, "written_at"),
+                    ),
+                )
+            )
+
+        next_cursor = accumulated[-1][0]
+        if next_cursor <= cursor:
+            raise RuntimeError("journal basis pagination cursor did not advance")
+        cursor = next_cursor
+        if len(page) < _JOURNAL_PAGE_SIZE:
+            break
+
+    def sort_key(item: tuple[str, tuple[Any, Any, Any]]) -> tuple[Any, ...]:
+        trade_id, row = item
+        payload = _payload_from_row(row)
+        ticker = _normalize_ticker(payload.get("ticker") or payload.get("symbol"))
+        filled_at = _row_value(row, "filled_at")
+        written_at = _row_value(row, "written_at")
+        effective_at = filled_at if filled_at is not None else written_at
+
+        # SQLite sorts NULL before text in ASC order. Preserve the old query's
+        # ticker/effective-time/written-time semantics exactly, with trade_id as
+        # a deterministic tie-breaker for rows whose timestamps are identical.
+        return (
+            ticker,
+            effective_at is not None,
+            str(effective_at or ""),
+            written_at is not None,
+            str(written_at or ""),
+            trade_id,
+        )
+
+    accumulated.sort(key=sort_key)
+    return [row for _trade_id, row in accumulated]
+
+
+def _derive_journal_state_from_rows(
+    rows: Iterable[Any],
+    *,
+    basis_tickers: Iterable[str] = (),
+    option_net_keys: Iterable[str] = (),
+    stock_net_tickers: Iterable[str] = (),
+    before: Optional[str] = None,
+) -> tuple[dict[str, float], dict[str, float]]:
+    """Pure row processor shared by the single-target and batched readers."""
+    normalized_basis_tickers = {
+        _normalize_ticker(ticker) for ticker in basis_tickers if _normalize_ticker(ticker)
+    }
+    normalized_stock_tickers = {
+        _normalize_ticker(ticker)
+        for ticker in stock_net_tickers
+        if _normalize_ticker(ticker)
+    }
+    normalized_option_keys = {str(key) for key in option_net_keys if str(key)}
+
+    buckets: dict[str, dict[str, Any]] = {}
+    basis_counted_parts: dict[str, set[str]] = {
+        ticker: set() for ticker in normalized_basis_tickers
+    }
+    net_qty_lookup = {key: 0.0 for key in sorted(normalized_option_keys)}
+    net_qty_lookup.update(
+        {f"{ticker}|STK": 0.0 for ticker in sorted(normalized_stock_tickers)}
+    )
+    net_counted_parts = {key: set() for key in net_qty_lookup}
+
+    for row in rows:
+        payload = _payload_from_row(row)
+        ticker = _normalize_ticker(payload.get("ticker") or payload.get("symbol"))
+        if not ticker:
+            continue
+
+        key = _bucket_key(payload)
+        qty_raw = payload.get("contracts")
+        if qty_raw is None:
+            qty_raw = payload.get("shares")
+        try:
+            qty = abs(float(qty_raw))
+        except (TypeError, ValueError):
+            continue
+
+        signed_qty = _signed_qty(payload.get("action"), qty)
+        if signed_qty == 0:
+            continue
+        exec_parts = _exec_id_parts(payload)
+
+        if before is None or _row_is_before_cutoff(row, before):
+            net_target: Optional[str] = None
+            if key in normalized_option_keys:
+                net_target = key
+            elif (
+                ticker in normalized_stock_tickers
+                and payload.get("strike") is None
+                and not payload.get("right")
+            ):
+                net_target = f"{ticker}|STK"
+
+            if net_target is not None and _claim_exec_parts(
+                net_counted_parts[net_target],
+                exec_parts,
+                ticker if net_target.endswith("|STK") else net_target,
+            ):
+                net_qty_lookup[net_target] += signed_qty
+
+        if ticker not in normalized_basis_tickers or key is None:
+            continue
+
+        try:
+            total_cost = float(payload.get("total_cost"))
+        except (TypeError, ValueError):
+            continue
+
+        persisted_open_basis = payload.get("open_basis")
+        try:
+            persisted_open_basis = (
+                float(persisted_open_basis)
+                if persisted_open_basis is not None
+                else None
+            )
+        except (TypeError, ValueError):
+            persisted_open_basis = None
+
+        if not _claim_exec_parts(basis_counted_parts[ticker], exec_parts, key):
+            continue
+
+        bucket = buckets.setdefault(
+            key,
+            {"net_qty": 0.0, "fills": [], "latest_persisted_open_basis": None},
+        )
+        bucket["net_qty"] += signed_qty
+        bucket["fills"].append(
+            {
+                "signed_qty": signed_qty,
+                "qty": qty,
+                "total_cost": total_cost,
+            }
+        )
+        if persisted_open_basis is not None:
+            bucket["latest_persisted_open_basis"] = persisted_open_basis
+
+    open_basis_lookup: dict[str, float] = {}
+    for key, bucket in buckets.items():
+        net_qty = float(bucket["net_qty"])
+        if net_qty == 0:
+            continue
+
+        if bucket["latest_persisted_open_basis"] is not None:
+            open_basis_lookup[key] = round(bucket["latest_persisted_open_basis"], 4)
+            continue
+
+        opening_sign = 1 if net_qty > 0 else -1
+        opening_qty = 0.0
+        opening_cost = 0.0
+        for fill in bucket["fills"]:
+            if (1 if fill["signed_qty"] > 0 else -1) != opening_sign:
+                continue
+            opening_qty += fill["qty"]
+            opening_cost += fill["total_cost"]
+
+        if opening_qty <= 0:
+            continue
+
+        avg_per_contract = opening_cost / opening_qty
+        open_basis_lookup[key] = round(avg_per_contract * abs(net_qty), 4)
+
+    return open_basis_lookup, net_qty_lookup
+
+
+def compute_open_basis_and_net_qty_for_tickers(
+    db,
+    *,
+    tickers: Iterable[str],
+    contract_keys: Iterable[str],
+) -> tuple[dict[str, float], dict[str, float]]:
+    """Read current option tickers once and derive basis plus net quantities."""
+    normalized_tickers = tuple(
+        sorted({_normalize_ticker(ticker) for ticker in tickers if _normalize_ticker(ticker)})
+    )
+    normalized_contract_keys = tuple(sorted({str(key) for key in contract_keys if str(key)}))
+    rows = _fetch_journal_rows_for_tickers(db, normalized_tickers)
+    return _derive_journal_state_from_rows(
+        rows,
+        basis_tickers=normalized_tickers,
+        option_net_keys=normalized_contract_keys,
+    )
+
+
 def prior_net_qty_for_contract(
     db,
     *,
@@ -246,61 +489,21 @@ def prior_net_qty_for_contract(
         if target_key is None:
             return 0.0
 
-    result = db.execute(
-        """
-        SELECT payload, filled_at, written_at
-        FROM journal
-        WHERE UPPER(COALESCE(
-            json_extract(payload, '$.ticker'),
-            json_extract(payload, '$.symbol'),
-            ''
-        )) = ?
-        ORDER BY COALESCE(filled_at, written_at) ASC, written_at ASC
-        """,
-        (normalized_ticker,),
+    rows = _fetch_journal_rows_for_tickers(db, (normalized_ticker,))
+    if target_key is None:
+        _, net_qty_lookup = _derive_journal_state_from_rows(
+            rows,
+            stock_net_tickers=(normalized_ticker,),
+            before=before,
+        )
+        return net_qty_lookup[f"{normalized_ticker}|STK"]
+
+    _, net_qty_lookup = _derive_journal_state_from_rows(
+        rows,
+        option_net_keys=(target_key,),
+        before=before,
     )
-
-    net_qty = 0.0
-    # Executions already accounted for by an earlier row, so a rehydrate
-    # composite and the per-fill rows it collapses can't both be counted.
-    counted_parts: set[str] = set()
-    for row in result.fetchall():
-        if before is not None and not _row_is_before_cutoff(row, before):
-            continue
-
-        payload = _payload_from_row(row)
-        if _normalize_ticker(payload.get("ticker") or payload.get("symbol")) != normalized_ticker:
-            continue
-
-        if target_key is not None:
-            if _bucket_key(payload) != target_key:
-                continue
-        else:
-            # STK match: skip rows that look like options (have strike/right).
-            if payload.get("strike") is not None or payload.get("right"):
-                continue
-
-        qty_raw = payload.get("contracts")
-        if qty_raw is None:
-            qty_raw = payload.get("shares")
-        try:
-            qty = abs(float(qty_raw))
-        except (TypeError, ValueError):
-            continue
-
-        signed_qty = _signed_qty(payload.get("action"), qty)
-        if signed_qty == 0:
-            continue
-        if not _claim_exec_parts(
-            counted_parts,
-            _exec_id_parts(payload),
-            target_key or normalized_ticker,
-        ):
-            continue
-
-        net_qty += signed_qty
-
-    return net_qty
+    return net_qty_lookup[target_key]
 
 
 def compute_open_basis_for_ticker(db, ticker: str) -> dict[str, float]:
@@ -315,111 +518,9 @@ def compute_open_basis_for_ticker(db, ticker: str) -> dict[str, float]:
     if not normalized_ticker:
         return {}
 
-    result = db.execute(
-        """
-        SELECT payload, filled_at, written_at
-        FROM journal
-        WHERE UPPER(COALESCE(
-            json_extract(payload, '$.ticker'),
-            json_extract(payload, '$.symbol'),
-            ''
-        )) = ?
-        ORDER BY COALESCE(filled_at, written_at) ASC, written_at ASC
-        """,
-        (normalized_ticker,),
+    rows = _fetch_journal_rows_for_tickers(db, (normalized_ticker,))
+    open_basis_lookup, _ = _derive_journal_state_from_rows(
+        rows,
+        basis_tickers=(normalized_ticker,),
     )
-
-    buckets: dict[str, dict[str, Any]] = {}
-    # Executions already accounted for by an earlier row (see
-    # ``_claim_exec_parts``). Exec ids are globally unique, so one set covers
-    # every bucket in this ticker's scan.
-    counted_parts: set[str] = set()
-    for row in result.fetchall():
-        payload = _payload_from_row(row)
-        if _normalize_ticker(payload.get("ticker") or payload.get("symbol")) != normalized_ticker:
-            continue
-
-        key = _bucket_key(payload)
-        if key is None:
-            continue
-
-        qty_raw = payload.get("contracts")
-        if qty_raw is None:
-            qty_raw = payload.get("shares")
-        try:
-            qty = abs(float(qty_raw))
-        except (TypeError, ValueError):
-            continue
-
-        signed_qty = _signed_qty(payload.get("action"), qty)
-        if signed_qty == 0:
-            continue
-
-        try:
-            total_cost = float(payload.get("total_cost"))
-        except (TypeError, ValueError):
-            continue
-
-        # `open_basis` is persisted by journal_rehydrate.py on every row
-        # as the basis allocated to the still-open residual after that
-        # row. When present, the latest row's value supersedes the
-        # bucket-level lot-match recomputation below — that's the whole
-        # point of persisting it. Stays None for rows written by the
-        # real-time daemon (journal_sync.py), which still need the
-        # fallback compute path.
-        persisted_open_basis = payload.get("open_basis")
-        try:
-            persisted_open_basis = (
-                float(persisted_open_basis)
-                if persisted_open_basis is not None
-                else None
-            )
-        except (TypeError, ValueError):
-            persisted_open_basis = None
-
-        if not _claim_exec_parts(counted_parts, _exec_id_parts(payload), key):
-            continue
-
-        bucket = buckets.setdefault(
-            key,
-            {"net_qty": 0.0, "fills": [], "latest_persisted_open_basis": None},
-        )
-        bucket["net_qty"] += signed_qty
-        bucket["fills"].append(
-            {
-                "signed_qty": signed_qty,
-                "qty": qty,
-                "total_cost": total_cost,
-            }
-        )
-        # Rows arrive ORDER BY filled_at ASC so the last write wins —
-        # exactly what we want for "basis as of latest row".
-        if persisted_open_basis is not None:
-            bucket["latest_persisted_open_basis"] = persisted_open_basis
-
-    open_basis_lookup: dict[str, float] = {}
-    for key, bucket in buckets.items():
-        net_qty = float(bucket["net_qty"])
-        if net_qty == 0:
-            continue
-
-        if bucket["latest_persisted_open_basis"] is not None:
-            open_basis_lookup[key] = round(bucket["latest_persisted_open_basis"], 4)
-            continue
-
-        opening_sign = 1 if net_qty > 0 else -1
-        opening_qty = 0.0
-        opening_cost = 0.0
-        for fill in bucket["fills"]:
-            if (1 if fill["signed_qty"] > 0 else -1) != opening_sign:
-                continue
-            opening_qty += fill["qty"]
-            opening_cost += fill["total_cost"]
-
-        if opening_qty <= 0:
-            continue
-
-        avg_per_contract = opening_cost / opening_qty
-        open_basis_lookup[key] = round(avg_per_contract * abs(net_qty), 4)
-
     return open_basis_lookup

--- a/scripts/ib_sync.py
+++ b/scripts/ib_sync.py
@@ -60,8 +60,7 @@ from clients.ib_client import (
 )
 from clients.ib_timing import PhaseTimer
 from clients.journal_basis import (
-    compute_open_basis_for_ticker,
-    prior_net_qty_for_contract,
+    compute_open_basis_and_net_qty_for_tickers,
 )
 from db.client import get_db
 from db.readers import (
@@ -735,12 +734,7 @@ def build_journal_basis_lookup(client: IBClient, db=None) -> dict[str, float]:
             return _with_net_qty(lookup, net_qty_lookup)
 
     tickers = sorted({str(pos.contract.symbol).strip().upper() for pos in option_positions})
-    for ticker in tickers:
-        try:
-            lookup.update(compute_open_basis_for_ticker(db, ticker))
-        except Exception as exc:
-            print(f"  Warning: journal basis lookup failed for {ticker}: {exc}")
-
+    journal_keys: set[str] = set()
     for pos in option_positions:
         contract = pos.contract
         journal_key = _journal_basis_key(
@@ -749,19 +743,21 @@ def build_journal_basis_lookup(client: IBClient, db=None) -> dict[str, float]:
             getattr(contract, "right", None),
             getattr(contract, "strike", None),
         )
-        if not journal_key or journal_key in net_qty_lookup:
-            continue
-        try:
-            net_qty_lookup[journal_key] = prior_net_qty_for_contract(
-                db,
-                ticker=contract.symbol,
-                sec_type=contract.secType,
-                strike=getattr(contract, "strike", None),
-                right=getattr(contract, "right", None),
-                expiry=getattr(contract, "lastTradeDateOrContractMonth", None),
-            )
-        except Exception as exc:
-            print(f"  Warning: journal net-qty lookup failed for {journal_key}: {exc}")
+        if journal_key:
+            journal_keys.add(journal_key)
+
+    try:
+        lookup, net_qty_lookup = compute_open_basis_and_net_qty_for_tickers(
+            db,
+            tickers=tickers,
+            contract_keys=sorted(journal_keys),
+        )
+    except Exception as exc:
+        joined_tickers = ", ".join(tickers)
+        print(
+            "  Warning: journal basis batch lookup failed for "
+            f"{joined_tickers}, falling back to IB avgCost: {exc}"
+        )
 
     return _with_net_qty(lookup, net_qty_lookup)
 

--- a/scripts/tests/test_ib_sync_basis_guard.py
+++ b/scripts/tests/test_ib_sync_basis_guard.py
@@ -35,16 +35,29 @@ class _FakeCursor:
 
 class _FakeDb:
     def __init__(self, rows):
-        self._rows = rows
+        self._rows = [
+            (f"test-{index:08d}", *row)
+            for index, row in enumerate(rows, start=1)
+        ]
         self.calls = []
 
     def execute(self, sql, params=()):
         self.calls.append((sql, params))
-        return _FakeCursor(self._rows)
+        cursor = str(params[0])
+        tickers = {str(value) for value in params[1:-1]}
+        limit = int(params[-1])
+        rows = []
+        for row in self._rows:
+            trade_id, payload_json, _filled_at, _written_at = row
+            payload = json.loads(payload_json)
+            ticker = str(payload.get("ticker") or payload.get("symbol") or "").upper()
+            if trade_id > cursor and ticker in tickers:
+                rows.append(row)
+        return _FakeCursor(rows[:limit])
 
 
 def _journal_row(payload: dict, filled_at: str) -> tuple:
-    # Driver-faithful row shape: (payload, filled_at, written_at) tuple.
+    # Derivation-row shape; _FakeDb adds the paginated trade_id cursor column.
     return (json.dumps(payload), filled_at, filled_at)
 
 

--- a/scripts/tests/test_journal_basis.py
+++ b/scripts/tests/test_journal_basis.py
@@ -14,7 +14,9 @@ SCRIPTS_DIR = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 import ib_sync  # noqa: E402
+from clients import journal_basis  # noqa: E402
 from clients.journal_basis import (  # noqa: E402
+    compute_open_basis_and_net_qty_for_tickers,
     compute_open_basis_for_ticker,
     prior_net_qty_for_contract,
 )
@@ -35,12 +37,52 @@ class _FakeCursor:
 
 class _FakeDb:
     def __init__(self, rows):
+        self._rows = [
+            (f"test-{index:08d}", *row)
+            for index, row in enumerate(rows, start=1)
+        ]
+        self.calls = []
+
+    def execute(self, sql, params=()):
+        self.calls.append((sql, params))
+        cursor = str(params[0])
+        tickers = {str(value) for value in params[1:-1]}
+        limit = int(params[-1])
+        matches = []
+        for row in self._rows:
+            trade_id, payload_json, _filled_at, _written_at = row
+            payload = json.loads(payload_json)
+            ticker = str(payload.get("ticker") or payload.get("symbol") or "").upper()
+            if trade_id > cursor and ticker in tickers:
+                matches.append(row)
+        return _FakeCursor(matches[:limit])
+
+
+class _CursorPagedDb:
+    """Driver-faithful cursor fake for journal trade_id pagination."""
+
+    def __init__(self, rows):
         self._rows = rows
         self.calls = []
 
     def execute(self, sql, params=()):
         self.calls.append((sql, params))
-        return _FakeCursor(self._rows)
+        assert "trade_id > ?" in sql
+        assert "ORDER BY trade_id ASC" in sql
+        assert "LIMIT ?" in sql
+
+        cursor = str(params[0])
+        tickers = {str(value) for value in params[1:-1]}
+        limit = int(params[-1])
+        matches = []
+        for row in self._rows:
+            trade_id, payload_json, _filled_at, _written_at = row
+            payload = json.loads(payload_json)
+            ticker = str(payload.get("ticker") or payload.get("symbol") or "").upper()
+            if trade_id > cursor and ticker in tickers:
+                matches.append(row)
+        matches.sort(key=lambda row: row[0])
+        return _FakeCursor(matches[:limit])
 
 
 def _journal_row(payload: dict, filled_at: str) -> tuple:
@@ -332,3 +374,352 @@ def test_fetch_positions_and_collapse_positions_use_journal_basis_for_combo_entr
     assert combo["entry_cost"] == pytest.approx(-1.31, abs=0.01)
     assert combo["legs"][0]["ib_avg_cost"] == pytest.approx(2730.50, abs=0.0001)
     assert combo["legs"][1]["ib_avg_cost"] == pytest.approx(2596.50, abs=0.0001)
+
+
+def test_build_journal_basis_lookup_batches_all_option_contracts_in_one_query():
+    """The live-sync lookup must preserve legacy math without its journal N+1."""
+    part_a = "0001de5f.69f22890.01.01"
+    part_b = "0001de5f.69f23721.02.01"
+    rows = [
+        _journal_row(
+            {
+                "ticker": "WULF",
+                "action": "BUY_OPTION",
+                "contracts": 8,
+                "total_cost": 800.0,
+                "right": "C",
+                "strike": 17,
+                "expiry": "20270115",
+                "ib_exec_id": part_a,
+            },
+            "2026-07-10T10:00:00Z",
+        ),
+        _journal_row(
+            {
+                "ticker": "NVDA",
+                "action": "SELL_TO_OPEN",
+                "contracts": 4,
+                "total_cost": 2000.0,
+                "open_basis": 1987.65432,
+                "right": "P",
+                "strike": 100,
+                "expiry": "20261218",
+                "ib_exec_id": "nvda-open",
+            },
+            "2026-07-10T10:00:01Z",
+        ),
+        _journal_row(
+            {
+                "ticker": "WULF",
+                "action": "BUY_OPTION",
+                "contracts": 69,
+                "total_cost": 6900.0,
+                "right": "C",
+                "strike": 17,
+                "expiry": "20270115",
+                "ib_exec_id": part_b,
+            },
+            "2026-07-10T10:00:02Z",
+        ),
+        # The rehydrated composite duplicates the first two per-fill rows.
+        _journal_row(
+            {
+                "ticker": "WULF",
+                "action": "BUY_OPTION",
+                "contracts": 77,
+                "total_cost": 7777.0,
+                "right": "C",
+                "strike": 17,
+                "expiry": "20270115",
+                "ib_exec_id": f"{part_a}+{part_b}",
+            },
+            "2026-07-10T10:00:03Z",
+        ),
+        # A distinct contract proves per-contract net-quantity isolation.
+        _journal_row(
+            {
+                "ticker": "WULF",
+                "action": "BUY_OPTION",
+                "contracts": 10,
+                "total_cost": 1500.0,
+                "right": "C",
+                "strike": 20,
+                "expiry": "20270115",
+                "ib_exec_id": "wulf-20-open",
+            },
+            "2026-07-10T10:00:04Z",
+        ),
+        # Partial close leaves 52 contracts at the original $100 basis.
+        _journal_row(
+            {
+                "ticker": "WULF",
+                "action": "SELL_OPTION",
+                "contracts": 25,
+                "total_cost": 2500.0,
+                "right": "C",
+                "strike": 17,
+                "expiry": "20270115",
+                "ib_exec_id": "wulf-17-close",
+            },
+            "2026-07-11T10:00:00Z",
+        ),
+    ]
+    positions = [
+        _make_position(
+            symbol="WULF",
+            sec_type="OPT",
+            position=52,
+            avg_cost=101.0,
+            strike=17,
+            right="C",
+            expiry="20270115",
+        ),
+        _make_position(
+            symbol="WULF",
+            sec_type="OPT",
+            position=10,
+            avg_cost=151.0,
+            strike=20,
+            right="C",
+            expiry="20270115",
+        ),
+        _make_position(
+            symbol="NVDA",
+            sec_type="OPT",
+            position=-4,
+            avg_cost=510.0,
+            strike=100,
+            right="P",
+            expiry="20261218",
+        ),
+    ]
+    client = SimpleNamespace(get_positions=lambda: positions)
+
+    legacy_db = _FakeDb(rows)
+    legacy_basis = {}
+    for ticker in ("NVDA", "WULF"):
+        legacy_basis.update(compute_open_basis_for_ticker(legacy_db, ticker))
+    legacy_net_qty = {
+        "WULF|20270115|C|17.0": prior_net_qty_for_contract(
+            legacy_db,
+            ticker="WULF",
+            sec_type="OPT",
+            strike=17,
+            right="C",
+            expiry="20270115",
+        ),
+        "WULF|20270115|C|20.0": prior_net_qty_for_contract(
+            legacy_db,
+            ticker="WULF",
+            sec_type="OPT",
+            strike=20,
+            right="C",
+            expiry="20270115",
+        ),
+        "NVDA|20261218|P|100.0": prior_net_qty_for_contract(
+            legacy_db,
+            ticker="NVDA",
+            sec_type="OPT",
+            strike=100,
+            right="P",
+            expiry="20261218",
+        ),
+    }
+    assert len(legacy_db.calls) == 5
+    assert legacy_basis == {
+        "NVDA|20261218|P|100.0": 1987.6543,
+        "WULF|20270115|C|17.0": 5200.0,
+        "WULF|20270115|C|20.0": 1500.0,
+    }
+    assert legacy_net_qty == {
+        "WULF|20270115|C|17.0": 52.0,
+        "WULF|20270115|C|20.0": 10.0,
+        "NVDA|20261218|P|100.0": -4.0,
+    }
+
+    batched_db = _FakeDb(rows)
+    batched = ib_sync.build_journal_basis_lookup(client, db=batched_db)
+
+    assert len(batched_db.calls) == 1
+    assert batched_db.calls[0][1] == ("", "NVDA", "WULF", 200)
+    expected_bytes = json.dumps(
+        {"basis": legacy_basis, "net_qty": legacy_net_qty},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    actual_bytes = json.dumps(
+        {"basis": dict(batched), "net_qty": batched.net_qty},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    assert actual_bytes == expected_bytes
+
+
+def test_batched_journal_basis_pages_by_trade_id_and_preserves_ordered_bytes(monkeypatch):
+    """Each Hrana response is bounded without changing chronological semantics."""
+    rows = [
+        # trade_id order deliberately disagrees with effective-time order. The
+        # close must still be the latest persisted basis after Python sorting.
+        (
+            "001-close-first-by-id",
+            json.dumps({
+                "ticker": "WULF",
+                "action": "SELL_OPTION",
+                "contracts": 5,
+                "total_cost": 500.0,
+                "open_basis": 500.0,
+                "right": "C",
+                "strike": 17,
+                "expiry": "20270115",
+                "ib_exec_id": "wulf-close",
+            }),
+            "2026-07-11T10:00:00Z",
+            "2026-07-11T10:00:01Z",
+        ),
+        (
+            "002-nvda",
+            json.dumps({
+                "ticker": "NVDA",
+                "action": "SELL_TO_OPEN",
+                "contracts": 4,
+                "total_cost": 2000.0,
+                "open_basis": 1987.65432,
+                "right": "P",
+                "strike": 100,
+                "expiry": "20261218",
+                "ib_exec_id": "nvda-open",
+            }),
+            "2026-07-10T10:00:01Z",
+            "2026-07-10T10:00:02Z",
+        ),
+        (
+            "003-unrelated",
+            json.dumps({
+                "ticker": "AAPL",
+                "action": "BUY_OPTION",
+                "contracts": 99,
+                "total_cost": 9900.0,
+                "right": "C",
+                "strike": 200,
+                "expiry": "20270115",
+                "ib_exec_id": "unrelated",
+            }),
+            "2026-07-09T10:00:00Z",
+            "2026-07-09T10:00:01Z",
+        ),
+        (
+            "004-wulf-other-contract",
+            json.dumps({
+                "ticker": "WULF",
+                "action": "BUY_OPTION",
+                "contracts": 2,
+                "total_cost": 300.0,
+                "open_basis": 300.0,
+                "right": "C",
+                "strike": 20,
+                "expiry": "20270115",
+                "ib_exec_id": "wulf-20-open",
+            }),
+            "2026-07-10T10:00:02Z",
+            "2026-07-10T10:00:03Z",
+        ),
+        (
+            "999-open-last-by-id",
+            json.dumps({
+                "ticker": "WULF",
+                "action": "BUY_OPTION",
+                "contracts": 10,
+                "total_cost": 1000.0,
+                "open_basis": 1000.0,
+                "right": "C",
+                "strike": 17,
+                "expiry": "20270115",
+                "ib_exec_id": "wulf-open",
+            }),
+            "2026-07-10T10:00:00Z",
+            "2026-07-10T10:00:01Z",
+        ),
+    ]
+    kwargs = {
+        "tickers": ("NVDA", "WULF"),
+        "contract_keys": (
+            "NVDA|20261218|P|100.0",
+            "WULF|20270115|C|17.0",
+            "WULF|20270115|C|20.0",
+        ),
+    }
+
+    monkeypatch.setattr(journal_basis, "_JOURNAL_PAGE_SIZE", 100)
+    single_page_db = _CursorPagedDb(rows)
+    single_page = compute_open_basis_and_net_qty_for_tickers(single_page_db, **kwargs)
+
+    monkeypatch.setattr(journal_basis, "_JOURNAL_PAGE_SIZE", 2)
+    paged_db = _CursorPagedDb(rows)
+    paged = compute_open_basis_and_net_qty_for_tickers(paged_db, **kwargs)
+
+    expected_bytes = json.dumps(
+        {
+            "basis": {
+                "NVDA|20261218|P|100.0": 1987.6543,
+                "WULF|20270115|C|17.0": 500.0,
+                "WULF|20270115|C|20.0": 300.0,
+            },
+            "net_qty": {
+                "NVDA|20261218|P|100.0": -4.0,
+                "WULF|20270115|C|17.0": 5.0,
+                "WULF|20270115|C|20.0": 2.0,
+            },
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    single_page_bytes = json.dumps(
+        {"basis": single_page[0], "net_qty": single_page[1]},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    paged_bytes = json.dumps(
+        {"basis": paged[0], "net_qty": paged[1]},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+
+    assert single_page_bytes == expected_bytes
+    assert paged_bytes == expected_bytes
+    assert len(single_page_db.calls) == 1
+    assert len(paged_db.calls) == 3
+    assert paged_db.calls[0][1] == ("", "NVDA", "WULF", 2)
+    assert paged_db.calls[1][1] == ("002-nvda", "NVDA", "WULF", 2)
+    assert paged_db.calls[2][1] == ("999-open-last-by-id", "NVDA", "WULF", 2)
+
+
+def test_build_journal_basis_lookup_batch_failure_keeps_ib_fallback(capsys):
+    class _FailingDb:
+        def __init__(self):
+            self.calls = 0
+
+        def execute(self, _sql, _params=()):
+            self.calls += 1
+            raise RuntimeError("journal unavailable")
+
+    position = _make_position(
+        symbol="NVDA",
+        sec_type="OPT",
+        position=2,
+        avg_cost=510.0,
+        strike=100,
+        right="C",
+        expiry="20261218",
+    )
+    client = SimpleNamespace(get_positions=lambda: [position])
+    db = _FailingDb()
+
+    lookup = ib_sync.build_journal_basis_lookup(client, db=db)
+    positions = ib_sync.fetch_positions(client, journal_basis_lookup=lookup)
+
+    assert db.calls == 1
+    assert dict(lookup) == {}
+    assert lookup.net_qty == {}
+    assert positions[0]["avgCost"] == pytest.approx(510.0)
+    assert positions[0]["entry_cost"] == pytest.approx(1020.0)
+    assert "falling back to IB avgCost" in capsys.readouterr().out

--- a/scripts/tests/test_journal_basis_accessors.py
+++ b/scripts/tests/test_journal_basis_accessors.py
@@ -89,12 +89,59 @@ class _FakeCursor:
 
 class _FakeDb:
     def __init__(self, rows):
-        self._rows = rows
+        self._rows = [
+            self._with_trade_id(row, index)
+            for index, row in enumerate(rows, start=1)
+        ]
         self.calls = []
 
     def execute(self, sql, params=()):
         self.calls.append((sql, params))
-        return _FakeCursor(self._rows)
+        cursor = str(params[0])
+        tickers = {str(value) for value in params[1:-1]}
+        limit = int(params[-1])
+        matching = [
+            row
+            for row in self._rows
+            if self._trade_id(row) > cursor and self._ticker(row) in tickers
+        ]
+        matching.sort(key=self._trade_id)
+        return _FakeCursor(matching[:limit])
+
+    @staticmethod
+    def _with_trade_id(row, index):
+        trade_id = f"test-{index:08d}"
+        if isinstance(row, dict):
+            return {"trade_id": trade_id, **row}
+        if isinstance(row, (tuple, list)):
+            return (trade_id, *row)
+        return SimpleNamespace(
+            trade_id=trade_id,
+            payload=getattr(row, "payload", None),
+            filled_at=getattr(row, "filled_at", None),
+            written_at=getattr(row, "written_at", None),
+        )
+
+    @staticmethod
+    def _trade_id(row):
+        if isinstance(row, dict):
+            return str(row["trade_id"])
+        if isinstance(row, (tuple, list)):
+            return str(row[0])
+        return str(row.trade_id)
+
+    @staticmethod
+    def _ticker(row):
+        if isinstance(row, dict):
+            raw_payload = row.get("payload")
+        elif isinstance(row, (tuple, list)):
+            raw_payload = row[1]
+        else:
+            raw_payload = getattr(row, "payload", None)
+        payload = json.loads(raw_payload) if isinstance(raw_payload, str) else raw_payload
+        if not isinstance(payload, dict):
+            return ""
+        return str(payload.get("ticker") or payload.get("symbol") or "").upper()
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_monitor_daemon/test_journal_sync.py
+++ b/scripts/tests/test_monitor_daemon/test_journal_sync.py
@@ -674,10 +674,32 @@ class TestSellCloseLabeling:
     def _fake_db(self, rows):
         # Real libsql cursors expose fetchall(), NOT .rows (CTA-01): keep the
         # fake driver-faithful so a .rows regression fails here.
-        result = MagicMock(spec=["fetchall"])
-        result.fetchall.return_value = rows
+        paginated = [
+            (f"test-{index:08d}", *row)
+            for index, row in enumerate(rows, start=1)
+        ]
+
+        def execute(sql, params=()):
+            result = MagicMock(spec=["fetchall"])
+            if "WHERE trade_id > ?" not in str(sql):
+                result.fetchall.return_value = []
+                return result
+
+            cursor = str(params[0])
+            tickers = {str(value) for value in params[1:-1]}
+            limit = int(params[-1])
+            matching = []
+            for row in paginated:
+                trade_id, payload_json, _filled_at, _written_at = row
+                payload = json.loads(payload_json)
+                ticker = str(payload.get("ticker") or payload.get("symbol") or "").upper()
+                if trade_id > cursor and ticker in tickers:
+                    matching.append(row)
+            result.fetchall.return_value = matching[:limit]
+            return result
+
         db = MagicMock()
-        db.execute.return_value = result
+        db.execute.side_effect = execute
         return db
 
     def _row(self, payload: dict, filled_at: str = "2026-04-15T10:00:00Z") -> tuple:

--- a/tasks/artifacts/portfolio-api-db-performance-audit.md
+++ b/tasks/artifacts/portfolio-api-db-performance-audit.md
@@ -1,0 +1,379 @@
+# `/portfolio` API and database performance audit
+
+Date: 2026-08-25
+Scope: Next.js route handlers, shared Turso helpers, FastAPI, IB synchronization, disk fallbacks, and page-adjacent requests triggered by `/portfolio`.
+Method: source trace plus read-only production Turso queries and `EXPLAIN QUERY PLAN`. No production writes or live IB actions were performed.
+
+## Executive findings
+
+1. **The blocking `/api/portfolio` response does three Turso reads, but two are not used by the portfolio page.** The latest portfolio snapshot is followed by two journal-wide JSON scans for `trade_log_dates` and `contract_open_dates` (`web/app/api/portfolio/route.ts:46-62`, `:64-163`, `:166-177`). Those maps are consumed only by the executed-order share-card path on `/orders` (`web/components/WorkspaceSections.tsx:3697-3702`). `/portfolio` waits for them before setting portfolio state.
+2. **The journal work grows with all-time trade history.** Production held 1,601 journal rows / 765,022 payload bytes at audit time; 1,184 rows / 570,986 payload bytes matched the option-contract scan. The current query plans are `SCAN journal`, with a temporary B-tree for the per-ticker aggregate. The existing journal indexes do not cover these JSON expressions.
+3. **The global shell also fetches and polls orders on `/portfolio`.** `WorkspaceShell` always mounts `useOrders`; it performs an initial GET regardless of market state and polls every 30 seconds during market hours (`web/components/WorkspaceShell.tsx:103-107`, `web/lib/useOrders.ts:149-177`). Each `/api/orders` GET performs two uncached Turso queries serially (`web/lib/orders/readOrdersFromDb.ts:62-81`).
+4. **Cache TTLs do not help a single active tab.** Portfolio polls every 30 seconds, while the snapshot cache is 3 seconds and the entry-date caches are 10 seconds (`web/lib/usePortfolio.ts:13-16`, `web/app/api/portfolio/route.ts:25-32`). The autonomous writer runs every 60 seconds during RTH (`cloud/services/radon-portfolio-sync.timer:2-10`). Therefore every steady-state poll from one tab misses all three caches; the caches only coalesce nearly simultaneous tabs.
+5. **The live IB sync has a separate serial journal N+1.** For each distinct option ticker it runs `compute_open_basis_for_ticker`, then for each option contract it runs `prior_net_qty_for_contract` (`scripts/ib_sync.py:704-766`, `scripts/clients/journal_basis.py:196-329`). The current snapshot implies 10 unique option tickers and 18 unique option contracts, so the current shape can issue up to 28 repeated journal statements before the other sync reads. Raw IB positions remain the definitive count; they were not queried in this read-only audit.
+6. **The latest-snapshot lookup is not the demonstrated problem.** Production `EXPLAIN` uses the `portfolio_snapshots` primary-key index. A separate `COUNT(*)` probe timed out at the 4-second audit bound, but that count is not on the request path and is not evidence that the indexed `ORDER BY taken_at DESC LIMIT 1` read scans every payload.
+7. **No `/api/performance` request is triggered by `/portfolio`.** `PerformancePanel` is mounted only in the `performance` switch branch (`web/components/WorkspaceSections.tsx:4142-4155`), and `usePerformance` is owned by that panel (`web/components/PerformancePanel.tsx:417`, `web/lib/usePerformance.ts:8-19`).
+
+## Exact request and data-flow tree
+
+```text
+GET /portfolio
+└─ Next page -> <WorkspaceShell section="portfolio">
+   ├─ blocking portfolio state: GET /api/portfolio (no-store, 12s browser bound)
+   │  ├─ requireRouteAccess + 20/min per-user read limiter
+   │  ├─ cachedReadResult("portfolio:snapshot", TTL 3s, stale-on-error 60s)
+   │  │  └─ Turso Q1 latest portfolio snapshot
+   │  ├─ Promise.all after Q1
+   │  │  ├─ cachedRead("portfolio:tradeLogDates", TTL 10s) -> Turso Q2
+   │  │  └─ cachedRead("portfolio:contractOpenDates", TTL 10s) -> Turso Q3
+   │  │     └─ JS groups and sorts all returned option fills
+   │  └─ JSON snapshot + both maps; explicit no-store response
+   ├─ parallel shell state: GET /api/orders (no-store, 12s browser bound)
+   │  ├─ direct-cloud replica sync hook (no-op by default)
+   │  ├─ Turso Q4 open orders
+   │  └─ then Turso Q5 executed orders (serial, not Promise.all)
+   ├─ after Clerk identity resolves: GET /api/watchlist
+   │  └─ Turso Q6 user watchlist; browser module caches for identity lifetime
+   ├─ footer: GET /api/service-health every 60s
+   │  └─ cachedRead("service_health:rows", TTL 3s) -> Turso Q7
+   ├─ footer: GET /api/flex-token
+   │  └─ read data/flex_token_config.json
+   ├─ realtime status provider
+   │  ├─ POST /api/ib/ws-ticket -> FastAPI POST /ws-ticket -> status relay WS
+   │  └─ production GET /edge-health/status; local/fault attribution GET /api/admin/health
+   ├─ price hook
+   │  └─ second POST /api/ib/ws-ticket -> FastAPI POST /ws-ticket -> price relay WS
+   └─ after price messages, conditional fallbacks
+      ├─ POST /api/previous-close for stock marks missing close
+      ├─ GET /api/index-quote for watchlist indexes missing relay marks
+      └─ GET /api/futures-quote for ES/NQ/RTY missing relay marks during Globex
+```
+
+The portfolio route itself is a pure snapshot read. `GET /api/portfolio` never calls IB (`web/app/api/portfolio/route.ts:195-240`). Live synchronization is a separate manual/stale path:
+
+```text
+stale render or Sync Now
+└─ POST /api/portfolio (42s browser bound)
+   ├─ operator authorization + 4/min per-user rate limit
+   ├─ radonFetch POST /portfolio/sync (35s Next bound)
+   │  └─ FastAPI sync coordinator
+   │     ├─ coalesces same-key in-flight work
+   │     ├─ reuses successful result for 30s
+   │     └─ ib_sync.py --sync --json-output --db-optional (30s child bound)
+   │        ├─ IB managed accounts + account summary
+   │        ├─ account P&L subscription
+   │        ├─ journal-basis N+1
+   │        ├─ IB positions
+   │        ├─ all reqPnLSingle + market-data requests issued together
+   │        ├─ bounded wait, maximum 2.5s
+   │        ├─ journal entry-date read + previous portfolio read
+   │        ├─ margin sample + portfolio snapshot write + return-capital reconcile
+   │        └─ live JSON payload
+   └─ Next loads both entry-date maps again before responding
+```
+
+Anchors: `web/lib/useAutoSyncOnStale.ts:77-123`, `web/app/api/portfolio/route.ts:242-287`, `web/lib/radonApi.ts:61-99`, `scripts/api/server.py:192-263`, `scripts/api/server.py:2399-2425`, `scripts/ib_sync.py:1535-1789`.
+
+## Cold page query inventory
+
+A signed-in, cold-cache `/portfolio` load can initiate **seven Turso statements** from the page shell before optional fallbacks: three portfolio statements, two orders statements, one watchlist statement, and one service-health statement. They are not all on the same critical path, but they share the same bounded eight-connection Next.js Turso pool (`web/lib/db.ts:44-62`, `:92-101`).
+
+During RTH, one steady-state tab produces this source-derived cadence:
+
+| Source | Poll cadence | Turso statements per poll | Steady-state statements/minute |
+|---|---:|---:|---:|
+| `/api/portfolio` | 30s | 3 after TTL expiry | 6 |
+| `/api/orders` | 30s | 2 | 4 |
+| `/api/service-health` | 60s | 1 after TTL expiry | 1 |
+| Total | | | 11 |
+
+This excludes one-time watchlist load, DB keepalive, optional price fallbacks, navigation/visibility refreshes, and any stale-triggered POST. Portfolio and service-health caches single-flight nearly simultaneous tabs; orders currently has no server-side coalescing. Unaligned tabs can therefore multiply the orders workload and share pool capacity with the blocking portfolio read.
+
+## Production SQL and query-plan evidence
+
+The read-only audit queried the configured production Turso database through two clients: a direct-source probe (five runs) and the bounded Hrana HTTP reader from the development Mac (three runs). The latter includes its own network/TLS behavior. These are evidence of query behavior, not VPS route TTFB. The Next.js server uses a warm, bounded Undici pool, so do not transplant either series into a production latency budget.
+
+Audit state: schema migration 57; `data/replica.db` absent; direct-to-cloud remains the default (`web/lib/db.ts:1-29`, `scripts/db/client.py:11-16`).
+
+### Q1: latest portfolio snapshot
+
+```sql
+SELECT taken_at, payload
+FROM portfolio_snapshots
+ORDER BY taken_at DESC
+LIMIT 1;
+```
+
+Plan:
+
+```text
+SCAN portfolio_snapshots USING INDEX sqlite_autoindex_portfolio_snapshots_1
+```
+
+Evidence:
+
+- 1 row.
+- Stored payload: 11,194 bytes at `2026-08-25T21:50:54.972647Z`.
+- Direct-source samples: 24.5-112.4ms across five runs.
+- Bounded Hrana development-Mac samples: 339.6ms, 143.6ms, 274.5ms.
+- The table primary key is `taken_at` (`scripts/db/migrations/0001_init.sql:78-81`), so SQLite can walk that index in descending order and stop after one row.
+
+### Q2: portfolio `trade_log_dates`
+
+```sql
+SELECT
+  json_extract(payload, '$.ticker') AS ticker,
+  MAX(COALESCE(filled_at, json_extract(payload, '$.date'))) AS date
+FROM journal
+WHERE json_extract(payload, '$.ticker') IS NOT NULL
+GROUP BY json_extract(payload, '$.ticker');
+```
+
+Plan:
+
+```text
+SCAN journal
+USE TEMP B-TREE FOR GROUP BY
+```
+
+Evidence:
+
+- 305 result rows; audit result serialization 10,916 bytes.
+- Direct-source samples: 33.0-59.4ms across five runs.
+- Bounded Hrana development-Mac samples: 158.1ms, 361.3ms, 152.9ms.
+- No current index begins with `json_extract(payload, '$.ticker')`. Production journal indexes were the primary key, `idx_journal_filled`, and `idx_journal_effective_at`.
+
+### Q3: portfolio `contract_open_dates`
+
+```sql
+SELECT
+  json_extract(payload, '$.ticker')    AS ticker,
+  json_extract(payload, '$.expiry')    AS expiry,
+  json_extract(payload, '$.right')     AS opt_right,
+  json_extract(payload, '$.strike')    AS strike,
+  json_extract(payload, '$.action')    AS action,
+  json_extract(payload, '$.contracts') AS contracts,
+  COALESCE(filled_at, json_extract(payload, '$.date')) AS date
+FROM journal
+WHERE json_extract(payload, '$.right')  IS NOT NULL
+  AND json_extract(payload, '$.strike') IS NOT NULL;
+```
+
+Plan:
+
+```text
+SCAN journal
+```
+
+Evidence:
+
+- 1,184 result rows from 1,601 journal rows; audit result serialization 75,036 bytes.
+- Matching option journal payloads total 570,986 bytes; all journal payloads total 765,022 bytes.
+- Direct-source samples: 49.6-141.4ms across five runs.
+- Bounded Hrana development-Mac samples: 384.3ms, 266.2ms, 1,414.2ms.
+- JS then groups and sorts fills per contract (`web/lib/entryDates.ts:93-136`). Current output was 149 contract dates.
+- The direct-source GET body was 25,565 bytes. The latest stored snapshot payload was 11,194 bytes, so the maps add roughly 14.4KB at the response level; a compact reserialization of the parsed snapshot alone was 10,244 bytes. Exact HTTP framing/compression was not measured in this backend-only pass.
+- The predicate matched 74% of current journal rows, so a simple `right/strike` filter index would likely have weak selectivity. Removing the work from `/portfolio`, narrowing it to requested order contracts, or maintaining a derived map is higher leverage than indexing this broad scan alone.
+
+### Q4 and Q5: global orders read
+
+```sql
+SELECT payload, updated_at
+FROM open_orders
+ORDER BY updated_at DESC;
+
+SELECT payload, fill_time
+FROM executed_orders
+WHERE fill_time >= ?
+ORDER BY fill_time DESC;
+```
+
+Plans:
+
+```text
+open_orders:      SCAN open_orders; USE TEMP B-TREE FOR ORDER BY
+executed_orders:  SEARCH executed_orders USING INDEX executed_orders_fill_time_idx (fill_time>?)
+```
+
+Evidence from the audit snapshot:
+
+- Open orders: 3 rows / 2,469 serialized audit bytes / 368.9ms sample.
+- Executed orders for the audit's fixed lookback: 88 rows / 65,478 serialized audit bytes / 147.8ms sample.
+- Production code uses a moving 48-hour cutoff and runs the statements serially (`web/lib/orders/readOrdersFromDb.ts:18-21`, `:62-81`).
+- The executed-order plan is appropriate. Adding `open_orders(updated_at DESC)` removes a sort but is low impact at three rows; parallel execution and short server coalescing matter more.
+
+### Q6: user watchlist
+
+```sql
+SELECT id, symbol, sector, added_at
+FROM user_watchlist
+WHERE user_id = ?
+ORDER BY added_at DESC;
+```
+
+Plan:
+
+```text
+SEARCH user_watchlist USING INDEX user_watchlist_user_date (user_id=?)
+```
+
+The index is correct (`scripts/db/migrations/0010_user_profiles_bookmarks_watchlist.sql:28-36`). The browser hook loads once per authenticated identity and retains the module-level result (`web/lib/useWatchlist.ts:20-35`, `:50-99`). This is not a primary optimization target.
+
+### Q7: service health
+
+```sql
+SELECT service, state, last_attempt_started_at, last_attempt_finished_at,
+       last_error, updated_at
+FROM service_health
+ORDER BY updated_at DESC;
+```
+
+Plan:
+
+```text
+SCAN service_health
+USE TEMP B-TREE FOR ORDER BY
+```
+
+Evidence: 73 rows / 10,402 serialized audit bytes / 225.4ms sample. The route already has a three-second single-flight cache (`web/app/api/service-health/route.ts:27-49`, `:157-161`). An `updated_at` index would remove the small sort, but query frequency and table size make it lower priority than the portfolio and orders paths.
+
+### IB-sync journal basis statement
+
+Both `compute_open_basis_for_ticker` and `prior_net_qty_for_contract` execute this statement; the latter reruns it for each contract and filters the contract in Python:
+
+```sql
+SELECT payload, filled_at, written_at
+FROM journal
+WHERE UPPER(COALESCE(
+  json_extract(payload, '$.ticker'),
+  json_extract(payload, '$.symbol'),
+  ''
+)) = ?
+ORDER BY COALESCE(filled_at, written_at) ASC, written_at ASC;
+```
+
+Production plan and one current-ticker audit sample:
+
+```text
+SCAN journal USING INDEX idx_journal_effective_at
+USE TEMP B-TREE FOR LAST TERM OF ORDER BY
+6 result rows; 115.9ms audit sample
+```
+
+`idx_journal_effective_at` begins with `COALESCE(filled_at, written_at)`, so it helps ordering but cannot seek on the JSON ticker expression (`scripts/db/migrations/0025_journal_effective_at_index.sql:1-11`). The Python loop makes the repeated transport and repeated journal walk the concern, not the six returned rows.
+
+## Cache, timeout, and fallback matrix
+
+| Path | Authority | Current cache/coalescing | Bounds | Required cache posture |
+|---|---|---|---|---|
+| `GET /api/portfolio` | Latest Turso snapshot + journal-derived maps | snapshot 3s TTL / 60s stale-on-error; maps 10s; per-key single-flight | DB transport 2.75s, DB caller 3s, browser 12s | Keep `force-dynamic`, client `no-store`, response `no-store`; in-process TTL is safe when bounded and warning provenance is preserved. |
+| `POST /api/portfolio` | Live IB payload, Turso fallback | FastAPI same-key single-flight + 30s success reuse | child 30s < Next 35s < browser 42s | Never HTTP-cache. Existing deadline ordering is correct. |
+| `GET /api/orders` | Turso `open_orders` + `executed_orders` | none server-side | each DB statement 2.75/3s; browser 12s | Keep dynamic/no-store. A 1-3s in-process single-flight cache is safe for read coalescing if writes/POST invalidate it. |
+| `GET /api/watchlist` | Per-user Turso state | browser module cache by user | DB 2.75/3s | Keep dynamic/no-store; any server cache must key by user and invalidate on mutations. Not needed first. |
+| `GET /api/service-health` | Live Turso health rows | 3s single-flight | DB 2.75/3s; browser 10s | Keep dynamic/no-store; current server cache is appropriate. |
+| `GET /api/flex-token` | `data/flex_token_config.json` | framework behavior only | browser 10s | Disk-backed live route must add `force-dynamic`; client must use `cache: "no-store"`. A tiny in-process TTL can still avoid repeated file parsing without enabling HTTP/framework caching. |
+| `POST /api/previous-close` | IB snapshot, then UW, then Yahoo | per-session module cache for successful closes | ticket 750ms; IB snapshot 3s; UW/Yahoo 5s each | Daily successful-result cache is appropriate. Do not cache failures for the day; they retry. Not an initial portfolio-data blocker. |
+| `/api/ib/ws-ticket` | Single-use, 30s FastAPI memory ticket | none | client ticket request 8s | Never cache or reuse: tickets are single-use (`scripts/api/ws_ticket.py:17-45`). |
+| `/edge-health/status`, `/api/admin/health` | Live daemon/FastAPI state | none | status poll request bound in provider; Next health proxy 10s | Keep no-store. |
+| `/api/performance` | Turso/disk performance snapshot | not requested by `/portfolio` | n/a here | No change for portfolio load. |
+
+The database timeout stack is already ordered correctly: hard Undici transport abort at 2,750ms precedes the 3,000ms `dbExecute` Promise bound (`web/lib/db.ts:60-62`, `:153-188`, `web/lib/dbExecute.ts:25-60`). This releases the occupied socket before the caller gives up. Do not raise these deadlines to mask query work, and do not attribute the current scans to pool reset behavior without correlated pool statistics.
+
+## Prioritized issues and recommendations
+
+### Priority 1: remove orders-only journal maps from the default portfolio payload
+
+**Evidence:** `trade_log_dates` and `contract_open_dates` are created on every portfolio response (`web/app/api/portfolio/route.ts:166-177`, also POST at `:251-276`) but their only production consumer is `/orders` (`web/components/WorkspaceSections.tsx:3697-3702`). The two scans return 305 + 1,184 rows and block `usePortfolio` from receiving its snapshot.
+
+Recommended design:
+
+1. Make `GET /api/portfolio` snapshot-only by default.
+2. Move order-share entry dates to a dedicated authenticated endpoint or an explicit `include=entry-dates` request used only by `OrdersSections`.
+3. Narrow contract reconstruction to the executed contracts for the rendered session/page, rather than every option row in the journal.
+4. Cache that derived result for 60 seconds or key it by a journal revision/watermark; it is not live mark data.
+5. Preserve the default portfolio route's `force-dynamic` and client/response `no-store` contracts. The optimization is server work elimination, not stale HTTP caching.
+
+Acceptance evidence for an implementation: a cold `/api/portfolio` request issues exactly Q1, returns the snapshot contract, and does not reference `FROM journal`; `/orders` share-card regressions continue to pass from the lazy entry-date path.
+
+### Priority 2: coalesce and parallelize the global orders read
+
+**Evidence:** `/portfolio` mounts `useOrders` and performs the initial read even outside market hours. During RTH it polls every 30 seconds. The two Turso statements are independent but serial and have no cross-request cache.
+
+Recommended design:
+
+1. Run `open_orders` and `executed_orders` with `Promise.all` after the direct-cloud `syncDb()` no-op.
+2. Wrap the combined result in a 2-second `cachedReadResult` single-flight cache. Invalidate it after orders POST/cancel/modify/place transitions handled by the same Next process. A two-second cap preserves operational freshness while collapsing simultaneous tabs.
+3. Consider a page-scoped orders mode for `/portfolio`: open-order symbols plus today's realized P&L are the shell consumers (`web/components/WorkspaceShell.tsx:109-143`, `:324-329`). The full orders payload and UI-only history can remain for `/orders`.
+4. If the table is expected to grow beyond a handful of working orders, add `CREATE INDEX ... ON open_orders(updated_at DESC)` and verify the temp B-tree disappears. At the current three rows, this is not the first change.
+
+Acceptance evidence: simultaneous `/api/orders` GETs share one pair of DB statements; the two statements overlap; existing ET-day and stale-DAY filtering tests stay green.
+
+### Priority 3: align portfolio caching with the 60-second writer
+
+**Evidence:** 30-second client polling always misses 3-second/10-second caches in a single tab, while the authoritative portfolio producer fires every 60 seconds RTH.
+
+Recommended design after Priority 1:
+
+- Raise `portfolio:snapshot` from 3 seconds to 15 seconds, retaining 60-second stale-on-error and warning headers. This bounds added in-process staleness to 15 seconds while coalescing unaligned tabs better.
+- Keep the browser poll at 30 seconds initially so it still observes a 60-second writer quickly. Measure before changing cadence.
+- If entry-date derivation remains request-time, use at least a 60-second TTL and restrict it to `/orders`; a 10-second TTL has no benefit against a 30-second poll.
+- Add a response `Server-Timing` field for snapshot DB, entry-date DB, and JSON assembly before choosing a larger cache window.
+
+### Priority 4: batch IB-sync journal reads and add a seekable ticker index
+
+**Evidence:** the sync loops serially over tickers and contracts, repeating the same ticker-filtered statement. The current plan scans the effective-time index and still uses a temp B-tree for the last order term.
+
+Recommended design:
+
+1. Fetch journal rows for all current option tickers once, then compute open basis and per-contract net quantity in one in-memory pass. At current scale, one bounded read is preferable to up to 28 repeated reads.
+2. If per-ticker reads remain, add and validate an expression index shaped to the actual predicate and full order:
+
+   ```sql
+   CREATE INDEX IF NOT EXISTS idx_journal_ticker_effective_v2
+   ON journal (
+     UPPER(COALESCE(
+       json_extract(payload, '$.ticker'),
+       json_extract(payload, '$.symbol'),
+       ''
+     )),
+     COALESCE(filled_at, written_at),
+     written_at
+   );
+   ```
+
+3. Run production `EXPLAIN QUERY PLAN` before and after the migration; require a ticker seek and no temp B-tree. Do not add the index based only on theory.
+4. Longer term, normalize ticker/contract/effective-time columns or maintain a derived current-contract state table at the journal writer. That removes repeated JSON extraction, but it is a schema/data-contract project and should follow the surgical batching fix.
+
+This sync work does not block the default GET, but it matters when a stale render fires an automatic POST and for the every-minute producer. Existing FastAPI single-flight/30-second reuse should remain (`scripts/api/server.py:192-242`).
+
+### Priority 5: stop optional shell telemetry from competing with first portfolio data
+
+- Keep `/api/service-health` and `/api/flex-token` non-blocking in the footer; they already do not gate `PortfolioSections`.
+- Correct `/api/flex-token` to the disk-backed route contract (`dynamic = "force-dynamic"`, client `cache: "no-store"`). This is a freshness correction, not a latency claim.
+- The two relay sockets each mint a ticket because tickets are single-use. Consolidating status and price subscriptions onto one browser relay connection could remove one Next-to-FastAPI ticket round trip and one socket, but that is an architectural follow-up, not the first portfolio fix.
+- Add a browser abort to `/api/previous-close` consistent with its server fallback budget. It can wait for the 3-second IB snapshot and then 5-second fallbacks, but it begins only after a live price lacks a close and should never gate the base snapshot.
+
+## Existing safeguards to preserve
+
+- `GET /api/portfolio` must remain a snapshot read and must never call IB; after Priority 1, "snapshot-only" should also mean no journal-derived maps on its default path.
+- Direct-to-cloud is the default; `data/replica.db` was absent. Do not reintroduce the retired replica as a performance fix.
+- The Next DB pool is capped at eight connections, reaps idle sockets, keeps one connection warm in production, and aborts transport before the route's caller timeout (`web/lib/db.ts:44-83`, `web/lib/dbKeepAlive.ts:3-9`, `web/instrumentation.ts:1-15`).
+- Snapshot stale-on-error is bounded and surfaces `X-Sync-Warning`; do not turn stale data into silent success (`web/app/api/portfolio/route.ts:200-227`).
+- IB sync deadline order is sound: child 30s, Next/FastAPI call 35s, browser 42s. The autonomous wrapper also uses a 35-second curl bound (`scripts/run_portfolio_refresh.sh:130-151`).
+- The IB sync coordinator shields shared work from disconnected callers and coalesces concurrent requests (`scripts/api/server.py:192-236`).
+- `force-dynamic`, `cache: "no-store"`, and explicit no-store response headers remain required for live DB/disk routes. In-process coalescing does not relax that network cache contract.
+
+## Verification and measurement gaps
+
+- Read-only production `EXPLAIN QUERY PLAN`, row counts, payload sizes, and repeated query samples are included above.
+- Chrome DevTools MCP was unavailable in this agent session, so no browser waterfall or Core Web Vitals numbers are claimed here. The parallel browser trace should supply request start/end timing, TTFB, and render milestones.
+- No production VPS journal was available locally. `PhaseTimer` already emits `ib_hot_path_timing` with connect/qualify/sleep/done marks (`scripts/clients/ib_timing.py:16-53`); collect those logs before assigning wall time among IB, journal basis, and post-sync writes.
+- No local server was started, avoiding build/cache mutations. Exact compressed HTTP payload bytes and route TTFB should come from the browser/network pass.
+
+## Implementation order for the parent report
+
+1. Split entry-date maps out of the default portfolio response.
+2. Parallelize and 2-second single-flight cache `/api/orders` reads.
+3. Raise portfolio snapshot cache to 15 seconds and measure `Server-Timing`.
+4. Batch IB-sync journal basis reads; then verify whether the expression index is still needed.
+5. Re-profile `/portfolio` with one tab and five staggered tabs, during RTH and closed market, before considering broader pool or timeout changes.

--- a/tasks/artifacts/portfolio-frontend-performance-audit.md
+++ b/tasks/artifacts/portfolio-frontend-performance-audit.md
@@ -1,0 +1,215 @@
+# `/portfolio` frontend performance audit
+
+- Scope: read-only trace of the Next.js navigation, client render path, API initiation, realtime connections, polling, fallbacks, service worker, and production client assets.
+- Repository: `web/` at `88514b9b` on 2026-08-25.
+- Measurement boundary: the local production harness could validate request initiation and asset transfer sizes, but its in-route API requests were rejected by local Clerk middleware. No loopback API latency is presented as production latency.
+- Contract retained: live disk-backed GET handlers remain `dynamic = "force-dynamic"`; their clients remain `cache: "no-store"`. Recommendations below use application-memory snapshots, server-side bounded caches/single-flight, smaller payloads, and deferred work instead of browser HTTP caching of live portfolio data.
+
+## Executive priority
+
+| Priority | Finding | Evidence | Expected effect | Surgical direction |
+|---|---|---|---|---|
+| P0 | The initial cached portfolio read can be superseded by an immediate live sync POST. | `usePortfolio` starts GET on mount, while null `lastSync` is classified stale and `useAutoSyncOnStale` calls POST. POST increments `dataGenerationRef` before the fetch, so a faster GET response is discarded. A controlled production-build trace observed GET start 146 ms, POST start 155 ms, GET finish 602 ms, POST finish 3,158 ms, and rows only at 3,476 ms. See `lib/usePortfolio.ts:50-105,125-185`, `lib/useSnapshotStaleness.ts:27-35,73-76`, `lib/useAutoSyncOnStale.ts:99-123`. | This is the reproduced deterioration trigger: first useful portfolio data waited for the live upstream sync rather than the cached snapshot. POST has a 42 s client deadline; the route gives its upstream 35 s. | Do not auto-sync while the initial cached GET is pending. Paint the GET result before starting producer refresh, then preserve true-blackout recovery by syncing if the completed GET has no usable snapshot or reports a genuinely stale timestamp. Add a deferred GET/POST regression test. |
+| P0 | The portfolio loads a route-agnostic 1.20 MB raw client chunk. | `WorkspaceShell` dynamically imports `WorkspaceSections`; that file is 4,193 lines, 177,495 source bytes, has 69 static imports, and contains every workspace. Its production chunk is 1,198,604 raw / 316,954 gzip / 248,220 brotli bytes. `components/WorkspaceShell.tsx:39-41,563-575`; `components/WorkspaceSections.tsx:1280-1449,4148-4152,4193`. | Adds a large parse/compile/evaluate task before the portfolio tables settle, despite most code being unrelated to `/portfolio`. | Split sections by route or dynamically import the portfolio section directly. Move scanner, journal, admin, profile, options, workflow, and performance imports behind their own route chunks. Add a per-route compressed-JS budget. |
+| P1 | Sidebar default prefetch starts a broad RSC request storm during the cold load. | Links have no `prefetch` override at `components/Sidebar.tsx:112-159,178-197`. The production browser trace initiated 21 RSC prefetch GETs across two waves for `/cta`, `/regime/cri`, `/options`, `/profile`, `/flow-analysis`, `/scanner`, `/watchlist`, `/orders`, `/performance`, `/dashboard`, and `/portfolio`. | Competes with current-page JS, APIs, authentication, and server work for routes the user may not visit. | Set `prefetch={false}` on sidebar/profile links; optionally call `router.prefetch` only on pointer intent or focus. Verify the cold `/portfolio` trace has no unrelated RSC requests. |
+| P1 | `/api/portfolio` blocks its response on two journal-derived maps the portfolio UI does not consume. | The cached snapshot resolves first, then `portfolioResponseFromSnapshot` awaits `loadPortfolioEntryDates()` at `app/api/portfolio/route.ts:153-176`. That runs two queries in parallel, including full journal JSON extraction at `:70-150`. Only the orders share-P&L path reads these maps, at `components/WorkspaceSections.tsx:3701`; no portfolio view does. | Adds database query, JSON extraction, transfer, parsing, and allocation to the critical cached-read path. | Remove entry-date maps from the default portfolio response. Fetch them lazily for the orders share action, or gate with an explicit include flag. Keep the base endpoint no-store. |
+| P1 | One global shell subscribes `/portfolio` to unrelated data and opens two independently authenticated realtime sockets. | `WorkspaceShell` merges portfolio, open-order, watchlist, global futures, and ticker-detail subscriptions at `components/WorkspaceShell.tsx:83-98,109-143,168-205,236-261`. `usePrices` opens a price socket, while `IBStatusProvider` opens another relay socket and health polling independently. | More subscription work, token/ticket requests, socket setup, quote traffic, and render invalidation than the portfolio needs. | Route-scope quote subjects; keep only portfolio positions and genuinely visible header data on `/portfolio`. Multiplex IB status and price status through one authenticated relay connection or a shared client connection manager. |
+| P1 | Every quote update invalidates the whole prices map and broad portfolio render subtree. | `usePrices` object-spreads the complete map on every message at `lib/usePrices.ts:553-575`. `WorkspaceShell`, `MetricCards`, and `WorkspaceSections` receive the new map. `PositionRow` calculations depend on the whole map and repeat implied-value work at `components/PositionTable.tsx:350-440`; rows are not memoized at `:705-707`. | Unrelated watchlist/order/futures ticks can rerender all portfolio rows and repeatedly run exposure, day-move, and option calculations, extending time-to-settled and causing ongoing CPU load. | Use a keyed external quote store/selectors, pass only each position's relevant price slice, memoize rows, and calculate implied value once per position. Scope subscriptions first so fewer updates arrive. |
+| P2 | Header fallbacks race the realtime bootstrap. | When prices are initially empty, the shell immediately invokes index and futures fallbacks at `components/WorkspaceShell.tsx:263-287`. Futures fallback can launch ES/NQ/RTY requests in parallel every 30 s; index fallback launches one per missing watched index every 60 s. | Adds up to three Yahoo-backed futures calls on normal cold loads while the relay is still authenticating, plus optional index calls. | Start fallback only after a short relay-bootstrap deadline or a definite socket failure. Batch and single-flight fallback symbols server-side. |
+| P2 | Previous-close recovery opens another server-side realtime path and retries missing values every second. | `usePreviousClose` POSTs after live quotes arrive (`lib/usePreviousClose.ts:55-80`), with a 1 s missing-value retry. The route obtains auth, attempts a FastAPI ticket, opens a dedicated WS, then falls through to UW/Yahoo (`app/api/previous-close/route.ts:42-134,247-318`). | Adds a post-paint waterfall and repeated work before day-change metrics settle when close data is absent. | Include close in the relay bootstrap/snapshot or share the existing socket; use bounded exponential retry. Keep the POST no-store. |
+| P2 | Risk-free rate can be fetched once per rendered position table, without client deduplication, and the route's upstream fetch is no-store. | Each `PositionTable` calls `useRiskFreeRate` at `components/PositionTable.tsx:592`; portfolio can render stock, options, and crypto tables at `components/WorkspaceSections.tsx:1375,1406,1437`. Hook: `lib/useRiskFreeRate.ts:17`. Route upstream: `app/api/risk-free-rate/route.ts:24-31`. | Up to three cold concurrent calls for one stable scalar. | Put the value in one provider/module-level in-flight cache and use a bounded server revalidation cache, such as 24 hours. This metric is not live disk state. |
+| P2 | All six font files are preloaded by the root layout. | `app/layout.tsx:10-27` declares Inter variable plus five IBM Plex Mono faces. Production font transfers total 256,296 bytes: Inter 179,724 bytes and Plex 76,572 bytes. | Consumes cold-load bandwidth before all weights/styles are known to be needed above the fold. | Prefer a Plex variable file, or set non-critical italic/600/700 faces to `preload: false`; retain self-hosting and `display: swap`. |
+| P2 | Noncritical shell utilities are statically reachable and start background APIs on every route. | Footer invokes service health and flex-token (`components/FooterTelemetryStrip.tsx:69-83`); Sidebar invokes profile (`components/Sidebar.tsx:84-90`); closed chat still statically imports `ChatPanel` (`components/ChatLauncher.tsx:3-5,51,71-77`); dashboard modules are statically imported by the shell. | More initial module and network work unrelated to primary portfolio content. | Defer footer telemetry until after primary paint/idle, and dynamically import closed overlays and route-only surfaces. Retain module-level profile/watchlist deduplication. |
+| P3 | `/api/flex-token` violates the repository's live-disk no-store contract. | The route reads disk-backed config at `app/api/flex-token/route.ts:5-24` but lacks `dynamic = "force-dynamic"`; its caller at `components/FooterTelemetryStrip.tsx:72-83` omits `cache: "no-store"`. | Potentially stale operational status; fixing it will not make the route faster, but avoids using accidental HTTP caching as a performance mechanism. | Fix the contract, then defer the request instead of caching the live disk value in the browser. |
+| Positive | Service worker does not cache or intercept portfolio navigations/APIs. | Registration occurs after `load` (`components/PwaRegister.tsx:5-26`). Policy bypasses navigation, `/api`, `/_next/data`, and `/ws`; only static assets are cache-first (`public/sw-decisions.js:16-35`, `public/sw.js:39-60`). | No service-worker API staleness or cold critical-path interception. Warm static chunks/fonts can benefit. | Preserve the policy. Never place portfolio/orders payloads in Cache Storage. |
+
+## Navigation-to-settled call tree
+
+```text
+GET /portfolio (RSC/HTML navigation)
+└─ app/portfolio/page.tsx:1-5
+   └─ <WorkspaceShell section="portfolio">                    client boundary
+      ├─ root Providers
+      │  ├─ Clerk/auth bridge
+      │  ├─ IBStatusProvider
+      │  │  ├─ GET realtime token -> POST /api/ws-ticket -> WS /ws/prices
+      │  │  └─ GET /edge-health/status (or /api/admin/health)
+      │  └─ other state-only providers
+      ├─ usePortfolio
+      │  ├─ GET /api/portfolio                                 starts on mount
+      │  │  ├─ cached Turso snapshot query (3 s server TTL)
+      │  │  └─ then two journal entry-date queries (10 s server TTL)
+      │  └─ useSnapshotStaleness(null) -> useAutoSyncOnStale
+      │     └─ POST /api/portfolio                              can overlap/supersede GET
+      │        └─ POST FastAPI /portfolio/sync -> entry-date queries
+      ├─ useOrders
+      │  └─ GET /api/orders
+      │     └─ open orders query -> then executed orders query
+      ├─ useWatchlist
+      │  └─ GET /api/watchlist                                 module-deduplicated
+      ├─ usePrices (waits for subscription subjects from portfolio/orders/watchlist)
+      │  └─ get Clerk token -> POST /api/ws-ticket -> WS /ws/prices
+      │     └─ subscribe -> price messages -> replace whole prices object
+      ├─ quote fallback branch, conditional on initially missing prices
+      │  ├─ GET /api/futures-quote?symbol=ES|NQ|RTY           parallel when Globex open
+      │  └─ GET /api/index-quote?symbol=...                    parallel per watched index
+      ├─ usePreviousClose, after price objects exist without close
+      │  └─ POST /api/previous-close
+      │     └─ ticket -> server WS -> UW -> Yahoo fallback
+      ├─ Sidebar -> useProfile -> GET /api/profile             module-deduplicated
+      ├─ FooterTelemetryStrip
+      │  ├─ GET /api/service-health
+      │  └─ GET /api/flex-token
+      ├─ Next Link viewport prefetch
+      │  └─ unrelated route RSC GETs (21 requests observed across two waves)
+      ├─ dynamic import WorkspaceSections (1,198,604 raw bytes)
+      │  └─ PortfolioSections
+      │     ├─ filter/partition positions
+      │     ├─ PositionTable[stock]   -> GET /api/risk-free-rate
+      │     ├─ PositionTable[options] -> GET /api/risk-free-rate
+      │     └─ PositionTable[crypto]  -> GET /api/risk-free-rate
+      └─ after window load: register /sw.js -> precache static PWA icons/manifest
+```
+
+### Critical ordering
+
+1. React mounts `usePortfolio` with `lastSync = null`.
+2. Its mount effect starts `GET /api/portfolio` (`lib/usePortfolio.ts:177-185`).
+3. `useSnapshotStaleness(null)` returns `state = "unknown"` and `isStale = true` (`lib/useSnapshotStaleness.ts:27-35,73-76`).
+4. The auto-sync effect can claim the cross-tab lock and call `syncNow` (`lib/useAutoSyncOnStale.ts:99-123`).
+5. `syncNow` increments `dataGenerationRef` before starting POST (`lib/usePortfolio.ts:125-164`).
+6. If GET now resolves with the previous generation, the hook discards it (`lib/usePortfolio.ts:82`). The operator waits for live POST instead of seeing the cache immediately.
+
+The Web Lock and cooldown can prevent some duplicate syncs, but they do not make the first GET authoritative. The race is deterministic from code ordering; its occurrence depends on response scheduling and lock/cooldown state.
+
+### Reproduced regression and introducing change
+
+- Commit `e0f508bd7a1054094bcdde1098542335a2054cc4` (`Reliability weekend 2026-08-22 — remediation`, committed 2026-08-24) introduced the relevant `unknown` state and returned `isStale: state !== "fresh"` for null/unparseable timestamps at `lib/useSnapshotStaleness.ts:29-40,73-76`.
+- `WorkspaceShell` immediately passes that boolean to `useAutoSyncOnStale` (`components/WorkspaceShell.tsx:470-489`). It has no signal that the initial GET is still pending.
+- Controlled Playwright mocks against the production build recorded this sequence from navigation start: cached GET began at 146 ms; producer POST began at 155 ms; GET completed at 602 ms; the deliberately delayed POST completed at 3,158 ms; position rows appeared at 3,476 ms.
+- The 9 ms GET-to-POST gap proves this is not a slow cached query in that trace. The response is intentionally ignored by the generation guard at `lib/usePortfolio.ts:82` after `doSync` advances the generation.
+- Correct gating must retain blackout behavior: wait for the initial read to settle, show a usable snapshot immediately, and only trigger producer recovery when the read returns no usable data or its actual `last_sync` is stale. Null hook state while the read is pending is not evidence of a backend blackout.
+
+## HTTP, WebSocket, and polling inventory
+
+| Request/channel | Initiator and code | Start condition | Relationship | Cache | Deadline/retry/cadence |
+|---|---|---|---|---|---|
+| `GET /portfolio` | Next navigation, `app/portfolio/page.tsx:1-5` | Direct navigation/link | Root request | Next/RSC semantics; authenticated navigation bypasses SW | Browser/navigation controlled |
+| Route RSC prefetches | `next/link`, `components/Sidebar.tsx:112-159,178-197` | Links enter viewport | Parallel with current load; two waves observed | Next prefetch cache | 21 requests observed in local production topology trace |
+| `GET /api/portfolio` | `usePortfolio`, `lib/usePortfolio.ts:50-105,177-185` | Every hook mount; also route-key change | Starts in first effect; may overlap POST | `cache: "no-store"` | 12 s timeout; additional GET on route key; 30 s polling only while market active; 500 ms after visibility regain |
+| `POST /api/portfolio` | stale auto-sync through `lib/useAutoSyncOnStale.ts:99-123` | Initial null timestamp is stale unless cross-tab cooldown blocks | Overlaps GET and can invalidate its generation | `cache: "no-store"` | 42 s client timeout; cross-tab cooldown 1 min, exponential to 16 min (`lib/autoSyncClaim.ts:20-39`) |
+| FastAPI `POST /portfolio/sync` | Next handler, `app/api/portfolio/route.ts:243-262` | Portfolio POST | Sequential inside POST, before response assembly | Not browser-cached | 35 s upstream timeout |
+| Turso portfolio snapshot | `app/api/portfolio/route.ts:25-62` | Portfolio GET | First server phase | Server module TTL 3 s; stale-on-error 60 s | Single snapshot load per cache window |
+| Two journal entry-date queries | `app/api/portfolio/route.ts:70-176` | Every assembled portfolio response after cache miss | Parallel to each other, but sequential after snapshot | Server module TTL 10 s | DB/client timeout governs |
+| `GET /api/orders` | `useOrders`, `lib/useOrders.ts:47-83,149-177` | Every mount | Parallel with portfolio GET | `cache: "no-store"` | 12 s timeout; route-key GET; 30 s poll on orders page or market-active shell |
+| Turso orders queries | `lib/orders/readOrdersFromDb.ts:40-81,119-125` via `app/api/orders/route.ts:12-27` | Orders GET | Open orders query, then executed orders query sequentially | No explicit response snapshot TTL/single-flight | DB/client timeout governs |
+| `GET /api/watchlist` | `useWatchlist`, `lib/useWatchlist.ts:20-75`; shell at `components/WorkspaceShell.tsx:168-186` | Authenticated first consumer | Parallel with shell APIs | `cache: "no-store"`; module cache + in-flight dedup | One load per module lifetime unless mutation/reload |
+| `GET /api/profile` | `useProfile`, `lib/useProfile.ts:21-71`; Sidebar at `components/Sidebar.tsx:84-90` | First Sidebar/profile consumer | Parallel with shell APIs | `cache: "no-store"`; module cache + in-flight dedup | One load per module lifetime unless mutation/reload |
+| Client realtime token | `RealtimeAuthContext` consumed by `usePrices`; `lib/realtimeSocketAuth.ts:29-46` | Nonempty quote subscriptions | Before ticket and socket, sequential | Auth provider policy | Provider controlled |
+| `POST /api/ws-ticket` for prices | `lib/wsTicket.ts:12-28`, `lib/realtimeSocketAuth.ts:29-46` | Token resolved | Token -> ticket -> WS | POST/no HTTP cache | Ticket request deadline from helper |
+| Price `WS /ws/prices` | `lib/usePrices.ts:460-575,816-856` | Any symbol/option/index/depth subject | After token/ticket | Not cacheable | 8 s open deadline; stale check each 15 s; close after 60 s no data; reconnect 1 s to 30 s, max 10 attempts (`lib/reconnectStrategy.ts:20-35`) |
+| Second token/ticket/IB-status WS | `lib/IBStatusContext.tsx:203-239,295-410` | Production provider mount | Independent and parallel to price socket | Not cacheable | 8 s open; 15 s stale checks/60 s cutoff; reconnect backoff |
+| `GET /edge-health/status` | `lib/IBStatusContext.tsx:431-501` | Provider mount in production | Parallel; detailed fallback only if aggregate missing/unhealthy | `cache: "no-store"` | 5 s timeout, every 15 s |
+| `GET /api/admin/health` | `lib/IBStatusContext.tsx:431-501` | Local mode, or detailed production fallback | Sequential fallback branch | `cache: "no-store"` | 5 s timeout, every 15 s |
+| `GET /api/service-health` | `useServiceHealth`, `lib/useServiceHealth.ts:51-97`; footer at `components/FooterTelemetryStrip.tsx:69` | Footer mount | Parallel, noncritical | `cache: "no-store"` | 10 s timeout; every 60 s |
+| `GET /api/flex-token` | footer, `components/FooterTelemetryStrip.tsx:72-83` | Footer mount | Parallel, noncritical | Default fetch cache; currently violates live-disk contract | 10 s timeout; one-shot per mount |
+| `GET /api/futures-quote?symbol=...` | `useFuturesQuoteFallback`, `lib/useFuturesQuoteFallback.ts:22-76` | Globex open and ES/NQ/RTY price missing | Up to three parallel calls; races socket | `cache: "no-store"` | Server Yahoo fetch 5 s; repeats every 30 s |
+| `GET /api/index-quote?symbol=...` | `useIndexQuoteFallback`, `lib/useIndexQuoteFallback.ts:36-83` | Watched/index subject lacks usable price | Parallel per missing index; races socket | `cache: "no-store"` | Repeats every 60 s |
+| `POST /api/previous-close` | `usePreviousClose`, `lib/usePreviousClose.ts:55-80` | A received price has last but no close | After price socket/fallback; can repeat | POST/no-store semantics | Missing close retried every 1 s |
+| Previous-close server ticket/WS/providers | `app/api/previous-close/route.ts:42-134,247-318` | Previous-close POST | Token -> ticket (750 ms) -> WS (up to 3 s) -> UW/Yahoo fallbacks; symbols parallel | Server day-scoped result caching | UW/Yahoo provider timeout up to 5 s each |
+| `GET /api/risk-free-rate` | `useRiskFreeRate`, `lib/useRiskFreeRate.ts:17`; each table at `components/PositionTable.tsx:592` | Each mounted position table | Up to three concurrent duplicate calls | Hook default fetch; route sends 24 h public cache header, but upstream fetch is `no-store` | One per table mount |
+| `GET /sw.js` | `PwaRegister`, `components/PwaRegister.tsx:5-26` | Production after `window.load` | After load, outside primary content path | `updateViaCache: "none"` for SW script; static assets cache-first | Browser SW lifecycle |
+
+## Component and render path evidence
+
+- `app/portfolio/page.tsx` is a server component with no data fetch; it only returns `WorkspaceShell`.
+- `WorkspaceShell` is a monolithic client boundary (`components/WorkspaceShell.tsx:1,58`). Portfolio, orders, watchlist, market hours, quotes, prior close, global futures, notifications, sidebar, footer, chat, mobile shell, and command palette all initialize under it.
+- `WorkspaceSections` is one delayed chunk, but its module statically pulls unrelated route implementations. The portfolio switch is only at `components/WorkspaceSections.tsx:4148-4152`.
+- `PortfolioSections` partitions positions multiple times and instantiates three filtering and three column-visibility hooks (`components/WorkspaceSections.tsx:1280-1299`) before rendering up to three `PositionTable` trees.
+- `MetricCards` recomputes aggregate totals, exposure detail, and day-move breakdown on price-map identity changes (`components/MetricCards.tsx:624-648`) even while drill-down modals are closed.
+- `PositionRow` option calculations depend on the full prices object and call `computePositionImpliedValue` for both net and notional values (`components/PositionTable.tsx:350-425`).
+- Every price message creates a fresh top-level prices map (`lib/usePrices.ts:553-575`), so these memo boundaries do not isolate unrelated symbols.
+- The shell also pushes each new map into `TickerDetailContext` through an effect even on `/portfolio` (`components/WorkspaceShell.tsx:332-339`).
+
+## Production asset evidence
+
+Measured from the existing successful Next production output at commit `88514b9b`:
+
+| Asset set | Raw | gzip | brotli | Notes |
+|---|---:|---:|---:|---|
+| Distinct `/portfolio` route entry JS | 791,851 B | 231,257 B | 200,068 B | Layout, error boundaries, portfolio route references from the client reference manifest |
+| `WorkspaceSections` dynamic chunk | 1,198,604 B | 316,954 B | 248,220 B | `14xu5ck7lf8q8.js`; requested/preloaded on cold route |
+| Route CSS | 385,541 B | 58,222 B | 46,170 B | Global CSS contributes 377,291 raw / 44,903 brotli bytes |
+| Six WOFF2 fonts | 256,296 B | already compressed | already compressed | Inter variable 179,724 B; five Plex faces total 76,572 B |
+
+- Cold route JS is therefore approximately 448 KB brotli before HTML and external authentication resources.
+- Client JS + route CSS + fonts is approximately 750 KB of cold compressed transfer before HTML and external authentication resources.
+- Compression figures are file-level comparisons, not production origin content-encoding guarantees.
+- Largest relevant source files: `WorkspaceSections.tsx` 4,193 lines; `MetricCards.tsx` 1,081; `PositionTable.tsx` 724; `WorkspaceShell.tsx` 592.
+
+## Cache boundary recommendations
+
+### Safe, high-value application/server caches
+
+- Retain the last successful portfolio and orders snapshots in a persistent client provider or module store. Render the memory value immediately and revalidate via `cache: "no-store"`. This is SWR behavior in application memory, not HTTP caching of live data.
+- Add in-flight single-flight to portfolio/order snapshot loads so remounts or concurrent consumers share one server query cycle.
+- Separate the stable/derived journal entry-date payload from the live portfolio snapshot; cache it by journal revision or short TTL only where consumed.
+- Cache the risk-free-rate scalar server-side with bounded revalidation and deduplicate its client request.
+- Batch and single-flight identical futures/index fallback requests; use short server TTLs appropriate for delayed quotes.
+
+### Must remain uncached by browser/SW
+
+- `/api/portfolio`, `/api/orders`, `/api/watchlist`, `/api/profile`, service/admin health, live disk status, websocket tickets, and realtime socket data.
+- Navigations, RSC payloads, `/api`, `/_next/data`, and `/ws` must continue to bypass Cache Storage.
+- Producer POSTs must not be treated as reads; they should refresh state in the background after an existing snapshot is visible.
+
+## Suggested implementation sequence
+
+```text
+F1 initial read wins
+├─> F2 split portfolio response from entry-date metadata
+└─> F3 add persistent in-memory snapshot + no-store revalidation
+
+F4 split WorkspaceSections by route
+├─> F5 dynamic-load closed overlays/route-only surfaces
+└─> F6 enforce route bundle budget
+
+F7 disable viewport nav prefetch
+
+F8 route-scope quote subscriptions
+├─> F9 multiplex realtime status
+├─> F10 keyed quote selectors + memoized rows
+└─> F11 defer fallbacks until relay deadline
+
+F12 deduplicate/cache risk-free rate
+F13 trim font preloads
+F14 defer footer telemetry and fix flex-token no-store contract
+```
+
+## Regression and validation plan
+
+- Initial-data race unit test: defer portfolio GET and POST independently; assert GET snapshot renders before POST completes and POST cannot invalidate it.
+- Response-shape test: default `/api/portfolio` does not query or serialize entry-date maps; the orders share path obtains them explicitly.
+- Browser request-budget test: cold `/portfolio` has zero unrelated RSC viewport-prefetch requests and exactly one portfolio GET before any background POST.
+- Bundle-budget test: parse the client reference/build output and fail if `/portfolio` pulls the omnibus workspace chunk or exceeds an agreed compressed budget.
+- Realtime topology test: `/portfolio` subscription payload contains portfolio symbols plus explicitly visible header subjects, not watchlist/order/ticker-detail subjects by default.
+- Render-isolation test: publish a watchlist-only quote and assert unaffected portfolio rows do not rerender; publish one position-leg quote and assert only that row and aggregates update.
+- Fallback test: futures/index HTTP fallback does not start before the relay bootstrap deadline and is cancelled when the live quote arrives.
+- Cache-contract test: retain `web/tests/api-routes-no-cache-contract.test.ts`; add `/api/flex-token` and its client caller.
+- Service-worker test: retain assertions that navigation, `/api`, `/_next/data`, and `/ws` are bypassed.
+
+Useful read-only commands:
+
+```bash
+git status --short --branch
+rg -n 'fetch\(|new WebSocket|setInterval|setTimeout' components/WorkspaceShell.tsx lib/usePortfolio.ts lib/useOrders.ts lib/usePrices.ts lib/usePreviousClose.ts lib/useFuturesQuoteFallback.ts lib/useIndexQuoteFallback.ts components/IBStatusContext.tsx components/FooterTelemetryStrip.tsx
+wc -l components/WorkspaceSections.tsx components/MetricCards.tsx components/PositionTable.tsx components/WorkspaceShell.tsx
+find .next/static/chunks -type f -name '*.js' -print0 | xargs -0 wc -c | sort -n | tail
+npm test -- --run tests/api-routes-no-cache-contract.test.ts
+```
+
+## Local topology trace caveat
+
+- A production `next start` browser run confirmed the request list, duplicate RSC prefetch waves, font list, and chunk transfers.
+- Local Clerk middleware rejected application API responses in that harness. The harness therefore cannot support claims about production API duration, database duration, Web Vitals, or the time at which real portfolio rows become visible.
+- Timings in this report are only explicit code deadlines/intervals. No synthetic loopback time is presented as user-facing performance.

--- a/tasks/artifacts/portfolio-performance-best-practices.md
+++ b/tasks/artifacts/portfolio-performance-best-practices.md
@@ -1,0 +1,92 @@
+# `/portfolio` performance: applicable current practices
+
+Date: 2026-08-25
+Scope: Next.js 16.2 / React 19 client, shared shell, `/api/portfolio`, Turso/libSQL, and portfolio-adjacent layout/provider load paths. This is a code-and-query-plan review, not a measured production trace. Chrome DevTools MCP was unavailable, so impact is directional and confidence distinguishes strong code evidence from runtime measurement.
+
+## Non-negotiable constraints
+
+- Keep live disk/DB GET handlers `dynamic = "force-dynamic"` and every corresponding browser fetch `cache: "no-store"`.
+- Do not put operator portfolio, orders, health diagnostics, or other authenticated trading state in browser/CDN caches. Vercel's current CDN guidance says CDN caching is not appropriate for sensitive or user-specific content, and authenticated or `no-store` responses are ineligible anyway: [Vercel CDN Cache](https://vercel.com/docs/caching/cdn-cache).
+- Keep explicit freshness and warning provenance. Do not make a stale portfolio look authoritative.
+- Do not reintroduce the retired embedded replica or replace Radon's bounded/self-healing HTTP transport merely because the generic Hrana spec calls WebSocket more efficient.
+
+## Priority findings
+
+### P0. Remove journal-derived entry-date work from the `/portfolio` critical response
+
+- **Code evidence:** `web/app/api/portfolio/route.ts:171` awaits `loadPortfolioEntryDates()` after the latest portfolio snapshot is ready. That helper starts two journal queries at `web/app/api/portfolio/route.ts:159-162`. Both parse JSON across journal history (`:72-82` and `:111-126`). The response cannot finish until they finish.
+- **Why this is route waste:** the returned `trade_log_dates` and `contract_open_dates` are consumed only by the executed-order share calculation at `web/components/WorkspaceSections.tsx:3701`; `/portfolio` rendering does not read them.
+- **DB evidence:** reproducing the current schema/indexes from `scripts/db/migrations/0001_init.sql:70-80` and `0025_journal_effective_at_index.sql:10-11` with `EXPLAIN QUERY PLAN` reports `SCAN journal` plus `USE TEMP B-TREE FOR GROUP BY` for the ticker aggregate, and `SCAN journal` for contract-open rows. The current effective-time index does not match either query. By contrast, latest `portfolio_snapshots` uses the primary-key index.
+- **Surgical change:** return the portfolio snapshot immediately. Fetch entry-date maps only for the orders/share surface, through a dedicated endpoint or an explicit `includeEntryDates` mode requested only when that surface becomes active. Preserve the current short in-process cache there.
+- **Follow-on DB shape:** if the dedicated path remains slow, compute both maps from one canonical journal read or maintain normalized/materialized entry-date rows at journal-write time. A libSQL batch can cut network round trips, but two batched statements still perform two full scans; it is secondary to removing/reshaping the scans.
+- **Official source claim:** Turso says to use `EXPLAIN QUERY PLAN`; missing suitable indexes forces full scans, and queries can scan many more rows than they return: [Turso Usage & Billing](https://docs.turso.tech/help/usage-and-billing). Turso supports expression and partial indexes, but index cost must be justified by the actual plan: [Turso `CREATE INDEX`](https://docs.turso.tech/sql-reference/statements/create-index). Hrana batches reduce round trips by carrying multiple statements in one request: [Hrana 3 protocol](https://github.com/tursodatabase/libsql/blob/main/docs/HRANA_3_SPEC.md).
+- **Priority / impact / confidence:** P0 / high server latency and Turso work on every cold cache / high.
+
+### P0. Split the all-routes client module graph before tuning individual components
+
+- **Code evidence:** `web/components/WorkspaceShell.tsx:39-41` dynamically loads one `WorkspaceSections` chunk, but that 4,193-line, 177 KB source module statically imports 76 route implementations at `web/components/WorkspaceSections.tsx:24-140`, then selects one at runtime at `:4142-4188`. `/portfolio` therefore reaches scanner, regime, performance, admin, workflow, ticker, mobile, and order code through one client entry. `RegimePanel` alone statically imports the D3-backed chart family at `web/components/RegimePanel.tsx:8-33`.
+- **Additional always-imported but conditional UI:** `WorkspaceShell.tsx:31` imports `DashboardSurface` although it renders only at `:553-559`; `:51` imports the closed-by-default command palette; `web/components/ChatLauncher.tsx:4` imports the full chat/Markdown/risk tree although it returns `null` until open at `:51`; `web/components/MetricCards.tsx:22-25` imports four click-only modals.
+- **Surgical change:** extract a small `PortfolioSections` module and dynamically import route implementations with statically analyzable import functions. Independently lazy-load ChatPanel, CommandPalette, metric modals, and dashboard-only UI at their render conditions. Keep the lightweight launchers/skeletons eager.
+- **Official source claim:** Next.js says lazy loading improves initial load by reducing JavaScript and defers Client Components/libraries until needed: [How to lazy load Client Components and libraries](https://nextjs.org/docs/app/guides/lazy-loading). Next.js also recommends the bundle analyzer to identify modules to split or lazy-load: [How to optimize package bundling](https://nextjs.org/docs/app/guides/package-bundling). React's `lazy` similarly defers component code until first render: [React `lazy`](https://react.dev/reference/react/lazy).
+- **Priority / impact / confidence:** P0 / high parse-compile-hydration and earlier navigation prefetch / high for bundle reachability, medium until production bundle bytes are measured.
+
+### P1. Eliminate the hydration-to-portfolio request waterfall with server-provided initial data
+
+- **Code evidence:** `web/app/portfolio/page.tsx:1-5` renders only the client `WorkspaceShell`. The first portfolio request starts in a client effect at `web/lib/usePortfolio.ts:179-185`, after the shell JavaScript has loaded and hydrated. The positions table therefore waits for document, shared JS, hydration, `/api/portfolio`, Turso, JSON transfer, and client render.
+- **Surgical change:** make the page a real Server Component data boundary. Start the bounded latest-snapshot read on the server and pass a serializable snapshot or promise into a narrow portfolio client surface as initial data. Keep client `no-store` polling for updates, but skip the redundant mount GET when the server snapshot already satisfies the same freshness window. Stream a meaningful shell/skeleton around the data boundary rather than blocking the whole page.
+- **Constraint:** do not server-fetch Radon's own Route Handler over HTTP. Extract the authenticated data-access helper and call it directly. Keep request-time/dynamic behavior; this is not static caching.
+- **Official source claim:** Next.js recommends Server Components for database/API reads close to the source, reducing client JavaScript and improving FCP; data can be passed to Client Components: [Server and Client Components](https://nextjs.org/docs/app/getting-started/server-and-client-components). It also documents server fetching, streaming, and starting independent requests in parallel: [Fetching Data](https://nextjs.org/docs/app/getting-started/fetching-data). React documents client-effect fetching as an expensive client-server waterfall: [React Server Components](https://react.dev/reference/rsc/server-components).
+- **Priority / impact / confidence:** P1 / high cold-load latency, especially at non-local RTT / high mechanism confidence, medium net gain until TTFB and LCP are traced.
+
+### P1. Reduce non-critical startup competition and tailor the bootstrap payload
+
+- **Code evidence:** the shared shell starts an unconditional orders GET on mount even away from `/orders` (`web/lib/useOrders.ts:149-153`); `/portfolio` also mounts profile (`web/components/Sidebar.tsx:84-88` -> `web/lib/useProfile.ts:60-67`), watchlist (`web/components/WorkspaceShell.tsx:173-186`), service health and flex-token reads (`web/components/FooterTelemetryStrip.tsx:67-83`), two authenticated realtime sockets (`web/lib/IBStatusContext.tsx:393-416` and `web/lib/usePrices.ts:485-506`), and up to three initial futures fallbacks before live prices arrive (`web/components/WorkspaceShell.tsx:275-286`, `web/lib/useFuturesQuoteFallback.ts:40-76`).
+- **Why it matters:** several of those requests also read Turso while Radon's process pool is capped at eight connections (`web/lib/db.ts:55-59`). They are parallel, but they compete with the only payload required to replace the portfolio loading state.
+- **Surgical changes:**
+  - Return only today's executions/realized P&L needed by portfolio metrics instead of the complete orders snapshot, or fold that small derived value into the portfolio bootstrap.
+  - Delay profile, service-health detail, flex status, and watchlist expansion until after the critical snapshot/first paint. Do not remove status monitoring; change priority and mount timing.
+  - Give the realtime relay a short bounded opportunity to populate ES/NQ/RTY before launching all Yahoo fallback calls; live relay still wins.
+  - Preserve the existing browser module-level single-flight caches in `useProfile` and `useWatchlist`; they already prevent duplicate same-session reads.
+- **Official source claim:** Next.js recommends parallel requests when all are necessary, but also says slow critical data should be optimized/cached and streamed; Server Components can reduce multiple client round trips: [Fetching Data](https://nextjs.org/docs/app/getting-started/fetching-data). This recommendation is about removing or deprioritizing non-critical work, not serializing necessary critical work.
+- **Priority / impact / confidence:** P1 / medium-high under cold sessions and Turso tail latency / medium pending a network trace.
+
+### P1. Shrink route-global CSS, then verify actual production transfer
+
+- **Code evidence:** `web/app/layout.tsx:6` imports `web/app/globals.css` for every route. The file is 20,500 lines / 502,888 bytes source (85,135 bytes gzip and 65,982 bytes Brotli before minification in this review). It contains feature-specific styling for the entire workstation, so `/portfolio` pays beyond base tokens/shell/portfolio styles.
+- **Surgical change:** leave resets, tokens, typography primitives, and shared shell rules global. Move feature/component rules into colocated CSS Modules imported by the newly split route components. Measure production CSS chunks before/after; source bytes are not transfer bytes.
+- **Official source claim:** Next.js says root-imported global CSS applies to every route, recommends global CSS only for truly global styles and CSS Modules for scoped custom CSS, and production-build CSS is minified/code-split: [CSS in Next.js](https://nextjs.org/docs/app/getting-started/css).
+- **Priority / impact / confidence:** P1 / medium render-blocking bytes and style calculation / high scope evidence, medium byte impact pending a production build.
+
+### P2. Add route-specific field and server timing before setting budgets
+
+- **Code evidence:** `web/instrumentation.ts:4-27` starts DB keepalive, loop-lag monitoring, and bounded shutdown, but there is no `useReportWebVitals` integration. `/api/portfolio` labels DB calls internally but emits no `Server-Timing` breakdown.
+- **Surgical change:** report LCP, INP, CLS, FCP, and TTFB with pathname/navigation type; add sanitized `Server-Timing` spans for auth, snapshot query, entry-date query, serialization, and total API time. Do not include SQL, account data, tokens, or user identifiers.
+- **Official source claim:** Next.js provides `useReportWebVitals` and recommends a separate tiny Client Component to confine the boundary: [Next.js `useReportWebVitals`](https://nextjs.org/docs/app/api-reference/functions/use-report-web-vitals). Chrome DevTools displays `Server-Timing` for network requests: [Chrome Performance features reference](https://developer.chrome.com/docs/devtools/performance/reference).
+- **Priority / impact / confidence:** P2 / enables regression detection and validates rankings / high.
+
+## Safe caching decisions
+
+| Surface | Decision | Radon applicability |
+|---|---|---|
+| `/api/portfolio` HTTP response | **Do not browser/CDN cache.** Keep `force-dynamic`, `no-store`, and response no-store headers. | `web/app/api/portfolio/route.ts:18-23`, `web/lib/usePortfolio.ts:59-62`, `web/app/api/portfolio/route.ts:177` |
+| Latest portfolio DB read | **Keep short in-process single-flight/stale-on-error.** The existing 3 s TTL is a coalescer, not a user-visible freshness policy. Do not increase broadly because this portfolio also feeds order-risk coverage. | `web/app/api/portfolio/route.ts:25-32`, `:200-205`; cache semantics at `web/lib/dbCache.ts:1-21` |
+| Entry-date maps | **Cache only on the surface that needs them.** Longer TTL is plausible because values are day-granularity, but only after explicit fill/journal invalidation or a measured acceptable bound. | `web/app/api/portfolio/route.ts:29-32`, `:159-162`; consumer `web/components/WorkspaceSections.tsx:3701` |
+| React `cache()` | **Not a fix for this Route Handler.** React documents it as Server-Component-only and request-scoped; the current duplicated cost is cross-request polling and DB scans. | [React `cache`](https://react.dev/reference/react/cache); current handler `web/app/api/portfolio/route.ts:195-240` |
+| Next `use cache` / static Route Handler | **Reject for live portfolio.** Route Handlers are uncached by default, and opting a GET into static/cache behavior conflicts with live authenticated trading data. | [Next.js Route Handlers](https://nextjs.org/docs/app/getting-started/route-handlers) |
+| Static JS/CSS/font/image assets | **Keep framework immutable caching.** Focus on reducing what `/portfolio` references, not weakening cache-busting. | Next self-hosting documents hashed immutable assets: [Self-Hosting](https://nextjs.org/docs/app/guides/self-hosting) |
+
+## Practices already present or not applicable
+
+- Independent entry-date queries already use `Promise.all` at `web/app/api/portfolio/route.ts:159-162`; the issue is unnecessary/scanning work, not a JavaScript waterfall between those two calls.
+- `lucide-react` already uses `optimizePackageImports` at `web/next.config.mjs:69-72`; adding the same option again will not split Radon's own monolithic module graph.
+- Local fonts already use `next/font/local` with `display: "swap"` at `web/app/layout.tsx:10-27`; do not prioritize font changes without a trace showing them on the critical path.
+- The service worker registration is deferred until `load` at `web/components/PwaRegister.tsx:11-24`, and the project contract bypasses live API routes. It is not a leading cold-load suspect.
+- Sidebar navigation already uses Next `<Link>` at `web/components/Sidebar.tsx:142-155`. Next automatically prefetches visible links after hydration, but current large JavaScript can delay that hydration: [Linking and Navigating](https://nextjs.org/docs/app/getting-started/linking-and-navigating).
+- Do not remove route-local auth checks to save latency. Middleware plus handler defense-in-depth is a security boundary (`web/middleware.ts:321-395`, `web/lib/routeAccess.ts:77-90`). Reduce initial request count instead.
+
+## Measurement gates for implementation
+
+1. Run the official Next bundle analyzer on a production compile; record `/portfolio` first-load JS and the `WorkspaceSections`/D3/Markdown contributors before and after splitting.
+2. Run `EXPLAIN QUERY PLAN` against production Turso for the two current journal queries, and use Turso analytics to capture latency and rows touched. Confirm the dedicated portfolio response performs only the indexed latest-snapshot lookup.
+3. Capture cold and warm `/portfolio` traces with cache enabled and disabled, separating document TTFB, hydration, `/api/portfolio` wait, JSON download, scripting, and LCP.
+4. Report field metrics at p75 separately for desktop/mobile. Current good thresholds are LCP <= 2.5 s, INP <= 200 ms, and CLS <= 0.1; poor begins above 4.0 s, 500 ms, and 0.25 respectively: [web.dev, Core Web Vitals thresholds](https://web.dev/articles/defining-core-web-vitals-thresholds).

--- a/tasks/artifacts/show-me-portfolio-page-load-performance.html
+++ b/tasks/artifacts/show-me-portfolio-page-load-performance.html
@@ -1,0 +1,914 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <title>Radon Portfolio Page-Load Performance Audit</title>
+  <style>
+    :root {
+      --canvas: #0a0f14;
+      --panel: #0f1519;
+      --raised: #151c22;
+      --grid: #1e293b;
+      --signal: #05ad98;
+      --ink: #dce7ea;
+      --muted: #8ea0a8;
+      --faint: #5f727b;
+      --warn: #e3a95b;
+      --bad: #e46f65;
+      --info: #79a7ff;
+      --white: #f3f7f7;
+    }
+
+    * { box-sizing: border-box; }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      margin: 0;
+      background: var(--canvas);
+      color: var(--ink);
+      font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      font-size: 16px;
+      line-height: 1.6;
+      font-kerning: normal;
+    }
+
+    a { color: var(--signal); text-underline-offset: 3px; }
+    a:hover { color: var(--white); }
+    a:focus-visible, summary:focus-visible {
+      outline: 2px solid var(--signal);
+      outline-offset: 3px;
+    }
+
+    code, .mono, .eyebrow, .metric-value, th, .tag, .device-label, .rail-time {
+      font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-variant-numeric: tabular-nums;
+    }
+
+    code {
+      color: var(--white);
+      font-size: 0.88em;
+      overflow-wrap: anywhere;
+    }
+
+    .shell {
+      width: min(1480px, calc(100% - 32px));
+      margin: 0 auto;
+      padding: 32px 0 72px;
+    }
+
+    .masthead {
+      display: grid;
+      grid-template-columns: minmax(0, 1.35fr) minmax(300px, 0.65fr);
+      gap: 32px;
+      align-items: end;
+      padding: 24px 0 32px;
+      border-bottom: 1px solid var(--grid);
+    }
+
+    .eyebrow, .device-label {
+      color: var(--signal);
+      font-size: 0.72rem;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+
+    h1, h2, h3, p { margin-top: 0; }
+
+    h1 {
+      margin-bottom: 12px;
+      max-width: 16ch;
+      color: var(--white);
+      font-size: clamp(2.35rem, 5.7vw, 5.6rem);
+      font-weight: 650;
+      letter-spacing: -0.055em;
+      line-height: 0.95;
+    }
+
+    .dek {
+      margin: 0;
+      max-width: 64ch;
+      color: var(--muted);
+      font-size: 1.05rem;
+    }
+
+    .audit-meta {
+      display: grid;
+      gap: 10px;
+      padding-left: 20px;
+      border-left: 1px solid var(--grid);
+    }
+
+    .meta-row {
+      display: grid;
+      grid-template-columns: 112px minmax(0, 1fr);
+      gap: 16px;
+      padding-bottom: 10px;
+      border-bottom: 1px solid var(--grid);
+    }
+
+    .meta-row span:first-child {
+      color: var(--faint);
+      font-size: 0.78rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+
+    .meta-row strong { color: var(--white); font-size: 0.94rem; }
+
+    .jump-nav {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+      padding: 20px 0;
+      border-bottom: 1px solid var(--grid);
+    }
+
+    .jump-nav a, .tag {
+      display: inline-flex;
+      align-items: center;
+      min-height: 32px;
+      padding: 5px 10px;
+      border: 1px solid var(--grid);
+      border-radius: 999px;
+      color: var(--muted);
+      font-size: 0.72rem;
+      letter-spacing: 0.04em;
+      text-decoration: none;
+      text-transform: uppercase;
+    }
+
+    .jump-nav a:hover { border-color: var(--signal); color: var(--white); }
+
+    .section { padding-top: 52px; }
+
+    .section-head {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(240px, 0.42fr);
+      gap: 24px;
+      align-items: end;
+      margin-bottom: 20px;
+      padding-bottom: 14px;
+      border-bottom: 1px solid var(--grid);
+    }
+
+    .section-head h2 {
+      margin-bottom: 0;
+      color: var(--white);
+      font-size: clamp(1.55rem, 3vw, 2.45rem);
+      font-weight: 600;
+      letter-spacing: -0.035em;
+      line-height: 1.08;
+    }
+
+    .section-head p { margin: 0; color: var(--muted); font-size: 0.9rem; }
+
+    .verdict {
+      display: grid;
+      grid-template-columns: 118px minmax(0, 1fr);
+      border: 1px solid var(--bad);
+      background: var(--panel);
+    }
+
+    .verdict-label {
+      display: grid;
+      place-items: center;
+      min-height: 136px;
+      padding: 16px;
+      border-right: 1px solid var(--bad);
+      color: var(--bad);
+      text-align: center;
+    }
+
+    .verdict-body { padding: 24px; }
+
+    .verdict-body h2 {
+      margin-bottom: 8px;
+      color: var(--white);
+      font-size: clamp(1.45rem, 2.8vw, 2.2rem);
+      line-height: 1.15;
+    }
+
+    .verdict-body p { margin: 0; max-width: 92ch; color: var(--muted); }
+
+    .metrics {
+      display: grid;
+      grid-template-columns: repeat(6, minmax(0, 1fr));
+      margin-top: 16px;
+      border-top: 1px solid var(--grid);
+      border-left: 1px solid var(--grid);
+    }
+
+    .metric {
+      min-height: 138px;
+      padding: 18px 16px;
+      border-right: 1px solid var(--grid);
+      border-bottom: 1px solid var(--grid);
+      background: var(--panel);
+    }
+
+    .metric-value {
+      display: block;
+      margin-bottom: 8px;
+      color: var(--white);
+      font-size: clamp(1.4rem, 3vw, 2.25rem);
+      line-height: 1;
+    }
+
+    .metric-value.bad { color: var(--bad); }
+    .metric-value.warn { color: var(--warn); }
+    .metric-value.signal { color: var(--signal); }
+    .metric-label { color: var(--muted); font-size: 0.8rem; line-height: 1.35; }
+
+    .finding-grid {
+      display: grid;
+      grid-template-columns: repeat(12, minmax(0, 1fr));
+      border-top: 1px solid var(--grid);
+      border-left: 1px solid var(--grid);
+    }
+
+    .finding {
+      grid-column: span 6;
+      min-height: 310px;
+      padding: 22px;
+      border-right: 1px solid var(--grid);
+      border-bottom: 1px solid var(--grid);
+      background: var(--panel);
+    }
+
+    .finding.primary { grid-column: span 12; min-height: auto; }
+    .finding-number { color: var(--faint); font-size: 0.72rem; }
+    .finding h3 { margin: 12px 0 10px; color: var(--white); font-size: 1.2rem; line-height: 1.25; }
+    .finding p { color: var(--muted); font-size: 0.92rem; }
+    .finding ul { margin: 14px 0 0; padding-left: 18px; color: var(--muted); font-size: 0.9rem; }
+    .finding li + li { margin-top: 8px; }
+
+    .priority-line {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    .tag.p0 { border-color: var(--bad); color: var(--bad); }
+    .tag.p1 { border-color: var(--warn); color: var(--warn); }
+    .tag.p2 { border-color: var(--info); color: var(--info); }
+    .tag.safe { border-color: var(--signal); color: var(--signal); }
+
+    .race {
+      padding: 24px;
+      border: 1px solid var(--grid);
+      background: var(--panel);
+    }
+
+    .race-scale {
+      display: grid;
+      grid-template-columns: 112px minmax(0, 1fr);
+      gap: 16px;
+      align-items: center;
+    }
+
+    .race-scale + .race-scale { margin-top: 16px; }
+    .rail-label { color: var(--muted); font-size: 0.82rem; }
+
+    .rail {
+      position: relative;
+      height: 42px;
+      border-left: 1px solid var(--grid);
+      border-right: 1px solid var(--grid);
+      background: var(--canvas);
+    }
+
+    .rail-bar {
+      position: absolute;
+      top: 8px;
+      height: 26px;
+      border: 1px solid currentColor;
+      background: var(--raised);
+    }
+
+    .rail-bar.get { left: 4.2%; width: 13.1%; color: var(--signal); }
+    .rail-bar.post { left: 4.5%; width: 86.4%; color: var(--bad); }
+    .rail-marker {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 99%;
+      width: 2px;
+      background: var(--warn);
+    }
+
+    .rail-time {
+      position: absolute;
+      top: 50%;
+      left: 8px;
+      transform: translateY(-50%);
+      color: var(--white);
+      font-size: 0.7rem;
+      white-space: nowrap;
+    }
+
+    .race-notes {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 1px;
+      margin-top: 24px;
+      background: var(--grid);
+      border: 1px solid var(--grid);
+    }
+
+    .race-note { padding: 14px; background: var(--raised); }
+    .race-note strong { display: block; color: var(--white); font-size: 0.83rem; }
+    .race-note span { color: var(--muted); font-size: 0.75rem; }
+
+    .flow {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+      align-items: stretch;
+    }
+
+    .flow-node {
+      position: relative;
+      min-height: 148px;
+      padding: 18px;
+      border: 1px solid var(--grid);
+      background: var(--panel);
+    }
+
+    .flow-node:not(:last-child)::after {
+      content: "→";
+      position: absolute;
+      top: 50%;
+      right: -12px;
+      z-index: 2;
+      width: 24px;
+      color: var(--signal);
+      text-align: center;
+      transform: translateY(-50%);
+      background: var(--canvas);
+    }
+
+    .flow-node strong { display: block; margin: 8px 0; color: var(--white); font-size: 0.95rem; }
+    .flow-node p { margin: 0; color: var(--muted); font-size: 0.8rem; line-height: 1.45; }
+
+    .db-grid {
+      display: grid;
+      grid-template-columns: 0.8fr 1.2fr;
+      gap: 16px;
+    }
+
+    .panel {
+      min-width: 0;
+      border: 1px solid var(--grid);
+      background: var(--panel);
+    }
+
+    .table-wrap { max-width: 100%; }
+
+    .panel-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      min-height: 42px;
+      padding: 8px 14px;
+      border-bottom: 1px solid var(--grid);
+      background: var(--raised);
+    }
+
+    .panel-body { padding: 18px; }
+    .panel-body p:last-child { margin-bottom: 0; }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.84rem;
+    }
+
+    th, td {
+      padding: 12px 10px;
+      border-bottom: 1px solid var(--grid);
+      text-align: left;
+      vertical-align: top;
+    }
+
+    th { color: var(--faint); font-size: 0.68rem; letter-spacing: 0.06em; text-transform: uppercase; }
+    td { color: var(--muted); }
+    td strong { color: var(--white); }
+    tr:last-child td { border-bottom: 0; }
+
+    .scan { color: var(--bad); }
+    .index { color: var(--signal); }
+
+    .bar-list { display: grid; gap: 14px; }
+    .bar-row { display: grid; grid-template-columns: 156px minmax(0, 1fr) 88px; gap: 12px; align-items: center; }
+    .bar-label { color: var(--muted); font-size: 0.8rem; }
+    .bar-track { height: 12px; border: 1px solid var(--grid); background: var(--canvas); }
+    .bar-fill { height: 100%; background: var(--signal); }
+    .bar-fill.bad { background: var(--bad); }
+    .bar-fill.warn { background: var(--warn); }
+    .bar-value { color: var(--white); font-size: 0.75rem; text-align: right; }
+
+    .plan {
+      display: grid;
+      grid-template-columns: 92px minmax(0, 1fr) 168px 168px;
+      border-top: 1px solid var(--grid);
+      border-left: 1px solid var(--grid);
+    }
+
+    .plan-row { display: contents; }
+    .plan-cell {
+      padding: 16px;
+      border-right: 1px solid var(--grid);
+      border-bottom: 1px solid var(--grid);
+      background: var(--panel);
+    }
+
+    .plan-cell.step { color: var(--signal); }
+    .plan-cell strong { display: block; margin-bottom: 5px; color: var(--white); }
+    .plan-cell p { margin: 0; color: var(--muted); font-size: 0.82rem; }
+
+    .cache-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 16px;
+    }
+
+    .cache-card { border: 1px solid var(--grid); background: var(--panel); }
+    .cache-card h3 { margin: 0; padding: 12px 16px; border-bottom: 1px solid var(--grid); color: var(--white); font-size: 0.95rem; }
+    .cache-card ul { margin: 0; padding: 16px 18px 18px 34px; color: var(--muted); font-size: 0.86rem; }
+    .cache-card li + li { margin-top: 9px; }
+
+    .cwv-note {
+      padding: 14px 16px;
+      border: 1px solid var(--warn);
+      color: var(--muted);
+      background: var(--panel);
+      font-size: 0.84rem;
+    }
+
+    details {
+      border: 1px solid var(--grid);
+      background: var(--panel);
+    }
+
+    details + details { margin-top: 10px; }
+    summary { cursor: pointer; padding: 14px 16px; color: var(--white); font-weight: 600; }
+    details[open] summary { border-bottom: 1px solid var(--grid); }
+    .detail-body { padding: 16px; color: var(--muted); font-size: 0.86rem; }
+    .detail-body ul { margin: 0; padding-left: 20px; }
+
+    .sources {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px 28px;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .sources li { padding-bottom: 10px; border-bottom: 1px solid var(--grid); color: var(--muted); font-size: 0.84rem; }
+
+    .footer {
+      display: flex;
+      justify-content: space-between;
+      gap: 24px;
+      margin-top: 56px;
+      padding-top: 18px;
+      border-top: 1px solid var(--grid);
+      color: var(--faint);
+      font-size: 0.76rem;
+    }
+
+    @media (max-width: 1100px) {
+      .metrics { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+      .finding { grid-column: span 12; min-height: auto; }
+      .db-grid, .cache-grid { grid-template-columns: 1fr; }
+      .flow { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .flow-node::after { display: none; }
+      .plan { grid-template-columns: 72px minmax(0, 1fr); }
+      .plan-cell:nth-child(3), .plan-cell:nth-child(4) { grid-column: span 1; }
+    }
+
+    @media (max-width: 720px) {
+      .shell { width: min(100% - 20px, 1480px); padding-top: 12px; }
+      .masthead, .section-head { grid-template-columns: 1fr; gap: 18px; }
+      .audit-meta { padding-left: 0; border-left: 0; }
+      .verdict { grid-template-columns: 1fr; }
+      .verdict-label { min-height: 52px; border-right: 0; border-bottom: 1px solid var(--bad); }
+      .metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .race-scale { grid-template-columns: 1fr; gap: 5px; }
+      .race-notes { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .flow { grid-template-columns: 1fr; }
+      .bar-row { grid-template-columns: 1fr 72px; }
+      .bar-track { grid-row: 2; grid-column: 1 / -1; }
+      .plan { grid-template-columns: 1fr; }
+      .plan-row { display: grid; grid-template-columns: 1fr; }
+      .sources { grid-template-columns: 1fr; }
+      .footer { flex-direction: column; }
+      .table-wrap { overflow-x: auto; }
+      table { min-width: 720px; }
+    }
+  </style>
+</head>
+<body>
+  <main class="shell">
+    <header class="masthead">
+      <div>
+        <p class="eyebrow">Radon / Performance audit / Portfolio</p>
+        <h1>Page load waits on live sync.</h1>
+        <p class="dek">The deterioration is reproducible. A cold tab starts the cached portfolio GET, classifies the still-empty client state as a blackout, then launches a live IB sync POST. The POST invalidates the faster GET result, so positions wait for the slower producer path.</p>
+      </div>
+      <div class="audit-meta" aria-label="Audit metadata">
+        <div class="meta-row"><span>Audit date</span><strong>2026-08-25</strong></div>
+        <div class="meta-row"><span>Checkout</span><strong><code>88514b9b</code></strong></div>
+        <div class="meta-row"><span>Framework</span><strong>Next.js 16.2.9 / React 19.2</strong></div>
+        <div class="meta-row"><span>Method</span><strong>Production build, controlled browser trace, live read-only Turso plans</strong></div>
+      </div>
+    </header>
+
+    <nav class="jump-nav" aria-label="Report sections">
+      <a href="#verdict">Verdict</a>
+      <a href="#race">Cold-load race</a>
+      <a href="#findings">Findings</a>
+      <a href="#database">Database</a>
+      <a href="#bundle">Bundle</a>
+      <a href="#plan">Remediation</a>
+      <a href="#cache">Caching</a>
+      <a href="#measurement">Measurement</a>
+    </nav>
+
+    <section class="section" id="verdict">
+      <div class="verdict">
+        <div class="verdict-label">
+          <span class="device-label">P0<br>Regression</span>
+        </div>
+        <div class="verdict-body">
+          <h2>Commit <code>e0f508bd</code> on Aug 24 put live synchronization on the cold-load critical path.</h2>
+          <p>The reliability change correctly made a missing timestamp read as unknown instead of healthy. The shell cannot distinguish “initial GET still pending” from “backend has no usable snapshot,” so the recovery POST fires about 9 ms after the GET. <code>doSync()</code> advances <code>dataGenerationRef</code>, and <code>fetchPortfolio()</code> then discards the earlier generation at <code>lib/usePortfolio.ts:82</code>.</p>
+        </div>
+      </div>
+
+      <div class="metrics" aria-label="Key evidence">
+        <div class="metric"><span class="metric-value bad">3,476 ms</span><span class="metric-label">Rows visible in the controlled 3 s POST trace</span></div>
+        <div class="metric"><span class="metric-value signal">602 ms</span><span class="metric-label">Cached GET had already completed, then was ignored</span></div>
+        <div class="metric"><span class="metric-value warn">448 KB</span><span class="metric-label">Approximate brotli route JavaScript before auth resources</span></div>
+        <div class="metric"><span class="metric-value bad">2 scans</span><span class="metric-label">Journal-wide reads blocking the default portfolio payload</span></div>
+        <div class="metric"><span class="metric-value warn">21</span><span class="metric-label">Unrelated sidebar RSC prefetch requests observed cold</span></div>
+        <div class="metric"><span class="metric-value bad">11/min</span><span class="metric-label">Steady RTH Turso statements from one portfolio tab</span></div>
+      </div>
+    </section>
+
+    <section class="section" id="race">
+      <div class="section-head">
+        <div><span class="device-label">Trace 01</span><h2>The cached read loses the race by design.</h2></div>
+        <p>Controlled Playwright run against the production build. The GET delay was 455 ms; the POST delay was 3 s. The payload carried a current timestamp.</p>
+      </div>
+
+      <div class="race">
+        <div class="race-scale">
+          <div class="rail-label">Cached GET</div>
+          <div class="rail" aria-label="GET begins at 146 milliseconds and finishes at 602 milliseconds">
+            <div class="rail-bar get"><span class="rail-time">146 → 602 ms</span></div>
+          </div>
+        </div>
+        <div class="race-scale">
+          <div class="rail-label">Live sync POST</div>
+          <div class="rail" aria-label="POST begins at 155 milliseconds and finishes at 3158 milliseconds">
+            <div class="rail-bar post"><span class="rail-time">155 → 3,158 ms</span></div>
+            <div class="rail-marker" title="Rows visible at 3,476 ms"></div>
+          </div>
+        </div>
+        <div class="race-notes">
+          <div class="race-note"><strong>146 ms</strong><span>Mount effect starts <code>GET /api/portfolio</code>.</span></div>
+          <div class="race-note"><strong>155 ms</strong><span>Unknown state claims auto-sync and starts POST.</span></div>
+          <div class="race-note"><strong>602 ms</strong><span>GET returns, but generation mismatch rejects it.</span></div>
+          <div class="race-note"><strong>3,476 ms</strong><span>Rows render only after the delayed POST response.</span></div>
+        </div>
+      </div>
+
+      <div class="flow" style="margin-top:16px">
+        <div class="flow-node"><span class="device-label">01 / Mount</span><strong><code>lastSync = null</code></strong><p>The client has not received the cached snapshot yet.</p></div>
+        <div class="flow-node"><span class="device-label">02 / Classify</span><strong><code>unknown → isStale</code></strong><p><code>useSnapshotStaleness</code> treats missing data as untrusted.</p></div>
+        <div class="flow-node"><span class="device-label">03 / Supersede</span><strong><code>generation 0 → 1</code></strong><p>The producer POST advances the data generation before either request settles.</p></div>
+        <div class="flow-node"><span class="device-label">04 / Wait</span><strong>GET is ignored</strong><p>Useful content waits on live IB, bounded by 35 s upstream and 42 s in the browser.</p></div>
+      </div>
+    </section>
+
+    <section class="section" id="findings">
+      <div class="section-head">
+        <div><span class="device-label">Priority register</span><h2>Six changes account for most of the recoverable load cost.</h2></div>
+        <p>Priority reflects direct critical-path evidence, not a generic performance checklist.</p>
+      </div>
+
+      <div class="finding-grid">
+        <article class="finding primary">
+          <div class="priority-line"><span class="tag p0">P0</span><span class="finding-number mono">F-01 / Cold state</span></div>
+          <h3>Let the initial GET settle before blackout recovery can POST.</h3>
+          <p>Render a usable GET snapshot immediately. Only trigger producer recovery after the initial read finishes and proves missing or stale. If a background sync runs, it must not invalidate an already successful snapshot response.</p>
+          <ul>
+            <li>Regression: fast fresh GET plus delayed POST must paint GET data first.</li>
+            <li>Recovery: missing GET must still arm the producer sync.</li>
+            <li>Stale data: paint the stale snapshot with warning provenance while refresh runs.</li>
+          </ul>
+        </article>
+
+        <article class="finding">
+          <div class="priority-line"><span class="tag p0">P0</span><span class="finding-number mono">F-02 / API payload</span></div>
+          <h3>Remove orders-only entry-date maps from <code>/api/portfolio</code>.</h3>
+          <p>The default response waits for two journal-wide JSON scans after the indexed snapshot lookup. The portfolio UI does not read either map; only the executed-order share path does.</p>
+          <ul>
+            <li>Snapshot payload: 11,194 B.</li>
+            <li>Merged response: 25,565 B.</li>
+            <li>Move maps to an orders-only endpoint or an explicit include mode.</li>
+          </ul>
+        </article>
+
+        <article class="finding">
+          <div class="priority-line"><span class="tag p0">P0</span><span class="finding-number mono">F-03 / JavaScript</span></div>
+          <h3>Split the 4,193-line all-routes workspace module.</h3>
+          <p><code>WorkspaceSections</code> is one delayed chunk, but it statically imports portfolio, orders, scanner, regime, admin, workflow, profile, options, ticker, mobile, and performance code before switching at runtime.</p>
+          <ul>
+            <li>Dynamic chunk: 1,198,604 B raw / 248,220 B brotli.</li>
+            <li>Cold route JavaScript: approximately 448 KB brotli.</li>
+            <li>Create statically analyzable route-specific imports and a compressed budget.</li>
+          </ul>
+        </article>
+
+        <article class="finding">
+          <div class="priority-line"><span class="tag p1">P1</span><span class="finding-number mono">F-04 / Navigation</span></div>
+          <h3>Stop viewport prefetching the entire workstation during cold load.</h3>
+          <p>Visible sidebar links initiated 21 unrelated RSC requests across two waves while the current route was loading. Disable automatic prefetch for the fixed rail, then prefetch on focus or pointer intent.</p>
+        </article>
+
+        <article class="finding">
+          <div class="priority-line"><span class="tag p1">P1</span><span class="finding-number mono">F-05 / Data boundary</span></div>
+          <h3>Start the snapshot on the server, not after hydration.</h3>
+          <p><code>app/portfolio/page.tsx</code> renders only the client shell. The first portfolio read began around 136 to 146 ms after navigation in local production traces. A dynamic Server Component boundary can pass initial data into a narrow client surface, while no-store polling continues for updates.</p>
+        </article>
+
+        <article class="finding">
+          <div class="priority-line"><span class="tag p1">P1</span><span class="finding-number mono">F-06 / Background work</span></div>
+          <h3>Defer and deduplicate noncritical shell work.</h3>
+          <p>The cold shell starts profile, service health, flex token, orders, relay health, two sockets, optional quote fallbacks, and up to three identical risk-free-rate requests. Keep the portfolio snapshot first.</p>
+          <ul>
+            <li>Use one client in-flight cache/provider for the daily risk-free scalar.</li>
+            <li>Defer footer detail and closed overlays until after primary paint.</li>
+            <li>Route-scope quote subjects; share one relay connection manager.</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section class="section" id="database">
+      <div class="section-head">
+        <div><span class="device-label">Query path</span><h2>The indexed snapshot is followed by avoidable full scans.</h2></div>
+        <p>Read-only measurements used the configured production Turso database. Timings include the audit client path, not VPS request TTFB.</p>
+      </div>
+
+      <div class="db-grid">
+        <div class="panel">
+          <div class="panel-head"><span class="device-label">Critical response</span><span class="tag p0">3 statements</span></div>
+          <div class="panel-body">
+            <div class="flow" style="grid-template-columns:1fr">
+              <div class="flow-node"><span class="device-label">Q1</span><strong>Latest snapshot</strong><p class="index">Primary-key index; 1 row; 24.5 to 112.4 ms in five direct-source samples.</p></div>
+              <div class="flow-node"><span class="device-label">Q2 + Q3</span><strong>Entry-date maps</strong><p class="scan">Two full journal scans run in parallel, but only after Q1 and before JSON can return.</p></div>
+              <div class="flow-node"><span class="device-label">Response</span><strong>Snapshot + unused maps</strong><p>Raw response grows by roughly 14.4 KB before transport compression.</p></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-head"><span class="device-label">Production explain</span><span class="tag">1,601 journal rows</span></div>
+          <div class="table-wrap">
+            <table>
+              <thead><tr><th>Query</th><th>Plan</th><th>Rows</th><th>Five-run range</th><th>Use on portfolio</th></tr></thead>
+              <tbody>
+                <tr><td><strong>Q1 snapshot</strong></td><td class="index">PK index</td><td>1</td><td>24.5–112.4 ms</td><td>Required</td></tr>
+                <tr><td><strong>Q2 ticker dates</strong></td><td class="scan">SCAN + temp B-tree</td><td>305</td><td>33.0–59.4 ms</td><td>Unused</td></tr>
+                <tr><td><strong>Q3 contract dates</strong></td><td class="scan">SCAN journal</td><td>1,184</td><td>49.6–141.4 ms</td><td>Unused</td></tr>
+                <tr><td><strong>Q4 open orders</strong></td><td class="scan">SCAN + sort</td><td>3</td><td>One 368.9 ms audit sample</td><td>Partial shell use</td></tr>
+                <tr><td><strong>Q5 executions</strong></td><td class="index">fill-time index</td><td>88</td><td>One 147.8 ms audit sample</td><td>Today P&amp;L only</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <div class="panel" style="margin-top:16px">
+        <div class="panel-head"><span class="device-label">RTH query cadence / one tab</span><span class="tag p1">11 statements per minute</span></div>
+        <div class="panel-body">
+          <div class="bar-list">
+            <div class="bar-row"><span class="bar-label">Portfolio poll</span><div class="bar-track"><div class="bar-fill bad" style="width:55%"></div></div><span class="bar-value mono">6 / min</span></div>
+            <div class="bar-row"><span class="bar-label">Orders poll</span><div class="bar-track"><div class="bar-fill warn" style="width:36%"></div></div><span class="bar-value mono">4 / min</span></div>
+            <div class="bar-row"><span class="bar-label">Service health</span><div class="bar-track"><div class="bar-fill" style="width:9%"></div></div><span class="bar-value mono">1 / min</span></div>
+          </div>
+          <p style="margin-top:18px;color:var(--muted);font-size:.84rem">The client polls portfolio and orders every 30 s. Current portfolio caches expire after 3 s and 10 s, so one steady tab misses every cache. The caches coalesce only nearly simultaneous tabs. Orders has no server single-flight cache and reads open plus executed orders serially.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="bundle">
+      <div class="section-head">
+        <div><span class="device-label">Client payload</span><h2>The route pays for code it does not render.</h2></div>
+        <p>File-level brotli measurements from the successful production build. External Clerk resources are excluded.</p>
+      </div>
+
+      <div class="panel">
+        <div class="panel-head"><span class="device-label">Cold compressed transfer budget</span><span class="tag p1">Before HTML + auth</span></div>
+        <div class="panel-body">
+          <div class="bar-list">
+            <div class="bar-row"><span class="bar-label">Route entry JS</span><div class="bar-track"><div class="bar-fill warn" style="width:40%"></div></div><span class="bar-value mono">200 KB</span></div>
+            <div class="bar-row"><span class="bar-label">WorkspaceSections JS</span><div class="bar-track"><div class="bar-fill bad" style="width:50%"></div></div><span class="bar-value mono">248 KB</span></div>
+            <div class="bar-row"><span class="bar-label">Route CSS</span><div class="bar-track"><div class="bar-fill" style="width:9%"></div></div><span class="bar-value mono">46 KB</span></div>
+            <div class="bar-row"><span class="bar-label">Fonts</span><div class="bar-track"><div class="bar-fill" style="width:51%"></div></div><span class="bar-value mono">256 KB</span></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="finding-grid" style="margin-top:16px">
+        <article class="finding">
+          <div class="priority-line"><span class="tag p1">Module graph</span></div>
+          <h3>One switch, every route implementation.</h3>
+          <p>The portfolio branch appears at <code>WorkspaceSections.tsx:4150</code>, after 69 static imports and thousands of lines of scanner, journal, orders, admin, options, regime, workflow, and ticker code have entered the same client chunk.</p>
+        </article>
+        <article class="finding">
+          <div class="priority-line"><span class="tag p2">Global CSS</span></div>
+          <h3>All workstation feature styles load from the root.</h3>
+          <p><code>globals.css</code> is about 503 KB of source and contributes roughly 45 KB brotli to every route. Keep tokens and shell primitives global; move feature rules into route-level CSS Modules after the section split.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section" id="plan">
+      <div class="section-head">
+        <div><span class="device-label">Implementation plan</span><h2>Fix the critical path before tuning the pool.</h2></div>
+        <p>Each stage has an observable acceptance check. No recommendation requires browser or CDN caching of portfolio state.</p>
+      </div>
+
+      <div class="plan" role="table" aria-label="Recommended implementation plan">
+        <div class="plan-row" role="row">
+          <div class="plan-cell step mono" role="cell">01</div>
+          <div class="plan-cell" role="cell"><strong>Initial read wins</strong><p>Gate auto-sync until GET settles; preserve blackout and stale-background-refresh behavior.</p></div>
+          <div class="plan-cell" role="cell"><strong>Impact</strong><p>Removes live IB from first paint.</p></div>
+          <div class="plan-cell" role="cell"><strong>Proof</strong><p>Delayed POST test paints GET first.</p></div>
+        </div>
+        <div class="plan-row" role="row">
+          <div class="plan-cell step mono" role="cell">02</div>
+          <div class="plan-cell" role="cell"><strong>Snapshot-only API</strong><p>Move entry-date maps to the orders share path; default GET issues exactly Q1.</p></div>
+          <div class="plan-cell" role="cell"><strong>Impact</strong><p>Removes two scans and ~14.4 KB.</p></div>
+          <div class="plan-cell" role="cell"><strong>Proof</strong><p>No <code>FROM journal</code> on base GET.</p></div>
+        </div>
+        <div class="plan-row" role="row">
+          <div class="plan-cell step mono" role="cell">03</div>
+          <div class="plan-cell" role="cell"><strong>Route-specific client chunks</strong><p>Extract portfolio and dynamically import every other workspace independently.</p></div>
+          <div class="plan-cell" role="cell"><strong>Impact</strong><p>Reduces parse, compile, and transfer.</p></div>
+          <div class="plan-cell" role="cell"><strong>Proof</strong><p>No omnibus chunk; compressed budget passes.</p></div>
+        </div>
+        <div class="plan-row" role="row">
+          <div class="plan-cell step mono" role="cell">04</div>
+          <div class="plan-cell" role="cell"><strong>Server initial data</strong><p>Call extracted snapshot access directly from the Server Component and seed the client store.</p></div>
+          <div class="plan-cell" role="cell"><strong>Impact</strong><p>Removes hydration-to-fetch waterfall.</p></div>
+          <div class="plan-cell" role="cell"><strong>Proof</strong><p>No redundant mount GET for seeded data.</p></div>
+        </div>
+        <div class="plan-row" role="row">
+          <div class="plan-cell step mono" role="cell">05</div>
+          <div class="plan-cell" role="cell"><strong>Quiet the shell</strong><p>Disable rail viewport prefetch; parallelize and 2 s single-flight orders; dedupe risk-free rate; defer telemetry.</p></div>
+          <div class="plan-cell" role="cell"><strong>Impact</strong><p>Fewer competing requests and DB reads.</p></div>
+          <div class="plan-cell" role="cell"><strong>Proof</strong><p>One GET; zero unrelated RSC prefetches.</p></div>
+        </div>
+        <div class="plan-row" role="row">
+          <div class="plan-cell step mono" role="cell">06</div>
+          <div class="plan-cell" role="cell"><strong>Batch sync journal reads</strong><p>Read all current option tickers once; verify any expression index with production EXPLAIN.</p></div>
+          <div class="plan-cell" role="cell"><strong>Impact</strong><p>Replaces up to 28 repeated statements.</p></div>
+          <div class="plan-cell" role="cell"><strong>Proof</strong><p>One bounded journal read per sync phase.</p></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="cache">
+      <div class="section-head">
+        <div><span class="device-label">Cache policy</span><h2>Coalesce work without making trading data stale.</h2></div>
+        <p>HTTP freshness and application-memory coalescing are separate decisions.</p>
+      </div>
+
+      <div class="cache-grid">
+        <article class="cache-card">
+          <h3><span class="tag safe">Keep</span> Live-data boundaries</h3>
+          <ul>
+            <li><code>/api/portfolio</code>, orders, watchlist, health, tickets, and realtime data remain <code>force-dynamic</code> where required and <code>no-store</code> in the client and response.</li>
+            <li>Service worker continues to bypass navigations, RSC data, <code>/api</code>, and <code>/ws</code>.</li>
+            <li>Static hashed JavaScript already sends one-year immutable caching.</li>
+            <li>Direct-to-cloud remains the default; do not reintroduce <code>data/replica.db</code>.</li>
+          </ul>
+        </article>
+        <article class="cache-card">
+          <h3><span class="tag p1">Add</span> Safe coalescing</h3>
+          <ul>
+            <li>Persist the last successful portfolio snapshot in a client provider or module store, paint it immediately, then no-store revalidate.</li>
+            <li>After removing entry maps, raise the server snapshot coalescing TTL from 3 s toward 15 s and measure.</li>
+            <li>Wrap the combined orders read in a 2 s single-flight cache, invalidated on order mutations.</li>
+            <li>Cache the daily risk-free scalar with bounded server revalidation and a client in-flight promise.</li>
+          </ul>
+        </article>
+      </div>
+
+      <div class="table-wrap panel" style="margin-top:16px">
+        <table>
+          <thead><tr><th>Surface</th><th>Current</th><th>Decision</th><th>Reason</th></tr></thead>
+          <tbody>
+            <tr><td><strong>Portfolio HTTP</strong></td><td>No-store</td><td class="index">Preserve</td><td>User-specific trading state must not enter browser or CDN caches.</td></tr>
+            <tr><td><strong>Portfolio DB read</strong></td><td>3 s TTL + single-flight</td><td class="index">15 s candidate after F-02</td><td>The writer runs every 60 s; measure freshness and order-risk constraints before changing.</td></tr>
+            <tr><td><strong>Entry-date maps</strong></td><td>10 s on every portfolio response</td><td class="index">Orders-only, revision or 60 s TTL</td><td>Day-granularity metadata is not a live mark.</td></tr>
+            <tr><td><strong>Orders DB read</strong></td><td>Two serial uncached reads</td><td class="index">Parallel + 2 s single-flight</td><td>Collapses simultaneous tabs while preserving operational recency.</td></tr>
+            <tr><td><strong>Risk-free rate</strong></td><td>Up to 3 client GETs; upstream no-store</td><td class="index">One client promise + 24 h server revalidation</td><td>Stable daily public scalar, not disk-backed live state.</td></tr>
+            <tr><td><strong>Static chunks</strong></td><td>One-year immutable</td><td class="index">Preserve</td><td>Reduce referenced assets, not their cache lifetime.</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="section" id="measurement">
+      <div class="section-head">
+        <div><span class="device-label">Measurement quality</span><h2>What was measured, and what still needs field data.</h2></div>
+        <p>The audit does not present local loopback paint times as production user experience.</p>
+      </div>
+
+      <div class="cwv-note">
+        <strong style="color:var(--white)">Core Web Vitals status:</strong> production p75 LCP, INP, and CLS are not instrumented. The local synthetic build produced FCP/LCP at 60 ms, which reflects the static shell rather than portfolio completion. Synthetic CLS was 0.110, just above the good threshold, with the main shift coming from the section replacement. Treat these as diagnostic signals only. Good field thresholds are LCP ≤ 2.5 s, INP ≤ 200 ms, and CLS ≤ 0.1.
+      </div>
+
+      <div class="table-wrap panel" style="margin-top:16px">
+        <table>
+          <thead><tr><th>Metric</th><th>Evidence</th><th>Rating</th><th>Next measurement</th></tr></thead>
+          <tbody>
+            <tr><td><strong>Portfolio content visible</strong></td><td>3,476 ms in controlled 3 s POST race</td><td class="scan">Reproduced blocker</td><td>Production field mark after first position row or confirmed empty state.</td></tr>
+            <tr><td><strong>LCP</strong></td><td>60 ms local shell only</td><td>Not representative</td><td>Route-tagged p75 desktop/mobile via <code>useReportWebVitals</code>.</td></tr>
+            <tr><td><strong>INP</strong></td><td>Not measured</td><td>Unknown</td><td>Field telemetry and interaction trace after quote updates.</td></tr>
+            <tr><td><strong>CLS</strong></td><td>0.110 local synthetic</td><td class="scan">Needs improvement signal</td><td>Reserve table/skeleton geometry; validate p75 field CLS.</td></tr>
+            <tr><td><strong>API server time</strong></td><td>Query plans and direct samples only</td><td>Partial</td><td>Add sanitized <code>Server-Timing</code> for auth, snapshot, entry maps, serialization.</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div style="margin-top:16px">
+        <details open>
+          <summary>Method and constraints</summary>
+          <div class="detail-body">
+            <ul>
+              <li>Built the current checkout with <code>next build --experimental-build-mode=compile</code> and served it with <code>next start</code>.</li>
+              <li>Used controlled API responses to isolate browser ordering, bundle loading, request initiation, and the GET/POST generation race.</li>
+              <li>Ran read-only production Turso queries and <code>EXPLAIN QUERY PLAN</code>; no IB actions or database writes were performed.</li>
+              <li>Chrome DevTools trace tooling was unavailable, so Playwright Performance APIs and build artifacts supplied the browser evidence.</li>
+              <li>Measurements from the development Mac include local topology and are not substituted for VPS TTFB or field p75 metrics.</li>
+            </ul>
+          </div>
+        </details>
+        <details>
+          <summary>Regression tests required with implementation</summary>
+          <div class="detail-body">
+            <ul>
+              <li>Fast fresh GET plus delayed POST: rows paint from GET; POST cannot invalidate them.</li>
+              <li>Missing GET: producer recovery still fires once under shared cooldown.</li>
+              <li>Base portfolio GET: exactly one snapshot query and no journal SQL.</li>
+              <li>Cold browser: one initial portfolio GET, no automatic POST for a fresh snapshot, zero unrelated RSC viewport prefetches.</li>
+              <li>Bundle contract: portfolio no longer references the omnibus workspace chunk and stays below an agreed compressed budget.</li>
+              <li>Orders coalescing: concurrent GETs share one parallel pair of statements; mutations invalidate the entry.</li>
+            </ul>
+          </div>
+        </details>
+      </div>
+    </section>
+
+    <section class="section" id="sources">
+      <div class="section-head">
+        <div><span class="device-label">Evidence and sources</span><h2>Primary references.</h2></div>
+        <p>Current framework and performance guidance was checked against official documentation.</p>
+      </div>
+
+      <ul class="sources">
+        <li><a href="portfolio-frontend-performance-audit.md">Frontend trace archive</a>: exact request inventory, bundle files, render path, and controlled race.</li>
+        <li><a href="portfolio-api-db-performance-audit.md">API and DB archive</a>: SQL inventory, production plans, timings, cache matrix, and sync N+1.</li>
+        <li><a href="portfolio-performance-best-practices.md">Best-practices archive</a>: official-source mapping to exact Radon files.</li>
+        <li><a href="https://nextjs.org/docs/app/guides/lazy-loading">Next.js lazy loading</a>: defer Client Components and libraries to reduce initial JavaScript.</li>
+        <li><a href="https://nextjs.org/docs/app/getting-started/server-and-client-components">Next.js Server and Client Components</a>: read near the data source and pass serializable initial data.</li>
+        <li><a href="https://nextjs.org/docs/app/getting-started/fetching-data">Next.js fetching data</a>: parallel work, streaming, and avoiding request waterfalls.</li>
+        <li><a href="https://nextjs.org/docs/app/getting-started/css">Next.js CSS</a>: keep global CSS global and colocate route/component styles.</li>
+        <li><a href="https://react.dev/reference/rsc/server-components">React Server Components</a>: client-effect fetching creates sequential client-server round trips.</li>
+        <li><a href="https://web.dev/articles/defining-core-web-vitals-thresholds">web.dev Core Web Vitals thresholds</a>: p75 LCP, INP, and CLS quality boundaries.</li>
+        <li><a href="https://vercel.com/docs/caching/cdn-cache">Vercel CDN cache</a>: do not CDN-cache authenticated or user-specific data.</li>
+        <li><a href="https://docs.turso.tech/help/usage-and-billing">Turso query inspection</a>: use query plans and measure rows scanned, not just rows returned.</li>
+        <li><a href="https://docs.turso.tech/sql-reference/statements/create-index">Turso CREATE INDEX</a>: expression indexes must match the actual predicate and plan.</li>
+      </ul>
+    </section>
+
+    <footer class="footer">
+      <span>Radon operator workstation / Portfolio page-load audit</span>
+      <span>Report-only task. Production code, database state, and IB state were not changed.</span>
+    </footer>
+  </main>
+</body>
+</html>

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -3662,7 +3662,7 @@ Per /indicator swarm (spec: docs/indicators/skew.md). Slug/service `skew`, tab S
 - [x] T5 Integrate and review the implementation.
 - [x] T6 Complete focused and full verification.
 - [x] T7 Complete browser and visual verification.
-- [ ] T8 Publish and verify the PR.
+- [x] T8 Publish and verify the PR.
 
 ## Review
 
@@ -3673,4 +3673,4 @@ Per /indicator swarm (spec: docs/indicators/skew.md). Slug/service `skew`, tab S
 - Verification: final web suite 7,085/7,085; affected Python 263/263; journal-sync 55/55; TypeScript, ESLint (0 errors, 14 baseline warnings), Python compilation, and Next compile passed. Full Python recorded 7,933 passed and 46 failed under the active Flex embargo; four touched-path failures were pagination-unaware fakes and were fixed/rerun green, leaving 42 unrelated Flex-lockout baseline failures.
 - Local output-trace audit remains baseline-red because the development checkout contains 14.2 GB across 7,333 backup/archive files traced by the existing orders/place route; production compile itself passed.
 
-- Pending.
+- PR: `#97` at commit `1e15b612`; replacement CI passed every build, security, Vitest, coverage, Python, perimeter, Playwright, Vercel preview, and app-image check.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -3609,3 +3609,68 @@ Per /indicator swarm (spec: docs/indicators/skew.md). Slug/service `skew`, tab S
 - [x] HHLEV (`/regime/hhlev`, service `hhlev`, migration 0057): Z.1 household liabilities as pct of net worth (TLBSHNO/TNWBSHNO via keyless fredgraph CSV; keyed API fallback). 304 quarters 1945Q4+; current 11.78% DELEVERAGED; 2009Q1 peak 24.26 — matches the JPM chart. Full-history re-upsert per run (Z.1 revisions).
 - Cross-cutting fixes: `scripts/utils/ipv4_first.py` (VPS IPv6 blackholes Yahoo/GitHub → 60s/request in urllib; wired into all three fetchers), midnight-safe `_TODAY` anchors in test_divyield/test_hyad (CI 00:0x UTC flake), HYAD strip merged to 5 cells (fixed 5-col grid).
 - Evidence: red suites (25+27+33 pytest, 5/5/16/17 vitest) → per-lane green → full gates 7,097 pytest + 1,012 cloud + 7,162 vitest + typecheck → live screenshots docs/indicators/{divyield,hyad,hhlev}-tab.png → Turso rows verified → CI + deploy per run links in git log.
+
+# Task: Portfolio page-load performance audit (2026-08-25)
+
+## Dependency graph
+
+- T1 depends_on: [] - Establish repository/runtime constraints, available profiling surfaces, and audit success criteria.
+- T2 depends_on: [T1] - Trace `/portfolio` client rendering, hooks, fetches, and request sequencing; identify waterfalls and bundle/render costs.
+- T3 depends_on: [T1] - Trace portfolio API handlers through FastAPI/data stores; inspect SQL, query plans, indexes, timeouts, and server-side cache behavior.
+- T4 depends_on: [T1] - Research current Next.js, React, Core Web Vitals, and HTTP/data caching guidance from primary sources; map only applicable practices.
+- T5 depends_on: [T1] - Profile the runnable application and capture navigation/resource timing, API latency, cache headers, and rendered-state evidence.
+- T6 depends_on: [T2, T3, T4, T5] - Synthesize evidence into a prioritized, browser-viewable HTML report with code-path and caching diagrams.
+- T7 depends_on: [T6] - Validate report links/content/visuals, open it in the in-app browser, and record review evidence.
+
+## Checklist
+
+- [x] T1 Establish constraints and audit plan.
+- [x] T2 Trace portfolio frontend and network paths.
+- [x] T3 Trace APIs, database queries, and server caching.
+- [x] T4 Research applicable current best practices.
+- [x] T5 Capture runtime/browser measurements.
+- [x] T6 Build the HTML report.
+- [x] T7 Verify and open the report.
+
+## Review
+
+- Root cause: commit `e0f508bd` made an unknown snapshot stale on first render, triggering a live-sync POST about 9 ms after the cached GET. The POST invalidates the GET result, so `/portfolio` waits for the 35-second live-IB path.
+- Database: the required snapshot lookup is indexed; two unused journal scans inflate the response by about 14.4 KB. `/api/orders` adds two serial uncached queries. Current short TTLs miss the 30-second polling cadence.
+- Frontend: the route loads about 448 KB Brotli JS, a 316,954-byte shared workspace chunk, about 46 KB CSS, and 21 unrelated route-prefetch requests.
+- Deliverable: `tasks/artifacts/show-me-portfolio-page-load-performance.html`, with detailed traces in the three adjacent audit artifacts.
+- Verification: production compile passed; focused portfolio cadence Playwright passed; report validated at 1440×1000 and 390×844 with zero horizontal overflow.
+
+# Task: Implement portfolio page-load performance plan (2026-08-25)
+
+## Dependency graph
+
+- T1 depends_on: [] - Isolate a feature branch from current `origin/main`, preserve unrelated worktree files, and confirm audited baselines.
+- T2 depends_on: [T1] - Add a failing cold-load regression and fix the initial portfolio GET/live-sync POST invalidation race without weakening stale-data recovery.
+- T3 depends_on: [T1] - Remove portfolio response queries unused by `/portfolio`, parallelize independent order queries, add bounded server-side single-flight caching with mutation-safe invalidation, and batch the live-sync journal basis reads.
+- T4 depends_on: [T1] - Seed `/portfolio` from a server snapshot, deduplicate risk-free-rate requests, suppress unsolicited route prefetch, and split the portfolio client bundle from the omnibus workspace chunk.
+- T5 depends_on: [T2, T3, T4] - Integrate the parallel workstreams, review correctness and cache contracts, and resolve any overlap with the smallest production diff.
+- T6 depends_on: [T5] - Run focused regressions, affected suites, typecheck, lint, production compile, and the full web test suite.
+- T7 depends_on: [T6] - Run authless Playwright portfolio E2E and visually verify desktop/mobile behavior with screenshots and request-timing evidence.
+- T8 depends_on: [T7] - Review staged scope, commit only task-owned paths, push the branch, create a draft PR, and verify GitHub CI status.
+
+## Checklist
+
+- [x] T1 Isolate branch and confirm baselines.
+- [x] T2 Fix cold-load synchronization race with regression coverage.
+- [x] T3 Optimize API/database query, cache, and live-sync basis paths with regressions.
+- [x] T4 Remove the hydration fetch waterfall and reduce startup/bundle/prefetch overhead with regressions.
+- [x] T5 Integrate and review the implementation.
+- [x] T6 Complete focused and full verification.
+- [x] T7 Complete browser and visual verification.
+- [ ] T8 Publish and verify the PR.
+
+## Review
+
+- Result: `/portfolio` now paints a cached/server-seeded snapshot before any stale recovery POST, with RSC seeding capped at 750 ms during a Turso outage.
+- API/database: the base portfolio GET performs one indexed snapshot statement instead of three statements and omits about 14.4 KB of orders-only entry-date metadata; orders statements run concurrently behind a mutation-safe 2-second single-flight cache; live journal basis reads collapse from one query per ticker/contract to 200-row `trade_id` cursor pages with exact legacy ordering.
+- Client: the portfolio surface no longer loads the 248.2 KB Brotli omnibus workspace chunk; its route chunk is 16.4 KB Brotli, a 93.4% reduction. Persistent navigation produces zero automatic RSC prefetches. Risk-free-rate consumers share one request and cache only confirmed non-stale FRED observations.
+- Browser: desktop cold-load cadence passed 4/4; manual desktop/mobile captures had zero horizontal overflow and zero unrelated RSC prefetches. Mobile rendered the card surface with no desktop table. The broader mobile spec was 4/5 with one pre-existing stale return-percentage fixture expecting a price-derived value while mocked live prices are absent.
+- Verification: final web suite 7,085/7,085; affected Python 263/263; journal-sync 55/55; TypeScript, ESLint (0 errors, 14 baseline warnings), Python compilation, and Next compile passed. Full Python recorded 7,933 passed and 46 failed under the active Flex embargo; four touched-path failures were pagination-unaware fakes and were fixed/rerun green, leaving 42 unrelated Flex-lockout baseline failures.
+- Local output-trace audit remains baseline-red because the development checkout contains 14.2 GB across 7,333 backup/archive files traced by the existing orders/place route; production compile itself passed.
+
+- Pending.

--- a/web/app/api/orders/cancel/route.ts
+++ b/web/app/api/orders/cancel/route.ts
@@ -10,6 +10,7 @@ import {
   EMPTY_ORDERS,
   readOrdersSnapshotFromDb,
 } from "@/lib/orders/readOrdersFromDb";
+import { invalidateOrdersSnapshotCache } from "@/lib/orders/ordersReadCache";
 import {
   isWorkingOrderMissingDetail,
   workingOrderMissingMessage,
@@ -72,10 +73,13 @@ export async function POST(request: Request): Promise<Response> {
     });
 
     // Refresh orders after cancel
+    invalidateOrdersSnapshotCache();
     try {
       await radonFetch("/orders/refresh", { method: "POST", timeout: 10_000 });
     } catch {
       // Non-fatal
+    } finally {
+      invalidateOrdersSnapshotCache();
     }
     const orders = await readOrdersSnapshotBestEffort();
 
@@ -85,12 +89,15 @@ export async function POST(request: Request): Promise<Response> {
       orders,
     });
   } catch (error) {
+    invalidateOrdersSnapshotCache();
     if (error instanceof RadonApiError) {
       if (isWorkingOrderMissingDetail(error.detail)) {
         try {
           await radonFetch("/orders/refresh", { method: "POST", timeout: 10_000 });
         } catch {
           // Non-fatal
+        } finally {
+          invalidateOrdersSnapshotCache();
         }
         const orders = await readOrdersSnapshotBestEffort();
         const tif = orders.open_orders.find((order) =>

--- a/web/app/api/orders/modify/route.ts
+++ b/web/app/api/orders/modify/route.ts
@@ -12,6 +12,7 @@ import {
   readOrdersSnapshotFromDb,
   type OrdersSnapshot,
 } from "@/lib/orders/readOrdersFromDb";
+import { invalidateOrdersSnapshotCache } from "@/lib/orders/ordersReadCache";
 import {
   isWorkingOrderMissingDetail,
   workingOrderMissingMessage,
@@ -213,10 +214,13 @@ export async function POST(request: Request): Promise<Response> {
         timeout: 180_000,
       });
 
+      invalidateOrdersSnapshotCache();
       try {
         await radonFetch("/orders/refresh", { method: "POST", timeout: 10_000 });
       } catch {
         // Non-fatal
+      } finally {
+        invalidateOrdersSnapshotCache();
       }
       const orders = await readOrdersSnapshotBestEffort();
 
@@ -267,10 +271,13 @@ export async function POST(request: Request): Promise<Response> {
     });
 
     // Refresh orders after modify
+    invalidateOrdersSnapshotCache();
     try {
       await radonFetch("/orders/refresh", { method: "POST", timeout: 10_000 });
     } catch {
       // Non-fatal
+    } finally {
+      invalidateOrdersSnapshotCache();
     }
     const orders = await readOrdersSnapshotFromDb();
 
@@ -290,12 +297,15 @@ export async function POST(request: Request): Promise<Response> {
       orders,
     });
   } catch (error) {
+    invalidateOrdersSnapshotCache();
     if (error instanceof RadonApiError) {
       if (isWorkingOrderMissingDetail(error.detail)) {
         try {
           await radonFetch("/orders/refresh", { method: "POST", timeout: 10_000 });
         } catch {
           // Non-fatal: still return the missing-order copy
+        } finally {
+          invalidateOrdersSnapshotCache();
         }
         const orders = await readOrdersSnapshotBestEffort();
         const tif = existingTif ?? findOpenOrder(orders, orderId, permId)?.tif;

--- a/web/app/api/orders/place/route.ts
+++ b/web/app/api/orders/place/route.ts
@@ -27,6 +27,7 @@ import {
   CLIENT_KEY_TTL_MS,
   IndeterminatePlacementError,
 } from "@/lib/orders/orderIdempotency";
+import { invalidateOrdersSnapshotCache } from "@/lib/orders/ordersReadCache";
 
 export const runtime = "nodejs";
 
@@ -193,6 +194,7 @@ export async function POST(request: Request): Promise<Response> {
           timeout: 30_000,
         },
       );
+      invalidateOrdersSnapshotCache();
       const orders = await readOrdersSnapshotBestEffort();
       return setNoStoreResponseHeaders(
         NextResponse.json({ ...paperResult, demo: true, paper: true, orders, requestId }),
@@ -394,6 +396,7 @@ export async function POST(request: Request): Promise<Response> {
         return result;
       });
     } catch (placeErr) {
+      invalidateOrdersSnapshotCache();
       if (placeErr instanceof OrderRejectedError) {
         const reason =
           placeErr.initialStatus === "Unknown"
@@ -431,10 +434,14 @@ export async function POST(request: Request): Promise<Response> {
     const orderResult = placement.value;
 
     // Refresh orders after placement
+    invalidateOrdersSnapshotCache();
     try {
       await radonFetch("/orders/refresh", { method: "POST", timeout: 10_000 });
     } catch {
       // Non-fatal — order was placed, refresh failed
+    } finally {
+      // A GET racing the refresh may have repopulated the old snapshot.
+      invalidateOrdersSnapshotCache();
     }
     const orders = await readOrdersSnapshotBestEffort();
 
@@ -452,6 +459,7 @@ export async function POST(request: Request): Promise<Response> {
     });
     return setNoStoreResponseHeaders(response, requestId);
   } catch (error) {
+    invalidateOrdersSnapshotCache();
     if (error instanceof RadonApiError) {
       return setNoStoreResponseHeaders(
         jsonApiError({

--- a/web/app/api/orders/route.ts
+++ b/web/app/api/orders/route.ts
@@ -2,6 +2,7 @@ import { requireRouteAccess } from "@/lib/routeAccess";
 import { NextResponse } from "next/server";
 import { radonFetch } from "@/lib/radonApi";
 import { readOrdersSnapshotFromDb } from "@/lib/orders/readOrdersFromDb";
+import { invalidateOrdersSnapshotCache } from "@/lib/orders/ordersReadCache";
 import { getRequestId, setNoStoreResponseHeaders } from "@/lib/apiContracts";
 
 export const runtime = "nodejs";
@@ -43,6 +44,7 @@ export async function POST(): Promise<Response> {
     }
     await syncInFlight;
   } catch {
+    invalidateOrdersSnapshotCache();
     let cached;
     try {
       cached = await readOrdersSnapshotFromDb();
@@ -70,6 +72,7 @@ export async function POST(): Promise<Response> {
     );
   }
 
+  invalidateOrdersSnapshotCache();
   try {
     const data = await readOrdersSnapshotFromDb();
     return setNoStoreResponseHeaders(NextResponse.json(data), requestId);

--- a/web/app/api/portfolio/route.ts
+++ b/web/app/api/portfolio/route.ts
@@ -8,12 +8,18 @@ import {
   setNoStoreResponseHeaders,
 } from "@/lib/apiContracts";
 import { dbExecute } from "@/lib/dbExecute";
-import { cachedRead, cachedReadResult } from "@/lib/dbCache";
 import { buildContractEntryDates, type JournalEntryRow } from "@/lib/entryDates";
 import {
-  isPortfolioSnapshotUnexpectedlyStale,
-  PORTFOLIO_SNAPSHOT_STALE_WARNING,
-} from "@/lib/portfolioSnapshotFreshness";
+  invalidatePortfolioReadCaches,
+  readCachedPortfolioContractOpenDates,
+  readCachedPortfolioTradeLogDates,
+} from "@/lib/portfolio/portfolioReadCache";
+import {
+  readPortfolioFromDb,
+  readPortfolioSnapshot,
+  type PortfolioSnapshot,
+  withoutPortfolioEntryDates,
+} from "@/lib/portfolio/readPortfolioSnapshot.server";
 
 // Disable Next.js static caching: this handler reads live Turso state.
 // Without this, the framework freezes the first response and serves stale
@@ -23,43 +29,6 @@ export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 const DB_READ_TIMEOUT_MS = 3_000;
-// Server-side coalescing of the polled GET reads. The snapshot is the hot one;
-// staleWhileError serves the last good portfolio through a brief Turso stall
-// without turning a browser read into an IB synchronization request.
-// Trade-log dates are day-granularity, so a longer TTL is invisible.
-const SNAPSHOT_CACHE_TTL_MS = 3_000;
-const SNAPSHOT_MAX_STALE_MS = 60_000;
-const TRADE_LOG_DATES_CACHE_TTL_MS = 10_000;
-
-type PortfolioSnapshot = {
-  data: Record<string, unknown>;
-  takenAt: string;
-  timestampMs: number | null;
-};
-
-function parseTimestampMs(value: unknown): number | null {
-  if (typeof value !== "string" || value.length === 0) return null;
-  const ms = Date.parse(value);
-  return Number.isFinite(ms) ? ms : null;
-}
-
-/** Read the latest portfolio snapshot from Turso. */
-async function readPortfolioFromDb(): Promise<PortfolioSnapshot | null> {
-  const result = await dbExecute({
-    sql: `SELECT taken_at, payload FROM portfolio_snapshots ORDER BY taken_at DESC LIMIT 1`,
-    args: [],
-  }, { label: "portfolio snapshot", timeoutMs: DB_READ_TIMEOUT_MS });
-  if (result.rows.length === 0) return null;
-  const row = result.rows[0] as unknown as { taken_at?: string; payload?: string };
-  if (typeof row.payload !== "string") return null;
-  const data = JSON.parse(row.payload) as Record<string, unknown>;
-  const takenAt = typeof row.taken_at === "string" ? row.taken_at : "";
-  return {
-    data,
-    takenAt,
-    timestampMs: parseTimestampMs(data.last_sync) ?? parseTimestampMs(takenAt),
-  };
-}
 
 /** Load ticker → latest trade date.
  *
@@ -157,8 +126,8 @@ async function loadPortfolioEntryDates(): Promise<{
   contract_open_dates: Record<string, string>;
 }> {
   const [trade_log_dates, contract_open_dates] = await Promise.all([
-    cachedRead("portfolio:tradeLogDates", TRADE_LOG_DATES_CACHE_TTL_MS, loadTradeLogDates),
-    cachedRead("portfolio:contractOpenDates", TRADE_LOG_DATES_CACHE_TTL_MS, loadContractOpenDates),
+    readCachedPortfolioTradeLogDates(loadTradeLogDates),
+    readCachedPortfolioContractOpenDates(loadContractOpenDates),
   ]);
   return { trade_log_dates, contract_open_dates };
 }
@@ -166,9 +135,10 @@ async function loadPortfolioEntryDates(): Promise<{
 async function portfolioResponseFromSnapshot(
   snapshot: PortfolioSnapshot,
   requestId: string,
-  warning?: string,
+  warning: string | null,
+  includeEntryDates: boolean,
 ): Promise<Response> {
-  const entryDates = await loadPortfolioEntryDates();
+  const entryDates = includeEntryDates ? await loadPortfolioEntryDates() : {};
   const response = NextResponse.json({ ...snapshot.data, ...entryDates });
   if (warning) {
     response.headers.set("X-Sync-Warning", warning);
@@ -192,48 +162,25 @@ function unavailablePortfolioResponse(
   ));
 }
 
-export async function GET(): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "portfolio:route", limit: 20, windowMs: 60_000 } });
+export async function GET(request?: Request): Promise<Response> {
+  const access = await requireRouteAccess(request, { rate: { key: "portfolio:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
+  const includeEntryDates = request
+    ? new URL(request.url).searchParams.get("include") === "entry-dates"
+    : false;
   try {
-    const cachedSnapshot = await cachedReadResult(
-      "portfolio:snapshot",
-      SNAPSHOT_CACHE_TTL_MS,
-      readPortfolioFromDb,
-      { staleWhileError: true, maxStaleMs: SNAPSHOT_MAX_STALE_MS },
-    );
-    const snapshot = cachedSnapshot.value;
-    if (!snapshot) {
+    const read = await readPortfolioSnapshot();
+    if (!read) {
       return unavailablePortfolioResponse(requestId, "Portfolio snapshot unavailable");
     }
-    const warnings: string[] = [];
-    if (cachedSnapshot.staleWhileError) {
-      warnings.push("Turso read failed; serving last in-memory portfolio snapshot");
-    }
-    // Age relative to portfolio-sync schedule (RTH tight, weekend wide).
-    // Do not treat expected off-hours lag as LIVE DATA DEGRADED.
-    if (isPortfolioSnapshotUnexpectedlyStale(snapshot.timestampMs)) {
-      warnings.push(PORTFOLIO_SNAPSHOT_STALE_WARNING);
-    }
-    if (warnings.length > 0) {
-      return portfolioResponseFromSnapshot(
-        snapshot,
-        requestId,
-        warnings.join("; "),
-      );
-    }
-
-    return portfolioResponseFromSnapshot(snapshot, requestId);
+    return portfolioResponseFromSnapshot(
+      read.snapshot,
+      requestId,
+      read.warning,
+      includeEntryDates,
+    );
   } catch (error) {
-    // dbExecute has already invalidated a failed client operation. Retry once
-    // without turning a browser GET into live IB work.
-    try {
-      const retry = await readPortfolioFromDb();
-      if (retry) return portfolioResponseFromSnapshot(retry, requestId);
-    } catch {
-      // fall through to the explicit unavailable response below
-    }
     const message = error instanceof Error ? error.message : "Failed to read portfolio";
     return unavailablePortfolioResponse(requestId, `Turso portfolio read failed: ${message}`);
   }
@@ -249,10 +196,17 @@ export async function POST(): Promise<Response> {
   const requestId = getRequestId();
   try {
     const data = await radonFetch("/portfolio/sync", { method: "POST", timeout: 35_000 });
-    const entryDates = await loadPortfolioEntryDates();
-    const response = NextResponse.json({ ...data, ...entryDates });
+    // The sync can publish both a portfolio snapshot and new journal fills;
+    // do not merge its live response with pre-sync entry-date maps.
+    invalidatePortfolioReadCaches();
+    const response = NextResponse.json(
+      withoutPortfolioEntryDates(data),
+    );
     return setNoStoreResponseHeaders(response, requestId);
   } catch {
+    // The upstream can time out after publishing both snapshot and fills.
+    // Invalidate every derived read before resolving the indeterminate result.
+    invalidatePortfolioReadCaches();
     let snapshot: PortfolioSnapshot | null = null;
     try {
       snapshot = await readPortfolioFromDb();
@@ -270,8 +224,7 @@ export async function POST(): Promise<Response> {
     }
     if (snapshot) {
       console.warn("[Portfolio] Sync failed, serving latest Turso snapshot");
-      const entryDates = await loadPortfolioEntryDates();
-      const res = NextResponse.json({ ...snapshot.data, ...entryDates });
+      const res = NextResponse.json(snapshot.data);
       res.headers.set("X-Sync-Warning", "IB sync failed - serving latest Turso snapshot");
       return setNoStoreResponseHeaders(res, requestId);
     }

--- a/web/app/api/risk-free-rate/route.ts
+++ b/web/app/api/risk-free-rate/route.ts
@@ -5,7 +5,7 @@ import { NextResponse } from "next/server";
  * decimal (e.g. 0.0364 for 3.64%). FRED publishes a free CSV without
  * authentication. We pull the last 30 days and pick the latest non-stale row.
  *
- * Cached 24h via Next.js fetch revalidation. On any failure the route
+ * The public FRED read is cached for 24h via Next.js fetch revalidation. On any failure the route
  * returns rate=0 with `stale: true` so callers can fall back to a 0
  * risk-free rate without throwing.
  */
@@ -27,7 +27,7 @@ async function fetchLatestDff(): Promise<{ rate: number; asOf: string } | null> 
   const cosd = since.toISOString().slice(0, 10);
 
   const res = await fetch(`${FRED_DFF_URL}&cosd=${cosd}`, {
-    cache: "no-store",
+    next: { revalidate: REVALIDATE_SECONDS },
   });
   if (!res.ok) return null;
 

--- a/web/app/portfolio/page.tsx
+++ b/web/app/portfolio/page.tsx
@@ -1,5 +1,14 @@
 import WorkspaceShell from "@/components/WorkspaceShell";
+import { readPortfolioSnapshotSeed } from "@/lib/portfolio/readPortfolioSnapshot.server";
 
-export default function PortfolioPage() {
-  return <WorkspaceShell section="portfolio" />;
+export const dynamic = "force-dynamic";
+
+export default async function PortfolioPage() {
+  // Playwright owns /api/portfolio through browser route mocks. Avoid a direct
+  // RSC DB read in that explicit authless harness so production and test data
+  // sources cannot race each other.
+  const initialPortfolio = process.env.RADON_AUTHLESS_TEST === "1"
+    ? undefined
+    : await readPortfolioSnapshotSeed();
+  return <WorkspaceShell section="portfolio" initialPortfolio={initialPortfolio} />;
 }

--- a/web/components/PortfolioSections.tsx
+++ b/web/components/PortfolioSections.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import { CheckCircle2, Circle, TriangleAlert } from "lucide-react";
+import type { PortfolioData, PortfolioPosition } from "@/lib/types";
+import type { PriceData } from "@/lib/pricesProtocol";
+import { useColumnVisibility } from "@/lib/useColumnVisibility";
+import { useTableFilter } from "@/lib/useTableFilter";
+import { SECTION_TOOLTIPS } from "@/lib/sectionTooltips";
+import { ColumnsToggle, type ColumnsToggleEntry } from "./ColumnsToggle";
+import InfoTooltip from "./InfoTooltip";
+import PositionTable, {
+  POSITION_COLUMNS,
+  POSITION_COLUMN_DEFAULTS,
+  type PositionToggleableColumnKey,
+} from "./PositionTable";
+import TableSearch from "./TableSearch";
+
+export type PortfolioSectionsProps = {
+  portfolio: PortfolioData | null;
+  prices?: Record<string, PriceData>;
+};
+
+function positionColumnEntries(hasOptions: boolean, hasExpiry: boolean) {
+  let columns = POSITION_COLUMNS as readonly ColumnsToggleEntry<PositionToggleableColumnKey>[];
+  if (!hasOptions) {
+    columns = columns.filter((column) => column.key !== "implied" && column.key !== "implied_market_value");
+  }
+  if (!hasExpiry) {
+    columns = columns.filter((column) => column.key !== "expiry");
+  }
+  return columns;
+}
+
+/** Route-local surface so /portfolio does not download every workspace route. */
+export default function PortfolioSections({ portfolio, prices }: PortfolioSectionsProps) {
+  const positions = portfolio?.positions ?? [];
+  const definedPositions = positions.filter((p) => p.risk_profile === "defined");
+  const equityPositions = positions.filter((p) => p.risk_profile === "equity");
+  const undefinedPositions = positions.filter((p) => p.risk_profile === "undefined" || p.risk_profile === "complex");
+
+  const extractPositionSearchText = useCallback(
+    (p: PortfolioPosition) => `${p.ticker} ${p.structure} ${p.direction} ${p.expiry}`,
+    [],
+  );
+  const definedFilter = useTableFilter(definedPositions, extractPositionSearchText);
+  const undefinedFilter = useTableFilter(undefinedPositions, extractPositionSearchText);
+  const equityFilter = useTableFilter(equityPositions, extractPositionSearchText);
+
+  const definedCols = useColumnVisibility<PositionToggleableColumnKey>("positions-defined", POSITION_COLUMN_DEFAULTS);
+  const undefinedCols = useColumnVisibility<PositionToggleableColumnKey>("positions-undefined", POSITION_COLUMN_DEFAULTS);
+  const equityCols = useColumnVisibility<PositionToggleableColumnKey>("positions-equity", POSITION_COLUMN_DEFAULTS);
+
+  const definedHasOptions = useMemo(
+    () => definedFilter.filtered.some((p) => p.structure_type !== "Stock"),
+    [definedFilter.filtered],
+  );
+  const undefinedHasOptions = useMemo(
+    () => undefinedFilter.filtered.some((p) => p.structure_type !== "Stock"),
+    [undefinedFilter.filtered],
+  );
+  const equityHasOptions = useMemo(
+    () => equityFilter.filtered.some((p) => p.structure_type !== "Stock"),
+    [equityFilter.filtered],
+  );
+
+  const definedColEntries = useMemo(() => positionColumnEntries(definedHasOptions, true), [definedHasOptions]);
+  const undefinedColEntries = useMemo(() => positionColumnEntries(undefinedHasOptions, true), [undefinedHasOptions]);
+  const equityColEntries = useMemo(() => positionColumnEntries(equityHasOptions, false), [equityHasOptions]);
+
+  if (!portfolio) {
+    return (
+      <div className="section">
+        <div className="section-header">
+          <h2 className="section-title">
+            <Circle size={14} />
+            Portfolio
+            <InfoTooltip text={SECTION_TOOLTIPS["Defined Risk Positions"]} />
+          </h2>
+          <span className="pill neutral">LOADING</span>
+        </div>
+        <div className="section-body">
+          <div className="alert-item">Waiting for portfolio data...</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {definedPositions.length > 0 && (
+        <div className="section">
+          <div className="section-header">
+            <h2 className="section-title">
+              <CheckCircle2 size={14} />
+              Defined Risk Positions
+              <InfoTooltip text={SECTION_TOOLTIPS["Defined Risk Positions"]} />
+            </h2>
+            <div className="section-header-actions">
+              <ColumnsToggle<PositionToggleableColumnKey>
+                columns={definedColEntries}
+                visible={definedCols.visible}
+                onToggle={definedCols.toggle}
+                onReset={definedCols.reset}
+              />
+              <TableSearch
+                query={definedFilter.query}
+                setQuery={definedFilter.setQuery}
+                placeholder="Filter positions..."
+                resultCount={definedFilter.filtered.length}
+                totalCount={definedPositions.length}
+              />
+              <span className="pill defined">{definedPositions.length} POSITIONS</span>
+            </div>
+          </div>
+          <div className="section-body">
+            <PositionTable positions={definedFilter.filtered} showUnderlying={true} prices={prices} portfolio={portfolio} tableId="positions-defined" columnVisibility={definedCols.visible} />
+          </div>
+        </div>
+      )}
+
+      {undefinedPositions.length > 0 && (
+        <div className="section">
+          <div className="section-header">
+            <h2 className="section-title">
+              <TriangleAlert size={14} />
+              Undefined Risk Positions
+              <InfoTooltip text={SECTION_TOOLTIPS["Undefined Risk Positions"]} />
+            </h2>
+            <div className="section-header-actions">
+              <ColumnsToggle<PositionToggleableColumnKey>
+                columns={undefinedColEntries}
+                visible={undefinedCols.visible}
+                onToggle={undefinedCols.toggle}
+                onReset={undefinedCols.reset}
+              />
+              <TableSearch
+                query={undefinedFilter.query}
+                setQuery={undefinedFilter.setQuery}
+                placeholder="Filter positions..."
+                resultCount={undefinedFilter.filtered.length}
+                totalCount={undefinedPositions.length}
+              />
+              <span className="pill undefined">{undefinedPositions.length} POSITIONS</span>
+            </div>
+          </div>
+          <div className="section-body">
+            <PositionTable positions={undefinedFilter.filtered} showUnderlying={true} prices={prices} portfolio={portfolio} tableId="positions-undefined" columnVisibility={undefinedCols.visible} />
+          </div>
+        </div>
+      )}
+
+      {equityPositions.length > 0 && (
+        <div className="section">
+          <div className="section-header">
+            <h2 className="section-title">
+              <Circle size={14} />
+              Equity Positions
+              <InfoTooltip text={SECTION_TOOLTIPS["Equity Positions"]} />
+            </h2>
+            <div className="section-header-actions">
+              <ColumnsToggle<PositionToggleableColumnKey>
+                columns={equityColEntries}
+                visible={equityCols.visible}
+                onToggle={equityCols.toggle}
+                onReset={equityCols.reset}
+              />
+              <TableSearch
+                query={equityFilter.query}
+                setQuery={equityFilter.setQuery}
+                placeholder="Filter positions..."
+                resultCount={equityFilter.filtered.length}
+                totalCount={equityPositions.length}
+              />
+              <span className="pill neutral">{equityPositions.length} POSITIONS</span>
+            </div>
+          </div>
+          <div className="section-body">
+            <PositionTable positions={equityFilter.filtered} showExpiry={false} prices={prices} portfolio={portfolio} tableId="positions-equity" columnVisibility={equityCols.visible} />
+          </div>
+        </div>
+      )}
+
+      <div className="section">
+        <div className="report-meta">
+          Last Sync: {new Date(portfolio.last_sync).toLocaleString()} • Source: IB Gateway
+        </div>
+      </div>
+    </>
+  );
+}

--- a/web/components/Sidebar.tsx
+++ b/web/components/Sidebar.tsx
@@ -142,6 +142,7 @@ export default function Sidebar({ activeSection, actionTone }: SidebarProps) {
                       <Link
                         key={item.label}
                         href={item.href}
+                        prefetch={false}
                         className={item.route === activeSection ? "nav-item active" : "nav-item"}
                         aria-current={item.route === activeSection ? "page" : undefined}
                         aria-label={collapsed ? item.label : undefined}
@@ -177,6 +178,7 @@ export default function Sidebar({ activeSection, actionTone }: SidebarProps) {
 
       <Link
         href="/profile"
+        prefetch={false}
         className={`sidebar-user-card${profileActive ? " sidebar-user-card--active" : ""}`}
         aria-current={profileActive ? "page" : undefined}
         aria-label={collapsed ? "Profile" : undefined}

--- a/web/components/WorkspaceSections.tsx
+++ b/web/components/WorkspaceSections.tsx
@@ -105,11 +105,6 @@ import MobileJournalList from "./mobile/MobileJournalList";
 import SignalCard from "./mobile/SignalCard";
 import MobileFlowSparkline from "./mobile/MobileFlowSparkline";
 import { buildGroupedComboModifyTarget } from "@/lib/openOrderComboModify";
-import PositionTable, {
-  POSITION_COLUMNS,
-  POSITION_COLUMN_DEFAULTS,
-  type PositionToggleableColumnKey,
-} from "./PositionTable";
 import SpectralLoader from "./SpectralLoader";
 import CancelOrderDialog from "./CancelOrderDialog";
 import ModifyOrderModal from "./ModifyOrderModal";
@@ -1269,179 +1264,6 @@ function FlowSectionsBody() {
           {lastSync
             ? `Report Generated: ${new Date(lastSync).toLocaleString()} • Source: UW API • Dark Pool Lookback: 5 Trading Days • ${totalScanned} Positions Scanned`
             : "Awaiting initial flow analysis..."}
-        </div>
-      </div>
-    </>
-  );
-}
-
-/* ─── Portfolio sections ──────────────────────────────────── */
-
-function PortfolioSections({ portfolio, prices }: { portfolio: PortfolioData | null; prices?: Record<string, PriceData> }) {
-  const positions = portfolio?.positions ?? [];
-  const definedPositions = positions.filter((p) => p.risk_profile === "defined");
-  const equityPositions = positions.filter((p) => p.risk_profile === "equity");
-  const undefinedPositions = positions.filter((p) => p.risk_profile === "undefined" || p.risk_profile === "complex");
-
-  const extractPositionSearchText = useCallback(
-    (p: PortfolioPosition) => `${p.ticker} ${p.structure} ${p.direction} ${p.expiry}`,
-    [],
-  );
-  const definedFilter = useTableFilter(definedPositions, extractPositionSearchText);
-  const undefinedFilter = useTableFilter(undefinedPositions, extractPositionSearchText);
-  const equityFilter = useTableFilter(equityPositions, extractPositionSearchText);
-
-  // Column visibility per section. Each section gets its own localStorage
-  // bucket so toggling one doesn't affect the others. The toggle UI is
-  // rendered inside each section-header (left of TableSearch).
-  const definedCols = useColumnVisibility<PositionToggleableColumnKey>("positions-defined", POSITION_COLUMN_DEFAULTS);
-  const undefinedCols = useColumnVisibility<PositionToggleableColumnKey>("positions-undefined", POSITION_COLUMN_DEFAULTS);
-  const equityCols = useColumnVisibility<PositionToggleableColumnKey>("positions-equity", POSITION_COLUMN_DEFAULTS);
-
-  const definedHasOptions = useMemo(
-    () => definedFilter.filtered.some((p) => p.structure_type !== "Stock"),
-    [definedFilter.filtered],
-  );
-  const undefinedHasOptions = useMemo(
-    () => undefinedFilter.filtered.some((p) => p.structure_type !== "Stock"),
-    [undefinedFilter.filtered],
-  );
-  const equityHasOptions = useMemo(
-    () => equityFilter.filtered.some((p) => p.structure_type !== "Stock"),
-    [equityFilter.filtered],
-  );
-
-  const filterEntries = (hasOptions: boolean, hasExpiry: boolean) => {
-    let cols = POSITION_COLUMNS as readonly ColumnsToggleEntry<PositionToggleableColumnKey>[];
-    if (!hasOptions) {
-      cols = cols.filter((c) => c.key !== "implied" && c.key !== "implied_market_value");
-    }
-    if (!hasExpiry) {
-      cols = cols.filter((c) => c.key !== "expiry");
-    }
-    return cols;
-  };
-  const definedColEntries = useMemo(() => filterEntries(definedHasOptions, true), [definedHasOptions]);
-  const undefinedColEntries = useMemo(() => filterEntries(undefinedHasOptions, true), [undefinedHasOptions]);
-  // Equity Positions section: stocks have no expiry, so omit the toggle entry.
-  const equityColEntries = useMemo(() => filterEntries(equityHasOptions, false), [equityHasOptions]);
-
-  if (!portfolio) {
-    return (
-      <div className="section">
-        <div className="section-header">
-          <h2 className="section-title">
-            <Circle size={14} />
-            Portfolio
-            <InfoTooltip text={SECTION_TOOLTIPS["Defined Risk Positions"]} />
-          </h2>
-          <span className="pill neutral">LOADING</span>
-        </div>
-        <div className="section-body">
-          <div className="alert-item">Waiting for portfolio data...</div>
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <>
-      {definedPositions.length > 0 && (
-        <div className="section">
-          <div className="section-header">
-            <h2 className="section-title">
-              <CheckCircle2 size={14} />
-              Defined Risk Positions
-              <InfoTooltip text={SECTION_TOOLTIPS["Defined Risk Positions"]} />
-            </h2>
-            <div className="section-header-actions">
-              <ColumnsToggle<PositionToggleableColumnKey>
-                columns={definedColEntries}
-                visible={definedCols.visible}
-                onToggle={definedCols.toggle}
-                onReset={definedCols.reset}
-              />
-              <TableSearch
-                query={definedFilter.query}
-                setQuery={definedFilter.setQuery}
-                placeholder="Filter positions..."
-                resultCount={definedFilter.filtered.length}
-                totalCount={definedPositions.length}
-              />
-              <span className="pill defined">{definedPositions.length} POSITIONS</span>
-            </div>
-          </div>
-          <div className="section-body">
-            <PositionTable positions={definedFilter.filtered} showUnderlying={true} prices={prices} portfolio={portfolio} tableId="positions-defined" columnVisibility={definedCols.visible} />
-          </div>
-        </div>
-      )}
-
-      {undefinedPositions.length > 0 && (
-        <div className="section">
-          <div className="section-header">
-            <h2 className="section-title">
-              <TriangleAlert size={14} />
-              Undefined Risk Positions
-              <InfoTooltip text={SECTION_TOOLTIPS["Undefined Risk Positions"]} />
-            </h2>
-            <div className="section-header-actions">
-              <ColumnsToggle<PositionToggleableColumnKey>
-                columns={undefinedColEntries}
-                visible={undefinedCols.visible}
-                onToggle={undefinedCols.toggle}
-                onReset={undefinedCols.reset}
-              />
-              <TableSearch
-                query={undefinedFilter.query}
-                setQuery={undefinedFilter.setQuery}
-                placeholder="Filter positions..."
-                resultCount={undefinedFilter.filtered.length}
-                totalCount={undefinedPositions.length}
-              />
-              <span className="pill undefined">{undefinedPositions.length} POSITIONS</span>
-            </div>
-          </div>
-          <div className="section-body">
-            <PositionTable positions={undefinedFilter.filtered} showUnderlying={true} prices={prices} portfolio={portfolio} tableId="positions-undefined" columnVisibility={undefinedCols.visible} />
-          </div>
-        </div>
-      )}
-
-      {equityPositions.length > 0 && (
-        <div className="section">
-          <div className="section-header">
-            <h2 className="section-title">
-              <Circle size={14} />
-              Equity Positions
-              <InfoTooltip text={SECTION_TOOLTIPS["Equity Positions"]} />
-            </h2>
-            <div className="section-header-actions">
-              <ColumnsToggle<PositionToggleableColumnKey>
-                columns={equityColEntries}
-                visible={equityCols.visible}
-                onToggle={equityCols.toggle}
-                onReset={equityCols.reset}
-              />
-              <TableSearch
-                query={equityFilter.query}
-                setQuery={equityFilter.setQuery}
-                placeholder="Filter positions..."
-                resultCount={equityFilter.filtered.length}
-                totalCount={equityPositions.length}
-              />
-              <span className="pill neutral">{equityPositions.length} POSITIONS</span>
-            </div>
-          </div>
-          <div className="section-body">
-            <PositionTable positions={equityFilter.filtered} showExpiry={false} prices={prices} portfolio={portfolio} tableId="positions-equity" columnVisibility={equityCols.visible} />
-          </div>
-        </div>
-      )}
-
-      <div className="section">
-        <div className="report-meta">
-          Last Sync: {new Date(portfolio.last_sync).toLocaleString()} • Source: IB Gateway
         </div>
       </div>
     </>
@@ -4148,7 +3970,10 @@ function WorkspaceSections({ section, portfolio, portfolioLastSync, orders, pric
     case "options":
       return <OptionsWorkspacePanel symbol={tickerParam} />;
     case "portfolio":
-      return <PortfolioSections portfolio={portfolio ?? null} prices={prices} />;
+      // WorkspaceShell owns the isolated portfolio chunk. Keeping the branch
+      // explicit makes this switch exhaustive without pulling that surface
+      // into every non-portfolio workspace bundle.
+      return null;
     case "performance":
       return <PerformancePanel portfolioLastSync={portfolioLastSync} marketState={marketState} />;
     case "orders":

--- a/web/components/WorkspaceShell.tsx
+++ b/web/components/WorkspaceShell.tsx
@@ -4,7 +4,7 @@ import dynamic from "next/dynamic";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePathname } from "next/navigation";
 import { RefreshCw } from "lucide-react";
-import type { OrdersData, WorkspaceSection } from "@/lib/types";
+import type { OrdersData, PortfolioSnapshotSeed, WorkspaceSection } from "@/lib/types";
 import { navItems } from "@/lib/data";
 import { resolveSectionFromPath } from "@/lib/chat";
 import { usePortfolio } from "@/lib/usePortfolio";
@@ -39,6 +39,9 @@ import InstrumentSkeleton from "@/components/ui/InstrumentSkeleton";
 const WorkspaceSections = dynamic(() => import("@/components/WorkspaceSections"), {
   loading: () => <InstrumentSkeleton testId="workspace-sections-skeleton" />,
 });
+const PortfolioSections = dynamic(() => import("@/components/PortfolioSections"), {
+  loading: () => <InstrumentSkeleton testId="portfolio-sections-skeleton" />,
+});
 import FooterTelemetryStrip from "@/components/FooterTelemetryStrip";
 import { useTickerDetail } from "@/lib/TickerDetailContext";
 import { assessMargin, rankOf, type MarginLevel } from "@/lib/marginWarning";
@@ -53,9 +56,10 @@ import CommandPalette from "@/components/CommandPalette";
 type WorkspaceShellProps = {
   section?: WorkspaceSection;
   tickerParam?: string;
+  initialPortfolio?: PortfolioSnapshotSeed;
 };
 
-export default function WorkspaceShell({ section, tickerParam }: WorkspaceShellProps) {
+export default function WorkspaceShell({ section, tickerParam, initialPortfolio }: WorkspaceShellProps) {
   const { theme: resolvedTheme, toggleTheme } = useTheme();
   const getRealtimeToken = useRealtimeAuth();
   const [isFullscreen, setIsFullscreen] = useState(false);
@@ -64,6 +68,7 @@ export default function WorkspaceShell({ section, tickerParam }: WorkspaceShellP
   const { isMobile, hasMounted } = useViewport();
   const showMobileChrome = isMobile && hasMounted;
   const activeSection: WorkspaceSection = section ?? resolveSectionFromPath(pathname, "dashboard");
+  const isOrdersPage = activeSection === "orders";
   const isOptionsWorkspace = activeSection === "options";
   const navLabel = navItems.find((item) => item.route === activeSection)?.label ?? "Dashboard";
   const activeLabel = activeSection === "ticker-detail" && tickerParam ? tickerParam : navLabel;
@@ -78,7 +83,17 @@ export default function WorkspaceShell({ section, tickerParam }: WorkspaceShellP
   // independent of the equities session above.
   const globexOpen = useGlobexOpen();
 
-  const { data: portfolio, syncing: portfolioSyncing, error: portfolioError, lastSync: portfolioLastSync, syncNow: portfolioSyncNow } = usePortfolio(isMarketActive);
+  const {
+    data: portfolio,
+    loading: portfolioLoading,
+    syncing: portfolioSyncing,
+    error: portfolioError,
+    lastSync: portfolioLastSync,
+    syncNow: portfolioSyncNow,
+  } = usePortfolio(isMarketActive, {
+    initialSnapshot: initialPortfolio,
+    includeEntryDates: isOrdersPage,
+  });
 
   const portfolioSymbols = useMemo(
     () => (portfolio?.positions ?? []).map((p) => p.ticker),
@@ -100,11 +115,18 @@ export default function WorkspaceShell({ section, tickerParam }: WorkspaceShellP
   // Bridge order-actions context → toasts & orders updater
   const { drainNotifications, setOrdersUpdater } = useOrderActions();
 
-  const isOrdersPage = activeSection === "orders";
   // Poll cached orders on the orders page (always), and elsewhere during market hours.
   const shouldAutoSyncOrders = isOrdersPage || isMarketActive;
   // Live IB refresh remains an explicit operator action; initial cached read always runs.
-  const { data: orders, syncing: ordersSyncing, error: ordersError, lastSync: ordersLastSync, syncNow: ordersSyncNow, updateData: updateOrdersData } = useOrders(shouldAutoSyncOrders);
+  const {
+    data: orders,
+    loading: ordersLoading,
+    syncing: ordersSyncing,
+    error: ordersError,
+    lastSync: ordersLastSync,
+    syncNow: ordersSyncNow,
+    updateData: updateOrdersData,
+  } = useOrders(shouldAutoSyncOrders);
 
   const orderSymbols = useMemo(
     () => (orders?.open_orders ?? []).map((o) => o.contract.symbol),
@@ -484,9 +506,17 @@ export default function WorkspaceShell({ section, tickerParam }: WorkspaceShellP
       ? "Sync failed. Reconstruction incomplete."
       : "No sample yet. Reconstruction unavailable.";
 
-  // A render that surfaces a stale snapshot triggers the producer sync
-  // itself — the stale pill's Sync button remains the manual fallback.
-  useAutoSyncOnStale(isStale, syncNow, syncTarget, !isDemoMode, stalenessTick);
+  // A null timestamp during the initial cached read is not yet evidence of a
+  // blackout. Let that GET paint first; a completed missing/stale snapshot
+  // still arms recovery, while explicit syncs retain generation protection.
+  const initialSnapshotSettled = isOrdersPage ? !ordersLoading : !portfolioLoading;
+  useAutoSyncOnStale(
+    isStale,
+    syncNow,
+    syncTarget,
+    !isDemoMode && initialSnapshotSettled,
+    stalenessTick,
+  );
 
   // Sections that render live marks from the prices map. Scanner/discover (and
   // other non-price modules) must not receive a new `prices` identity on every
@@ -560,7 +590,9 @@ export default function WorkspaceShell({ section, tickerParam }: WorkspaceShellP
 
           {activeSection !== "dashboard" && activeSection !== "ticker-detail" && activeSection !== "watchlist" && activeSection !== "admin" && activeSection !== "preferences" && activeSection !== "profile" && activeSection !== "alerts" && activeSection !== "workflow" && !isOptionsWorkspace ? <div className={isStale ? "metric-cards--stale" : undefined}><MetricCards portfolio={portfolio} prices={prices} realizedPnl={todayRealizedPnl} executedOrders={executedOrders} section={activeSection} /></div> : null}
 
-          {activeSection !== "dashboard" ? (
+          {activeSection === "portfolio" ? (
+            <PortfolioSections portfolio={portfolio} prices={pricesForSections} />
+          ) : activeSection !== "dashboard" ? (
             <WorkspaceSections
               section={activeSection}
               portfolio={portfolio}

--- a/web/components/mobile/MobileAppBar.tsx
+++ b/web/components/mobile/MobileAppBar.tsx
@@ -138,6 +138,7 @@ function MobileAppBarView({
           ) : null}
           <Link
             href="/profile"
+            prefetch={false}
             className={`mobile-app-bar__avatar tap-target${profileActive ? " mobile-app-bar__avatar--active" : ""}`}
             aria-label="Profile"
             data-testid="mobile-app-bar-profile"

--- a/web/components/mobile/MobileMoreDrawer.tsx
+++ b/web/components/mobile/MobileMoreDrawer.tsx
@@ -163,6 +163,7 @@ function MobileMoreDrawerView({
                     <Link
                       key={link.label}
                       href={link.href}
+                      prefetch={false}
                       className="mobile-drawer__link"
                       onClick={onClose}
                       data-testid={`mobile-drawer-${link.label.toLowerCase().replace(/\s+/g, "-")}`}

--- a/web/components/mobile/MobileTabBar.tsx
+++ b/web/components/mobile/MobileTabBar.tsx
@@ -60,6 +60,7 @@ export default function MobileTabBar({ onOpenMore }: MobileTabBarProps) {
           <Link
             key={tab.label}
             href={tab.href ?? "#"}
+            prefetch={false}
             className={className}
             data-testid={`mobile-tab-${tab.label.toLowerCase()}`}
           >

--- a/web/e2e/cash-flows-section.spec.ts
+++ b/web/e2e/cash-flows-section.spec.ts
@@ -71,7 +71,7 @@ const CASH_FLOWS = {
 
 async function setupMocks(page: Page) {
   await page.unrouteAll({ behavior: "ignoreErrors" });
-  await page.route("**/api/portfolio", (r) =>
+  await page.route("**/api/portfolio**", (r) =>
     r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(PORTFOLIO) }),
   );
   await page.route("**/api/orders", (r) =>

--- a/web/e2e/cash-flows-withdrawal-may8.spec.ts
+++ b/web/e2e/cash-flows-withdrawal-may8.spec.ts
@@ -61,7 +61,7 @@ const EMPTY_CASH_FLOWS = {
 
 async function setupBaseMocks(page: Page) {
   await page.unrouteAll({ behavior: "ignoreErrors" });
-  await page.route("**/api/portfolio", (r) =>
+  await page.route("**/api/portfolio**", (r) =>
     r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(PORTFOLIO) }),
   );
   await page.route("**/api/orders", (r) =>

--- a/web/e2e/fill-toast.spec.ts
+++ b/web/e2e/fill-toast.spec.ts
@@ -142,7 +142,7 @@ async function setupMocks(page: Page) {
       body: JSON.stringify(ordersPayload(executed)),
     });
   });
-  await page.route("**/api/portfolio", (route) =>
+  await page.route("**/api/portfolio**", (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",

--- a/web/e2e/header-fullscreen.spec.ts
+++ b/web/e2e/header-fullscreen.spec.ts
@@ -25,7 +25,7 @@ const ORDERS = {
 };
 
 async function stubRoutes(page: import("@playwright/test").Page) {
-  await page.route("**/api/portfolio", (route) =>
+  await page.route("**/api/portfolio**", (route) =>
     route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(PORTFOLIO) }),
   );
   await page.route("**/api/orders", (route) =>

--- a/web/e2e/historical-trades-filter.spec.ts
+++ b/web/e2e/historical-trades-filter.spec.ts
@@ -124,7 +124,7 @@ const BLOTTER_MOCK = {
 async function stubOrdersPage(page: import("@playwright/test").Page) {
   await page.unrouteAll({ behavior: "ignoreErrors" });
 
-  await page.route("**/api/portfolio", (route) =>
+  await page.route("**/api/portfolio**", (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",

--- a/web/e2e/mobile-blotter.spec.ts
+++ b/web/e2e/mobile-blotter.spec.ts
@@ -57,7 +57,7 @@ const BLOTTER_MOCK = {
 
 async function setupMocks(page: Page) {
   await page.unrouteAll({ behavior: "ignoreErrors" });
-  await page.route("**/api/portfolio", (route) =>
+  await page.route("**/api/portfolio**", (route) =>
     route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(PORTFOLIO_EMPTY) }),
   );
   await page.route("**/api/orders", (route) =>

--- a/web/e2e/mobile-executed-journal.spec.ts
+++ b/web/e2e/mobile-executed-journal.spec.ts
@@ -82,7 +82,7 @@ const JOURNAL = {
 
 async function setupBaseMocks(page: Page) {
   await page.unrouteAll({ behavior: "ignoreErrors" });
-  await page.route("**/api/portfolio", (route) =>
+  await page.route("**/api/portfolio**", (route) =>
     route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(PORTFOLIO) }),
   );
   await page.route("**/api/flex-token", (route) =>

--- a/web/e2e/mobile-orders.spec.ts
+++ b/web/e2e/mobile-orders.spec.ts
@@ -56,7 +56,7 @@ const ORDERS_MOCK = {
 
 async function setupMocks(page: Page) {
   await page.unrouteAll({ behavior: "ignoreErrors" });
-  await page.route("**/api/portfolio", (route) =>
+  await page.route("**/api/portfolio**", (route) =>
     route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(PORTFOLIO_EMPTY) }),
   );
   await page.route("**/api/orders", (route) =>

--- a/web/e2e/modify-combo-order.spec.ts
+++ b/web/e2e/modify-combo-order.spec.ts
@@ -300,7 +300,7 @@ async function installMockWebSocket(
 async function stubApis(page: import("@playwright/test").Page) {
   await page.unrouteAll({ behavior: "ignoreErrors" });
 
-  await page.route("**/api/portfolio", (route) =>
+  await page.route("**/api/portfolio**", (route) =>
     route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(PORTFOLIO) }),
   );
   await page.route("**/api/orders", (route) =>
@@ -435,7 +435,7 @@ test.describe("Combo order modify flow", () => {
       ],
     };
     await stubApis(page);
-    await page.route("**/api/portfolio", (route) =>
+    await page.route("**/api/portfolio**", (route) =>
       route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(portfolio) }),
     );
 
@@ -462,7 +462,7 @@ test.describe("Combo order modify flow", () => {
     await installMockWebSocket(page, MSFT_PRICE_FIXTURES);
     await page.unrouteAll({ behavior: "ignoreErrors" });
 
-    await page.route("**/api/portfolio", (route) =>
+    await page.route("**/api/portfolio**", (route) =>
       route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(MSFT_PORTFOLIO) }),
     );
     await page.route("**/api/orders", (route) =>

--- a/web/e2e/modify-order-confirmation.spec.ts
+++ b/web/e2e/modify-order-confirmation.spec.ts
@@ -92,7 +92,7 @@ const ORDERS = {
 async function stubApis(page: import("@playwright/test").Page) {
   await page.unrouteAll({ behavior: "ignoreErrors" });
 
-  await page.route("**/api/portfolio", (route) =>
+  await page.route("**/api/portfolio**", (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",

--- a/web/e2e/modify-order-correlation-risk.spec.ts
+++ b/web/e2e/modify-order-correlation-risk.spec.ts
@@ -62,7 +62,7 @@ async function stubApis(page: import("@playwright/test").Page) {
   await page.route("**/api/orders", (route) =>
     route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(ORDERS) }),
   );
-  await page.route("**/api/portfolio", (route) =>
+  await page.route("**/api/portfolio**", (route) =>
     route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(PORTFOLIO) }),
   );
   await page.route("**/api/regime", (route) =>

--- a/web/e2e/open-order-combo.spec.ts
+++ b/web/e2e/open-order-combo.spec.ts
@@ -87,7 +87,7 @@ const ORDERS_RISK_REVERSAL = {
 async function stubApis(page: import("@playwright/test").Page) {
   await page.unrouteAll({ behavior: "ignoreErrors" });
 
-  await page.route("**/api/portfolio", (route) => {
+  await page.route("**/api/portfolio**", (route) => {
     route.fulfill({
       status: 200,
       contentType: "application/json",

--- a/web/e2e/order-cancel-error-propagation.spec.ts
+++ b/web/e2e/order-cancel-error-propagation.spec.ts
@@ -105,7 +105,7 @@ test.afterAll(async () => {
 async function stubOrdersPageApis(page: import("@playwright/test").Page) {
   await page.unrouteAll({ behavior: "ignoreErrors" });
 
-  await page.route("**/api/portfolio", (route) => {
+  await page.route("**/api/portfolio**", (route) => {
     route.fulfill({
       status: 200,
       contentType: "application/json",

--- a/web/e2e/orders-empty-state.spec.ts
+++ b/web/e2e/orders-empty-state.spec.ts
@@ -49,7 +49,7 @@ const CASH_FLOWS_EMPTY = {
 
 async function setupEmptyMocks(page: Page) {
   await page.unrouteAll({ behavior: "ignoreErrors" });
-  await page.route("**/api/portfolio", (r) =>
+  await page.route("**/api/portfolio**", (r) =>
     r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(PORTFOLIO_EMPTY) }),
   );
   await page.route("**/api/orders", (r) =>

--- a/web/e2e/orders-historical-trades-refresh.spec.ts
+++ b/web/e2e/orders-historical-trades-refresh.spec.ts
@@ -93,7 +93,7 @@ const FRESH_BLOTTER = {
 async function stubOrdersPage(page: import("@playwright/test").Page) {
   await page.unrouteAll({ behavior: "ignoreErrors" });
 
-  await page.route("**/api/portfolio", (route) =>
+  await page.route("**/api/portfolio**", (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",

--- a/web/e2e/orders-historical-trades-today.spec.ts
+++ b/web/e2e/orders-historical-trades-today.spec.ts
@@ -89,7 +89,7 @@ const TODAY_BLOTTER = {
 async function stubOrdersPage(page: Page) {
   await page.unrouteAll({ behavior: "ignoreErrors" });
 
-  await page.route("**/api/portfolio", (route) =>
+  await page.route("**/api/portfolio**", (route) =>
     route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(PORTFOLIO_MOCK) }),
   );
   await page.route("**/api/orders", (route) =>

--- a/web/e2e/orders-partial-realized-pnl.spec.ts
+++ b/web/e2e/orders-partial-realized-pnl.spec.ts
@@ -83,7 +83,7 @@ const BLOTTER_MOCK = {
 async function stubOrdersPage(page: import("@playwright/test").Page) {
   await page.unrouteAll({ behavior: "ignoreErrors" });
 
-  await page.route("**/api/portfolio", (route) =>
+  await page.route("**/api/portfolio**", (route) =>
     route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(PORTFOLIO_MOCK) }),
   );
   await page.route("**/api/orders", (route) =>

--- a/web/e2e/orders-realized-pnl-portfolio-fallback.spec.ts
+++ b/web/e2e/orders-realized-pnl-portfolio-fallback.spec.ts
@@ -113,7 +113,7 @@ const ORDERS_BUY_TO_CLOSE_NO_REALIZED_PNL = {
 
 async function setup(page: Page) {
   await page.unrouteAll({ behavior: "ignoreErrors" });
-  await page.route("**/api/portfolio", (route) =>
+  await page.route("**/api/portfolio**", (route) =>
     route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(PORTFOLIO_WITH_SHORT_PUT) }),
   );
   await page.route("**/api/orders", (route) =>

--- a/web/e2e/orders-section-layout.spec.ts
+++ b/web/e2e/orders-section-layout.spec.ts
@@ -74,7 +74,7 @@ const BLOTTER = {
 
 async function setupMocks(page: Page) {
   await page.unrouteAll({ behavior: "ignoreErrors" });
-  await page.route("**/api/portfolio", (r) =>
+  await page.route("**/api/portfolio**", (r) =>
     r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(PORTFOLIO) }),
   );
   await page.route("**/api/orders", (r) =>

--- a/web/e2e/orders-ux-command-strip.spec.ts
+++ b/web/e2e/orders-ux-command-strip.spec.ts
@@ -49,7 +49,7 @@ function makeOpenOrder(overrides: Record<string, unknown> = {}) {
 
 async function stubOrdersPage(page: Page, orders: unknown) {
   await page.unrouteAll({ behavior: "ignoreErrors" });
-  await page.route("**/api/portfolio", (r) =>
+  await page.route("**/api/portfolio**", (r) =>
     r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(PORTFOLIO) }),
   );
   await page.route("**/api/orders**", (r) =>

--- a/web/e2e/portfolio-request-cadence.spec.ts
+++ b/web/e2e/portfolio-request-cadence.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "@playwright/test";
 
+// Fixed historical timestamps intentionally force stale-recovery behavior;
+// the fresh-snapshot case overrides last_sync at test runtime.
 const PORTFOLIO = {
   bankroll: 100_000,
   peak_value: 100_000,
@@ -35,6 +37,36 @@ const PORTFOLIO = {
     buying_power: 396_000,
     dividends: 0,
   },
+};
+
+const ORDERS = {
+  last_sync: "2026-08-13T20:00:00Z",
+  open_count: 1,
+  executed_count: 0,
+  executed_orders: [],
+  open_orders: [{
+    orderId: 1,
+    permId: 1001,
+    symbol: "AAPL",
+    contract: {
+      conId: 1,
+      symbol: "AAPL",
+      secType: "STK",
+      strike: null,
+      right: null,
+      expiry: null,
+    },
+    action: "BUY",
+    orderType: "LMT",
+    totalQuantity: 10,
+    limitPrice: 100,
+    auxPrice: null,
+    status: "Submitted",
+    filled: 0,
+    remaining: 10,
+    avgFillPrice: null,
+    tif: "DAY",
+  }],
 };
 
 test("portfolio shell owns one initial read and shares its symbols with the command palette", async ({ page }, testInfo) => {
@@ -99,4 +131,164 @@ test("portfolio shell owns one initial read and shares its symbols with the comm
     path: screenshotPath,
     contentType: "image/png",
   });
+});
+
+test("initial cached portfolio read paints before stale recovery can POST", async ({ page }) => {
+  test.setTimeout(90_000);
+  let releasePortfolioGet!: () => void;
+  const portfolioGetGate = new Promise<void>((resolve) => {
+    releasePortfolioGet = resolve;
+  });
+  let releasePortfolioPost!: () => void;
+  const portfolioPostGate = new Promise<void>((resolve) => {
+    releasePortfolioPost = resolve;
+  });
+  let portfolioGets = 0;
+  let portfolioPosts = 0;
+
+  await page.route("**/api/**", async (route) => {
+    const request = route.request();
+    const path = new URL(request.url()).pathname;
+    const payloads: Record<string, unknown> = {
+      "/api/orders": { open_orders: [], executed_orders: [], open_count: 0, executed_count: 0 },
+      "/api/watchlist": { watchlist: [] },
+      "/api/service-health": { services: [] },
+      "/api/profile": { username: "Operator", avatar_url: null },
+      "/api/alerts": { alerts: [] },
+      "/api/flex-token": { remaining: 240 },
+      "/api/previous-close": { closes: {} },
+    };
+
+    if (path === "/api/portfolio") {
+      if (request.method() === "POST") {
+        portfolioPosts += 1;
+        await portfolioPostGate;
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(PORTFOLIO),
+        });
+      }
+      portfolioGets += 1;
+      await portfolioGetGate;
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(PORTFOLIO),
+      });
+    }
+
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(payloads[path] ?? {}),
+    });
+  });
+
+  const navigation = page.goto("/portfolio", { waitUntil: "domcontentloaded" });
+  await expect.poll(() => portfolioGets).toBe(1);
+  await page.waitForTimeout(250);
+  expect(
+    portfolioPosts,
+    "unknown hook state while the initial GET is pending must not trigger recovery",
+  ).toBe(0);
+
+  releasePortfolioGet();
+  await navigation;
+  await expect.poll(() => portfolioPosts).toBe(1);
+  await expect(
+    page.getByText("AAPL", { exact: true }).first(),
+    "the cached snapshot must remain visible while live recovery is pending",
+  ).toBeVisible();
+  releasePortfolioPost();
+});
+
+test("fresh initial portfolio snapshot does not trigger recovery POST", async ({ page }) => {
+  let portfolioPosts = 0;
+  const freshPortfolio = { ...PORTFOLIO, last_sync: new Date().toISOString() };
+
+  await page.route("**/api/**", (route) => {
+    const request = route.request();
+    const path = new URL(request.url()).pathname;
+    if (path === "/api/portfolio") {
+      if (request.method() === "POST") portfolioPosts += 1;
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(freshPortfolio),
+      });
+    }
+    return route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+  });
+
+  await page.goto("/portfolio", { waitUntil: "domcontentloaded" });
+  await expect(page.getByText("AAPL", { exact: true }).first()).toBeVisible();
+  await page.waitForTimeout(500);
+  expect(portfolioPosts).toBe(0);
+});
+
+test("initial cached orders read paints before stale recovery can POST", async ({ page }) => {
+  test.setTimeout(90_000);
+  let releaseOrdersGet!: () => void;
+  const ordersGetGate = new Promise<void>((resolve) => {
+    releaseOrdersGet = resolve;
+  });
+  let releaseOrdersPost!: () => void;
+  const ordersPostGate = new Promise<void>((resolve) => {
+    releaseOrdersPost = resolve;
+  });
+  let ordersGets = 0;
+  let ordersPosts = 0;
+  let portfolioEntryDateGets = 0;
+
+  await page.route("**/api/**", async (route) => {
+    const request = route.request();
+    const path = new URL(request.url()).pathname;
+    if (path === "/api/orders") {
+      if (request.method() === "POST") {
+        ordersPosts += 1;
+        await ordersPostGate;
+      } else {
+        ordersGets += 1;
+        await ordersGetGate;
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(ORDERS),
+      });
+    }
+    if (path === "/api/portfolio") {
+      if (
+        request.method() === "GET"
+        && new URL(request.url()).searchParams.get("include") === "entry-dates"
+      ) {
+        portfolioEntryDateGets += 1;
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ...PORTFOLIO, last_sync: new Date().toISOString() }),
+      });
+    }
+    return route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+  });
+
+  const navigation = page.goto("/orders", { waitUntil: "domcontentloaded" });
+  await expect.poll(() => ordersGets).toBe(1);
+  await expect.poll(() => portfolioEntryDateGets).toBe(1);
+  await page.waitForTimeout(250);
+  expect(
+    ordersPosts,
+    "unknown hook state while the initial orders GET is pending must not trigger recovery",
+  ).toBe(0);
+
+  releaseOrdersGet();
+  await navigation;
+  await expect.poll(() => ordersPosts).toBe(1);
+  await expect(
+    page.getByTestId("orders-command-strip"),
+    "the cached orders snapshot must remain visible while live recovery is pending",
+  ).toBeVisible();
+  releaseOrdersPost();
 });

--- a/web/e2e/price-chart-theme.spec.ts
+++ b/web/e2e/price-chart-theme.spec.ts
@@ -65,7 +65,7 @@ const ORDERS = {
 
 /** Stub all API routes so the app renders without a live backend. */
 async function stubRoutes(page: import("@playwright/test").Page) {
-  await page.route("**/api/portfolio", (r) =>
+  await page.route("**/api/portfolio**", (r) =>
     r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(PORTFOLIO) }),
   );
   await page.route("**/api/orders", (r) =>

--- a/web/e2e/share-pnl.spec.ts
+++ b/web/e2e/share-pnl.spec.ts
@@ -351,7 +351,7 @@ async function stubOrdersShareApis(page: import("@playwright/test").Page) {
     };
   });
 
-  await page.route("**/api/portfolio", (route) =>
+  await page.route("**/api/portfolio**", (route) =>
     route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(PORTFOLIO_MOCK) }),
   );
   await page.route("**/api/orders", (route) =>

--- a/web/e2e/sync-fallback.spec.ts
+++ b/web/e2e/sync-fallback.spec.ts
@@ -122,7 +122,7 @@ async function setupSyncFallbackMocks(page: import("@playwright/test").Page) {
   await page.unrouteAll({ behavior: "ignoreErrors" });
 
   // Portfolio GET returns cached data; POST also returns cached data (simulating fallback)
-  await page.route("**/api/portfolio", (route) =>
+  await page.route("**/api/portfolio**", (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",

--- a/web/lib/orders/ordersReadCache.ts
+++ b/web/lib/orders/ordersReadCache.ts
@@ -1,0 +1,22 @@
+import { cachedRead, invalidateCache } from "@/lib/dbCache";
+
+/**
+ * Process-local coalescing for the polled Turso orders snapshot. HTTP caching
+ * remains disabled by the route; this only collapses nearly simultaneous tabs
+ * and duplicate shell reads against the same direct-to-cloud source.
+ */
+export const ORDERS_SNAPSHOT_CACHE_KEY = "orders:snapshot";
+export const ORDERS_SNAPSHOT_CACHE_TTL_MS = 2_000;
+
+export function readCachedOrdersSnapshot<T>(fetcher: () => Promise<T>): Promise<T> {
+  return cachedRead(
+    ORDERS_SNAPSHOT_CACHE_KEY,
+    ORDERS_SNAPSHOT_CACHE_TTL_MS,
+    fetcher,
+  );
+}
+
+/** Mutating order routes call this before reading back authoritative state. */
+export function invalidateOrdersSnapshotCache(): void {
+  invalidateCache(ORDERS_SNAPSHOT_CACHE_KEY);
+}

--- a/web/lib/orders/readOrdersFromDb.ts
+++ b/web/lib/orders/readOrdersFromDb.ts
@@ -9,6 +9,7 @@ import { withTimeout } from "@/lib/asyncTimeout";
 import type { OrdersData } from "@tools/schemas/ib-orders";
 import { filterExecutedToEtToday } from "@/lib/orders/executedToday";
 import { isPriorSessionDayOrder } from "@/lib/orders/workingOrders";
+import { readCachedOrdersSnapshot } from "@/lib/orders/ordersReadCache";
 
 export type OrdersSnapshot = Static<typeof OrdersData>;
 
@@ -59,26 +60,27 @@ export async function readOrdersFromDb(): Promise<OrdersSnapshot | null> {
     resetDb(syncIdentity);
   }
 
-  const openResult = await dbExecute(
-    {
-      sql: `SELECT payload, updated_at FROM open_orders ORDER BY updated_at DESC`,
-      args: [],
-    },
-    { timeoutMs: DB_READ_TIMEOUT_MS, label: "open orders" },
-  );
-
   const cutoff = new Date(
     Date.now() - EXECUTED_SQL_LOOKBACK_HOURS * 60 * 60 * 1000,
   ).toISOString();
-  const execResult = await dbExecute(
-    {
-      sql: `SELECT payload, fill_time FROM executed_orders
-            WHERE fill_time >= ?
-            ORDER BY fill_time DESC`,
-      args: [cutoff],
-    },
-    { timeoutMs: DB_READ_TIMEOUT_MS, label: "executed orders" },
-  );
+  const [openResult, execResult] = await Promise.all([
+    dbExecute(
+      {
+        sql: `SELECT payload, updated_at FROM open_orders ORDER BY updated_at DESC`,
+        args: [],
+      },
+      { timeoutMs: DB_READ_TIMEOUT_MS, label: "open orders" },
+    ),
+    dbExecute(
+      {
+        sql: `SELECT payload, fill_time FROM executed_orders
+              WHERE fill_time >= ?
+              ORDER BY fill_time DESC`,
+        args: [cutoff],
+      },
+      { timeoutMs: DB_READ_TIMEOUT_MS, label: "executed orders" },
+    ),
+  ]);
 
   const open: Open[] = [];
   let latestOpenSync = "";
@@ -117,5 +119,7 @@ export async function readOrdersFromDb(): Promise<OrdersSnapshot | null> {
 }
 
 export async function readOrdersSnapshotFromDb(): Promise<OrdersSnapshot> {
-  return (await readOrdersFromDb()) ?? EMPTY_ORDERS;
+  return readCachedOrdersSnapshot(
+    async () => (await readOrdersFromDb()) ?? EMPTY_ORDERS,
+  );
 }

--- a/web/lib/portfolio/portfolioReadCache.ts
+++ b/web/lib/portfolio/portfolioReadCache.ts
@@ -1,0 +1,62 @@
+import {
+  cachedRead,
+  cachedReadResult,
+  invalidateCache,
+  type CachedReadOpts,
+  type CachedReadResult,
+} from "@/lib/dbCache";
+
+export const PORTFOLIO_SNAPSHOT_CACHE_KEY = "portfolio:snapshot";
+export const PORTFOLIO_TRADE_LOG_DATES_CACHE_KEY = "portfolio:tradeLogDates";
+export const PORTFOLIO_CONTRACT_OPEN_DATES_CACHE_KEY = "portfolio:contractOpenDates";
+
+// Browser polling is 30 seconds. A 15-second bound coalesces overlapping tabs
+// without hiding a newly published 60-second writer snapshot for a full poll.
+export const PORTFOLIO_SNAPSHOT_CACHE_TTL_MS = 15_000;
+// Entry dates have day granularity and currently support the /orders share
+// card. Keep them warm across two browser poll intervals while that consumer
+// is separated from the default /portfolio payload.
+export const PORTFOLIO_ENTRY_DATES_CACHE_TTL_MS = 60_000;
+
+export function readCachedPortfolioSnapshot<T>(
+  fetcher: () => Promise<T>,
+  opts: CachedReadOpts = {},
+): Promise<CachedReadResult<T>> {
+  return cachedReadResult(
+    PORTFOLIO_SNAPSHOT_CACHE_KEY,
+    PORTFOLIO_SNAPSHOT_CACHE_TTL_MS,
+    fetcher,
+    opts,
+  );
+}
+
+export function readCachedPortfolioTradeLogDates<T>(
+  fetcher: () => Promise<T>,
+): Promise<T> {
+  return cachedRead(
+    PORTFOLIO_TRADE_LOG_DATES_CACHE_KEY,
+    PORTFOLIO_ENTRY_DATES_CACHE_TTL_MS,
+    fetcher,
+  );
+}
+
+export function readCachedPortfolioContractOpenDates<T>(
+  fetcher: () => Promise<T>,
+): Promise<T> {
+  return cachedRead(
+    PORTFOLIO_CONTRACT_OPEN_DATES_CACHE_KEY,
+    PORTFOLIO_ENTRY_DATES_CACHE_TTL_MS,
+    fetcher,
+  );
+}
+
+export function invalidatePortfolioSnapshotCache(): void {
+  invalidateCache(PORTFOLIO_SNAPSHOT_CACHE_KEY);
+}
+
+/** A successful live sync can publish both a new snapshot and journal fills. */
+export function invalidatePortfolioReadCaches(): void {
+  invalidateCache(PORTFOLIO_SNAPSHOT_CACHE_KEY);
+  invalidateCache(PORTFOLIO_TRADE_LOG_DATES_CACHE_KEY);
+  invalidateCache(PORTFOLIO_CONTRACT_OPEN_DATES_CACHE_KEY);
+}

--- a/web/lib/portfolio/readPortfolioSnapshot.server.ts
+++ b/web/lib/portfolio/readPortfolioSnapshot.server.ts
@@ -1,0 +1,117 @@
+import { dbExecute } from "@/lib/dbExecute";
+import { withTimeout } from "@/lib/asyncTimeout";
+import type { PortfolioData, PortfolioSnapshotSeed } from "@/lib/types";
+import { readCachedPortfolioSnapshot } from "@/lib/portfolio/portfolioReadCache";
+import {
+  isPortfolioSnapshotUnexpectedlyStale,
+  PORTFOLIO_SNAPSHOT_STALE_WARNING,
+} from "@/lib/portfolioSnapshotFreshness";
+
+const DB_READ_TIMEOUT_MS = 3_000;
+const SNAPSHOT_MAX_STALE_MS = 60_000;
+const TURSO_STALE_WARNING = "Turso read failed; serving last in-memory portfolio snapshot";
+export const PORTFOLIO_SEED_TIMEOUT_MS = 750;
+
+export type PortfolioSnapshot = {
+  data: PortfolioData;
+  takenAt: string;
+  timestampMs: number | null;
+};
+
+export type PortfolioSnapshotRead = {
+  snapshot: PortfolioSnapshot;
+  warning: string | null;
+};
+
+export function withoutPortfolioEntryDates<T>(data: T): T {
+  if (data == null || typeof data !== "object" || Array.isArray(data)) return data;
+  const snapshot = { ...data } as T & Record<string, unknown>;
+  delete snapshot.trade_log_dates;
+  delete snapshot.contract_open_dates;
+  return snapshot;
+}
+
+function parseTimestampMs(value: unknown): number | null {
+  if (typeof value !== "string" || value.length === 0) return null;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/** Direct-to-cloud read used by the API and the server-rendered portfolio page. */
+export async function readPortfolioFromDb(): Promise<PortfolioSnapshot | null> {
+  const result = await dbExecute({
+    sql: "SELECT taken_at, payload FROM portfolio_snapshots ORDER BY taken_at DESC LIMIT 1",
+    args: [],
+  }, { label: "portfolio snapshot", timeoutMs: DB_READ_TIMEOUT_MS });
+  if (result.rows.length === 0) return null;
+
+  const row = result.rows[0] as unknown as { taken_at?: string; payload?: string };
+  if (typeof row.payload !== "string") return null;
+  const data = withoutPortfolioEntryDates(JSON.parse(row.payload) as PortfolioData);
+  const takenAt = typeof row.taken_at === "string" ? row.taken_at : "";
+  return {
+    data,
+    takenAt,
+    timestampMs: parseTimestampMs(data.last_sync) ?? parseTimestampMs(takenAt),
+  };
+}
+
+function withFreshnessWarning(
+  snapshot: PortfolioSnapshot,
+  staleWhileError: boolean,
+): PortfolioSnapshotRead {
+  const warnings: string[] = [];
+  if (staleWhileError) warnings.push(TURSO_STALE_WARNING);
+  if (isPortfolioSnapshotUnexpectedlyStale(snapshot.timestampMs)) {
+    warnings.push(PORTFOLIO_SNAPSHOT_STALE_WARNING);
+  }
+  return { snapshot, warning: warnings.length > 0 ? warnings.join("; ") : null };
+}
+
+/**
+ * Shared cached snapshot accessor. It retries a failed direct read once and
+ * never initiates IB work, so it is safe in both a route handler and RSC.
+ */
+export async function readPortfolioSnapshot(): Promise<PortfolioSnapshotRead | null> {
+  try {
+    const cached = await readCachedPortfolioSnapshot(
+      readPortfolioFromDb,
+      { staleWhileError: true, maxStaleMs: SNAPSHOT_MAX_STALE_MS },
+    );
+    return cached.value
+      ? withFreshnessWarning(cached.value, cached.staleWhileError)
+      : null;
+  } catch (error) {
+    try {
+      const retry = await readPortfolioFromDb();
+      if (retry) return withFreshnessWarning(retry, false);
+    } catch {
+      // Preserve the first read's error and the API's existing status contract.
+    }
+    throw error;
+  }
+}
+
+/** Best-effort RSC seed. A miss leaves the client hook's existing GET path intact. */
+export async function readPortfolioSnapshotSeed(): Promise<PortfolioSnapshotSeed | undefined> {
+  try {
+    // Page TTFB must not inherit the API accessor's deliberate second 3s retry.
+    // Make one short cache/direct-read attempt; on a cold or wedged Turso pool,
+    // render the shell and let the client's bounded GET own recovery instead.
+    // Promise.race observes the underlying read if it rejects after this timeout,
+    // so a late transport failure cannot become an unhandled rejection.
+    const cached = await withTimeout(
+      readCachedPortfolioSnapshot(
+        readPortfolioFromDb,
+        { staleWhileError: true, maxStaleMs: SNAPSHOT_MAX_STALE_MS },
+      ),
+      PORTFOLIO_SEED_TIMEOUT_MS,
+      `portfolio RSC seed timed out after ${PORTFOLIO_SEED_TIMEOUT_MS}ms`,
+    );
+    if (!cached.value) return undefined;
+    const read = withFreshnessWarning(cached.value, cached.staleWhileError);
+    return { data: read.snapshot.data, warning: read.warning };
+  } catch {
+    return undefined;
+  }
+}

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -348,6 +348,12 @@ export type PortfolioData = {
   contract_open_dates?: Record<string, string>;
 };
 
+/** Serializable server-to-client seed for the portfolio hook. */
+export type PortfolioSnapshotSeed = {
+  data: PortfolioData;
+  warning: string | null;
+};
+
 export type PerformanceSeriesPoint = {
   date: string;
   equity: number;

--- a/web/lib/usePortfolio.ts
+++ b/web/lib/usePortfolio.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { PortfolioData } from "./types";
+import type { PortfolioData, PortfolioSnapshotSeed } from "./types";
 import { readOfflineMeta } from "./offline/offlineStatus";
 import {
   reportFetchFailure,
@@ -24,43 +24,70 @@ type UsePortfolioReturn = {
   syncNow: () => void;
 };
 
-export function usePortfolio(active: boolean = true): UsePortfolioReturn {
-  const [data, setData] = useState<PortfolioData | null>(null);
-  const [loading, setLoading] = useState(true);
+type UsePortfolioOptions = {
+  initialSnapshot?: PortfolioSnapshotSeed;
+  includeEntryDates?: boolean;
+};
+
+export function usePortfolio(
+  active: boolean = true,
+  options: UsePortfolioOptions = {},
+): UsePortfolioReturn {
+  const { initialSnapshot, includeEntryDates = false } = options;
+  const endpoint = includeEntryDates
+    ? "/api/portfolio?include=entry-dates"
+    : "/api/portfolio";
+  const [data, setData] = useState<PortfolioData | null>(() => initialSnapshot?.data ?? null);
+  const [loading, setLoading] = useState(() => initialSnapshot === undefined);
   const [syncing, setSyncing] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [lastSync, setLastSync] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(() => initialSnapshot?.warning ?? null);
+  const [lastSync, setLastSync] = useState<string | null>(() => initialSnapshot?.data.last_sync ?? null);
   const syncingRef = useRef(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pollCachedRef = useRef<() => Promise<void>>(async () => {});
-  const warningSnapshotRef = useRef<string | null>(null);
+  const warningSnapshotRef = useRef<string | null>(
+    initialSnapshot?.warning ? initialSnapshot.data.last_sync : null,
+  );
   const dataGenerationRef = useRef(0);
-  const readingRef = useRef(false);
+  const readingEndpointRef = useRef<string | null>(null);
+  const latestReadIdRef = useRef(0);
+  const currentEndpointRef = useRef(endpoint);
   const lastReadAtRef = useRef(0);
   const rateLimitedUntilRef = useRef(0);
-  const hasDataRef = useRef(false);
-  const initialLoadStartedRef = useRef(false);
+  const hasDataRef = useRef(initialSnapshot !== undefined);
+  const initialLoadStartedRef = useRef(initialSnapshot !== undefined);
   const previousActiveRef = useRef(active);
   const mountedRef = useRef(true);
   const activeRef = useRef(active);
   const routeKey = useRouteRefreshKey();
   const lastRouteKeyRef = useRef(routeKey);
+  const lastEndpointRef = useRef(endpoint);
   activeRef.current = active;
+  currentEndpointRef.current = endpoint;
 
   const fetchPortfolio = useCallback(async (): Promise<number | null> => {
     const pendingRateLimitMs = rateLimitedUntilRef.current - Date.now();
     if (pendingRateLimitMs > 0) return pendingRateLimitMs;
-    if (readingRef.current) return null;
-    readingRef.current = true;
+    // Deduplicate only an identical read. A route transition from the base
+    // snapshot to the /orders entry-date variant must start immediately even
+    // if the old endpoint is still resolving.
+    if (readingEndpointRef.current === endpoint) return null;
+    const readId = latestReadIdRef.current + 1;
+    latestReadIdRef.current = readId;
+    readingEndpointRef.current = endpoint;
     const generation = dataGenerationRef.current;
     let networkResolved = false;
     let retryDelayMs: number | null = null;
     try {
-      const res = await fetch("/api/portfolio", {
+      const res = await fetch(endpoint, {
         cache: "no-store",
         signal: AbortSignal.timeout(GET_FETCH_TIMEOUT_MS),
       });
       networkResolved = true;
+      if (
+        readId !== latestReadIdRef.current
+        || endpoint !== currentEndpointRef.current
+      ) return retryDelayMs;
       if (res.status === 429) {
         const retryAfterSeconds = Number(res.headers.get("Retry-After"));
         if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0) {
@@ -79,7 +106,12 @@ export function usePortfolio(active: boolean = true): UsePortfolioReturn {
       else reportFetchSuccess();
       if (!res.ok) throw new Error(`Failed to fetch portfolio (${res.status})`);
       const json = (await res.json()) as PortfolioData;
-      if (!mountedRef.current || generation !== dataGenerationRef.current) return retryDelayMs;
+      if (
+        !mountedRef.current
+        || readId !== latestReadIdRef.current
+        || endpoint !== currentEndpointRef.current
+        || generation !== dataGenerationRef.current
+      ) return retryDelayMs;
       hasDataRef.current = true;
       setData(json);
       setLastSync(json.last_sync);
@@ -93,17 +125,27 @@ export function usePortfolio(active: boolean = true): UsePortfolioReturn {
       rateLimitedUntilRef.current = 0;
       setError(null);
     } catch (err) {
-      if (!networkResolved) reportFetchFailure();
-      if (mountedRef.current && generation === dataGenerationRef.current) {
+      const isCurrentRead = readId === latestReadIdRef.current
+        && endpoint === currentEndpointRef.current;
+      if (!networkResolved && isCurrentRead) reportFetchFailure();
+      if (
+        mountedRef.current
+        && isCurrentRead
+        && generation === dataGenerationRef.current
+      ) {
         setError(err instanceof Error ? err.message : "Unknown error");
       }
     } finally {
-      readingRef.current = false;
-      lastReadAtRef.current = Date.now();
-      if (mountedRef.current) setLoading(false);
+      if (readId === latestReadIdRef.current) {
+        readingEndpointRef.current = null;
+        lastReadAtRef.current = Date.now();
+        if (mountedRef.current && endpoint === currentEndpointRef.current) {
+          setLoading(false);
+        }
+      }
     }
     return retryDelayMs;
-  }, []);
+  }, [endpoint]);
 
   const scheduleNext = useCallback((delay: number) => {
     if (!mountedRef.current || !activeRef.current) return;
@@ -145,7 +187,13 @@ export function usePortfolio(active: boolean = true): UsePortfolioReturn {
       if (!mountedRef.current || syncGeneration !== dataGenerationRef.current) return;
       dataGenerationRef.current += 1;
       hasDataRef.current = true;
-      setData(json);
+      setData((current) => includeEntryDates
+        ? {
+            ...json,
+            trade_log_dates: current?.trade_log_dates,
+            contract_open_dates: current?.contract_open_dates,
+          }
+        : json);
       setLastSync(json.last_sync);
       const warning = res.headers.get("X-Sync-Warning");
       if (warning) {
@@ -161,7 +209,7 @@ export function usePortfolio(active: boolean = true): UsePortfolioReturn {
       syncingRef.current = false;
       if (mountedRef.current) setSyncing(false);
     }
-  }, []);
+  }, [includeEntryDates]);
 
   const syncNow = useCallback(() => {
     void doSync();
@@ -184,6 +232,18 @@ export function usePortfolio(active: boolean = true): UsePortfolioReturn {
     });
   }, [fetchPortfolio, scheduleNext]);
 
+  // `WorkspaceShell` survives client navigation. The endpoint changes when
+  // entering or leaving /orders even if the hook instance does not remount;
+  // fetch that exact variant immediately and let the request-id guard discard
+  // any older base response still in flight.
+  useEffect(() => {
+    if (endpoint === lastEndpointRef.current) return;
+    lastEndpointRef.current = endpoint;
+    void fetchPortfolio().then((retryDelayMs) => {
+      if (retryDelayMs !== null && activeRef.current) scheduleNext(retryDelayMs);
+    });
+  }, [endpoint, fetchPortfolio, scheduleNext]);
+
   // Client navigations often keep this hook mounted (same shell instance).
   // The mount GET never re-runs, so without a pathname trigger the next
   // snapshot waits for the 30s poll — the latent delay on every route change.
@@ -204,7 +264,7 @@ export function usePortfolio(active: boolean = true): UsePortfolioReturn {
       timerRef.current = null;
     }
     if (active) {
-      const freshReadInFlight = readingRef.current;
+      const freshReadInFlight = readingEndpointRef.current !== null;
       const recentlyRead = Date.now() - lastReadAtRef.current < POLL_INTERVAL_MS;
       scheduleNext(becameActive && !freshReadInFlight && !recentlyRead ? 500 : POLL_INTERVAL_MS);
     }

--- a/web/lib/useRiskFreeRate.ts
+++ b/web/lib/useRiskFreeRate.ts
@@ -1,31 +1,84 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useSyncExternalStore } from "react";
+
+let cachedRate: number | null = null;
+let cachedAt = 0;
+let inFlight: Promise<void> | null = null;
+let storeGeneration = 0;
+const listeners = new Set<() => void>();
+const CLIENT_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getSnapshot() {
+  return cachedRate ?? 0;
+}
+
+function loadRiskFreeRate() {
+  const cacheIsFresh = cachedRate != null && Date.now() - cachedAt < CLIENT_CACHE_TTL_MS;
+  if (cacheIsFresh || inFlight) return inFlight;
+
+  const generation = storeGeneration;
+  let request: Promise<void>;
+  request = fetch("/api/risk-free-rate", { cache: "no-store" })
+    .then((response) => (response.ok ? response.json() : null))
+    .then((data: { rate?: number; source?: string; stale?: boolean } | null) => {
+      if (generation !== storeGeneration) return;
+      // The route deliberately answers transient FRED failures with a usable
+      // `rate: 0` fallback. That response is not a fresh observation: caching
+      // it for 24 hours would turn a brief upstream failure into a day of
+      // incorrect option inputs. Keep any last-good value and leave the cache
+      // expired so a later consumer can retry.
+      if (
+        !data
+        || data.source !== "FRED:DFF"
+        || data.stale !== false
+        || typeof data.rate !== "number"
+        || !Number.isFinite(data.rate)
+      ) return;
+      cachedRate = data.rate;
+      cachedAt = Date.now();
+      listeners.forEach((listener) => listener());
+    })
+    .catch(() => {
+      // Preserve a last-good value (or the initial 0). A later mount retries.
+    })
+    .finally(() => {
+      if (inFlight === request) inFlight = null;
+    });
+  inFlight = request;
+
+  return inFlight;
+}
+
+/** Test isolation seam for the module-level external store. */
+export function resetRiskFreeRateCacheForTests() {
+  storeGeneration += 1;
+  cachedRate = null;
+  cachedAt = 0;
+  inFlight = null;
+  listeners.clear();
+}
 
 /**
  * Latest effective Fed Funds rate (FRED:DFF) as a decimal — used as `r`
  * in Black-Scholes implied-value calculations. Returns 0 until the fetch
  * resolves, so consumers always have a usable number.
  *
- * Single fetch on mount; relies on the route's 24h revalidation for freshness.
+ * All mounted consumers share one no-store request and a bounded 24h client
+ * cache. An expired value remains renderable while one revalidation runs.
  */
 export function useRiskFreeRate(): number {
-  const [rate, setRate] = useState<number>(0);
+  const rate = useSyncExternalStore(subscribe, getSnapshot, () => 0);
 
   useEffect(() => {
-    let cancelled = false;
-    fetch("/api/risk-free-rate")
-      .then((r) => (r.ok ? r.json() : null))
-      .then((data: { rate?: number } | null) => {
-        if (cancelled || !data || typeof data.rate !== "number" || !Number.isFinite(data.rate)) return;
-        setRate(data.rate);
-      })
-      .catch(() => {
-        // silent — falls back to 0
-      });
-    return () => {
-      cancelled = true;
-    };
+    void loadRiskFreeRate();
   }, []);
 
   return rate;

--- a/web/tests/api-routes-no-cache-contract.test.ts
+++ b/web/tests/api-routes-no-cache-contract.test.ts
@@ -121,7 +121,7 @@ const DB_FIRST_ROUTES: { path: string; dbHelperPattern: RegExp }[] = [
   { path: "app/api/scanner/route.ts", dbHelperPattern: /readScannerFromDb\s*\(/ },
   { path: "app/api/flow-analysis/route.ts", dbHelperPattern: /readFlowAnalysisFromDb\s*\(/ },
   { path: "app/api/performance/route.ts", dbHelperPattern: /readPerformanceFromDb\s*\(/ },
-  { path: "app/api/portfolio/route.ts", dbHelperPattern: /readPortfolioFromDb\s*\(/ },
+  { path: "app/api/portfolio/route.ts", dbHelperPattern: /readPortfolioSnapshot\s*\(/ },
   { path: "app/api/journal/route.ts", dbHelperPattern: /readJournalFromDb\s*\(/ },
   // cash-flows reads via FastAPI proxy which queries Turso server-side
   { path: "app/api/cash-flows/route.ts", dbHelperPattern: /radonFetch\s*\(\s*[`"']\/cash-flows/ },
@@ -184,13 +184,13 @@ describe("Turso source-of-truth — orders routes must not read data/orders.json
 });
 
 describe("Turso source-of-truth — portfolio route must not read flat JSON", () => {
-  it("app/api/portfolio/route.ts reads portfolio and trade dates from Turso only", async () => {
+  it("app/api/portfolio/route.ts reads the snapshot and optional trade dates from Turso only", async () => {
     const src = await readFile(join(REPO_ROOT, "app/api/portfolio/route.ts"), "utf8");
     const stripped = src
       .replace(/\/\*[\s\S]*?\*\//g, "")
       .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
 
-    expect(stripped).toMatch(/readPortfolioFromDb\s*\(/);
+    expect(stripped).toMatch(/readPortfolioSnapshot\s*\(/);
     expect(stripped).toMatch(/FROM\s+journal/i);
     expect(stripped).not.toContain("data/portfolio.json");
     expect(stripped).not.toContain("data/trade_log.json");

--- a/web/tests/api-routes-smoke.test.ts
+++ b/web/tests/api-routes-smoke.test.ts
@@ -532,6 +532,10 @@ describe("GET /api/risk-free-rate", () => {
     const body = (await jsonOf(res)) as Record<string, unknown>;
     expect(body.rate).toBeCloseTo(0.0435, 4);
     expect(body.source).toBe("FRED:DFF");
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("fredgraph.csv?id=DFF"),
+      { next: { revalidate: 86_400 } },
+    );
   });
 
   it("returns 200 with stale fallback when FRED is unreachable", async () => {

--- a/web/tests/ib-sync-cached-polling.test.tsx
+++ b/web/tests/ib-sync-cached-polling.test.tsx
@@ -90,6 +90,102 @@ describe("cached polling does not amplify IB live sync", () => {
     second.unmount();
   });
 
+  it("paints a server-seeded portfolio synchronously and starts no-store polling after 30 seconds", async () => {
+    const refreshed = { ...portfolio, bankroll: 101_000 };
+    const fetchMock = vi.fn().mockResolvedValue(response(refreshed));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const hook = renderHook(() => usePortfolio(true, {
+      initialSnapshot: {
+        data: portfolio,
+        warning: "Turso read failed; serving last in-memory portfolio snapshot",
+      },
+    }));
+
+    expect(hook.result.current.loading).toBe(false);
+    expect(hook.result.current.data).toEqual(portfolio);
+    expect(hook.result.current.error).toContain("Turso read failed");
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(29_999);
+      await Promise.resolve();
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/portfolio",
+      expect.objectContaining({ cache: "no-store" }),
+    );
+    expect(hook.result.current.data?.bankroll).toBe(101_000);
+    hook.unmount();
+  });
+
+  it("requests entry-date enrichment only when explicitly enabled", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(response(portfolio));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const hook = renderHook(() => usePortfolio(false, { includeEntryDates: true }));
+    await flush();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/portfolio?include=entry-dates",
+      expect.objectContaining({ cache: "no-store" }),
+    );
+    hook.unmount();
+  });
+
+  it("starts an enriched read immediately and ignores a pending base response on endpoint change", async () => {
+    let resolveBase!: (value: Response) => void;
+    const baseResponse = new Promise<Response>((resolve) => {
+      resolveBase = resolve;
+    });
+    const enriched = {
+      ...portfolio,
+      bankroll: 102_000,
+      trade_log_dates: { AAPL: "2026-08-25" },
+      contract_open_dates: { "AAPL|20260918|C|250": "2026-08-25" },
+    };
+    const fetchMock = vi.fn((url: string) => url.includes("include=entry-dates")
+      ? Promise.resolve(response(enriched))
+      : baseResponse);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const hook = renderHook(
+      ({ includeEntryDates }: { includeEntryDates: boolean }) =>
+        usePortfolio(false, { includeEntryDates }),
+      { initialProps: { includeEntryDates: false } },
+    );
+    await flush();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/portfolio");
+
+    hook.rerender({ includeEntryDates: true });
+    await flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1][0]).toBe("/api/portfolio?include=entry-dates");
+    expect(hook.result.current.data?.bankroll).toBe(102_000);
+    expect(hook.result.current.data?.trade_log_dates).toEqual({ AAPL: "2026-08-25" });
+
+    resolveBase(response({ ...portfolio, bankroll: 99_000 }));
+    await flush();
+
+    expect(hook.result.current.data?.bankroll).toBe(102_000);
+    expect(hook.result.current.data?.contract_open_dates).toEqual({
+      "AAPL|20260918|C|250": "2026-08-25",
+    });
+    hook.unmount();
+  });
+
   it("two active orders hooks poll cached GET and never auto-POST", async () => {
     const fetchMock = vi.fn().mockResolvedValue(response(orders));
     vi.stubGlobal("fetch", fetchMock);

--- a/web/tests/orders-performance-cache.test.ts
+++ b/web/tests/orders-performance-cache.test.ts
@@ -1,0 +1,123 @@
+/**
+ * @vitest-environment node
+ *
+ * Regression contracts for the short in-process orders cache. The HTTP route
+ * remains force-dynamic/no-store; this cache only coalesces direct-cloud reads.
+ */
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { __clearDbCache } from "@/lib/dbCache";
+import {
+  ORDERS_SNAPSHOT_CACHE_TTL_MS,
+  invalidateOrdersSnapshotCache,
+  readCachedOrdersSnapshot,
+} from "@/lib/orders/ordersReadCache";
+import {
+  invalidatePortfolioReadCaches,
+  readCachedPortfolioContractOpenDates,
+  readCachedPortfolioSnapshot,
+  readCachedPortfolioTradeLogDates,
+} from "@/lib/portfolio/portfolioReadCache";
+
+const REPO_ROOT = join(__dirname, "..");
+
+beforeEach(() => {
+  process.env.RADON_DB_CACHE_FORCE = "1";
+  __clearDbCache();
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  delete process.env.RADON_DB_CACHE_FORCE;
+});
+
+describe("orders snapshot read cache", () => {
+  it("single-flights concurrent reads and retains the result for two seconds", async () => {
+    expect(ORDERS_SNAPSHOT_CACHE_TTL_MS).toBe(2_000);
+    let resolve!: (value: string) => void;
+    const fetcher = vi.fn(() => new Promise<string>((done) => { resolve = done; }));
+
+    const first = readCachedOrdersSnapshot(fetcher);
+    const concurrent = readCachedOrdersSnapshot(fetcher);
+    resolve("orders-v1");
+
+    await expect(first).resolves.toBe("orders-v1");
+    await expect(concurrent).resolves.toBe("orders-v1");
+    await expect(readCachedOrdersSnapshot(fetcher)).resolves.toBe("orders-v1");
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches after the TTL and immediately after explicit invalidation", async () => {
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce("orders-v1")
+      .mockResolvedValueOnce("orders-v2")
+      .mockResolvedValueOnce("orders-v3");
+
+    await expect(readCachedOrdersSnapshot(fetcher)).resolves.toBe("orders-v1");
+    vi.setSystemTime(ORDERS_SNAPSHOT_CACHE_TTL_MS + 1);
+    await expect(readCachedOrdersSnapshot(fetcher)).resolves.toBe("orders-v2");
+    invalidateOrdersSnapshotCache();
+    await expect(readCachedOrdersSnapshot(fetcher)).resolves.toBe("orders-v3");
+    expect(fetcher).toHaveBeenCalledTimes(3);
+  });
+});
+
+const MUTATING_ORDER_ROUTES = [
+  "app/api/orders/route.ts",
+  "app/api/orders/place/route.ts",
+  "app/api/orders/cancel/route.ts",
+  "app/api/orders/modify/route.ts",
+];
+
+describe("order mutation cache invalidation contract", () => {
+  it.each(MUTATING_ORDER_ROUTES)("%s explicitly invalidates the orders snapshot cache", async (path) => {
+    const source = await readFile(join(REPO_ROOT, path), "utf8");
+    expect(source).toContain("invalidateOrdersSnapshotCache");
+    expect(source).toMatch(/invalidateOrdersSnapshotCache\s*\(\s*\)/);
+    expect(source).toMatch(
+      /invalidateOrdersSnapshotCache\s*\(\s*\)[\s\S]*?readOrdersSnapshot(?:FromDb|BestEffort)\s*\(\s*\)/,
+    );
+  });
+});
+
+describe("portfolio read cache policy", () => {
+  it("uses the shared 15-second snapshot and 60-second entry-date bounds", async () => {
+    const source = await readFile(join(REPO_ROOT, "lib/portfolio/portfolioReadCache.ts"), "utf8");
+    expect(source).toMatch(/PORTFOLIO_SNAPSHOT_CACHE_TTL_MS\s*=\s*15_000/);
+    expect(source).toMatch(/PORTFOLIO_ENTRY_DATES_CACHE_TTL_MS\s*=\s*60_000/);
+  });
+
+  it("invalidates all portfolio read caches on the successful live-sync path", async () => {
+    const source = await readFile(join(REPO_ROOT, "app/api/portfolio/route.ts"), "utf8");
+    expect(source).toMatch(
+      /await\s+radonFetch\(\s*["']\/portfolio\/sync[\s\S]*?invalidatePortfolioReadCaches\s*\(\s*\)/,
+    );
+  });
+
+  it("invalidates snapshot and both entry-date caches after a successful sync", async () => {
+    const snapshot = vi.fn()
+      .mockResolvedValueOnce("snapshot-v1")
+      .mockResolvedValueOnce("snapshot-v2");
+    const tradeDates = vi.fn()
+      .mockResolvedValueOnce("trade-v1")
+      .mockResolvedValueOnce("trade-v2");
+    const contractDates = vi.fn()
+      .mockResolvedValueOnce("contract-v1")
+      .mockResolvedValueOnce("contract-v2");
+
+    await readCachedPortfolioSnapshot(snapshot);
+    await readCachedPortfolioTradeLogDates(tradeDates);
+    await readCachedPortfolioContractOpenDates(contractDates);
+    invalidatePortfolioReadCaches();
+
+    await expect(readCachedPortfolioSnapshot(snapshot)).resolves.toMatchObject({ value: "snapshot-v2" });
+    await expect(readCachedPortfolioTradeLogDates(tradeDates)).resolves.toBe("trade-v2");
+    await expect(readCachedPortfolioContractOpenDates(contractDates)).resolves.toBe("contract-v2");
+    expect(snapshot).toHaveBeenCalledTimes(2);
+    expect(tradeDates).toHaveBeenCalledTimes(2);
+    expect(contractDates).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/tests/orders-read-from-db.test.ts
+++ b/web/tests/orders-read-from-db.test.ts
@@ -64,6 +64,60 @@ const execPayload = (execId: string, time = todayFillIso) => ({
 });
 
 describe("readOrdersFromDb", () => {
+  it("starts the independent open and executed order queries concurrently", async () => {
+    let resolveOpen!: (value: { rows: MockRow[] }) => void;
+    let resolveExecuted!: (value: { rows: MockRow[] }) => void;
+    const execute = vi.fn().mockImplementation(({ sql }: { sql: string }) => {
+      if (/FROM\s+open_orders/i.test(sql)) {
+        return new Promise<{ rows: MockRow[] }>((resolve) => { resolveOpen = resolve; });
+      }
+      return new Promise<{ rows: MockRow[] }>((resolve) => { resolveExecuted = resolve; });
+    });
+    vi.doMock("@/lib/db", () => ({
+      getDb: () => ({ execute }),
+      syncDb: vi.fn().mockResolvedValue(undefined),
+      resetDb: vi.fn(),
+    }));
+
+    const { readOrdersFromDb } = await import("../lib/orders/readOrdersFromDb");
+    const pending = readOrdersFromDb();
+
+    await vi.waitFor(() => expect(execute).toHaveBeenCalledTimes(2));
+    resolveOpen({ rows: [] });
+    resolveExecuted({ rows: [] });
+    await expect(pending).resolves.toBeNull();
+  });
+
+  it("coalesces concurrent snapshot callers into one two-query DB read", async () => {
+    process.env.RADON_DB_CACHE_FORCE = "1";
+    const execute = vi.fn().mockResolvedValue({ rows: [] });
+    vi.doMock("@/lib/db", () => ({
+      getDb: () => ({ execute }),
+      syncDb: vi.fn().mockResolvedValue(undefined),
+      resetDb: vi.fn(),
+    }));
+
+    try {
+      const { __clearDbCache } = await import("../lib/dbCache");
+      const { readOrdersSnapshotFromDb } = await import("../lib/orders/readOrdersFromDb");
+      const { invalidateOrdersSnapshotCache } = await import("../lib/orders/ordersReadCache");
+      __clearDbCache();
+
+      await Promise.all([
+        readOrdersSnapshotFromDb(),
+        readOrdersSnapshotFromDb(),
+      ]);
+      await readOrdersSnapshotFromDb();
+      expect(execute).toHaveBeenCalledTimes(2);
+
+      invalidateOrdersSnapshotCache();
+      await readOrdersSnapshotFromDb();
+      expect(execute).toHaveBeenCalledTimes(4);
+    } finally {
+      delete process.env.RADON_DB_CACHE_FORCE;
+    }
+  });
+
   it("returns null when both tables are empty", async () => {
     mockGetDb([], []);
     const { readOrdersFromDb } = await import("../lib/orders/readOrdersFromDb");

--- a/web/tests/portfolio-auto-sync.test.ts
+++ b/web/tests/portfolio-auto-sync.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PORTFOLIO_SNAPSHOT_CACHE_TTL_MS } from "../lib/portfolio/portfolioReadCache";
 
 /**
  * Verifies that GET /api/portfolio is a read-only snapshot surface. Browser
@@ -124,6 +125,57 @@ describe("GET /api/portfolio — cache-only polling", () => {
     expect(mockRadonFetch).not.toHaveBeenCalled();
   });
 
+  it("keeps the API accessor's single direct-read retry", async () => {
+    const portfolio = makePortfolio("2026-07-10T20:00:00.000Z");
+    mockExecute
+      .mockRejectedValueOnce(new Error("first Turso read failed"))
+      .mockResolvedValueOnce({
+        rows: [{ taken_at: portfolio.last_sync, payload: JSON.stringify(portfolio) }],
+      });
+
+    const { GET } = await import("../app/api/portfolio/route");
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(mockExecute).toHaveBeenCalledTimes(2);
+    expect(mockRadonFetch).not.toHaveBeenCalled();
+  });
+
+  it("bounds the RSC seed to one short DB attempt and absorbs its late rejection", async () => {
+    vi.useFakeTimers();
+    let rejectDb!: (error: Error) => void;
+    mockExecute.mockReturnValue(new Promise((_resolve, reject) => {
+      rejectDb = reject;
+    }));
+    try {
+      const {
+        PORTFOLIO_SEED_TIMEOUT_MS,
+        readPortfolioSnapshotSeed,
+      } = await import("../lib/portfolio/readPortfolioSnapshot.server");
+      let settled = false;
+      const seed = readPortfolioSnapshotSeed().then((value) => {
+        settled = true;
+        return value;
+      });
+
+      await vi.advanceTimersByTimeAsync(PORTFOLIO_SEED_TIMEOUT_MS - 1);
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(seed).resolves.toBeUndefined();
+      expect(mockExecute).toHaveBeenCalledTimes(1);
+
+      // The direct read can reject after the page has already fallen back to
+      // the client GET. Its rejection must remain observed, not surface as an
+      // unhandled promise after the RSC response has completed.
+      rejectDb(new Error("late Turso rejection"));
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockExecute).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps repeated weekend GETs free of IB side effects", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-11T18:00:00.000Z"));
@@ -153,7 +205,7 @@ describe("GET /api/portfolio — cache-only polling", () => {
       const fresh = await GET();
       expect(fresh.headers.get("X-Sync-Warning")).toBeNull();
 
-      vi.advanceTimersByTime(3_001);
+      vi.advanceTimersByTime(PORTFOLIO_SNAPSHOT_CACHE_TTL_MS + 1);
       mockExecute.mockRejectedValue(new Error("turso down"));
       const degraded = await GET();
 

--- a/web/tests/portfolio-startup-performance-contract.test.ts
+++ b/web/tests/portfolio-startup-performance-contract.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const WEB = join(import.meta.dirname, "..");
+const source = (path: string) => readFileSync(join(WEB, path), "utf8");
+
+describe("portfolio startup performance contracts", () => {
+  it("disables automatic Next.js prefetch on persistent shell navigation", () => {
+    for (const path of [
+      "components/Sidebar.tsx",
+      "components/mobile/MobileAppBar.tsx",
+      "components/mobile/MobileMoreDrawer.tsx",
+      "components/mobile/MobileTabBar.tsx",
+    ]) {
+      const linkTags = source(path).match(/<Link\b[\s\S]*?>/g) ?? [];
+      expect(linkTags.length, `${path} should contain navigation links`).toBeGreaterThan(0);
+      for (const tag of linkTags) {
+        expect(tag, `${path} must opt each shell link out of viewport prefetch`).toContain("prefetch={false}");
+      }
+    }
+  });
+
+  it("loads the portfolio surface without the all-routes workspace chunk", () => {
+    const shell = source("components/WorkspaceShell.tsx");
+    const workspace = source("components/WorkspaceSections.tsx");
+
+    expect(shell).toContain('dynamic(() => import("@/components/PortfolioSections")');
+    expect(shell).toMatch(/activeSection === "portfolio"[\s\S]*<PortfolioSections/);
+    expect(workspace).not.toContain('from "./PortfolioSections"');
+    expect(workspace).toMatch(/case "portfolio":[\s\S]*return null;/);
+    expect(workspace).not.toContain("function PortfolioSections(");
+    expect(workspace).not.toContain('from "./PositionTable"');
+  });
+
+  it("seeds the portfolio page on the server and enriches entry dates only for orders", () => {
+    const page = source("app/portfolio/page.tsx");
+    const shell = source("components/WorkspaceShell.tsx");
+
+    expect(page).toContain('export const dynamic = "force-dynamic"');
+    expect(page).toContain("readPortfolioSnapshotSeed");
+    expect(page).not.toContain("fetch(");
+    expect(page).toContain('process.env.RADON_AUTHLESS_TEST === "1"');
+    expect(shell).toContain("initialSnapshot: initialPortfolio");
+    expect(shell).toContain("includeEntryDates: isOrdersPage");
+  });
+
+  it("keeps FRED freshness in a bounded server cache", () => {
+    expect(source("app/api/risk-free-rate/route.ts")).toContain(
+      "next: { revalidate: REVALIDATE_SECONDS }",
+    );
+  });
+});

--- a/web/tests/portfolio-trade-log-dates.test.ts
+++ b/web/tests/portfolio-trade-log-dates.test.ts
@@ -72,6 +72,44 @@ beforeEach(() => {
 });
 
 describe("GET /api/portfolio — trade_log_dates source", () => {
+  it("keeps the base portfolio read to one snapshot statement with no journal scan", async () => {
+    mockDb({
+      portfolio: {
+        ...makePortfolio(),
+        trade_log_dates: { LEGACY: "2025-01-01" },
+        contract_open_dates: { "LEGACY|20260101|C|1": "2025-01-01" },
+      },
+    });
+    const { GET } = await import("../app/api/portfolio/route");
+    const res = await GET(new Request("http://localhost/api/portfolio"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.trade_log_dates).toBeUndefined();
+    expect(body.contract_open_dates).toBeUndefined();
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+    const statements = mockExecute.mock.calls.map(([statement]) => String(statement.sql));
+    expect(statements[0]).toMatch(/FROM\s+portfolio_snapshots/i);
+    expect(statements.join("\n")).not.toMatch(/FROM\s+journal/i);
+  });
+
+  it("returns a live sync snapshot without entry-date maps", async () => {
+    mockRadonFetch.mockResolvedValue({
+      ...makePortfolio(),
+      trade_log_dates: { LEGACY: "2025-01-01" },
+      contract_open_dates: { "LEGACY|20260101|C|1": "2025-01-01" },
+    });
+
+    const { POST } = await import("../app/api/portfolio/route");
+    const res = await POST();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.trade_log_dates).toBeUndefined();
+    expect(body.contract_open_dates).toBeUndefined();
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
   it("derives trade_log_dates from the journal table", async () => {
     mockDb({
       journalRows: [
@@ -84,7 +122,7 @@ describe("GET /api/portfolio — trade_log_dates source", () => {
     );
 
     const { GET } = await import("../app/api/portfolio/route");
-    const res = await GET();
+    const res = await GET(new Request("http://localhost/api/portfolio?include=entry-dates"));
     const body = await res.json();
 
     expect(res.status).toBe(200);
@@ -103,7 +141,7 @@ describe("GET /api/portfolio — trade_log_dates source", () => {
     );
 
     const { GET } = await import("../app/api/portfolio/route");
-    const res = await GET();
+    const res = await GET(new Request("http://localhost/api/portfolio?include=entry-dates"));
     const body = await res.json();
 
     expect(res.status).toBe(200);
@@ -124,7 +162,7 @@ describe("GET /api/portfolio — trade_log_dates source", () => {
     });
 
     const { GET } = await import("../app/api/portfolio/route");
-    const res = await GET();
+    const res = await GET(new Request("http://localhost/api/portfolio?include=entry-dates"));
     const body = await res.json();
 
     expect(res.status).toBe(200);
@@ -139,7 +177,7 @@ describe("GET /api/portfolio — trade_log_dates source", () => {
     );
 
     const { GET } = await import("../app/api/portfolio/route");
-    const res = await GET();
+    const res = await GET(new Request("http://localhost/api/portfolio?include=entry-dates"));
     const body = await res.json();
 
     expect(res.status).toBe(200);

--- a/web/tests/use-risk-free-rate-dedup.test.tsx
+++ b/web/tests/use-risk-free-rate-dedup.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { act } from "react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetRiskFreeRateCacheForTests, useRiskFreeRate } from "../lib/useRiskFreeRate";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function RateProbe({ id }: { id: string }) {
+  const rate = useRiskFreeRate();
+  return <output data-testid={id}>{rate}</output>;
+}
+
+beforeEach(() => {
+  resetRiskFreeRateCacheForTests();
+});
+
+afterEach(() => {
+  cleanup();
+  resetRiskFreeRateCacheForTests();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("useRiskFreeRate", () => {
+  it("shares one no-store request and cached result across concurrent consumers", async () => {
+    let now = Date.parse("2026-08-25T12:00:00Z");
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    let resolvePayload: ((value: { rate: number; source: "FRED:DFF"; stale: false }) => void) | null = null;
+    const payload = new Promise<{ rate: number; source: "FRED:DFF"; stale: false }>((resolve) => {
+      resolvePayload = resolve;
+    });
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => payload,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const first = render(
+      <>
+        <RateProbe id="rate-a" />
+        <RateProbe id="rate-b" />
+        <RateProbe id="rate-c" />
+      </>,
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(fetchMock).toHaveBeenCalledWith("/api/risk-free-rate", { cache: "no-store" });
+
+    await act(async () => {
+      resolvePayload?.({ rate: 0.0435, source: "FRED:DFF", stale: false });
+      await payload;
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rate-a").textContent).toBe("0.0435");
+      expect(screen.getByTestId("rate-b").textContent).toBe("0.0435");
+      expect(screen.getByTestId("rate-c").textContent).toBe("0.0435");
+    });
+
+    first.unmount();
+    render(<RateProbe id="rate-late" />);
+    expect(screen.getByTestId("rate-late").textContent).toBe("0.0435");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    cleanup();
+    now += 24 * 60 * 60 * 1000 + 1;
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ rate: 0.044, source: "FRED:DFF", stale: false }),
+    });
+    render(<RateProbe id="rate-stale" />);
+
+    expect(screen.getByTestId("rate-stale").textContent).toBe("0.0435");
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getByTestId("rate-stale").textContent).toBe("0.044"));
+  });
+
+  it("does not cache a stale fallback as a fresh zero and preserves the last-good rate", async () => {
+    let now = Date.parse("2026-08-25T12:00:00Z");
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ rate: 0.0435, source: "FRED:DFF", stale: false }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ rate: 0, source: "fallback", stale: true }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ rate: 0.044, source: "FRED:DFF", stale: false }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const initial = render(<RateProbe id="rate-initial" />);
+    await waitFor(() => expect(screen.getByTestId("rate-initial").textContent).toBe("0.0435"));
+    initial.unmount();
+
+    now += 24 * 60 * 60 * 1000 + 1;
+    const fallback = render(<RateProbe id="rate-fallback" />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(screen.getByTestId("rate-fallback").textContent).toBe("0.0435");
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    fallback.unmount();
+
+    render(<RateProbe id="rate-retry" />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+    await waitFor(() => expect(screen.getByTestId("rate-retry").textContent).toBe("0.044"));
+  });
+});

--- a/web/tests/workspace-sections-table-search-headers.test.ts
+++ b/web/tests/workspace-sections-table-search-headers.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { cleanup, render, screen, within } from "@testing-library/react";
 import React from "react";
 import WorkspaceSections from "../components/WorkspaceSections";
+import PortfolioSections from "../components/PortfolioSections";
 import type { PortfolioData, PortfolioPosition, TradeEntry } from "@/lib/types";
 
 vi.mock("../components/TickerLink", () => ({
@@ -104,8 +105,7 @@ describe("WorkspaceSections table search placement", () => {
       avg_kelly_optimal: null,
     };
 
-    render(React.createElement(WorkspaceSections, {
-      section: "portfolio",
+    render(React.createElement(PortfolioSections, {
       portfolio,
     }));
 


### PR DESCRIPTION
## Summary

- Paint the cached/server-seeded portfolio snapshot before stale recovery and cap best-effort RSC seeding at 750 ms.
- Remove orders-only entry-date scans from the base portfolio response; parallelize and coalesce orders reads with mutation-safe invalidation.
- Split `/portfolio` from the omnibus workspace bundle, disable viewport navigation prefetch, and deduplicate only confirmed non-stale FRED observations.
- Replace live-sync journal-basis N+1 reads with bounded 200-row `trade_id` cursor pages while preserving exact legacy ordering and basis semantics.
- Add the source, API/database, and current-practices audits plus the browser report under `tasks/artifacts/`.

## Measured effect

| Surface | Before | After |
|---|---:|---:|
| Base `/api/portfolio` DB statements | 3 | 1 |
| Portfolio response body in audit | 25.6 KB | about 11.2 KB snapshot |
| Portfolio route chunk, Brotli | 248.2 KB omnibus | 16.4 KB isolated |
| Automatic cold-load RSC prefetches | 21 | 0 |
| RSC seed outage exposure | about 6 s across two retries | 750 ms single attempt |
| Journal basis reads | ticker plus contract N+1, up to 28 for audited positions | bounded 200-row keyset pages independent of contract count |

## Verification

- `npm test`: 7,085/7,085 passed across 683 files.
- Affected Python: 263/263 passed; journal-sync: 55/55 passed.
- TypeScript, ESLint (0 errors), Python compilation, and Next production compile passed.
- Playwright portfolio cadence: 4/4 passed; desktop/mobile captures show zero horizontal overflow and zero unrelated RSC prefetches.
- Full Python run: 7,933 passed; 42 unrelated failures remain attributable to the active Flex embargo after four pagination-unaware touched-path fakes were corrected and rerun green.
- Local output-trace audit remains baseline-red because this checkout contains 14.2 GB of backup/archive data traced by the existing orders/place route; the production compile passed.

## Safety

- Live authenticated GETs remain `force-dynamic`/`no-store`; no browser or CDN cache was introduced.
- Portfolio and orders caches are process-local single-flight caches with explicit mutation invalidation.
- API retry behavior remains intact; only the optional server-render seed uses the shorter one-attempt budget.
