### PR TITLE
fix(tests): green main — property timeouts and a wall-clock time bomb

### DIFF
--- a/web/tests/fuzz/same-day-pnl-surfaces.fuzz.test.tsx
+++ b/web/tests/fuzz/same-day-pnl-surfaces.fuzz.test.tsx
@@ -15,8 +15,12 @@
  * resolveRealtimePrice to prefer the mid, a leg expiry that moves the price
  * key, and a missing quote that drops one walk to `market_price`.
  *
- * Run count is deliberately modest — each run mounts two React trees. The
- * seam is narrow and 120 draws saturate it; breadth lives in the lib suite.
+ * Run counts are deliberately modest — each run mounts a React tree, and the
+ * desktop table is the expensive one (full row, every column). The seam is
+ * narrow and these draws saturate it; breadth lives in the lib suite. Each
+ * property carries an explicit timeout: vitest's 5s default is a per-TEST
+ * budget, and a property is hundreds of renders, so the default turned CI red
+ * on a slower runner while passing locally.
  */
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -33,9 +37,13 @@ vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
 
 afterEach(cleanup);
 
-const FC_OPTS = process.env.RADON_FUZZ_RANDOM === "1"
-  ? { numRuns: 120 }
-  : { numRuns: 120, seed: 42 };
+const SEED = process.env.RADON_FUZZ_RANDOM === "1" ? {} : { seed: 42 };
+/** Mobile card: cheap to mount. */
+const FC_OPTS = { numRuns: 120, ...SEED };
+/** Desktop table: ~10x the render cost, so fewer draws over the same seam. */
+const FC_OPTS_DESKTOP = { numRuns: 40, ...SEED };
+/** A property is hundreds of renders; vitest's 5s per-test default is not it. */
+const PROPERTY_TIMEOUT_MS = 120_000;
 
 function todayET(): string {
   const parts = new Intl.DateTimeFormat("en-US", {
@@ -183,7 +191,7 @@ describe("same-day P&L identity, as rendered (property)", () => {
       }),
       FC_OPTS,
     );
-  });
+  }, PROPERTY_TIMEOUT_MS);
 
   it("S2 — the desktop row's Today P&L equals its P&L column", () => {
     fc.assert(
@@ -204,9 +212,9 @@ describe("same-day P&L identity, as rendered (property)", () => {
           view.unmount();
         }
       }),
-      FC_OPTS,
+      FC_OPTS_DESKTOP,
     );
-  });
+  }, PROPERTY_TIMEOUT_MS);
 
   it("S3 — desktop and mobile publish the same market value for one position", () => {
     fc.assert(
@@ -236,7 +244,7 @@ describe("same-day P&L identity, as rendered (property)", () => {
           mobile.unmount();
         }
       }),
-      FC_OPTS,
+      FC_OPTS_DESKTOP,
     );
-  });
+  }, PROPERTY_TIMEOUT_MS);
 });

--- a/web/tests/fuzz/same-day-pnl.fuzz.test.ts
+++ b/web/tests/fuzz/same-day-pnl.fuzz.test.ts
@@ -20,7 +20,10 @@
  * A future third route — a mismatched option key, a market_price fallback on
  * one side only, a new price field — fails here without anyone predicting it.
  *
- * Seed pinned to 42 for CI reproducibility; RADON_FUZZ_RANDOM=1 explores.
+ * Seed pinned to 42 for CI reproducibility; RADON_FUZZ_RANDOM=1 explores. Each
+ * property carries an explicit timeout: vitest's 5s default is a per-TEST
+ * budget and a property is a thousand cases, which is fine locally and not
+ * always fine on a loaded CI runner.
  */
 import { describe, expect, it } from "vitest";
 import fc from "fast-check";
@@ -41,6 +44,7 @@ import type { PortfolioPosition } from "@/lib/types";
 const FC_OPTS = process.env.RADON_FUZZ_RANDOM === "1"
   ? { numRuns: 1000 }
   : { numRuns: 1000, seed: 42 };
