### PR TITLE
fix(risk): stop installing a stale disk series, and survive a persist failure

### DIFF
--- a/scripts/portfolio_risk.py
+++ b/scripts/portfolio_risk.py
@@ -82,6 +82,11 @@ STALE_TOLERANCE_DAYS = 10
 BACKFILL_MAX_SYMBOLS_PER_RUN = 4
 BACKFILL_RETRY_S = 6 * 3600
 BACKFILL_TOTAL_BUDGET_S = 20.0
+# The budget is checked BEFORE a symbol starts, so a symbol already in flight
+# runs to its own timeouts: IB connect (10) + IB history (20) + UW (30) +
+# Yahoo (30). Stating it makes one call's ceiling checkable — budget + one
+# worst-case symbol — instead of implied by four scattered timeouts.
+BACKFILL_SYMBOL_WORST_CASE_S = 90.0
 _BACKFILL_MARKER_PATH = _DATA_DIR / "price_risk_backfill.json"
 
 IB_HISTORY_DURATION = "1 Y"
@@ -405,7 +410,15 @@ def load_price_series_for_portfolio(
 
     if unusable:
         for ticker, closes in _load_disk_cache_series(unusable, stocks_dir).items():
-            if not _has_target_depth(series.get(ticker)):
+            if _has_target_depth(series.get(ticker)):
+                continue
+            # The cached series itself must clear the same depth AND freshness
+            # bar. Testing only the Turso side installed a year-old cache as a
+            # current correlation input: the ticker looked measurable, then
+            # shared too few dates with a fresh sibling to correlate, so the
+            # pair silently vanished from the report instead of landing in
+            # insufficient_data (R-204).
+            if _has_target_depth(closes):
                 series[ticker] = closes
 
     return {t: s for t, s in series.items() if s}
@@ -461,8 +474,16 @@ def backfill_price_history(
         if not closes:
             print(f"  no daily closes for {symbol} from IB/UW/Yahoo", file=sys.stderr)
             continue
-        _persist_closes(symbol, closes, source)
+        # Closes already in hand are the caller's answer whether or not the
+        # write-back lands, and one symbol's write failure must not abandon the
+        # symbols after it. An unguarded _persist_closes raised straight out of
+        # the loop: the fetched series was dropped on the floor and the rest of
+        # `due` went unattempted for the whole retry window (R-205).
         fetched[symbol] = closes
+        try:
+            _persist_closes(symbol, closes, source)
+        except Exception as exc:  # noqa: BLE001 - Turso write is best-effort
+            print(f"  failed to persist {symbol} closes: {exc}", file=sys.stderr)
     return fetched
 
 

--- a/scripts/tests/test_portfolio_risk_gate3_measurability.py
+++ b/scripts/tests/test_portfolio_risk_gate3_measurability.py
@@ -82,7 +82,7 @@ class TestBackfillBlackoutIsPerSymbolAndAfterTheAttempt:
     def test_a_persist_failure_does_not_discard_the_other_symbols(self, marker, monkeypatch):
         attempted: list[str] = []
 
-        def ladder(symbol):
+        def ladder(symbol, deadline=None, clock=None):
             attempted.append(symbol)
             return ({"2026-08-20": 10.0}, "ib")
 
@@ -103,7 +103,7 @@ class TestBackfillBlackoutIsPerSymbolAndAfterTheAttempt:
     def test_a_fetched_series_survives_a_persist_failure(self, marker, monkeypatch):
         monkeypatch.setattr(
             portfolio_risk, "_fetch_closes_via_ladder",
-            lambda s: ({"2026-08-20": 10.0}, "ib"),
+            lambda s, *a: ({"2026-08-20": 10.0}, "ib"),
         )
         monkeypatch.setattr(
             portfolio_risk, "_persist_closes",
@@ -115,7 +115,7 @@ class TestBackfillBlackoutIsPerSymbolAndAfterTheAttempt:
     def test_the_blackout_is_stamped_per_symbol_after_the_attempt(self, marker, monkeypatch):
         monkeypatch.setattr(
             portfolio_risk, "_fetch_closes_via_ladder",
-            lambda s: ({"2026-08-20": 10.0}, "ib") if s == "AAA" else (None, None),
+            lambda s, *a: ({"2026-08-20": 10.0}, "ib") if s == "AAA" else (None, None),
         )
         monkeypatch.setattr(portfolio_risk, "_persist_closes", lambda *a: None)
 
@@ -128,7 +128,7 @@ class TestBackfillBlackoutIsPerSymbolAndAfterTheAttempt:
         monkeypatch.setattr(portfolio_risk, "BACKFILL_MAX_SYMBOLS_PER_RUN", 2)
         monkeypatch.setattr(
             portfolio_risk, "_fetch_closes_via_ladder",
-            lambda s: ({"2026-08-20": 10.0}, "ib"),
+            lambda s, *a: ({"2026-08-20": 10.0}, "ib"),
         )
         monkeypatch.setattr(portfolio_risk, "_persist_closes", lambda *a: None)
 
@@ -143,19 +143,23 @@ class TestLoaderIsTimeBoxed:
         `attach_correlation_risk_report` runs every minute during RTH.
         """
         calls: list[str] = []
-        clock = {"t": 0.0}
-        monkeypatch.setattr(portfolio_risk.time, "monotonic", lambda: clock["t"])
+        now = {"t": 0.0}
 
-        def slow_ladder(symbol):
+        def clock():
+            return now["t"]
+
+        def slow_ladder(symbol, deadline=None, _clock=None):
             calls.append(symbol)
             # A dead gateway: this symbol burned the whole budget on connect
             # timeouts before the ladder even reached UW.
-            clock["t"] += portfolio_risk.BACKFILL_WALL_CLOCK_BUDGET_S
+            now["t"] += portfolio_risk.BACKFILL_TOTAL_BUDGET_S
             return (None, None)
 
         monkeypatch.setattr(portfolio_risk, "_fetch_closes_via_ladder", slow_ladder)
         monkeypatch.setattr(portfolio_risk, "_persist_closes", lambda *a: None)
-        portfolio_risk.backfill_price_history(["AAA", "BBB", "CCC", "DDD"])
+        portfolio_risk.backfill_price_history(
+            ["AAA", "BBB", "CCC", "DDD"], clock=clock
+        )
         assert len(calls) == 1, (
             f"the ladder kept going past its wall-clock budget: {calls}"
         )
@@ -169,7 +173,7 @@ class TestLoaderIsTimeBoxed:
         inside two portfolio-sync cadences.
         """
         bound = (
-            portfolio_risk.BACKFILL_WALL_CLOCK_BUDGET_S
+            portfolio_risk.BACKFILL_TOTAL_BUDGET_S
             + portfolio_risk.BACKFILL_SYMBOL_WORST_CASE_S
         )
         assert bound <= 120, f"a single loader call can block for {bound}s"


### PR DESCRIPTION
## Why

`789aabea` (Reliability weekend #100) merged `test_portfolio_risk_gate3_measurability.py` without the source half of R-204/R-205. `pytest (scripts-npsz)` fails on `main`, and because the deploy job needs the full gate, **`Prestage VPS release` and `Deploy to VPS` are skipped** — nothing has shipped since.

Seven tests failed. Two were real defects; five were the tests written against an API `main` does not have.

## Real defects, fixed in `scripts/portfolio_risk.py`

**R-204 — a stale disk cache was installed as a current correlation input.** The fallback tested `_has_target_depth` on the *Turso* series it was replacing, not on the *cached* series it was installing:

```python
if not _has_target_depth(series.get(ticker)):   # ← wrong operand
    series[ticker] = closes
```

With Turso empty, that is always true, so a year-old cache passed the per-ticker sufficiency test. `_aligned_returns` then intersected too few shared dates against a fresh sibling, the pair produced no correlation, and neither ticker reached `insufficient_data` — the operator read zero clusters and zero insufficient tickers, a clean bill of health, while the concentration Gate 3 exists to surface was structurally invisible.

**R-205 — one write failure discarded work and stalled the rest.** `_persist_closes` was unguarded, so a transient Turso failure raised straight out of the backfill loop: the closes already in hand were dropped, and every symbol after it went unattempted for the full `BACKFILL_RETRY_S` (6h) window. Closes are now recorded before the best-effort write, and the write is guarded.

## Drift, fixed in the test file

- Ladder stubs took one argument; `_fetch_closes_via_ladder` takes `(symbol, deadline, clock)`.
- The wall-clock test patched `time.monotonic` globally, which cannot work — `backfill_price_history`'s `clock=time.monotonic` default binds at def time. Now injects `clock=`, as `test_portfolio_risk.py` already does.
- `BACKFILL_WALL_CLOCK_BUDGET_S` → `BACKFILL_TOTAL_BUDGET_S`, the name in the code and in the existing tests.

`BACKFILL_SYMBOL_WORST_CASE_S = 90.0` is added and derived from the real rung timeouts (IB connect 10 + IB history 20 + UW 30 + Yahoo 30) — that is what the "bound is stated rather than implied" test asks for, and it keeps one call's ceiling at budget + one worst-case symbol = 110s.

## Verification

| Suite | Result |
|---|---|
| `test_portfolio_risk_gate3_measurability.py` | 8 passed (was 7 failed / 1 passed) |
| `test_portfolio_risk.py` | 25 passed |
| full `scripts-npsz` shard | 1211 passed, 1 skipped |
| `test_ib_helpers.py` + `test_ib_sync*.py` (callers) | 81 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)