### PR TITLE
fix(chain-ticket): transmit was closed over a stale acknowledgement

### DIFF
--- a/web/components/ticker-detail/OptionsChainTab.tsx
+++ b/web/components/ticker-detail/OptionsChainTab.tsx
@@ -574,6 +574,7 @@ function OrderBuilder({
     structure,
     signedLimitPrice,
     submitPermitted,
+    transmitArmed,
   ]);
 
   // OrderPriceStrip prices (combo) or single-leg signed mid

--- a/web/tests/chain-transmit-gate.test.tsx
+++ b/web/tests/chain-transmit-gate.test.tsx
@@ -126,4 +126,23 @@ describe("ticket transmit gate", () => {
     expect((ack as HTMLInputElement).checked).toBe(false);
     expect(transmitButton().disabled).toBe(true);
   });
+
+  // Arming the button is not the same as being able to send. The submit
+  // handler re-checks the acknowledgement, so it must see the CURRENT one —
+  // a handler memoised without it stays closed over `false` forever and the
+  // armed button silently does nothing (production 2026-08-27).
+  it("transmits the order once acknowledged", async () => {
+    await shortCallTicket();
+    fireEvent.click(verifyButton());
+    fireEvent.click(await screen.findByTestId("ticket-unbounded-ack"));
+    await waitFor(() => expect(transmitButton().disabled).toBe(false));
+
+    fireEvent.click(transmitButton());
+
+    await waitFor(() =>
+      expect(
+        fetchMock.mock.calls.some(([input]) => String(input).includes("/api/orders/place")),
+      ).toBe(true),
+    );
+  });
 });


### PR DESCRIPTION
Ticking the unbounded-risk acknowledgement armed the Transmit button but never armed the submit handler: `handlePlace` was memoised without `transmitArmed`, so it stayed closed over the `false` captured at review time and returned early at its defence-in-depth guard. The operator saw an enabled TRANSMIT button that did nothing — no request, no error.

Fix: add `transmitArmed` to the `useCallback` deps.

Red/green: the new test in `chain-transmit-gate.test.tsx` clicks the armed button and asserts a POST to `/api/orders/place`. It fails on the parent commit (`expected false to be true`) and passes with the dep.

Full vitest suite from repo root: 7615 passed, 0 failed.

Not exercised live — verifying end to end means transmitting a real naked short call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177apGqsWaVFmiCkBvzNCSs