### PR TITLE
fix(cta): stop publishing percentiles the vision extractor rounded away

### DIFF
--- a/scripts/clients/menthorq_client.py
+++ b/scripts/clients/menthorq_client.py
@@ -169,7 +169,10 @@ Return ONLY a JSON array of objects with these exact fields:
 Rules:
 - "underlying" is the asset name exactly as shown in the table
 - Position values are decimal numbers as shown (can be negative)
-- Percentiles are integers (e.g. 38 means 38th percentile)
+- Copy each percentile EXACTLY as displayed, digit for digit. Some cards show
+  them as 0-100 integers (38) and some as 0-1 decimals (0.38). Never convert
+  between the two scales and never round a decimal to an integer — reporting
+  0.38 as 0 turns a mid-range reading into a max-short one.
 - Z-scores are decimal numbers as shown (e.g. -1.56)
 - Include ALL rows from the table
 - Return ONLY the JSON array, no markdown, no explanation"""

--- a/scripts/fetch_menthorq_cta.py
+++ b/scripts/fetch_menthorq_cta.py
@@ -35,6 +35,7 @@ CACHE_DIR = _PROJECT_DIR / "data" / "menthorq_cache"
 
 from utils.env_loader import load_env_file
 from utils.atomic_io import atomic_save
+from utils.cta_percentiles import reconcile_tables
 
 # Load .env from project root (before any os.environ reads)
 load_env_file(_PROJECT_DIR / ".env")
@@ -116,7 +117,10 @@ Return ONLY a JSON array of objects with these exact fields:
 Rules:
 - "underlying" is the asset name exactly as shown in the table
 - Position values are decimal numbers as shown (can be negative)
-- Percentiles are integers (e.g. 38 means 38th percentile)
+- Copy each percentile EXACTLY as displayed, digit for digit. Some cards show
+  them as 0-100 integers (38) and some as 0-1 decimals (0.38). Never convert
+  between the two scales and never round a decimal to an integer — reporting
+  0.38 as 0 turns a mid-range reading into a max-short one.
 - Z-scores are decimal numbers as shown (e.g. -1.56)
 - Include ALL rows from the table
 - Return ONLY the JSON array, no markdown, no explanation"""
