### PR TITLE
feat(ivrank): a freshness rail that counts down to the next sample

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -10850,6 +10850,126 @@ tr {
   }
 }
 
+/* ── Freshness rail ─────────────────────────────────────────────
+   Where an indicator's data stands, and when it moves. Sits directly
+   under a statistic strip and shares its seam, so it reads as the
+   strip's own footer rather than a second panel. The track is the
+   point: the wait between scheduled runs drawn as a length. */
+.freshness-rail {
+  display: grid;
+  grid-template-columns: minmax(0, auto) minmax(40px, 1fr) minmax(0, auto);
+  align-items: center;
+  gap: 20px;
+  background: var(--bg-panel);
+  border-top: 1px solid var(--border-dim);
+  padding: 12px 16px;
+}
+
+.freshness-rail-side {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.freshness-rail-side--end {
+  align-items: flex-end;
+  text-align: right;
+}
+
+.freshness-rail-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.freshness-rail-anchor {
+  font-family: var(--font-mono);
+  font-size: 15px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-primary);
+}
+
+/* Tabular figures are the whole reason this reads as an instrument and not a
+   toy: without them every tick shifts the digits sideways. */
+.freshness-rail-countdown {
+  font-family: var(--font-mono);
+  /* Peer-sized with .regime-strip-value on purpose. The rail is meta about the
+     panel; larger digits would out-shout the statistics it annotates. */
+  font-size: 20px;
+  font-weight: 500;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-primary);
+  white-space: nowrap;
+}
+
+.freshness-rail-note {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+}
+
+.freshness-rail-track {
+  height: 2px;
+  background: color-mix(in srgb, var(--text-muted) 38%, transparent);
+  overflow: hidden;
+}
+
+.freshness-rail-track-fill {
+  height: 100%;
+  background: var(--signal-core);
+  /* No transition — the fill advances once a second and easing would smear a
+     tick into a slide. */
+}
+
+/* Waiting on a session the market has closed: the reading is genuinely behind,
+   but the job has not missed anything yet. Muted, not alarming. */
+.freshness-rail[data-state="behind"] .freshness-rail-track-fill {
+  background: color-mix(in srgb, var(--signal-core) 70%, transparent);
+}
+
+/* The run fired and the session still is not here. This is the only state that
+   earns a colour — and it takes --warn, never --fault: the data is late, not
+   wrong (mirrors ivrankRegimeColor's restraint). */
+.freshness-rail[data-state="overdue"] .freshness-rail-countdown,
+.freshness-rail[data-state="overdue"] .freshness-rail-note {
+  color: var(--warn-text);
+}
+
+.freshness-rail[data-state="overdue"] .freshness-rail-track-fill {
+  background: var(--warn);
+}
+
+.freshness-rail[data-state="pending"] .freshness-rail-countdown {
+  color: var(--text-muted);
+}
+
+@media (max-width: 760px) {
+  .freshness-rail {
+    grid-template-columns: minmax(0, 1fr) minmax(0, auto);
+    gap: 6px 12px;
+    padding: 11px 14px;
+  }
+
+  /* The track spans the full width underneath both readings, where it still
+     reads as a single span of time rather than a gutter between two columns. */
+  .freshness-rail-track {
+    grid-column: 1 / -1;
+    order: 3;
+    margin-top: 4px;
+  }
+
+  .freshness-rail-countdown {
+    font-size: 18px;
+  }
+}
+
 /* VOL CONE selected-name analysis */
 .vol-cone-analysis .vol-cone-analysis-metrics {
   display: grid;
@@ -20019,6 +20139,13 @@ body[data-mobile="true"] .strength-card__head {
   border: 1px solid var(--line-grid);
   margin-bottom: 8px;
 }
+/* An odd cell count leaves a hole in the last row. Where a panel opts in, the
+   final cell takes the full width instead — which also stops the widest
+   readings (a 1Y IV range) from wrapping in a half-width cell. */
+.m-regime-grid2x2--fill-last > div:last-child:nth-child(odd) {
+  grid-column: span 2;
+}
+
 .m-regime-grid2x2 > div {
   background: var(--bg-panel);
   padding: 10px 12px;

--- a/web/components/FreshnessRail.tsx
+++ b/web/components/FreshnessRail.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+/**
+ * The freshness rail: where an indicator's data stands, and when it moves.
+ *
+ * An EOD indicator sits one session behind for most of the day by design, so
+ * "as of 2026-08-25" on a Wednesday afternoon is correct and still reads as
+ * broken. The rail answers the question that actually follows — how long until
+ * this is current — as a countdown to the job's own timer, with the wait drawn
+ * as a length so staleness is legible before the digits are read.
+ *
+ * Every figure is derived: the slot from the systemd timer constants pinned in
+ * `refreshSchedule`, the session from the ET clock. Nothing here is a cadence
+ * string a panel author typed.
+ */
+
+import { useEffect, useState } from "react";
+
+import { computeFreshnessRail, formatCountdown } from "@/lib/freshnessRail";
+import type { UtcSchedule } from "@/lib/refreshSchedule";
+
+type FreshnessRailProps = {
+  schedule: UtcSchedule;
+  /** Latest session the panel holds, `YYYY-MM-DD`. */
+  asOf: string | null;
+  testId: string;
+  /** Test id for the as-of value, so existing assertions keep their anchor. */
+  asOfTestId?: string;
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function localDayKey(date: Date): number {
+  return Math.floor(
+    new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime() / DAY_MS,
+  );
+}
+
+/** "Today 18:10" reads faster than a date, and the date is only worth spelling
+ *  out once the wait crosses into a day the reader has to think about. */
+function targetLabel(target: Date, now: Date): string {
+  const time = target.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
+  const delta = localDayKey(target) - localDayKey(now);
+  if (delta === 0) return `Today ${time}`;
+  if (delta === 1) return `Tomorrow ${time}`;
+  return `${target.toLocaleDateString([], { weekday: "short" })} ${time}`;
+}
+
+export default function FreshnessRail({ schedule, asOf, testId, asOfTestId }: FreshnessRailProps) {
+  // The clock starts on the client. Reading it during render would put a
+  // different countdown in the server HTML than in the first client paint —
+  // the hydration-mismatch class this app has already been bitten by.
+  const [now, setNow] = useState<Date | null>(null);
+  useEffect(() => {
+    setNow(new Date());
+    const id = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const rail = now ? computeFreshnessRail(schedule, asOf, now) : null;
+  const state = !rail ? "pending" : rail.overdue ? "overdue" : rail.behind ? "behind" : "current";
+
+  const countdown = rail ? (rail.overdue ? "Due" : formatCountdown(rail.msRemaining)) : "--";
+  const note = !rail
+    ? null
+    : rail.overdue
+      ? `${formatCountdown(rail.msOverdue)} past the run`
+      : targetLabel(rail.nextSampleAt, now!);
+  const anchorNote = !rail
+    ? null
+    : rail.awaitingSession
+      ? `Awaiting ${rail.awaitingSession}`
+      : "Current";
+
+  return (
+    <div
+      className="freshness-rail"
+      data-testid={testId}
+      data-state={state}
+      aria-label={
+        rail
+          ? rail.overdue
+            ? `Data as of ${asOf ?? "unknown"}. The ${targetLabel(rail.lastSampleAt, now!)} sample has not landed.`
+            : `Data as of ${asOf ?? "unknown"}. Next sample ${countdown} from now.`
+          : undefined
+      }
+    >
+      <div className="freshness-rail-side">
+        <div className="freshness-rail-label">As of</div>
+        <div className="freshness-rail-anchor" data-testid={asOfTestId}>
+          {asOf ?? "---"}
+        </div>
+        <div className="freshness-rail-note">{anchorNote ?? " "}</div>
+      </div>
+
+      {/* The wait as a length. No transition: the fill moves once a second and
+          an eased width would smear rather than tick. */}
+      <div className="freshness-rail-track" aria-hidden="true">
+        <div
+          className="freshness-rail-track-fill"
+          style={{ width: rail ? `${(rail.elapsedFraction * 100).toFixed(2)}%` : "0%" }}
+        />
+      </div>
+
+      <div className="freshness-rail-side freshness-rail-side--end">
+        <div className="freshness-rail-label">Next sample</div>
+        <div className="freshness-rail-countdown" data-testid={`${testId}-countdown`}>
+          {countdown}
+        </div>
+        <div className="freshness-rail-note">{note ?? " "}</div>
+      </div>
+    </div>
+  );
+}

--- a/web/components/IvRankPanel.tsx
+++ b/web/components/IvRankPanel.tsx
@@ -7,6 +7,8 @@ import PanelRefreshError from "./PanelRefreshError";
 import CriHistoryChart, { type ChartSeries } from "./CriHistoryChart";
 import HistoryRangeChips from "./HistoryRangeChips";
 import InfoTooltip from "./InfoTooltip";
+import FreshnessRail from "./FreshnessRail";
+import { IV_RANK_REFRESH } from "@/lib/refreshSchedule";
 import MetricCell from "./mobile/MetricCell";
 import SectionEmptyState from "./SectionEmptyState";
 import SpectralLoader from "./SpectralLoader";
@@ -162,13 +164,12 @@ export default function IvRankPanel() {
         </div>
 
         {compact ? (
-          <div className="m-regime-grid2x2" data-testid="ivrank-mobile-grid">
+          <div className="m-regime-grid2x2 m-regime-grid2x2--fill-last" data-testid="ivrank-mobile-grid">
             <MetricCell label="IV RANK" value={formatRank(current.iv_rank)} />
             <MetricCell label="REGIME" value={regime ?? "---"} />
             <MetricCell label="1M IV" value={formatIvPercent(current.iv)} />
             <MetricCell label="IV PCTILE" value={formatPctPoints(current.iv_pct)} />
             <MetricCell label="1Y IV RANGE" value={formatIvRange(current.iv_1y_low, current.iv_1y_high)} />
-            <MetricCell label="AS OF" value={data.as_of ?? current.date} />
           </div>
         ) : (
           <RegimeStrip>
@@ -221,13 +222,15 @@ export default function IvRankPanel() {
               }
               sub={<>PREMIUM VS TRAILING YEAR</>}
             />
-            <RegimeStripCell
-              testId="ivrank-strip-asof"
-              label="AS OF"
-              value={data.as_of ?? current.date}
-            />
           </RegimeStrip>
         )}
+
+        <FreshnessRail
+          schedule={IV_RANK_REFRESH}
+          asOf={data.as_of ?? current.date}
+          testId="ivrank-freshness-rail"
+          asOfTestId="ivrank-strip-asof"
+        />
       </div>
 
       {/* ── Rank over the 1M IV series ────────────────────── */}

--- a/web/e2e/ivrank-tab.spec.ts
+++ b/web/e2e/ivrank-tab.spec.ts
@@ -162,6 +162,34 @@ test.describe("/regime/ivrank — SPY 1M IV rank tab", () => {
     await expect(page.locator('[data-testid="ivrank-uw-check"]')).toContainText("UW CROSS-CHECK 10.6");
   });
 
+  test("the freshness rail counts down to the next scheduled sample", async ({ page }) => {
+    await setupMocks(page);
+    await page.goto("/regime/ivrank");
+
+    const rail = page.locator('[data-testid="ivrank-freshness-rail"]');
+    await rail.waitFor({ timeout: 15_000 });
+
+    // The date the panel holds, and the countdown to the run that replaces it.
+    await expect(rail).toContainText(LAST.date);
+    await expect(rail).toContainText("Next sample");
+
+    // The clock starts in an effect, so the countdown resolves after hydration
+    // rather than shipping a server-rendered time that would mismatch.
+    const countdown = page.locator('[data-testid="ivrank-freshness-rail-countdown"]');
+    await expect(countdown).not.toHaveText("--", { timeout: 15_000 });
+    await expect(countdown).toHaveText(/^(\d+h \d{2}m|\d+m \d{2}s|\d+s|Due)$/);
+
+    // Whatever the state, it is one of the four the rail models.
+    await expect(rail).toHaveAttribute("data-state", /^(current|behind|overdue)$/);
+
+    // The track is drawn, and its fill never exceeds the interval.
+    const fillWidth = await rail.locator(".freshness-rail-track-fill").evaluate(
+      (node) => (node as HTMLElement).style.width,
+    );
+    expect(Number.parseFloat(fillWidth)).toBeGreaterThanOrEqual(0);
+    expect(Number.parseFloat(fillWidth)).toBeLessThanOrEqual(100);
+  });
+
   test("renders the chart with real paths and a visible brush", async ({ page }) => {
     await setupMocks(page);
     await page.goto("/regime/ivrank");

--- a/web/lib/freshnessRail.ts
+++ b/web/lib/freshnessRail.ts
@@ -1,0 +1,90 @@
+/**
+ * "Is this reading current, and when does it stop being stale?"
+ *
+ * An EOD indicator is one session behind for most of the day by design — its
+ * bar cannot exist until the market prints a close. What the operator actually
+ * needs is the pair of facts underneath that: which session the panel is still
+ * missing, and when the job that fills it runs. Both are derived — the slot
+ * from the systemd timer constants in `refreshSchedule`, the session from the
+ * ET clock — so no panel has to carry a cadence string that can drift away
+ * from the job that really runs (root CLAUDE.md, UI Copy Rules).
+ */
+
+import { lastCompletedSessionDate } from "./marketSession";
+import { nextRefreshUtc, type UtcSchedule } from "./refreshSchedule";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export type FreshnessRail = {
+  /** When the next scheduled run fires. */
+  nextSampleAt: Date;
+  /** The run before it — the one whose output the panel should already hold. */
+  lastSampleAt: Date;
+  /** Milliseconds until `nextSampleAt`, floored at zero. */
+  msRemaining: number;
+  /** Share of the interval between runs already elapsed, 0-1. */
+  elapsedFraction: number;
+  /** The panel is missing a session the market has already closed. */
+  behind: boolean;
+  /** That session, or null when the panel is current. */
+  awaitingSession: string | null;
+  /** Behind, and the run that should have delivered it has already fired. */
+  overdue: boolean;
+  /** How long ago that run fired. Zero unless `overdue`. */
+  msOverdue: number;
+};
+
+function intervalMs(schedule: UtcSchedule): number {
+  return schedule.cadence === "weekly" ? 7 * DAY_MS : DAY_MS;
+}
+
+/**
+ * @param asOf   the latest session date the panel holds, `YYYY-MM-DD`
+ */
+export function computeFreshnessRail(
+  schedule: UtcSchedule,
+  asOf: string | null | undefined,
+  now: Date = new Date(),
+): FreshnessRail {
+  const nextSampleAt = nextRefreshUtc(schedule, now);
+  const lastSampleAt = new Date(nextSampleAt.getTime() - intervalMs(schedule));
+
+  const latestSession = lastCompletedSessionDate(now);
+  const behind = Boolean(asOf) && asOf! < latestSession;
+
+  // The last run is late only if the session it was meant to carry had already
+  // closed when it fired. Asking the ET-aware helper what was complete AT that
+  // instant is the same question, without a second copy of the clock math.
+  const overdue = behind && lastCompletedSessionDate(lastSampleAt) >= latestSession;
+
+  const msRemaining = Math.max(0, nextSampleAt.getTime() - now.getTime());
+  const elapsed = now.getTime() - lastSampleAt.getTime();
+
+  return {
+    nextSampleAt,
+    lastSampleAt,
+    msRemaining,
+    // A late run reads as a full track: the wait is over and the data is not here.
+    elapsedFraction: overdue ? 1 : Math.min(1, Math.max(0, elapsed / intervalMs(schedule))),
+    behind,
+    awaitingSession: behind ? latestSession : null,
+    overdue,
+    msOverdue: overdue ? Math.max(0, elapsed) : 0,
+  };
+}
+
+/**
+ * Seconds are noise beyond an hour and the only thing worth reading inside a
+ * minute. The timer carries `RandomizedDelaySec=120`, so the real fire time is
+ * up to two minutes past the slot — this counts to the earliest one, and the
+ * DUE state absorbs the rest.
+ */
+export function formatCountdown(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const seconds = total % 60;
+  if (hours > 0) return `${hours}h ${String(minutes).padStart(2, "0")}m`;
+  if (minutes > 0) return `${minutes}m ${String(seconds).padStart(2, "0")}s`;
+  return `${seconds}s`;
+}

--- a/web/lib/refreshSchedule.ts
+++ b/web/lib/refreshSchedule.ts
@@ -1,5 +1,5 @@
 /**
- * Frontend source of truth for the Equibles indicator refresh timers.
+ * Frontend source of truth for indicator refresh timers.
  *
  * Each constant mirrors the OnCalendar line of its systemd timer in
  * cloud/services/ — tests/refresh-schedule.test.ts pins them to the unit
@@ -24,6 +24,13 @@ export const SHORT_CROWDING_REFRESH: UtcSchedule = {
   cadence: "daily",
   hourUtc: 9,
   minuteUtc: 30,
+};
+
+/** cloud/services/radon-ivrank.timer */
+export const IV_RANK_REFRESH: UtcSchedule = {
+  cadence: "daily",
+  hourUtc: 22,
+  minuteUtc: 10,
 };
 
 /** cloud/services/radon-equibles-cot.timer */

--- a/web/tests/freshness-rail-render.test.tsx
+++ b/web/tests/freshness-rail-render.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render, screen } from "@testing-library/react";
+
+import FreshnessRail from "../components/FreshnessRail";
+import { IV_RANK_REFRESH } from "../lib/refreshSchedule";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+function renderAt(iso: string, asOf: string | null) {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(iso));
+  const view = render(
+    <FreshnessRail schedule={IV_RANK_REFRESH} asOf={asOf} testId="rail" asOfTestId="rail-asof" />,
+  );
+  // The clock starts in an effect, so the first paint carries no countdown.
+  act(() => { vi.advanceTimersByTime(0); });
+  return view;
+}
+
+describe("FreshnessRail", () => {
+  it("renders no countdown on the server paint, so hydration cannot mismatch", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-26T19:00:00Z"));
+    // Render without flushing effects: this is the markup the server produces.
+    const html = render(
+      <FreshnessRail schedule={IV_RANK_REFRESH} asOf="2026-08-25" testId="rail" />,
+    );
+    // After effects flush it fills in; the point is the placeholder exists at all.
+    expect(html.container.textContent).toContain("As of");
+  });
+
+  it("counts down to today's run while the market is open", () => {
+    // 15:00 ET Wednesday. The 18:10 ET run is 3h10m out, and an EOD panel
+    // holding Tuesday is CURRENT — Wednesday's close has not printed.
+    renderAt("2026-08-26T19:00:00Z", "2026-08-25");
+    expect(screen.getByTestId("rail-countdown").textContent).toBe("3h 10m");
+    expect(screen.getByTestId("rail").getAttribute("data-state")).toBe("current");
+    expect(screen.getByTestId("rail").textContent).toContain("Current");
+  });
+
+  it("names the session it is waiting on once that session has closed", () => {
+    // 17:00 ET Wednesday: the close has printed and the run has not fired.
+    renderAt("2026-08-26T21:00:00Z", "2026-08-25");
+    expect(screen.getByTestId("rail").getAttribute("data-state")).toBe("behind");
+    expect(screen.getByTestId("rail").textContent).toContain("Awaiting 2026-08-26");
+    expect(screen.getByTestId("rail-countdown").textContent).toBe("1h 10m");
+  });
+
+  it("reads DUE, in warn tone, once the run has fired without delivering", () => {
+    renderAt("2026-08-26T22:30:00Z", "2026-08-25");
+    expect(screen.getByTestId("rail-countdown").textContent).toBe("Due");
+    expect(screen.getByTestId("rail").getAttribute("data-state")).toBe("overdue");
+    expect(screen.getByTestId("rail").textContent).toContain("20m 00s past the run");
+  });
+
+  it("ticks", () => {
+    renderAt("2026-08-26T23:09:00Z", "2026-08-26");
+    expect(screen.getByTestId("rail-countdown").textContent).toBe("23h 01m");
+    act(() => { vi.advanceTimersByTime(60_000); });
+    expect(screen.getByTestId("rail-countdown").textContent).toBe("23h 00m");
+  });
+
+  it("keeps the as-of anchor its own test id", () => {
+    renderAt("2026-08-26T19:00:00Z", "2026-08-25");
+    expect(screen.getByTestId("rail-asof").textContent).toBe("2026-08-25");
+  });
+
+  it("renders without a data date", () => {
+    renderAt("2026-08-26T19:00:00Z", null);
+    expect(screen.getByTestId("rail-asof").textContent).toBe("---");
+    expect(screen.getByTestId("rail").getAttribute("data-state")).toBe("current");
+  });
+});

--- a/web/tests/freshness-rail.test.ts
+++ b/web/tests/freshness-rail.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The freshness rail turns "is this reading current?" into two facts a trader
+ * can act on: which session the panel is still missing, and how long until the
+ * job that fills it runs. Both are derived — the schedule from the systemd
+ * timer constants, the session from the ET clock — so neither can be a
+ * hardcoded cadence string that drifts from the job that really runs.
+ */
+import { describe, expect, it } from "vitest";
+
+import { IV_RANK_REFRESH } from "@/lib/refreshSchedule";
+import { computeFreshnessRail, formatCountdown } from "@/lib/freshnessRail";
+
+// 2026-08-26 is a Wednesday. The IV RANK timer fires 22:10 UTC = 18:10 ET.
+const WED_1500_ET = new Date("2026-08-26T19:00:00Z"); // 15:00 ET, market open
+const WED_1700_ET = new Date("2026-08-26T21:00:00Z"); // 17:00 ET, after the close
+const WED_1830_ET = new Date("2026-08-26T22:30:00Z"); // 18:30 ET, past the slot
+
+describe("computeFreshnessRail", () => {
+  it("counts down to today's slot while it is still ahead", () => {
+    const rail = computeFreshnessRail(IV_RANK_REFRESH, "2026-08-25", WED_1500_ET);
+    expect(rail.nextSampleAt.toISOString()).toBe("2026-08-26T22:10:00.000Z");
+    expect(rail.msRemaining).toBe(3 * 60 * 60 * 1000 + 10 * 60 * 1000);
+    expect(rail.overdue).toBe(false);
+  });
+
+  it("rolls to tomorrow's slot once today's has passed", () => {
+    const rail = computeFreshnessRail(IV_RANK_REFRESH, "2026-08-26", WED_1830_ET);
+    expect(rail.nextSampleAt.toISOString()).toBe("2026-08-27T22:10:00.000Z");
+    expect(rail.overdue).toBe(false);
+  });
+
+  it("names the session the panel is still missing", () => {
+    // 17:00 ET: Wednesday's close has happened, so 2026-08-26 is a completed
+    // session the panel does not have.
+    const rail = computeFreshnessRail(IV_RANK_REFRESH, "2026-08-25", WED_1700_ET);
+    expect(rail.behind).toBe(true);
+    expect(rail.awaitingSession).toBe("2026-08-26");
+  });
+
+  it("reads as current intraday, when today's close does not exist yet", () => {
+    // 15:00 ET Wednesday: the latest COMPLETED session is Tuesday, and the
+    // panel has it. An EOD indicator is not stale for lacking a bar the market
+    // has not printed.
+    const rail = computeFreshnessRail(IV_RANK_REFRESH, "2026-08-25", WED_1500_ET);
+    expect(rail.behind).toBe(false);
+    expect(rail.awaitingSession).toBeNull();
+  });
+
+  it("flags overdue when the slot has passed and the session never landed", () => {
+    // 18:30 ET and the panel still holds Tuesday: the 18:10 run should have
+    // written Wednesday and did not.
+    const rail = computeFreshnessRail(IV_RANK_REFRESH, "2026-08-25", WED_1830_ET);
+    expect(rail.overdue).toBe(true);
+    expect(rail.behind).toBe(true);
+    expect(rail.msOverdue).toBe(20 * 60 * 1000);
+  });
+
+  it("fills the track with the elapsed share of the interval between runs", () => {
+    // Six hours after the 22:10 UTC slot, a quarter of the 24h interval is gone.
+    const sixHoursOn = new Date("2026-08-27T04:10:00Z");
+    const rail = computeFreshnessRail(IV_RANK_REFRESH, "2026-08-26", sixHoursOn);
+    expect(rail.elapsedFraction).toBeCloseTo(0.25, 6);
+  });
+
+  it("clamps the track to the interval at both ends", () => {
+    const atSlot = new Date("2026-08-26T22:10:00Z");
+    expect(computeFreshnessRail(IV_RANK_REFRESH, "2026-08-26", atSlot).elapsedFraction).toBe(0);
+    const overdue = computeFreshnessRail(IV_RANK_REFRESH, "2026-08-25", WED_1830_ET);
+    expect(overdue.elapsedFraction).toBe(1);
+  });
+
+  it("survives a missing data date", () => {
+    const rail = computeFreshnessRail(IV_RANK_REFRESH, null, WED_1700_ET);
+    expect(rail.behind).toBe(false);
+    expect(rail.awaitingSession).toBeNull();
+    expect(rail.msRemaining).toBeGreaterThan(0);
+  });
+});
+
+describe("formatCountdown", () => {
+  it("drops seconds past an hour, where they are noise", () => {
+    expect(formatCountdown(3 * 60 * 60 * 1000 + 10 * 60 * 1000 + 41_000)).toBe("3h 10m");
+  });
+
+  it("counts minutes and seconds inside the last hour", () => {
+    expect(formatCountdown(47 * 60 * 1000 + 12_000)).toBe("47m 12s");
+  });
+
+  it("counts seconds alone inside the last minute", () => {
+    expect(formatCountdown(12_000)).toBe("12s");
+  });
+
+  it("floors at zero rather than counting backwards", () => {
+    expect(formatCountdown(-5_000)).toBe("0s");
+  });
+});

--- a/web/tests/refresh-schedule.test.ts
+++ b/web/tests/refresh-schedule.test.ts
@@ -13,6 +13,7 @@ import { fileURLToPath } from "url";
 import {
   ATS_VENUE_SHARE_REFRESH,
   COT_POSITIONING_REFRESH,
+  IV_RANK_REFRESH,
   SHORT_CROWDING_REFRESH,
   dataAgeDays,
   nextRefreshLabel,
@@ -49,6 +50,10 @@ describe("schedule constants are pinned to the systemd timers", () => {
     expect(expectedOnCalendar(SHORT_CROWDING_REFRESH)).toBe(
       timerOnCalendar("radon-equibles-short-crowding.timer"),
     );
+  });
+
+  it("IV rank mirrors radon-ivrank.timer", () => {
+    expect(expectedOnCalendar(IV_RANK_REFRESH)).toBe(timerOnCalendar("radon-ivrank.timer"));
   });
 
   it("COT positioning mirrors radon-equibles-cot.timer", () => {


### PR DESCRIPTION
## The problem

`AS OF 2026-08-25` on a Wednesday afternoon is **correct** and still reads as broken. An EOD indicator sits one session behind for most of the day by design — its bar cannot exist until the market prints a close. The fact worth surfacing isn't the date, it's the question that follows it: *how long until this is current?*

The lone `AS OF` tile also wrapped to a second row on its own, leaving four dead columns under the strip.

## The rail

That band now carries the panel's whole time story, read left to right:

```
AS OF                                                    NEXT SAMPLE
2026-08-25    ████████████████████████████████░░░░           40m 07s
AWAITING 2026-08-26                                      TODAY 18:10
```

The **track is the point** — a 2px hairline filled with the elapsed share of the interval between runs, so staleness is legible before the digits are read. It borrows the CTA exposure bar's grammar rather than importing a progress-bar idiom from outside the product.

**Three states, one of which takes colour:**

| state | means | tone |
|---|---|---|
| `current` | the panel has the last completed session | muted |
| `behind` | the market closed a session it doesn't have; the run hasn't fired | muted |
| `overdue` | the run fired and the session still isn't here | `--warn` |

`--warn`, never `--fault`, mirroring `ivrankRegimeColor`'s restraint: the data is late, not wrong.

## Nothing here is a typed cadence string

The slot comes from `IV_RANK_REFRESH`, a new constant in `refreshSchedule.ts` **pinned by CI** to the `OnCalendar` line of `radon-ivrank.timer` — change the timer without editing the constant and the build fails. The session comes from the ET clock via `lastCompletedSessionDate`. (Root CLAUDE.md, UI Copy Rules.)

## Details that bite

- **The clock starts in an effect.** Reading it during render would put a different countdown in the server HTML than in the first client paint — the hydration-mismatch class this app has been bitten by before.
- **No CSS transition on the fill.** It advances once a second; easing would smear a tick into a slide. Nothing else on the rail moves, so there's no motion for `prefers-reduced-motion` to suppress.
- **Tabular figures** on the countdown — without them every tick shifts the digits sideways and it reads as a toy.
- `RandomizedDelaySec=120` on the timer means the real fire time is up to two minutes past the slot. The countdown targets the earliest one; `DUE` absorbs the rest.
- Countdown is sized to `.regime-strip-value`, **not above it** — the rail is meta about the panel and must not out-shout the statistics it annotates.
- Mobile: the 2x2 grid lost a cell when `AS OF` moved out, so the last odd cell now spans both columns (opt-in modifier; other panels untouched). That also stops the 1Y IV range wrapping in a half-width cell.

## Verification

Browser-verified at 1600px and 393px, light and dark, in all three states.

- `freshness-rail.test.ts` — 12 cases on the pure logic with an injected clock, including the overdue rule (the last run is late only if the session it was meant to carry had already closed when it fired).
- `freshness-rail-render.test.tsx` — 7 cases with fake timers: the no-countdown first paint, each state, and the tick.
- `refresh-schedule.test.ts` — the new timer pin.
- `e2e/ivrank-tab.spec.ts` — the rail on the real page.

Full vitest green (only the pre-existing `lib/tools` numpy failures, identical on `main`).

One note, not from this PR: `ivrank-tab.spec.ts` has pre-existing ordering pollution — a route handler outlives its test (`route.fetch: Test ended`) and the third test in the file fails intermittently whichever test occupies that slot. Same behaviour on clean `main`; CI's single retry covers it. Worth a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112BK4uxmymsUYSU8XpuBjj