+const PROPERTY_TIMEOUT_MS = 60_000;
 
 function todayET(): string {
   const parts = new Intl.DateTimeFormat("en-US", {
@@ -179,7 +183,7 @@ describe("same-day P&L identity (property)", () => {
       }),
       FC_OPTS,
     );
-  });
+  }, PROPERTY_TIMEOUT_MS);
 
   it("P2 — no quote can make a same-day position read its stale ib_daily_pnl", () => {
     fc.assert(
@@ -191,7 +195,7 @@ describe("same-day P&L identity (property)", () => {
       }),
       FC_OPTS,
     );
-  });
+  }, PROPERTY_TIMEOUT_MS);
 
   it("P3 — the same-day day-change % is Today P&L over the entry cost", () => {
     fc.assert(
@@ -205,7 +209,7 @@ describe("same-day P&L identity (property)", () => {
       }),
       FC_OPTS,
     );
-  });
+  }, PROPERTY_TIMEOUT_MS);
 
   it("P4 — an overnight position is NOT forced onto the entry baseline", () => {
     // The guard against over-correcting: the identity is same-day only. If a
@@ -232,7 +236,7 @@ describe("same-day P&L identity (property)", () => {
       underlying: { last: 577.39, bid: null, ask: null, close: 582.4, present: true },
     }, "2026-01-05");
     expect(getTodayPnlDollars(pos, prices)).not.toBe(surfaceTotalPnl(pos, prices));
-  });
+  }, PROPERTY_TIMEOUT_MS);
 
   it("P5 — a same-day STOCK position obeys the same identity", () => {
     const arbStock = fc.record({
@@ -269,5 +273,5 @@ describe("same-day P&L identity (property)", () => {
       }),
       FC_OPTS,
     );
-  });
+  }, PROPERTY_TIMEOUT_MS);
 });

--- a/web/tests/return-capital-uncovered-short.test.ts
+++ b/web/tests/return-capital-uncovered-short.test.ts
@@ -18,7 +18,18 @@
 import { describe, it, expect } from "vitest";
 
 import { resolveReturnCapital, describeReturnCapital } from "../lib/positionUtils";
+import { lastCompletedSessionDate } from "../lib/marketSession";
 import type { PortfolioPosition } from "../lib/types";
+
+/**
+ * A NAV date is judged against the wall clock: past a two-session staleness
+ * budget, `buildPerformanceView` gates every return to null. A fixture that
+ * hardcodes one is a time bomb — "2026-08-22" passed until 2026-08-26, then
+ * turned three sessions stale and failed CI on main every run after. Any test
+ * asserting a return SURVIVES must date its payload from the same clock the
+ * reader uses.
+ */
+const FRESH_NAV_DATE = lastCompletedSessionDate();
 
 function position(
   legs: Array<{
@@ -117,7 +128,10 @@ describe("MWR is plausibility-gated like TWR", () => {
     const view = buildPerformanceView({
       schema_version: 2,
       status: "ok",
-      as_of: "2026-08-22",
+      // Fresh, so the suppression under test is the PLAUSIBILITY gate. A
+      // stale NAV date would null these anyway and the assertion would hold
+      // with the gate removed entirely.
+      as_of: FRESH_NAV_DATE,
       calendar_days: 30,
       n_returns: 60,
       twr: { cum_return: 9.51, annualized: { value: null, n: 60, min_n: 20 } },
@@ -139,7 +153,7 @@ describe("MWR is plausibility-gated like TWR", () => {
     const view = buildPerformanceView({
       schema_version: 2,
       status: "ok",
-      as_of: "2026-08-22",
+      as_of: FRESH_NAV_DATE,
       calendar_days: 400,
       n_returns: 300,
       twr: { cum_return: 0.12, annualized: { value: 0.11, n: 300, min_n: 20 } },


### PR DESCRIPTION
Main went red after #102 merged. Two failures, **neither a product regression**.

## 1. Vitest shard 1 — my fuzz suite timed out (mine)

`fuzz/same-day-pnl-surfaces.fuzz.test.tsx` S2/S3: `Test timed out in 5000ms`.

A property is hundreds of React mounts, and vitest's 5s default is a **per-test** budget, not per-case. 120 draws against the full `PositionTable` ran in ~1.5s locally and blew the budget on a slower CI runner.

- Explicit timeout on every property.
- The two that mount the desktop table drop to **40 draws** (the mobile one stays at 120 — it is ~10x cheaper).
- Re-verified adversarially at the lower count: S1 and S3 still fail against the reinstated pre-fix card, shrinking to the same 1-contract counterexample. S2 correctly does not — the desktop was never the broken surface.
- Same explicit timeout added defensively to the lib-level fuzz suite.

## 2. Vitest shard 5 — a wall-clock time bomb (pre-existing)

`return-capital-uncovered-short.test.ts > keeps an ordinary MWR` hardcoded `as_of: "2026-08-22"`. A NAV date is judged against the wall clock with a two-session staleness budget, so on 2026-08-26 the fixture went three sessions stale and `buildPerformanceView` gated every return to null.

Fails on `e3aa7885` (the merge before #102), so it predates that PR and would have failed every run from today on.

Both MWR fixtures now date from `lastCompletedSessionDate()` — including the suppression case, which was passing for the **wrong reason**: a stale NAV nulls those values whether or not the plausibility gate it names exists at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112BK4uxmymsUYSU8XpuBjj