### PR TITLE
fix(ci): green the four gate failures blocking every deploy on main

### DIFF
--- a/cloud/tests/test_env_contract_parity.py
+++ b/cloud/tests/test_env_contract_parity.py
@@ -50,10 +50,10 @@ EXEMPT: dict[str, str] = {
     "RADON_CTA_SYNC_SOURCE": "argparse default for --source; the CLI flag is the contract",
     # Feature flags whose unset state is the safe one.
     "RADON_AUTH_DISABLED": "local-dev escape hatch; unset is the production state",
-    # Demo instance. Neither secret is provisioned (see .github/workflows/ci.yml
-    # demo-isolation guard); the mirror skips when they are absent.
-    "TURSO_DEMO_DB_URL": "demo mirror only; not provisioned, the job skips without it",
-    "TURSO_DEMO_AUTH_TOKEN": "demo mirror only; not provisioned, the job skips without it",
+    # TURSO_DEMO_DB_URL / TURSO_DEMO_AUTH_TOKEN are deliberately NOT exempt.
+    # R-300 moved them into cloud/config/required-env.txt: radon-demo-mirror's
+    # ExecStartPre runs `migrate.py --demo`, whose resolve_target() exits 2 when
+    # either is unset, so the unit fails on every fire rather than skipping.
     # Override knobs with an in-code default URL/binary.
     "CBOE_DAILY_PRICES_BASE_URL": "override for _DEFAULT_BASE_URL in clients/cboe_client.py",
     "FINRA_MARGIN_XLSX_URL": "override for _DEFAULT_XLSX_URL in clients/finra_client.py",

--- a/scripts/watchdog/services.py
+++ b/scripts/watchdog/services.py
@@ -107,6 +107,10 @@ SCHEDULED_SERVICES: dict[str, FreshnessWindow] = {
     # nextjs-db-read registration above (REL-033). R-236.
     "breadth-scan":     {"open": 15 * _MIN, "closed": 3 * _DAY, "requires_ib": True},
     "cta-sync":         {"open": 25 * _HOUR, "closed": 72 * _HOUR, "requires_ib": False},
+    # Extraction-quality row written by the same radon-cta-sync.timer firings
+    # (R-297): `error` when more than half the rows lost their percentile to
+    # the z-score check. Same cadence as cta-sync, so the same windows.
+    "menthorq-cta":     {"open": 25 * _HOUR, "closed": 72 * _HOUR, "requires_ib": False},
     # Daily-cadence writers (mirror web/lib/serviceHealthWindows.ts):
     #  * llm-token-index — radon-llm-index.timer, once/UTC-day 06:30; pulls
     #    Artificial Analysis only, no IB. Has not fired on weekends in

--- a/scripts/watchdog/services.py
+++ b/scripts/watchdog/services.py
@@ -426,6 +426,10 @@ BUCKETS: dict[str, list[str]] = {
         "menthorq-session",
         "menthorq-login-probe",
         "cta-sync",
+        # Same timer as cta-sync, so the same daily age check. Without it the
+        # row carries a freshness window nothing evaluates and only _check_error
+        # would ever see it.
+        "menthorq-cta",
         # Once-per-day writers — hourly check surfaces a delay within 1h
         # of the window expiring.
         "llm-token-index",

--- a/web/tests/cta-percentile-reconcile.test.ts
+++ b/web/tests/cta-percentile-reconcile.test.ts
@@ -139,12 +139,19 @@ describe("reconcileCtaTables with no z-score to arbitrate", () => {
     ],
   };
 
-  it("prefers the unrounded row in every table", () => {
+  it("publishes nothing for a row no z-score can verify", () => {
+    // R-289 / REL-099(b) supersedes the earlier "prefer the unrounded copy"
+    // expectation here. The vision pass that mangles the percentile column is
+    // the same one that drops the z, so a missing z is evidence AGAINST the
+    // row, not a neutral absence — and the path where the check does not exist
+    // must be the reject path, not the pass path. The unrounded 0.81 sibling is
+    // still preferred when picking the trio; it just is not published while
+    // nothing can check it.
     const out = reconcileCtaTables(nullZ);
     for (const table of ["main", "index"] as const) {
-      expect(out[table][0].percentile_3m).toBe(81);
-      expect(out[table][0].percentile_1m).toBe(43);
-      expect(out[table][0].percentile_1y).toBe(88);
+      expect(out[table][0].percentile_3m).toBeNull();
+      expect(out[table][0].percentile_1m).toBeNull();
+      expect(out[table][0].percentile_1y).toBeNull();
     }
   });
 
@@ -163,7 +170,9 @@ describe("reconcileCtaTables with no z-score to arbitrate", () => {
         { underlying: "Gold", position_today: -1.9, percentile_1m: 0, percentile_3m: 0, percentile_1y: 1, z_score_3m: null },
       ],
     });
-    expect(out.main[0].percentile_3m).toBe(0);
-    expect(out.main[0].percentile_1y).toBe(1);
+    // Nothing is invented — and with no z on either copy, nothing is published
+    // either (R-289). The original 0/1 pass-through was the unverifiable path.
+    expect(out.main[0].percentile_3m).toBeNull();
+    expect(out.main[0].percentile_1y).toBeNull();
   });
 });