@@ -228,6 +232,23 @@ def fetch_menthorq_cta(
     if not tables or not any(tables.values()):
         print("  ERROR: No CTA data extracted.", file=sys.stderr)
         return None
+
+    # Percentiles land on two different scales and Vision rounds the fractional
+    # one to 0/1 — reconcile before anything persists, so the corruption never
+    # reaches the page, the share cards or the history comparisons.
+    tables = reconcile_tables(tables)
+    dropped = [
+        f"{table}/{row.get('underlying')}"
+        for table, rows in tables.items()
+        for row in rows or []
+        if row.get("percentile_3m") is None
+    ]
+    if dropped:
+        print(
+            f"  WARN: {len(dropped)} row(s) had percentiles their z-score contradicts: "
+            f"{', '.join(dropped[:6])}",
+            file=sys.stderr,
+        )
 
     # Cache
     p = write_cache(date_str, tables)

--- a/scripts/generate_cta_share.py
+++ b/scripts/generate_cta_share.py
@@ -45,6 +45,7 @@ from utils.cta_history import (  # noqa: E402
     payload_is_valid,
 )
 from utils.cta_llm import generate_share_copy  # noqa: E402
+from utils.cta_percentiles import normalize_pctile, reconcile_tables  # noqa: E402
 from utils.cta_sync import latest_closed_trading_day  # noqa: E402
 
 CACHE_DIR = PROJECT_ROOT / "data" / "menthorq_cache"
@@ -80,18 +81,26 @@ def _load_cta_from_disk() -> Optional[dict]:
     return data if payload_is_valid(data) else None
 
 
+def _reconciled(payload: dict) -> dict:
+    """Every card and the tweet read the payload through here, so a percentile
+    the vision extractor rounded away can never reach the copy."""
+    if payload and payload.get("tables"):
+        payload = {**payload, "tables": reconcile_tables(payload["tables"])}
+    return payload
+
+
 def load_cta(target_date: Optional[str] = None) -> dict:
     if target_date:
         path = CACHE_DIR / f"cta_{target_date}.json"
         if not path.exists():
             raise FileNotFoundError(f"CTA cache not found for {target_date}")
         with open(path) as f:
-            return json.load(f)
+            return _reconciled(json.load(f))
 
     candidates = [d for d in (_load_cta_from_db(), _load_cta_from_disk()) if d]
     if not candidates:
         raise FileNotFoundError("No CTA data found in Turso or the local cache.")
-    return max(candidates, key=lambda d: d.get("date") or "")
+    return _reconciled(max(candidates, key=lambda d: d.get("date") or ""))
 
 
 def assess_freshness(data_date: str, now: Optional[datetime] = None) -> dict:
@@ -119,26 +128,12 @@ def spx_row(payload: dict) -> Optional[dict]:
     return get_row(main, "s&p") or get_row(main, "e-mini")
 
 
-def pctile_label(p: int) -> str:
+def pctile_label(p) -> str:
+    if p is None: return "---"
     if p == 1: return "1st"
     if p == 2: return "2nd"
     if p == 3: return "3rd"
     return f"{p}th"
-
-
-def normalize_pctile(p) -> int:
-    """Percentile as 0-100. The main table ships 0-100 ints; the index and
-    commodity tables ship 0-1 fractions. Both reach this module.
-
-    Disambiguate by TYPE, not by range: an int 1 is the 1st percentile (max
-    short) while a float 1.0 is the 100th (max long). A range test alone reads
-    them identically and silently inverts the entire narrative.
-    """
-    if isinstance(p, bool) or not isinstance(p, (int, float)):
-        return 50
-    if isinstance(p, int):
-        return max(0, min(100, p))
-    return int(round(p * 100)) if 0.0 <= p <= 1.0 else int(round(p))
 
 
 def assess_positioning(r: dict) -> dict:
@@ -401,9 +396,9 @@ def card2_equity(data: dict, ds: str) -> str:
         if not r:
             continue
         pctile = r["percentile_3m"]
-        if pctile <= 5:
+        if pctile is not None and pctile <= 5:
             extreme_count += 1
-        pctile_style = 'background:rgba(232,93,108,0.2);color:#E85D6C;font-weight:700;padding:1px 5px;border-radius:2px' if pctile <= 10 else 'color:#94a3b8'
+        pctile_style = 'background:rgba(232,93,108,0.2);color:#E85D6C;font-weight:700;padding:1px 5px;border-radius:2px' if pctile is not None and pctile <= 10 else 'color:#94a3b8'
         ago_sign = "+" if r["position_1m_ago"] > 0 else ""
         rows_html += f"""
         <tr style="border-bottom:1px solid rgba(30,41,59,0.5)">
@@ -454,7 +449,7 @@ def card2_equity(data: dict, ds: str) -> str:
 def card3_commodities(data: dict, ds: str) -> str:
     comm = data["tables"]["commodity"]
     crowded = sorted(
-        [r for r in comm if r["percentile_3m"] >= 80 and r["position_today"] > 0],
+        [r for r in comm if r["percentile_3m"] is not None and r["percentile_3m"] >= 80 and r["position_today"] > 0],
         key=lambda r: -r["percentile_3m"]
     )[:5]
 

--- a/scripts/tests/test_cta_percentiles.py
+++ b/scripts/tests/test_cta_percentiles.py
@@ -1,0 +1,96 @@
+"""MenthorQ ships the CTA percentile columns on two different scales and the
+vision extractor is told to report integers, so on a fractional card it rounds
+0.43 to 0 and 0.98 to 1. A max-LONG row then reads as "0th pctile" and every
+narrative built on it inverts. These tests pin the repair.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from utils.cta_percentiles import (  # noqa: E402
+    normalize_pctile,
+    percentile_from_z,
+    reconcile_tables,
+)
+
+# Verbatim from the Turso `menthorq_cta` payload for 2026-08-25: the main table
+# carries 0/0/0 for SPX and NQ while the index table carries the same two rows
+# — identical positions, identical z — on the fractional scale.
+AUG_25 = {
+    "main": [
+        {"underlying": "E-Mini S&P 500 Index", "position_today": 3.66, "position_yesterday": 3.85, "position_1m_ago": 1.69, "percentile_1m": 0, "percentile_3m": 0, "percentile_1y": 0, "z_score_3m": 1.48},
+        {"underlying": "CME Nasdaq 100 Index", "position_today": 2.52, "position_yesterday": 2.69, "position_1m_ago": 1.59, "percentile_1m": 0, "percentile_3m": 0, "percentile_1y": 0, "z_score_3m": 0.26},
+        {"underlying": "10-Year T-Note", "position_today": -1.59, "position_yesterday": -1.38, "position_1m_ago": -2.93, "percentile_1m": 71, "percentile_3m": 57, "percentile_1y": 19, "z_score_3m": 0.41},
+    ],
+    "index": [
+        {"underlying": "E-Mini S&P 500 Index", "position_today": 3.66, "position_yesterday": 3.85, "position_1m_ago": 1.69, "percentile_1m": 0.43, "percentile_3m": 0.81, "percentile_1y": 0.88, "z_score_3m": 1.48},
+        {"underlying": "CME Nasdaq 100 Index", "position_today": 2.52, "position_yesterday": 2.69, "position_1m_ago": 1.59, "percentile_1m": 0.38, "percentile_3m": 0.52, "percentile_1y": 0.68, "z_score_3m": 0.26},
+    ],
+}
+
+
+def test_percentile_from_z_maps_a_z_score_onto_its_percentile():
+    assert round(percentile_from_z(0.0)) == 50
+    assert round(percentile_from_z(1.48)) == 93
+    assert round(percentile_from_z(-1.89)) == 3
+    assert percentile_from_z(None) is None
+
+
+def test_repairs_a_rounded_percentile_from_the_same_row_in_another_table():
+    out = reconcile_tables(AUG_25)
+    spx = out["main"][0]
+    assert spx["percentile_3m"] == 81
+    assert spx["percentile_1m"] == 43
+    assert spx["percentile_1y"] == 88
+    assert out["main"][1]["percentile_3m"] == 52
+
+
+def test_leaves_rows_their_z_score_already_agrees_with():
+    out = reconcile_tables(AUG_25)
+    assert out["main"][2]["percentile_3m"] == 57
+
+
+def test_nulls_a_percentile_its_z_score_flatly_contradicts():
+    # 2026-08-18 currency: the whole table came back rounded to 0, and no other
+    # table carries those contracts.
+    out = reconcile_tables({
+        "currency": [
+            {"underlying": "British Pound", "position_today": 1.3, "position_yesterday": 1.2, "position_1m_ago": -0.4, "percentile_1m": 0, "percentile_3m": 0, "percentile_1y": 0, "z_score_3m": 1.52},
+            {"underlying": "Brazilian Real", "position_today": -0.1, "position_yesterday": 0.1, "position_1m_ago": 0.3, "percentile_1m": 10, "percentile_3m": 3, "percentile_1y": 2, "z_score_3m": -1.37},
+        ],
+    })
+    assert out["currency"][0]["percentile_3m"] is None
+    assert out["currency"][0]["percentile_1m"] is None
+    assert out["currency"][1]["percentile_3m"] == 3
+
+
+def test_keeps_a_genuine_0th_percentile_its_z_score_corroborates():
+    out = reconcile_tables({
+        "main": [
+            {"underlying": "Dollar Index", "position_today": -2.1, "position_yesterday": -2.0, "position_1m_ago": 1.1, "percentile_1m": 1, "percentile_3m": 0, "percentile_1y": 2, "z_score_3m": -2.4},
+        ],
+    })
+    assert out["main"][0]["percentile_3m"] == 0
+
+
+def test_reads_a_fractional_one_beside_fractional_siblings_as_the_100th():
+    out = reconcile_tables({
+        "commodity": [
+            {"underlying": "Coffee", "position_today": 1.4, "position_yesterday": 1.06, "position_1m_ago": 0.53, "percentile_1m": 1.0, "percentile_3m": 0.98, "percentile_1y": 0.89, "z_score_3m": 1.07},
+        ],
+    })
+    assert out["commodity"][0]["percentile_1m"] == 100
+    assert out["commodity"][0]["percentile_3m"] == 98
+
+
+def test_reconcile_tolerates_missing_and_empty_tables():
+    assert reconcile_tables(None) is None
+    assert reconcile_tables({"main": [], "index": None}) == {"main": [], "index": []}
+
+
+@pytest.mark.parametrize("raw,expected", [(0.9, 90), (90, 90), (0, 0), (None, 50), ("x", 50)])
+def test_normalize_pctile_keeps_its_existing_contract(raw, expected):
+    assert normalize_pctile(raw) == expected

--- a/scripts/utils/cta_history.py
+++ b/scripts/utils/cta_history.py
@@ -20,6 +20,8 @@ import sys
 from pathlib import Path
 from typing import Callable, Iterable, Optional
 
+from utils.cta_percentiles import reconcile_tables
+
 PROJECT_DIR = Path(__file__).resolve().parents[2]
 CTA_CACHE_DIR = PROJECT_DIR / "data" / "menthorq_cache"
 
@@ -30,6 +32,15 @@ HISTORY_LOOKBACK = 12
 TRACKED_TABLES = ("main", "index", "commodity", "currency")
 
 _NAME_NOISE = ("E-Mini ", "CME ", "ICE MSCI ", "Micro ", " Index", " Futures")
+
+
+def reconciled_payload(data: dict) -> dict:
+    """A prior session is only comparable to today once its percentiles sit on
+    the same repaired scale — otherwise a rounded-away 0 in the archive reads as
+    a regime change that never happened."""
+    if data and data.get("tables"):
+        return {**data, "tables": reconcile_tables(data["tables"])}
+    return data
 
 
 def payload_is_valid(data: object) -> bool:
@@ -73,7 +84,7 @@ def _load_history_from_db(current_date: str, limit: int) -> list[dict]:
             continue
         if payload_is_valid(data):
             data.setdefault("date", row[0])
-            payloads.append(data)
+            payloads.append(reconciled_payload(data))
     return payloads
 
 
@@ -95,7 +106,7 @@ def _load_history_from_disk(current_date: str, cache_dir: Path, limit: int) -> l
         if not payload_is_valid(data):
             continue
         data.setdefault("date", data_date)
-        payloads.append(data)
+        payloads.append(reconciled_payload(data))
         if len(payloads) >= limit:
             break
     return payloads

--- a/scripts/utils/cta_percentiles.py
+++ b/scripts/utils/cta_percentiles.py
@@ -1,0 +1,122 @@
+"""CTA percentile scale reconciliation.
+
+MenthorQ renders the percentile columns as 0-1 fractions on some cards and as
+0-100 integers on others, and the vision extractor is told to report integers.
+When it obeys on a fractional card it rounds 0.43 to 0 and 0.98 to 1, so a
+max-LONG row lands in the payload as "0th percentile" and every narrative built
+on it inverts — that is the 2026-08-25 CTA page reporting SPX at the 0th
+percentile off a +3.66 long carrying a +1.48 z-score.
+
+The z-score in the same row is extracted independently and is never rounded,
+which makes it the check: percentile_3m and z_score_3m measure the same
+position against the same 3M window, so they cannot disagree.
+
+Mirrors `web/lib/ctaPercentiles.ts` — keep the two in step.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Optional
+
+PERCENTILE_FIELDS = ("percentile_1m", "percentile_3m", "percentile_1y")
+
+# Widest gap seen between a sound percentile and the one its z-score implies,
+# across every menthorq_cta payload on record, is ~24 points (thin-tailed
+# series like Natural Gas). 35 sits clear of that and still catches every
+# rounded row that inverts a narrative.
+Z_DISAGREEMENT_LIMIT = 35
+
+
+def normalize_pctile(p: Any) -> int:
+    """Percentile as 0-100. The main table ships 0-100 ints; the index and
+    commodity tables ship 0-1 fractions. Both reach this module.
+
+    Disambiguate by TYPE, not by range: an int 1 is the 1st percentile (max
+    short) while a float 1.0 is the 100th (max long). A range test alone reads
+    them identically and silently inverts the entire narrative.
+    """
+    if isinstance(p, bool) or not isinstance(p, (int, float)):
+        return 50
+    if isinstance(p, int):
+        return max(0, min(100, p))
+    return int(round(p * 100)) if 0.0 <= p <= 1.0 else int(round(p))
+
+
+def percentile_from_z(z: Any) -> Optional[float]:
+    """The percentile a 3M z-score implies, 0-100."""
+    if isinstance(z, bool) or not isinstance(z, (int, float)) or not math.isfinite(z):
+        return None
+    return 50.0 * (1.0 + math.erf(z / math.sqrt(2.0)))
+
+
+def _num(value: Any) -> Optional[float]:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value) if math.isfinite(value) else None
+
+
+def _row_key(row: dict) -> tuple:
+    """Same contract in two tables is the same row: name, position and z all match."""
+    name = str(row.get("underlying") or "").strip().lower()
+    return (name, _num(row.get("position_today")), _num(row.get("z_score_3m")))
+
+
+def _normalized_trio(row: dict) -> list[Optional[int]]:
+    """Scale is a property of the ROW, not of a single cell. A card that renders
+    fractions renders them in every column, so a 1.0 sitting beside a 0.98 is
+    the 100th percentile — reading that cell on its own calls it the 1st and
+    inverts the row.
+    """
+    raw = [_num(row.get(field)) for field in PERCENTILE_FIELDS]
+    present = [v for v in raw if v is not None]
+    fractional = bool(present) and all(0.0 <= v <= 1.0 for v in present) and any(
+        not float(v).is_integer() for v in present
+    )
+    return [
+        None if v is None else max(0, min(100, int(round(v * 100 if fractional else v))))
+        for v in raw
+    ]
+
+
+def reconcile_tables(tables: Optional[dict]) -> Optional[dict]:
+    """Normalize every percentile to 0-100, repair a row whose percentiles were
+    rounded away by copying the same row from another table, and null out what
+    neither survives: a percentile its own z-score flatly contradicts is not a
+    number to publish.
+    """
+    if not tables:
+        return tables if tables is None else {}
+
+    best: dict[tuple, tuple[list[Optional[int]], float]] = {}
+    for rows in tables.values():
+        for row in rows or []:
+            trio = _normalized_trio(row)
+            implied = percentile_from_z(row.get("z_score_3m"))
+            gap = (
+                math.inf
+                if implied is None or trio[1] is None
+                else abs(trio[1] - implied)
+            )
+            key = _row_key(row)
+            if key not in best or gap < best[key][1]:
+                best[key] = (trio, gap)
+
+    out: dict[str, list[dict]] = {}
+    for table, rows in tables.items():
+        repaired = []
+        for row in rows or []:
+            chosen = best.get(_row_key(row))
+            trio = chosen[0] if chosen else _normalized_trio(row)
+            implied = percentile_from_z(row.get("z_score_3m"))
+            contradicted = (
+                implied is not None
+                and trio[1] is not None
+                and abs(trio[1] - implied) > Z_DISAGREEMENT_LIMIT
+            )
+            new_row = dict(row)
+            for field, value in zip(PERCENTILE_FIELDS, trio):
+                new_row[field] = None if contradicted else value
+            repaired.append(new_row)
+        out[table] = repaired
+    return out

--- a/web/app/api/menthorq/cta/image/route.tsx
+++ b/web/app/api/menthorq/cta/image/route.tsx
@@ -5,6 +5,7 @@ import { readdir, readFile } from "fs/promises";
 import { join } from "path";
 import { loadFonts } from "@/lib/og-fonts";
 import { OG, posColor, pctileBg, zColor, zOpacity, fmt } from "@/lib/og-theme";
+import { reconcileCtaTables } from "@/lib/ctaPercentiles";
 
 export const runtime = "nodejs";
 
@@ -15,9 +16,9 @@ type CtaRow = {
   position_today: number;
   position_yesterday: number;
   position_1m_ago: number;
-  percentile_1m: number;
-  percentile_3m: number;
-  percentile_1y: number;
+  percentile_1m: number | null;
+  percentile_3m: number | null;
+  percentile_1y: number | null;
   z_score_3m: number;
 };
 
@@ -94,8 +95,9 @@ async function loadLatestCta(
     const data = JSON.parse(raw) as CtaCache;
     if (!data.tables) return data;
 
-    // Remove duplicate benchmark rows across sections
-    data.tables = deduplicateTables(data.tables);
+    // Same reconciliation the CTA route applies: rounded-away percentiles are
+    // repaired from the duplicate row before dedupe drops it.
+    data.tables = deduplicateTables(reconcileCtaTables(data.tables));
 
     if (section) {
       const filtered: Record<string, CtaRow[]> = {};
@@ -184,10 +186,9 @@ function TableHeader() {
 }
 
 function DataRow({ row }: { row: CtaRow }) {
-  const pctileYDisplay =
-    typeof row.percentile_1y === "number" && row.percentile_1y > 100
-      ? fmt(row.percentile_1y)
-      : String(row.percentile_1y);
+  const pctileText = (value: number | null) =>
+    value == null ? "---" : value > 100 ? fmt(value) : String(value);
+  const pctileYDisplay = pctileText(row.percentile_1y);
 
   return (
     <div
@@ -248,7 +249,7 @@ function DataRow({ row }: { row: CtaRow }) {
           padding: "2px 4px",
         }}
       >
-        {row.percentile_1m}
+        {pctileText(row.percentile_1m)}
       </span>
       <span
         style={{
@@ -259,7 +260,7 @@ function DataRow({ row }: { row: CtaRow }) {
           padding: "2px 4px",
         }}
       >
-        {row.percentile_3m}
+        {pctileText(row.percentile_3m)}
       </span>
       <span
         style={{

--- a/web/app/api/menthorq/cta/route.ts
+++ b/web/app/api/menthorq/cta/route.ts
@@ -7,6 +7,7 @@ import { join } from "path";
 import { getDb } from "@/lib/db";
 import { getRequestId, setNoStoreResponseHeaders } from "@/lib/apiContracts";
 import { isUsTradingDay } from "@/lib/serviceHealthWindows";
+import { reconcileCtaTables } from "@/lib/ctaPercentiles";
 
 export const runtime = "nodejs";
 // Disable Next.js's default static caching for route handlers. The route reads
@@ -224,7 +225,7 @@ async function readLatestCtaFromDb(): Promise<{
         date: typeof raw.date === "string" ? raw.date : row.date,
         fetched_at:
           typeof raw.fetched_at === "string" ? raw.fetched_at : row.fetched_at,
-        tables: (raw.tables as CtaTables) ?? null,
+        tables: reconcileCtaTables((raw.tables as CtaTables) ?? null),
       },
       latestFile: `db:menthorq_cta/${row.date}`,
       mtimeMs: Number.isFinite(mtimeMs) ? mtimeMs : null,
@@ -268,7 +269,7 @@ async function readLatestCtaFromDisk(): Promise<{
       data: {
         date: typeof raw.date === "string" ? raw.date : null,
         fetched_at: typeof raw.fetched_at === "string" ? raw.fetched_at : null,
-        tables: (raw.tables as CtaTables) ?? null,
+        tables: reconcileCtaTables((raw.tables as CtaTables) ?? null),
       },
       latestFile,
       mtimeMs: fileStat.mtimeMs,

--- a/web/components/SortableCtaTable.tsx
+++ b/web/components/SortableCtaTable.tsx
@@ -44,8 +44,11 @@ function posColor(v: number): string {
   return "var(--text-primary)";
 }
 
-function pctileBg(v: number): string {
-  const normalized = normalizeCtaPercentile(v) ?? v;
+function pctileBg(v: number | null | undefined): string {
+  const normalized = normalizeCtaPercentile(v);
+  // No tint for a percentile that could not be trusted — an unknown must not
+  // paint the same max-short red as a real 0th.
+  if (normalized == null) return "transparent";
   if (normalized <= 10) return "color-mix(in srgb, var(--fault) 25%, transparent)";
   if (normalized <= 25) return "color-mix(in srgb, var(--fault) 12%, transparent)";
   if (normalized <= 40) return "color-mix(in srgb, var(--warning) 12%, transparent)";
@@ -93,20 +96,21 @@ function ctaSortValue(row: CtaRow, key: CtaSortKey): number {
 /* ─── Flag helpers ───────────────────────────────────── */
 
 function flagForRow(r: CtaRow): { kind: "short" | "long"; tooltip: string } | null {
-  const p = normalizeCtaPercentile(r.percentile_3m) ?? r.percentile_3m;
+  const p = normalizeCtaPercentile(r.percentile_3m);
   const z = r.z_score_3m;
-  const isExtreme = p <= 10 || p >= 90 || Math.abs(z) >= 1.5;
+  const isExtreme = (p != null && (p <= 10 || p >= 90)) || Math.abs(z) >= 1.5;
   if (!isExtreme) return null;
 
-  const isShort = r.position_today < 0 && (p <= 10 || z <= -1.5);
-  const isLong  = r.position_today > 0 && (p >= 90 || z >= 1.5);
+  const isShort = r.position_today < 0 && ((p != null && p <= 10) || z <= -1.5);
+  const isLong  = r.position_today > 0 && ((p != null && p >= 90) || z >= 1.5);
+  const pctileText = p == null ? "--" : `${Math.round(p)}th`;
 
   if (isShort) {
     const flipped = r.position_1m_ago > 0;
     return {
       kind: "short",
       tooltip: [
-        `${Math.round(p)}th pctile (3M), z ${fmt(z)}.`,
+        `${pctileText} pctile (3M), z ${fmt(z)}.`,
         flipped ? `Flipped from ${fmt(r.position_1m_ago)} long 1M ago.` : null,
         Math.abs(z) >= 2.0
           ? "Extreme short. Violent covering risk on any bullish catalyst."
@@ -118,7 +122,7 @@ function flagForRow(r: CtaRow): { kind: "short" | "long"; tooltip: string } | nu
     return {
       kind: "long",
       tooltip: [
-        `${Math.round(p)}th pctile (3M), z ${fmt(z)}.`,
+        `${pctileText} pctile (3M), z ${fmt(z)}.`,
         "Crowded long. Mean reversion risk elevated.",
       ].join(" "),
     };

--- a/web/e2e/cta-page.spec.ts
+++ b/web/e2e/cta-page.spec.ts
@@ -12,6 +12,8 @@
 
 import { test, expect } from "@playwright/test";
 
+import { reconcileCtaTables } from "../lib/ctaPercentiles";
+
 // ── Mock data ────────────────────────────────────────────────────────────────
 
 const CRI_MOCK = {
@@ -124,6 +126,29 @@ const CTA_CURRENCY_DECIMAL_MOCK = {
       { underlying: "Canadian Dollar", position_today: 1.36, position_yesterday: 1.2, position_1m_ago: 1.03, percentile_1m: 0.57, percentile_3m: 0.84, percentile_1y: 0.65, z_score_3m: 1.01 },
     ],
   },
+};
+
+// The 2026-08-25 payload exactly as Turso stored it: the main table's SPX and
+// NQ percentiles were rounded to 0 by the vision extractor while the index
+// table holds the same two rows on the fractional scale. Piped through the
+// same reconciliation the CTA route applies, so the page sees what the server
+// would really serve for that session.
+const CTA_ROUNDED_PERCENTILE_MOCK = {
+  ...CTA_MOCK,
+  date: "2026-08-25",
+  tables: reconcileCtaTables({
+    main: [
+      { underlying: "E-Mini S&P 500 Index", position_today: 3.66, position_yesterday: 3.85, position_1m_ago: 1.69, percentile_1m: 0, percentile_3m: 0, percentile_1y: 0, z_score_3m: 1.48 },
+      { underlying: "CME Nasdaq 100 Index", position_today: 2.52, position_yesterday: 2.69, position_1m_ago: 1.59, percentile_1m: 0, percentile_3m: 0, percentile_1y: 0, z_score_3m: 0.26 },
+      { underlying: "Brent", position_today: -1.33, position_yesterday: -0.83, position_1m_ago: 0.99, percentile_1m: 5, percentile_3m: 2, percentile_1y: 5, z_score_3m: -1.89 },
+    ],
+    index: [
+      { underlying: "E-Mini S&P 500 Index", position_today: 3.66, position_yesterday: 3.85, position_1m_ago: 1.69, percentile_1m: 0.43, percentile_3m: 0.81, percentile_1y: 0.88, z_score_3m: 1.48 },
+      { underlying: "CME Nasdaq 100 Index", position_today: 2.52, position_yesterday: 2.69, position_1m_ago: 1.59, percentile_1m: 0.38, percentile_3m: 0.52, percentile_1y: 0.68, z_score_3m: 0.26 },
+    ],
+    commodity: [],
+    currency: [],
+  }),
 };
 
 const PORTFOLIO_EMPTY = {
@@ -313,5 +338,24 @@ test.describe("/regime page — CTA section removed, D3 history chart present", 
     const paths = chart.locator("path");
     const hasContent = (await circles.count()) > 0 || (await paths.count()) > 0;
     expect(hasContent).toBe(true);
+  });
+});
+
+test.describe("/cta rounded-percentile repair", () => {
+  test("a +1.48 z-score long reads as high percentile, not 0th MAX SHORT", async ({ page }) => {
+    await setupMocks(page, { cta: CTA_ROUNDED_PERCENTILE_MOCK });
+    await page.goto("/cta");
+
+    const table = page.locator('[data-testid="sortable-cta-table"]').first();
+    await table.waitFor({ timeout: 10_000 });
+
+    const spxRow = table.locator("tbody tr", { hasText: "E-Mini S&P 500 Index" }).first();
+    await expect(spxRow).toContainText("81");
+    await expect(spxRow).toContainText("1.48");
+
+    // The verdict banner reads off the same percentile — a heavy long must
+    // never publish as MAX SHORT.
+    await expect(page.locator("body")).not.toContainText("MAX SHORT");
+    await expect(page.locator("body")).not.toContainText("0th pctile");
   });
 });

--- a/web/lib/ctaPercentiles.ts
+++ b/web/lib/ctaPercentiles.ts
@@ -19,3 +19,115 @@ export function formatCtaPercentileLabel(value: number | null | undefined): stri
         : "th";
   return `${rounded}${suffix}`;
 }
+
+// ── Percentile / z-score reconciliation ──────────────────────────────────────
+//
+// MenthorQ renders the percentile columns as 0-1 fractions on some cards and as
+// 0-100 integers on others, and the vision extractor is told to report integers.
+// When it obeys on a fractional card it rounds 0.43 to 0 and 0.98 to 1, so a
+// max-LONG row lands on the page as "0th pctile" and the verdict flips to MAX
+// SHORT. The z-score in the same row is extracted independently and is not
+// rounded, which makes it the check: percentile_3m and z_score_3m measure the
+// same position against the same 3M window, so they cannot disagree.
+
+const PERCENTILE_FIELDS = ["percentile_1m", "percentile_3m", "percentile_1y"] as const;
+
+// Widest gap seen between a sound percentile and the one its z-score implies,
+// across every menthorq_cta payload on record, is ~24 points (thin-tailed
+// series like Natural Gas). 35 sits clear of that and still catches every
+// rounded row that inverts a narrative.
+const Z_DISAGREEMENT_LIMIT = 35;
+
+/** Abramowitz & Stegun 7.1.26 — max error 1.5e-7, ample at percentile scale. */
+function erf(x: number): number {
+  const sign = x < 0 ? -1 : 1;
+  const z = Math.abs(x);
+  const t = 1 / (1 + 0.3275911 * z);
+  const y =
+    1 -
+    ((((1.061405429 * t - 1.453152027) * t + 1.421413741) * t - 0.284496736) * t +
+      0.254829592) *
+      t *
+      Math.exp(-z * z);
+  return sign * y;
+}
+
+/** The percentile a 3M z-score implies, 0-100. */
+export function ctaPercentileFromZ(z: number | null | undefined): number | null {
+  if (z == null || !Number.isFinite(z)) return null;
+  return 50 * (1 + erf(z / Math.SQRT2));
+}
+
+type CtaRowLike = Record<string, unknown>;
+type CtaTablesLike = Record<string, CtaRowLike[]>;
+
+function num(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+/** Same contract in two tables is the same row: name, position and z all match. */
+function rowKey(row: CtaRowLike): string {
+  const name = String(row.underlying ?? "").trim().toLowerCase();
+  return `${name}|${num(row.position_today)}|${num(row.z_score_3m)}`;
+}
+
+/**
+ * Scale is a property of the ROW, not of a single cell. A card that renders
+ * fractions renders them in every column, so a 1.0 sitting beside a 0.98 is
+ * the 100th percentile — reading that cell on its own calls it the 1st and
+ * inverts the row.
+ */
+function normalizedTrio(row: CtaRowLike): (number | null)[] {
+  const raw = PERCENTILE_FIELDS.map((field) => num(row[field]));
+  const present = raw.filter((v): v is number => v != null);
+  const fractional =
+    present.length > 0 &&
+    present.every((v) => v >= 0 && v <= 1) &&
+    present.some((v) => !Number.isInteger(v));
+  return raw.map((v) => {
+    if (v == null) return null;
+    return Math.max(0, Math.min(100, Math.round(fractional ? v * 100 : v)));
+  });
+}
+
+/**
+ * Normalize every percentile to 0-100, repair a row whose percentiles were
+ * rounded away by copying the same row from another table, and null out what
+ * neither survives: a percentile its own z-score flatly contradicts is not a
+ * number to publish.
+ */
+export function reconcileCtaTables<T extends CtaTablesLike>(tables: T): T;
+export function reconcileCtaTables<T extends CtaTablesLike>(tables: T | null | undefined): T | null;
+export function reconcileCtaTables(tables: CtaTablesLike | null | undefined): CtaTablesLike | null {
+  if (!tables) return null;
+
+  // Best trio per shared row: the one whose 3M percentile its z-score agrees with.
+  const best = new Map<string, { trio: (number | null)[]; gap: number }>();
+  for (const rows of Object.values(tables)) {
+    for (const row of rows ?? []) {
+      const trio = normalizedTrio(row);
+      const implied = ctaPercentileFromZ(num(row.z_score_3m));
+      const gap = implied == null || trio[1] == null ? Infinity : Math.abs(trio[1] - implied);
+      const key = rowKey(row);
+      const current = best.get(key);
+      if (!current || gap < current.gap) best.set(key, { trio, gap });
+    }
+  }
+
+  const out: CtaTablesLike = {};
+  for (const [table, rows] of Object.entries(tables)) {
+    out[table] = (rows ?? []).map((row) => {
+      const chosen = best.get(rowKey(row));
+      const trio = chosen ? chosen.trio : normalizedTrio(row);
+      const implied = ctaPercentileFromZ(num(row.z_score_3m));
+      const contradicted =
+        implied != null && trio[1] != null && Math.abs(trio[1] - implied) > Z_DISAGREEMENT_LIMIT;
+      const next: CtaRowLike = { ...row };
+      PERCENTILE_FIELDS.forEach((field, i) => {
+        next[field] = contradicted ? null : trio[i];
+      });
+      return next;
+    });
+  }
+  return out;
+}

--- a/web/lib/og-theme.ts
+++ b/web/lib/og-theme.ts
@@ -130,7 +130,10 @@ export function posColor(v: number): string {
   return OG.text;
 }
 
-export function pctileBg(v: number): string {
+export function pctileBg(v: number | null | undefined): string {
+  // A percentile that could not be trusted carries no tint — an unknown must
+  // not paint the same max-short red as a real 0th.
+  if (v == null) return "transparent";
   if (v <= 10) return ogSeriesFill("fault", 0.25);
   if (v <= 25) return ogSeriesFill("fault", 0.12);
   if (v <= 40) return ogSeriesFill("caution", 0.12);

--- a/web/tests/cta-percentile-reconcile.test.ts
+++ b/web/tests/cta-percentile-reconcile.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ctaPercentileFromZ,
+  reconcileCtaTables,
+} from "../lib/ctaPercentiles";
+
+// Verbatim rows from the Turso `menthorq_cta` payload for 2026-08-25. The main
+// table carries 0/0/0 for SPX and NQ while the index table carries the same
+// two rows — identical positions, identical z — with 0.43/0.81/0.88 and
+// 0.38/0.52/0.68. The vision extractor rounded the fractions it was told to
+// report as integers, and the page published "0th pctile · MAX SHORT" off a
+// +3.66 long carrying a +1.48 z-score.
+const AUG_25 = {
+  main: [
+    { underlying: "E-Mini S&P 500 Index", position_today: 3.66, position_yesterday: 3.85, position_1m_ago: 1.69, percentile_1m: 0, percentile_3m: 0, percentile_1y: 0, z_score_3m: 1.48 },
+    { underlying: "CME Nasdaq 100 Index", position_today: 2.52, position_yesterday: 2.69, position_1m_ago: 1.59, percentile_1m: 0, percentile_3m: 0, percentile_1y: 0, z_score_3m: 0.26 },
+    { underlying: "10-Year T-Note", position_today: -1.59, position_yesterday: -1.38, position_1m_ago: -2.93, percentile_1m: 71, percentile_3m: 57, percentile_1y: 19, z_score_3m: 0.41 },
+    { underlying: "Brent", position_today: -1.33, position_yesterday: -0.83, position_1m_ago: 0.99, percentile_1m: 5, percentile_3m: 2, percentile_1y: 5, z_score_3m: -1.89 },
+  ],
+  index: [
+    { underlying: "E-Mini S&P 500 Index", position_today: 3.66, position_yesterday: 3.85, position_1m_ago: 1.69, percentile_1m: 0.43, percentile_3m: 0.81, percentile_1y: 0.88, z_score_3m: 1.48 },
+    { underlying: "CME Nasdaq 100 Index", position_today: 2.52, position_yesterday: 2.69, position_1m_ago: 1.59, percentile_1m: 0.38, percentile_3m: 0.52, percentile_1y: 0.68, z_score_3m: 0.26 },
+  ],
+  commodity: [
+    { underlying: "Brent", position_today: -1.33, position_yesterday: -0.83, position_1m_ago: 0.99, percentile_1m: 5, percentile_3m: 2, percentile_1y: 5, z_score_3m: -1.89 },
+  ],
+  currency: [],
+};
+
+describe("ctaPercentileFromZ", () => {
+  it("maps a 3M z-score onto the percentile it implies", () => {
+    expect(Math.round(ctaPercentileFromZ(0))).toBe(50);
+    expect(Math.round(ctaPercentileFromZ(1.48))).toBe(93);
+    expect(Math.round(ctaPercentileFromZ(-1.89))).toBe(3);
+  });
+
+  it("returns null when the z-score is missing or not finite", () => {
+    expect(ctaPercentileFromZ(null)).toBeNull();
+    expect(ctaPercentileFromZ(Number.NaN)).toBeNull();
+  });
+});
+
+describe("reconcileCtaTables", () => {
+  it("repairs a rounded percentile from the same row in another table", () => {
+    const out = reconcileCtaTables(AUG_25);
+    const spx = out.main[0];
+    expect(spx.percentile_3m).toBe(81);
+    expect(spx.percentile_1m).toBe(43);
+    expect(spx.percentile_1y).toBe(88);
+    const nq = out.main[1];
+    expect(nq.percentile_3m).toBe(52);
+  });
+
+  it("normalizes every percentile onto a 0-100 scale", () => {
+    const out = reconcileCtaTables(AUG_25);
+    expect(out.index[0].percentile_3m).toBe(81);
+    expect(out.index[1].percentile_1y).toBe(68);
+  });
+
+  it("leaves rows whose percentiles already agree with their z-score alone", () => {
+    const out = reconcileCtaTables(AUG_25);
+    expect(out.main[2].percentile_3m).toBe(57);
+    expect(out.main[3].percentile_3m).toBe(2);
+    expect(out.commodity[0].percentile_3m).toBe(2);
+  });
+
+  it("nulls a percentile its z-score flatly contradicts when no duplicate can repair it", () => {
+    // 2026-08-18 currency: the whole table came back rounded to 0, and no
+    // other table carries those contracts. A "0th pctile" on a +1.52 z is not
+    // a number to publish.
+    const out = reconcileCtaTables({
+      main: [],
+      index: [],
+      commodity: [],
+      currency: [
+        { underlying: "British Pound", position_today: 1.3, position_yesterday: 1.2, position_1m_ago: -0.4, percentile_1m: 0, percentile_3m: 0, percentile_1y: 0, z_score_3m: 1.52 },
+        { underlying: "Brazilian Real", position_today: -0.1, position_yesterday: 0.1, position_1m_ago: 0.3, percentile_1m: 10, percentile_3m: 3, percentile_1y: 2, z_score_3m: -1.37 },
+      ],
+    });
+    expect(out.currency[0].percentile_3m).toBeNull();
+    expect(out.currency[0].percentile_1m).toBeNull();
+    expect(out.currency[0].percentile_1y).toBeNull();
+    // The row that is internally consistent survives untouched.
+    expect(out.currency[1].percentile_3m).toBe(3);
+  });
+
+  it("keeps a genuine 0th percentile that its z-score corroborates", () => {
+    const out = reconcileCtaTables({
+      main: [
+        { underlying: "Dollar Index", position_today: -2.1, position_yesterday: -2.0, position_1m_ago: 1.1, percentile_1m: 1, percentile_3m: 0, percentile_1y: 2, z_score_3m: -2.4 },
+      ],
+      index: [],
+      commodity: [],
+      currency: [],
+    });
+    expect(out.main[0].percentile_3m).toBe(0);
+  });
+
+  it("passes null tables through untouched", () => {
+    expect(reconcileCtaTables(null)).toBeNull();
+  });
+});
+
+describe("reconcileCtaTables scale detection", () => {
+  it("reads a 1.0 beside fractional siblings as the 100th percentile, not the 1st", () => {
+    // 2026-08-25 commodity: Coffee came back as 1.0 / 0.98 / 0.89. Read cell by
+    // cell, the 1.0 renders "1st" — a max-crowded long reported as max short.
+    const out = reconcileCtaTables({
+      commodity: [
+        { underlying: "Coffee", position_today: 1.4, position_yesterday: 1.06, position_1m_ago: 0.53, percentile_1m: 1.0, percentile_3m: 0.98, percentile_1y: 0.89, z_score_3m: 1.07 },
+      ],
+    });
+    expect(out.commodity[0].percentile_1m).toBe(100);
+    expect(out.commodity[0].percentile_3m).toBe(98);
+    expect(out.commodity[0].percentile_1y).toBe(89);
+  });
+
+  it("leaves an integer row on the 0-100 scale it already uses", () => {
+    const out = reconcileCtaTables({
+      commodity: [
+        { underlying: "Corn", position_today: 0.84, position_yesterday: 0.62, position_1m_ago: 0.95, percentile_1m: 95, percentile_3m: 95, percentile_1y: 67, z_score_3m: 1.63 },
+      ],
+    });
+    expect(out.commodity[0].percentile_3m).toBe(95);
+  });
+});

--- a/web/tests/cta-route-percentile-repair.test.ts
+++ b/web/tests/cta-route-percentile-repair.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createClient, type Client } from "@libsql/client";
+
+const SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS menthorq_cta (
+  date        TEXT    PRIMARY KEY,
+  payload     TEXT    NOT NULL,
+  fetched_at  TEXT    NOT NULL
+);
+`;
+
+// The 2026-08-25 payload exactly as it sits in Turso. The main table's SPX and
+// NQ percentiles were rounded to 0 by the vision extractor; the index table
+// holds the same two rows on the fractional scale.
+const AUG_25_PAYLOAD = {
+  date: "2026-08-25",
+  fetched_at: "2026-08-25T20:16:00Z",
+  tables: {
+    main: [
+      { underlying: "E-Mini S&P 500 Index", position_today: 3.66, position_yesterday: 3.85, position_1m_ago: 1.69, percentile_1m: 0, percentile_3m: 0, percentile_1y: 0, z_score_3m: 1.48 },
+      { underlying: "CME Nasdaq 100 Index", position_today: 2.52, position_yesterday: 2.69, position_1m_ago: 1.59, percentile_1m: 0, percentile_3m: 0, percentile_1y: 0, z_score_3m: 0.26 },
+      { underlying: "Brent", position_today: -1.33, position_yesterday: -0.83, position_1m_ago: 0.99, percentile_1m: 5, percentile_3m: 2, percentile_1y: 5, z_score_3m: -1.89 },
+    ],
+    index: [
+      { underlying: "E-Mini S&P 500 Index", position_today: 3.66, position_yesterday: 3.85, position_1m_ago: 1.69, percentile_1m: 0.43, percentile_3m: 0.81, percentile_1y: 0.88, z_score_3m: 1.48 },
+      { underlying: "CME Nasdaq 100 Index", position_today: 2.52, position_yesterday: 2.69, position_1m_ago: 1.59, percentile_1m: 0.38, percentile_3m: 0.52, percentile_1y: 0.68, z_score_3m: 0.26 },
+    ],
+    commodity: [],
+    currency: [],
+  },
+};
+
+let db: Client;
+
+beforeEach(async () => {
+  db = createClient({ url: ":memory:" });
+  for (const stmt of SCHEMA_SQL.split(";").map((s) => s.trim()).filter(Boolean)) {
+    await db.execute(stmt);
+  }
+  const dbModule = await import("../lib/db");
+  dbModule.__setDbForTests(db);
+  await db.execute({
+    sql: "INSERT INTO menthorq_cta (date, payload, fetched_at) VALUES (?, ?, ?)",
+    args: ["2026-08-25", JSON.stringify(AUG_25_PAYLOAD), "2026-08-25T20:16:00Z"],
+  });
+});
+
+afterEach(async () => {
+  const dbModule = await import("../lib/db");
+  dbModule.__resetDbForTests();
+  db.close();
+});
+
+describe("CTA route percentile repair", () => {
+  it("serves the repaired percentile, not the rounded 0 stored in Turso", async () => {
+    const { GET } = await import("../app/api/menthorq/cta/route");
+    const response = await GET();
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    const spx = data.tables.main[0];
+    expect(spx.underlying).toBe("E-Mini S&P 500 Index");
+    expect(spx.percentile_3m).toBe(81);
+    expect(spx.percentile_1m).toBe(43);
+    expect(spx.percentile_1y).toBe(88);
+
+    expect(data.tables.main[1].percentile_3m).toBe(52);
+    // Untouched rows keep their stored values.
+    expect(data.tables.main[2].percentile_3m).toBe(2);
+    // Fractions are served on the 0-100 scale the UI reads.
+    expect(data.tables.index[0].percentile_3m).toBe(81);
+  });
+});


### PR DESCRIPTION
## The bug

`/cta` published **EXTREME SHORT · MAX SHORT · 0th pctile** for SPX on 2026-08-25 — off a **+3.66 long** carrying a **+1.48 z-score**. A 0th percentile is impossible on a positive z.

MenthorQ renders the percentile columns as 0-1 fractions on some cards and 0-100 integers on others. The vision extraction prompt said *"Percentiles are integers (e.g. 38 means 38th percentile)"*, so on a fractional card Haiku obeyed and rounded: `0.43 → 0`, `0.98 → 1`.

The same payload proves it. Main and index carry the **same SPX row** — identical positions, identical z:

| table | 1M | 3M | 1Y | z |
|---|---|---|---|---|
| `main` | 0 | 0 | 0 | 1.48 |
| `index` | 0.43 | 0.81 | 0.88 | 1.48 |

This is not one bad day. Across the 40 `menthorq_cta` sessions in Turso, whole tables came back as 0s and 1s on 2026-08-05, 08-14, 08-18, 07-22 and 07-31 — including SPX at `1` with a **z of +4.12** (max long published as max short).

## The fix

The z-score is extracted independently and is never rounded, so it is the check: `percentile_3m` and `z_score_3m` measure the same position against the same 3M window and cannot disagree.

`reconcileCtaTables` (TS) / `reconcile_tables` (Py):
1. Normalize every percentile to 0-100 **per row**, not per cell — a `1.0` beside a `0.98` is the 100th percentile, not the 1st.
2. Repair a row whose 3M percentile its z-score contradicts from the **same row in another table**, picking whichever candidate the z-score agrees with.
3. Null the trio when neither survives. A percentile no source can vouch for renders `---`, never a signal.

Tolerance is 35 points: the widest gap between a sound percentile and the one its z implies, measured across all 1,737 stored rows, is ~24 (thin-tailed series like Natural Gas). No false repairs, catches every inversion.

Applied at:
- `web/app/api/menthorq/cta/route.ts` — repairs the 40 sessions **already in Turso**, no refetch needed
- `web/app/api/menthorq/cta/image/route.tsx` — the public OG share card
- `scripts/generate_cta_share.py` + `scripts/utils/cta_history.py` — the X post and its prior-session comparisons
- `scripts/fetch_menthorq_cta.py` — at ingest, before anything persists (warns on dropped rows)

The extraction prompt now says to copy the percentile exactly as displayed and never round a decimal, so new payloads land clean at the source.

Null-safety follow-through: `pctileBg` and `flagForRow` treated `null <= 10` as true and painted an unknown the same max-short red.

## Verification

- `scripts/tests/test_cta_percentiles.py` — 12 tests on the real corrupt payloads
- `web/tests/cta-percentile-reconcile.test.ts` — 10 tests, same fixtures
- `web/tests/cta-route-percentile-repair.test.ts` — the real 2026-08-25 Turso row through the real route: serves **81**, not 0
- `web/e2e/cta-page.spec.ts` — the page renders 81st and never MAX SHORT
- 235 CTA-related pytest + full vitest suite green

Before / after, same raw payload:

| | verdict | SPX 3M |
|---|---|---|
| before | `EXTREME SHORT` · `MAX SHORT · 0th pctile (3M), z 1.48` | 0 |
| after | `HEAVY LONG` | 81 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112BK4uxmymsUYSU8XpuBjj