### PR TITLE
fix(p3): image uid, Clerk bake-in, relay notify

### DIFF
--- a/cloud/tests/test_app_images.py
+++ b/cloud/tests/test_app_images.py
@@ -99,6 +99,8 @@ class TestPythonImage:
     def test_user_radon_is_final(self) -> None:
         text = PYTHON_DF.read_text(encoding="utf-8")
         assert _final_user(text) == "radon"
+        assert "--uid 1000" in text
+        assert "chmod 755 /home/radon" in text
 
 
 class TestNodeImage:
@@ -120,7 +122,16 @@ class TestNodeImage:
     def test_user_radon_is_final(self) -> None:
         text = NODE_DF.read_text(encoding="utf-8")
         assert _final_user(text) == "radon"
-        assert "--uid 1000" not in text
+        assert "--uid 1000" in text
+        assert "chmod 755 /home/radon" in text
+        assert "web/public/data" in text
+        assert "socat" in text
+
+    def test_clerk_public_env_is_required_at_build(self) -> None:
+        text = NODE_DF.read_text(encoding="utf-8")
+        assert 'ARG NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=""' not in text
+        assert "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY" in text
+        assert 'test -n "$NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY"' in text
 
 
 class TestImageSafety:

--- a/cloud/tests/test_app_runtime.py
+++ b/cloud/tests/test_app_runtime.py
@@ -261,3 +261,7 @@ def test_image_workflow_exists_and_is_not_a_deploy_need() -> None:
     assert "--ignorefile" not in wf
     assert "packages: write" in wf
     assert "environment:" not in wf
+    assert "--build-arg NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY" in wf
+    assert "--build-arg NEXT_PUBLIC_RADON_API_URL" in wf
+    assert "--build-arg NEXT_PUBLIC_IB_REALTIME_WS_URL" in wf
+    assert "vars.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY" in wf

--- a/cloud/tests/test_relay_container_watchdog.py
+++ b/cloud/tests/test_relay_container_watchdog.py
@@ -115,6 +115,9 @@ def test_relay_source_pings_watchdog_when_socket_present() -> None:
     assert "WATCHDOG=1" in src
     assert "NOTIFY_SOCKET" in src
     assert "sdNotify" in src
+    assert "systemd-notify" in src
+    assert "UNIX-SENDTO" in src
+    assert "socat" in src
 
 
 def test_container_dropin_forwards_notify_socket() -> None:

--- a/docker/app/Dockerfile.node
+++ b/docker/app/Dockerfile.node
@@ -34,8 +34,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # node:22-bookworm-slim already owns uid 1000 (`node`). Host radon is 1000;
 # the wrapper remaps --user to that uid, so the image user must match.
-RUN userdel node \
-    && groupdel node \
+RUN userdel node || true \
+    && groupdel node || true \
     && groupadd --gid 1000 radon \
     && useradd --system --uid 1000 --gid 1000 --create-home --home-dir /home/radon --shell /usr/sbin/nologin radon \
     && mkdir -p /home/radon/radon/web/public/data \

--- a/docker/app/Dockerfile.node
+++ b/docker/app/Dockerfile.node
@@ -29,11 +29,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       libxfixes3 \
       libxkbcommon0 \
       libxrandr2 \
