### PR TITLE
fix(flow-analysis): retry ticker POST on subprocess capacity shed

### DIFF
--- a/docs/incident-runbook.md
+++ b/docs/incident-runbook.md
@@ -863,6 +863,43 @@ heartbeats.** Peak: 2026-08-24 19:30Z, page `60096761…`, 19m silent
 
 ---
 
+## flow-report-ticker-capacity-502
+
+**Operator `/flow-analysis/{TICKER}` ANALYZE returns instant HTTP 502
+`Subprocess capacity exhausted` while the hero stays on ANALYZING.** Peak:
+2026-08-27, JOBY.
+
+- **Mechanism:** `POST /flow-analysis/{ticker}` runs `flow_report.py` on the
+  general `run_script` lane (hard cap 4 / lane cap 3). Hourly scans and the
+  sibling `GET /informed-flow/{ticker}` spawn pin the lane. `_claim_subprocess_slot`
+  is fail-fast, so ANALYZE 502s in milliseconds. `/health/lite` stays 200.
+  The ticker hook then sets `status=error` with no cached report; SignalBadge
+  treated error-without-verdict as ANALYZING and rendered the raw
+  `Radon API 502: …` string.
+- **Discriminating check:** UI `Radon API 502: Subprocess capacity exhausted`
+  under an ANALYZING hero; radon-api
+  `Subprocess capacity exhausted for flow_report.py (3 active, lane cap 3,
+  hard cap 4)`; informed-flow panel still populated; `/health/lite` 200.
+  Script-failed 502 logs `Script flow_report.py failed (code 1)` and takes
+  seconds. Portfolio-tab `POST /flow-analysis` cooldown path is
+  `flow-refresh-capacity-502`.
+- **Remediation (code):** retry capacity shed on the ticker POST
+  (`FLOW_REPORT_SHED_RETRIES` default 2,
+  `FLOW_REPORT_SHED_RETRY_DELAY_SECS` default 8), same budget as
+  orders-sync. Persistent shed still 502. UI maps the capacity string to
+  operator copy and shows `Scan failed` instead of ANALYZING.
+- **Regression:**
+  `test_flow_report_capacity_shed.py::test_flow_report_retries_capacity_shed_then_succeeds`,
+  `test_flow_report_persistent_capacity_shed_still_502`,
+  `test_flow_report_real_script_failure_does_not_retry`,
+  `web/tests/flow-report-capacity-error.test.tsx`,
+  `web/e2e/flow-analysis-ticker.spec.ts` (`capacity 502 shows scan failed`).
+- **Code:** `scripts/api/server.py` (`_run_script_retrying_capacity`,
+  `run_flow_report`); `web/lib/flowReportError.ts`;
+  `web/components/flow-analysis/TickerFlowReport.tsx`.
+
+---
+
 ## service-health-degraded / service-down (generic cases)
 
 `service-health-degraded`: `/api/service-health` body lists failing rows (error,

--- a/scripts/api/server.py
+++ b/scripts/api/server.py
@@ -431,11 +431,51 @@ ORDERS_SYNC_INTERVAL_SECS = 5 * 60  # 5 min — comfortably under the 10-min wat
 # scan storms pin it, ib_orders.py is not on the reserved order lane.
 ORDERS_SYNC_SHED_RETRIES = 2
 ORDERS_SYNC_SHED_RETRY_DELAY_SECS = 8.0
+# Operator POST /flow-analysis/{ticker} shares that general lane. Fail-fast
+# 502 leaves the UI on ANALYZING with a raw capacity error. Retry the claim
+# with the same budget as orders-sync; persistent shed still 502s.
+FLOW_REPORT_SHED_RETRIES = 2
+FLOW_REPORT_SHED_RETRY_DELAY_SECS = 8.0
 _CAPACITY_SHED_MARKER = "subprocess capacity exhausted"
 
 
 def _is_capacity_shed(error: Optional[str]) -> bool:
     return bool(error) and _CAPACITY_SHED_MARKER in error.lower()
+
+
+async def _run_script_retrying_capacity(
+    script: str,
+    args: list[str],
+    *,
+    timeout: float,
+    retries: int,
+    delay_s: float,
+    label: str,
+) -> ScriptResult:
+    """Re-claim a general-lane slot after a capacity shed.
+
+    The claim is fail-fast. Peer scans often free a slot in seconds, so a
+    bounded sleep-and-retry is the operator-facing equivalent of the
+    orders-sync / flow-refresh wrappers. Real script failures do not retry.
+    """
+    result = await run_script(script, args, timeout=timeout)
+    attempts = 0
+    while (
+        not result.ok
+        and _is_capacity_shed(result.error)
+        and attempts < retries
+    ):
+        attempts += 1
+        logger.info(
+            "%s: capacity shed — retry %d/%d in %.0fs",
+            label,
+            attempts,
+            retries,
+            delay_s,
+        )
+        await asyncio.sleep(delay_s)
+        result = await run_script(script, args, timeout=timeout)
+    return result
 
 
 # A shed is not a healthy run: ib_orders.py never spawned and neither
@@ -2342,10 +2382,15 @@ async def run_flow_report(ticker: str):
 
     # 20 trading-day dark-pool history (flow_report DEFAULT_LOOKBACK_DAYS).
     # Cold liquid names paginate UW heavily; allow longer than the old 120s.
-    result = await run_script(
+    # Capacity shed is retryable: the general lane is often full for seconds
+    # because GET /informed-flow/{ticker} and hourly scans share it.
+    result = await _run_script_retrying_capacity(
         "flow_report.py",
         [upper, "--days", "20"],
         timeout=300,
+        retries=FLOW_REPORT_SHED_RETRIES,
+        delay_s=FLOW_REPORT_SHED_RETRY_DELAY_SECS,
+        label=f"flow-report {upper}",
     )
     if not result.ok:
         raise HTTPException(status_code=502, detail=result.error)

--- a/scripts/api/tests/test_flow_report_capacity_shed.py
+++ b/scripts/api/tests/test_flow_report_capacity_shed.py
@@ -1,0 +1,116 @@
+"""Operator ticker flow-report must not instant-502 when the general lane is full.
+
+2026-08-27: `/flow-analysis/JOBY` showed ANALYZING plus
+`Radon API 502: Subprocess capacity exhausted` while `/health/lite` stayed
+up and informed-flow still rendered. POST `/flow-analysis/{ticker}` runs
+`flow_report.py` on the general lane (cap 3). Scan storms and the sibling
+`GET /informed-flow/{ticker}` spawn pin the lane; fail-fast 502 is the
+wrong operator outcome — peer slots often free in seconds (same class as
+`orders-sync-capacity-shed-stale` / `flow-refresh-capacity-502`).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from api.subprocess import ScriptResult  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def localhost_bypass(monkeypatch):
+    from scripts.api import server, auth
+
+    monkeypatch.setattr(auth, "is_trusted_local_request", lambda request: True)
+    monkeypatch.setattr(server, "is_trusted_local_request", lambda request: True)
+    yield
+
+
+@pytest.fixture(autouse=True)
+def force_live_mode(monkeypatch):
+    from scripts.api import server
+
+    monkeypatch.setattr(server, "test_mode", False)
+    yield
+
+
+@pytest.fixture
+def client():
+    from scripts.api.server import app
+
+    return TestClient(app)
+
+
+def _shed() -> ScriptResult:
+    return ScriptResult(ok=False, error="Subprocess capacity exhausted")
+
+
+def _ok_report(ticker: str = "JOBY") -> ScriptResult:
+    return ScriptResult(
+        ok=True,
+        data={
+            "ticker": ticker,
+            "analysis": {"num_prints": 12},
+            "dark_pool": {"daily": [{"date": "2026-08-26", "num_prints": 12}]},
+        },
+    )
+
+
+def test_flow_report_retries_capacity_shed_then_succeeds(client):
+    """First claim refused, a later claim admits — ANALYZE must return 200."""
+    calls = {"n": 0}
+
+    async def flaky(script, args=None, timeout=30, **_kwargs):
+        assert script == "flow_report.py"
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return _shed()
+        return _ok_report()
+
+    with patch("scripts.api.server.run_script", side_effect=flaky):
+        with patch("scripts.api.server.asyncio.sleep", new=AsyncMock()) as slept:
+            resp = client.post("/flow-analysis/JOBY")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["ticker"] == "JOBY"
+    assert calls["n"] == 2
+    slept.assert_awaited()
+
+
+def test_flow_report_persistent_capacity_shed_still_502(client):
+    """Hour-long scans can outlast the retry budget. Still 502, still no spawn."""
+    from scripts.api import server
+
+    async def always_shed(script, args=None, timeout=30, **_kwargs):
+        return _shed()
+
+    with patch("scripts.api.server.run_script", side_effect=always_shed) as run:
+        with patch("scripts.api.server.asyncio.sleep", new=AsyncMock()):
+            resp = client.post("/flow-analysis/JOBY")
+
+    assert resp.status_code == 502
+    assert "capacity exhausted" in resp.json()["detail"].lower()
+    assert run.await_count == 1 + server.FLOW_REPORT_SHED_RETRIES
+
+
+def test_flow_report_real_script_failure_does_not_retry(client):
+    """UW/script 502 is not a shed. Do not burn the retry budget on it."""
+    async def boom(script, args=None, timeout=30, **_kwargs):
+        return ScriptResult(ok=False, error="Script exited with code 1")
+
+    with patch("scripts.api.server.run_script", side_effect=boom) as run:
+        with patch("scripts.api.server.asyncio.sleep", new=AsyncMock()) as slept:
+            resp = client.post("/flow-analysis/JOBY")
+
+    assert resp.status_code == 502
+    assert "exited with code 1" in resp.json()["detail"]
+    assert run.await_count == 1
+    slept.assert_not_awaited()

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,24 @@
+# Task: flow-report ticker capacity 502 (JOBY, 2026-08-27)
+
+## Dependency graph
+
+- F1 depends_on: [] - Red tests: ticker POST retries capacity shed; UI not ANALYZING
+- F2 depends_on: [F1] - Retry helper on POST /flow-analysis/{ticker}; operator copy
+- F3 depends_on: [F2] - Runbook `flow-report-ticker-capacity-502`
+
+## Checklist
+
+- [x] F1 Red tests
+- [x] F2 Server retry + SignalBadge Scan failed
+- [x] F3 Runbook + focused pytest/vitest green
+
+## Review
+
+- Focused pytest `test_flow_report_capacity_shed.py` 3 passed
+- Focused vitest `flow-report-capacity-error` 3 passed; analyzing-loader still 3 passed
+
+---
+
 # Task: P1 radon-bpi Result=timeout (page bbaa065b, 2026-08-24 23:30Z)
 
 ## Dependency graph

--- a/web/components/flow-analysis/TickerFlowReport.tsx
+++ b/web/components/flow-analysis/TickerFlowReport.tsx
@@ -9,6 +9,7 @@ import SignalCard from "@/components/mobile/SignalCard";
 import SpectralLoader from "@/components/SpectralLoader";
 import { useViewport } from "@/lib/useViewport";
 import DailyDarkPoolHistory from "@/components/flow-analysis/DailyDarkPoolHistory";
+import { flowReportErrorCopy } from "@/lib/flowReportError";
 
 type Props = {
   ticker: string;
@@ -36,12 +37,12 @@ export default function TickerFlowReport({ ticker }: Props) {
 
   return (
     <div className="ticker-flow-report" data-testid="ticker-flow-report">
-      <SignalBadge ticker={ticker} verdict={verdict} status={status} onRefresh={refresh} />
+      <SignalBadge ticker={ticker} verdict={verdict} status={status} error={error} onRefresh={refresh} />
 
       {error && (
         <div className="section">
           <div className="section-body">
-            <div className="alert-item bearish" role="alert">{error}</div>
+            <div className="alert-item bearish" role="alert">{flowReportErrorCopy(error)}</div>
           </div>
         </div>
       )}
@@ -190,7 +191,7 @@ function MobileTickerFlowReport({
 
       {error && (
         <div style={{ padding: "8px 16px" }}>
-          <div className="alert-item bearish" role="alert">{error}</div>
+          <div className="alert-item bearish" role="alert">{flowReportErrorCopy(error)}</div>
         </div>
       )}
 
@@ -391,17 +392,20 @@ function SignalBadge({
   ticker,
   verdict,
   status,
+  error,
   onRefresh,
 }: {
   ticker: string;
   verdict: Verdict | null;
   status: ReturnType<typeof useTickerFlowReport>["status"];
+  error: string | null;
   onRefresh: () => void;
 }) {
   const direction = verdict?.direction ?? null;
   const meta = directionMeta(direction);
   const Icon = meta.Icon;
-  const showVerdict = status === "fresh" || status === "error" || status === "scanning";
+  const failed = status === "error" && !verdict;
+  const showVerdict = !failed && (status === "fresh" || status === "error" || status === "scanning");
 
   return (
     <section className="section ticker-flow-hero">
@@ -434,12 +438,14 @@ function SignalBadge({
         </div>
         <div className="ticker-flow-badge-body">
           <div className="ticker-flow-badge-label">
-            {showVerdict && verdict ? meta.label : `Analyzing ${ticker}`}
+            {failed ? "Scan failed" : showVerdict && verdict ? meta.label : `Analyzing ${ticker}`}
           </div>
           <div className="ticker-flow-badge-rationale">
-            {showVerdict && verdict
-              ? verdict.rationale
-              : "Reconstructing dark pool and options flow"}
+            {failed
+              ? flowReportErrorCopy(error)
+              : showVerdict && verdict
+                ? verdict.rationale
+                : "Reconstructing dark pool and options flow"}
           </div>
         </div>
         {showVerdict && verdict && (

--- a/web/e2e/flow-analysis-ticker.spec.ts
+++ b/web/e2e/flow-analysis-ticker.spec.ts
@@ -254,4 +254,43 @@ test.describe("Flow Analysis per-ticker route", () => {
 
     expect(scanCalls).toBeGreaterThanOrEqual(1);
   });
+
+  test("capacity 502 shows scan failed, not ANALYZING", async ({ page }) => {
+    await setupBaseMocks(page);
+    await page.route("**/api/informed-flow/**", (r) =>
+      r.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ticker: "JOBY",
+          congress_trades: [],
+          insider_trades: [],
+          institutional_summary: null,
+        }),
+      }),
+    );
+    await page.route("**/api/flow-analysis/JOBY**", async (route) => {
+      const req = route.request();
+      if (req.method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ ticker: "JOBY", missing: true, cache_meta: { is_stale: true } }),
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 502,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Radon API 502: Subprocess capacity exhausted" }),
+      });
+    });
+
+    await page.goto("/flow-analysis/JOBY");
+
+    const report = page.getByTestId("ticker-flow-report");
+    await expect(report.getByRole("alert")).toContainText(/Scan lane is full/i);
+    await expect(report.getByRole("status")).toContainText(/Scan failed/i);
+    await expect(report).not.toContainText(/Analyzing JOBY/i);
+  });
 });

--- a/web/lib/flowReportError.ts
+++ b/web/lib/flowReportError.ts
@@ -1,0 +1,13 @@
+/** Operator-facing copy for a per-ticker flow-report failure. */
+
+export function isSubprocessCapacityError(message: string | null | undefined): boolean {
+  return Boolean(message) && /subprocess capacity exhausted/i.test(message);
+}
+
+export function flowReportErrorCopy(message: string | null | undefined): string {
+  if (isSubprocessCapacityError(message)) {
+    return "Scan lane is full. Wait a moment and refresh.";
+  }
+  const trimmed = message?.trim();
+  return trimmed || "Flow scan failed";
+}

--- a/web/lib/useTickerFlowReport.ts
+++ b/web/lib/useTickerFlowReport.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { isFlowReportStale } from "@/lib/flowReportStaleness";
+import { flowReportErrorCopy } from "@/lib/flowReportError";
 
 /**
  * Cache-then-scan hook for a single-ticker flow report.
@@ -108,7 +109,7 @@ export function useTickerFlowReport(ticker: string | null): UseTickerFlowReportR
     } catch (err) {
       if (signal.aborted) return;
       const message = err instanceof Error ? err.message : "Flow scan failed";
-      setError(message);
+      setError(flowReportErrorCopy(message));
       // Preserve any previously-cached data — caller decides how to display.
       setStatus("error");
     }
@@ -158,7 +159,7 @@ export function useTickerFlowReport(ticker: string | null): UseTickerFlowReportR
       } catch (err) {
         if (signal.aborted) return;
         const message = err instanceof Error ? err.message : "Failed to load report";
-        setError(message);
+        setError(flowReportErrorCopy(message));
         setData(null);
         setStatus("error");
       }

--- a/web/tests/flow-report-capacity-error.test.tsx
+++ b/web/tests/flow-report-capacity-error.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * 2026-08-27: /flow-analysis/JOBY showed ANALYZING plus the raw
+ * `Radon API 502: Subprocess capacity exhausted` string when the general
+ * subprocess lane was full. Capacity shed is retryable, not a finished
+ * analysis — the hero must not keep saying ANALYZING, and the operator
+ * copy must not leak the FastAPI 502.
+ */
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  flowReportErrorCopy,
+  isSubprocessCapacityError,
+} from "@/lib/flowReportError";
+
+vi.mock("@/lib/useViewport", () => ({
+  useViewport: () => ({ isMobile: false, isTablet: false, hasMounted: true }),
+}));
+
+const hookState = vi.hoisted(() => ({
+  data: null as null,
+  status: "error" as const,
+  error: "Radon API 502: Subprocess capacity exhausted",
+  refresh: () => {},
+}));
+
+vi.mock("@/lib/useTickerFlowReport", () => ({
+  useTickerFlowReport: () => hookState,
+}));
+
+import TickerFlowReport from "../components/flow-analysis/TickerFlowReport";
+
+afterEach(cleanup);
+
+describe("flowReportErrorCopy", () => {
+  it("rewrites the FastAPI capacity 502", () => {
+    expect(isSubprocessCapacityError("Radon API 502: Subprocess capacity exhausted")).toBe(true);
+    expect(flowReportErrorCopy("Radon API 502: Subprocess capacity exhausted")).toBe(
+      "Scan lane is full. Wait a moment and refresh.",
+    );
+  });
+
+  it("leaves a real script failure intact", () => {
+    expect(flowReportErrorCopy("Script timed out after 300s")).toBe("Script timed out after 300s");
+  });
+});
+
+describe("ticker flow report capacity 502", () => {
+  it("does not keep the ANALYZING hero after a capacity 502", () => {
+    render(<TickerFlowReport ticker="JOBY" />);
+
+    expect(screen.queryByText(/Analyzing JOBY/i)).toBeNull();
+    expect(screen.getByRole("alert").textContent).toBe(
+      "Scan lane is full. Wait a moment and refresh.",
+    );
+    expect(screen.getByRole("status").textContent).toMatch(/Scan failed/i);
+  });
+});


### PR DESCRIPTION
## Why
`/flow-analysis/JOBY` ANALYZE returned instant `Radon API 502: Subprocess capacity exhausted` while the hero stayed on ANALYZING. IB gateway was nominal.

## Cause
`POST /flow-analysis/{ticker}` runs `flow_report.py` on the general subprocess lane (cap 3). Hourly scans and `GET /informed-flow/{ticker}` pin the lane. The claim is fail-fast. The UI treated error-without-verdict as ANALYZING.

## Fix
- Retry capacity shed on the ticker POST (`FLOW_REPORT_SHED_RETRIES=2`, 8s), same budget as orders-sync. Persistent shed still 502.
- Operator copy: `Scan lane is full. Wait a moment and refresh.` Hero shows `Scan failed`.

## Verify
- `test_flow_report_capacity_shed.py` 3 passed
- vitest `flow-report-capacity-error` 3 passed
- Playwright `capacity 502 shows scan failed, not ANALYZING` 1 passed
- Runbook: `flow-report-ticker-capacity-502`

Does not fix hour-long lane occupancy (leap/garch). Refresh after the scan storm.