--- a/web/tests/sync-fallback.test.ts
+++ b/web/tests/sync-fallback.test.ts
@@ -155,17 +155,29 @@ describe("GET /api/portfolio — cached snapshot only", () => {
   });
 
   it("serves a stale snapshot with a warning and no background IB sync", async () => {
-    const snapshot = makePortfolio("2026-03-13T15:45:00Z");
-    mockPortfolioDb(snapshot);
+    // `portfolio-sync` is an RTH_ONLY_SERVICES member, so while the market is
+    // open isStale() measures age from TODAY'S OPEN, not from the snapshot. In
+    // the first 10 minutes of the session even a months-old snapshot is inside
+    // the window, no warning is set, and this read a null header — which is
+    // exactly what CI hit at 09:36 ET. Pin the clock mid-session so the case
+    // under test is staleness rather than the hour CI happened to run.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date("2026-03-20T18:00:00Z")); // Fri 14:00 ET
+    try {
+      const snapshot = makePortfolio("2026-03-13T15:45:00Z");
+      mockPortfolioDb(snapshot);
 
-    const { GET } = await import("../app/api/portfolio/route");
-    const response = await GET();
-    const body = await response.json();
+      const { GET } = await import("../app/api/portfolio/route");
+      const response = await GET();
+      const body = await response.json();
 
-    expect(response.status).toBe(200);
-    expect(body.last_sync).toBe(snapshot.last_sync);
-    expect(response.headers.get("X-Sync-Warning")).toContain("stale");
-    expect(mockRadonFetch).not.toHaveBeenCalled();
+      expect(response.status).toBe(200);
+      expect(body.last_sync).toBe(snapshot.last_sync);
+      expect(response.headers.get("X-Sync-Warning")).toContain("stale");
+      expect(mockRadonFetch).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 


### PR DESCRIPTION
## Why

Three weekend PRs landed inside 40 minutes (#112 12:56, #111 13:27, #113 14:10) and left `main` red on four jobs. Because the deploy job needs the full gate, **`Prestage VPS release` and `Deploy to VPS` have been skipped ever since** — nothing has shipped today.

None of the four is a defect in shipped behaviour. Three are contracts that disagree with each other; one is a test that depends on the hour CI runs.

## `pytest (cloud al)` — a key that is exempt and required at once

`TURSO_DEMO_DB_URL` / `TURSO_DEMO_AUTH_TOKEN` were in `EXEMPT` **and** in `required-env.txt`. #111 added them deliberately (R-300: `radon-demo-mirror`'s `ExecStartPre` runs `migrate.py --demo`, whose `resolve_target()` `sys.exit(2)`s when either is unset, so the unit fails on every fire) but left the stale exemptions behind. Their stated reason — *"not provisioned, the job skips without it"* — is now false twice: the keys **are** provisioned (`grep -c` on the host → `2`), and the unit exits rather than skipping. The contract addition stands; the exemptions go.

## `pytest (scripts-daemons)` — a scheduled writer in one catalog only

`menthorq-cta` is `category: "scheduled"` in `serviceHealthWindows.ts` and absent from `SCHEDULED_SERVICES`. Added with `cta-sync`'s windows (25h / 72h, no IB) — it is the extraction-quality row written by the same `radon-cta-sync.timer` firings (R-297).

## `Vitest 2/8` — two audits with opposing intent

#112 added tests asserting a null-z row is published from the unrounded cross-table copy, and built `roundedRank`/`candidateRank`/`ranksBetter` for exactly that case. 31 minutes later #111 added R-289 (REL-099b), which nulls any percentile no z-score can verify — making that branch unreachable. **Neither audit range saw the other** (#111 audited `1b326772..789aabea`, which predates #112's merge).

R-289 wins here: it is the later and explicitly reasoned P1, and its rationale holds — the vision pass that mangles the percentile column is the same one that drops the z, so a missing z is evidence *against* the row. Publishing it is what inverts a narrative into "max short" on the card. The affected assertions now encode that.

⚠️ This is a judgement call between two deliberate decisions. If the intent was #112's, revert this hunk and scope R-289's `unverifiable` clause instead.

## `Vitest 8/8` — not flaky, time-of-day dependent

`sync-fallback`'s stale-snapshot test fails in a ~10-minute daily window. `portfolio-sync` is in `RTH_ONLY_SERVICES`, so while the market is open `isStale()` measures age **from today's open**:

```js
if (ts < todayOpenEt) return elapsedOpenMs > window;   // window = 10 min
```

In the first 10 minutes of the session even a months-old snapshot is inside the window, no warning is set, and `expect(headers.get("X-Sync-Warning")).toContain("stale")` gets `null` — the exact CI error. CI ran at **09:36 ET**. Pinning the clock to 09:36 ET reproduces it exactly; the test now pins mid-session so it measures staleness rather than the hour.

## Verification

| Suite | Result |
|---|---|
| `cloud/tests` | 1160 passed, 7 skipped (3 `caddy is not on PATH` env-only failures) |
| `scripts/tests/test_monitor_daemon` + `test_watchdog` | 766 passed |
| Vitest shard 2/8 | 913 passed |
| Vitest shard 8/8 | 1082 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)