+      socat \
     && rm -rf /var/lib/apt/lists/*
 
-RUN useradd --system --create-home --home-dir /home/radon --shell /usr/sbin/nologin radon \
-    && mkdir -p /home/radon/radon \
-    && chown -R radon:radon /home/radon
+# node:22-bookworm-slim already owns uid 1000 (`node`). Host radon is 1000;
+# the wrapper remaps --user to that uid, so the image user must match.
+RUN userdel node \
+    && groupdel node \
+    && groupadd --gid 1000 radon \
+    && useradd --system --uid 1000 --gid 1000 --create-home --home-dir /home/radon --shell /usr/sbin/nologin radon \
+    && mkdir -p /home/radon/radon/web/public/data \
+    && chown -R radon:radon /home/radon \
+    && chmod 755 /home/radon
 
 WORKDIR /home/radon/radon
 
@@ -46,11 +53,14 @@ RUN bun install --frozen-lockfile
 WORKDIR /home/radon/radon/web
 RUN bun install --frozen-lockfile
 
-ARG NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=""
-ARG NEXT_PUBLIC_RADON_API_URL=""
-ARG NEXT_PUBLIC_IB_REALTIME_WS_URL=""
+ARG NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+ARG NEXT_PUBLIC_RADON_API_URL
+ARG NEXT_PUBLIC_IB_REALTIME_WS_URL
 ARG NEXT_PUBLIC_CLERK_SIGN_IN_URL="/sign-in"
 ARG NEXT_PUBLIC_CLERK_SIGN_UP_URL="/sign-up"
+RUN test -n "$NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY" \
+    && test -n "$NEXT_PUBLIC_RADON_API_URL" \
+    && test -n "$NEXT_PUBLIC_IB_REALTIME_WS_URL"
 ENV NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=$NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY \
     NEXT_PUBLIC_RADON_API_URL=$NEXT_PUBLIC_RADON_API_URL \
     NEXT_PUBLIC_IB_REALTIME_WS_URL=$NEXT_PUBLIC_IB_REALTIME_WS_URL \
@@ -59,7 +69,7 @@ ENV NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=$NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY \
     PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
 RUN bun run build \
-    && mkdir -p /ms-playwright \
+    && mkdir -p /ms-playwright /home/radon/radon/web/public/data \
     && bun x playwright install chromium chromium-headless-shell \
     && chown -R radon:radon /home/radon/radon /ms-playwright
 

--- a/docker/app/Dockerfile.python
+++ b/docker/app/Dockerfile.python
@@ -4,9 +4,11 @@
 #   cp docker/app/.dockerignore .dockerignore && docker build -f docker/app/Dockerfile.python .
 FROM python:3.13-slim
 
-RUN useradd --system --create-home --home-dir /home/radon --shell /usr/sbin/nologin radon \
+RUN groupadd --gid 1000 radon \
+    && useradd --system --uid 1000 --gid 1000 --create-home --home-dir /home/radon --shell /usr/sbin/nologin radon \
     && mkdir -p /home/radon/radon/scripts \
-    && chown -R radon:radon /home/radon
+    && chown -R radon:radon /home/radon \
+    && chmod 755 /home/radon
 
 WORKDIR /home/radon/radon
 

--- a/scripts/ib_realtime_server.js
+++ b/scripts/ib_realtime_server.js
@@ -22,7 +22,7 @@ import fs from "node:fs";
 import path from "node:path";
 import http from "node:http";
 import net from "node:net";
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { WebSocketServer } from "ws";
 import { IBApi, EventName, SecType, OptionType, TickByTickDataType } from "@stoqey/ib";
 import { classifyIBConnectionError } from "./ib_connection_status.js";
@@ -98,14 +98,35 @@ const SD_NOTIFY_SOCKET = process.env.NOTIFY_SOCKET || "";
 const SD_WATCHDOG_USEC = parseInt(process.env.WATCHDOG_USEC || "0", 10);
 const sdWatchdogEnabled = Boolean(SD_NOTIFY_SOCKET && SD_WATCHDOG_USEC > 0);
 
+function sdNotifyViaSocat(state) {
+  const child = spawn(
+    "socat",
+    ["-t0", "-", `UNIX-SENDTO:${SD_NOTIFY_SOCKET}`],
+    { stdio: ["pipe", "ignore", "ignore"] },
+  );
+  child.stdin.end(state);
+}
+
 function sdNotify(state) {
   if (!sdWatchdogEnabled) return;
   try {
     // Fire-and-forget; the callback swallows ENOENT / send errors so a watchdog
-    // hiccup can never throw or block the event loop.
-    execFile("systemd-notify", [state], () => {});
+    // hiccup can never throw or block the event loop. Host has systemd-notify;
+    // the app-plane node image has socat and no systemd.
+    execFile("systemd-notify", [state], (err) => {
+      if (!err) return;
+      try {
+        sdNotifyViaSocat(state);
+      } catch {
+        /* never propagate into the loop */
+      }
+    });
   } catch {
-    /* never propagate into the loop */
+    try {
+      sdNotifyViaSocat(state);
+    } catch {
+      /* never propagate into the loop */
+    }
   }
 }
 


### PR DESCRIPTION
Fixes the three cutover mismatches. Does not install drop-ins.

- Images pin uid/gid 1000 (delete `node` user first); home 755; newsfeed `web/public/data`.
- Node image `RUN test -n` on NEXT_PUBLIC_*; GitHub Actions vars now populated from prod.
- Relay: systemd-notify on host, socat UNIX-SENDTO in the image.

Host ExecStart unchanged.