### PR TITLE
fix(options): retry a transient IB handshake on the equity chain

### DIFF
--- a/scripts/ib_option_chain.py
+++ b/scripts/ib_option_chain.py
@@ -10,12 +10,26 @@ import argparse
 import asyncio
 import json
 import sys
+import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from scripts.clients.ib_client import IBClient
 from scripts.utils.ib_preflight import IB_REQUEST_TIMEOUT_S
+
+# Transient-handshake resilience. The Gateway serialises API handshakes, so a
+# connect issued while several scheduled scans are claiming their own sockets
+# can time out even though the Gateway is authenticated and healthy — ib_insync
+# surfaces that as `API connection failed: TimeoutError()`, which the
+# auto-allocator does not treat as a collision and therefore does not rotate.
+# Production 2026-08-27: /options/expirations?symbol=NOW 504'd on the single
+# attempt and served in 1.1s two minutes later. Sibling `ib_chain.py` already
+# retries this class; the budget below leaves room for the two bounded IB
+# requests inside _EQUITY_OPTIONS_CHAIN_TIMEOUT_S (45s).
+CONNECT_ATTEMPTS = 3
+CONNECT_TIMEOUT_S = 4
+CONNECT_BACKOFF_S = 1.0
 
 
 def _normalize_expiry(expiry) -> str:
@@ -66,6 +80,24 @@ def _preferred_multiplier(chains) -> str:
     return str(getattr(chains[0], "multiplier", ""))
 
 
+def _connect_with_retry(client, port: int, client_id) -> None:
+    """Connect, retrying a transient handshake timeout within a bounded budget.
+
+    Raises the last exception when every attempt fails, so the caller's error
+    envelope still names the timeout and the endpoint still answers 504.
+    """
+    for attempt in range(1, CONNECT_ATTEMPTS + 1):
+        try:
+            client.connect(
+                port=port, client_id=client_id, timeout=CONNECT_TIMEOUT_S
+            )
+            return
+        except Exception:
+            if attempt == CONNECT_ATTEMPTS:
+                raise
+            time.sleep(CONNECT_BACKOFF_S)
+
+
 def _set_ib_request_timeout(ib, timeout_s: float = IB_REQUEST_TIMEOUT_S) -> None:
     """Bound sync ib_insync requests; default RequestTimeout can block forever."""
     setattr(ib, "RequestTimeout", timeout_s)
@@ -113,7 +145,7 @@ def main():
     client = IBClient()
 
     try:
-        client.connect(port=args.port, client_id=client_id)
+        _connect_with_retry(client, args.port, client_id)
 
         # Qualify the underlying to get a valid conId (required by reqSecDefOptParams).
         # Index symbols (VIX, SPX, NDX, RUT, XSP, VVIX) MUST be qualified as

--- a/scripts/ib_option_chain.py
+++ b/scripts/ib_option_chain.py
@@ -19,14 +19,19 @@ from scripts.clients.ib_client import IBClient
 from scripts.utils.ib_preflight import IB_REQUEST_TIMEOUT_S
 
 # Transient-handshake resilience. The Gateway serialises API handshakes, so a
-# connect issued while several scheduled scans are claiming their own sockets
-# can time out even though the Gateway is authenticated and healthy — ib_insync
+# connect issued while other subprocesses are claiming their own sockets can
+# time out even though the Gateway is authenticated and healthy — ib_insync
 # surfaces that as `API connection failed: TimeoutError()`, which the
 # auto-allocator does not treat as a collision and therefore does not rotate.
-# Production 2026-08-27: /options/expirations?symbol=NOW 504'd on the single
-# attempt and served in 1.1s two minutes later. Sibling `ib_chain.py` already
-# retries this class; the budget below leaves room for the two bounded IB
-# requests inside _EQUITY_OPTIONS_CHAIN_TIMEOUT_S (45s).
+# Production 2026-08-27 14:22:10: /options/expirations?symbol=NOW 504'd on its
+# single attempt while ten browser-driven POST /portfolio/sync calls in 90s
+# were each spawning an ib_sync.py that claimed a socket; the same request
+# served in 1.1s two minutes later. ib_sync.py is 51 of the 53 connect
+# failures in that 24h window — the real fix is shedding the multi-tab sync
+# fan-in, and this retry only stops the chain losing that race.
+# Sibling `ib_chain.py` already retries this class; the budget below leaves
+# room for the two bounded IB requests inside
+# _EQUITY_OPTIONS_CHAIN_TIMEOUT_S (45s).
 CONNECT_ATTEMPTS = 3
 CONNECT_TIMEOUT_S = 4
 CONNECT_BACKOFF_S = 1.0

--- a/scripts/tests/test_ib_option_chain_connect_retry.py
+++ b/scripts/tests/test_ib_option_chain_connect_retry.py
@@ -1,0 +1,102 @@
+"""ib_option_chain.py must ride out a transient IB handshake timeout.
+
+Production 2026-08-27 14:22:10: `/options/expirations?symbol=NOW` returned 504
+because `ib_option_chain.py` connected exactly once and the Gateway handshake
+timed out while several scheduled scans were connecting on the same socket.
+Two minutes later the identical request served in 1.1s. The sibling
+`ib_chain.py` already retries this class of failure; the equity chain did not.
+
+These tests inject a fake IBClient so no live Gateway is needed.
+"""
+
+import json
+
+import pytest
+
+from scripts import ib_option_chain
+
+
+class _FakeExpiryChain:
+    def __init__(self):
+        self.tradingClass = "NOW"
+        self.expirations = ["20260828", "20260904"]
+        self.exchange = "SMART"
+        self.strikes = [100.0, 110.0]
+        self.multiplier = "100"
+
+
+class _FakeIB:
+    RequestTimeout = 0
+
+    def qualifyContracts(self, contract):
+        contract.conId = 1234
+        return [contract]
+
+    def reqSecDefOptParams(self, *_args):
+        return [_FakeExpiryChain()]
+
+
+class _FakeClient:
+    """IBClient stand-in whose first N connects raise the production error."""
+
+    def __init__(self, fail_connects=0):
+        self._fail_connects = fail_connects
+        self.connect_calls = 0
+        self.connect_timeouts = []
+        self._ib = _FakeIB()
+        self.disconnected = False
+
+    def connect(self, **kwargs):
+        self.connect_calls += 1
+        self.connect_timeouts.append(kwargs.get("timeout"))
+        if self.connect_calls <= self._fail_connects:
+            raise ConnectionError("API connection failed: TimeoutError()")
+
+    def disconnect(self):
+        self.disconnected = True
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    monkeypatch.setattr(ib_option_chain.time, "sleep", lambda _s: None)
+
+
+def _run(monkeypatch, capsys, client, argv=("--symbol", "NOW")):
+    monkeypatch.setattr(ib_option_chain, "IBClient", lambda *a, **k: client)
+    monkeypatch.setattr("sys.argv", ["ib_option_chain.py", *argv])
+    ib_option_chain.main()
+    return json.loads(capsys.readouterr().out.strip())
+
+
+def test_transient_handshake_timeout_is_retried(monkeypatch, capsys):
+    client = _FakeClient(fail_connects=2)
+    out = _run(monkeypatch, capsys, client)
+    assert "error" not in out, out
+    assert out["expirations"] == ["20260828", "20260904"]
+    assert client.connect_calls == 3
+    assert client.disconnected is True
+
+
+def test_connect_retries_are_bounded(monkeypatch, capsys):
+    client = _FakeClient(fail_connects=99)
+    monkeypatch.setattr(ib_option_chain, "IBClient", lambda *a, **k: client)
+    monkeypatch.setattr("sys.argv", ["ib_option_chain.py", "--symbol", "NOW"])
+    with pytest.raises(SystemExit) as exc:
+        ib_option_chain.main()
+    assert exc.value.code == 1
+    assert client.connect_calls == ib_option_chain.CONNECT_ATTEMPTS
+    out = json.loads(capsys.readouterr().out.strip())
+    assert "timeout" in out["error"].lower()
+
+
+def test_connect_budget_fits_the_endpoint_timeout():
+    """Worst-case connect must leave room for qualify + reqSecDefOptParams."""
+    from scripts.utils.ib_preflight import IB_REQUEST_TIMEOUT_S
+
+    attempts = ib_option_chain.CONNECT_ATTEMPTS
+    worst_connect_s = (
+        attempts * ib_option_chain.CONNECT_TIMEOUT_S
+        + (attempts - 1) * ib_option_chain.CONNECT_BACKOFF_S
+    )
+    # scripts/api/server.py:_EQUITY_OPTIONS_CHAIN_TIMEOUT_S
+    assert worst_connect_s + 2 * IB_REQUEST_TIMEOUT_S <= 45.0


### PR DESCRIPTION
## Problem

`/api/options/expirations?symbol=NOW` returned 504 (`Option expirations unavailable: Options request timed out`) at 14:22:10 ET while the IB Gateway was authenticated and healthy.

```
14:22:10 Script ib_option_chain.py failed (code 1): API connection failed: TimeoutError()
14:22:10 "GET /options/expirations?symbol=NOW HTTP/1.1" 504 Gateway Timeout
14:24:48 "GET /options/expirations?symbol=NOW HTTP/1.1" 200 OK
```

`ib_option_chain.py` connects exactly once. `IBClient._connect_auto_allocate` only rotates client IDs on an explicit `client id is already in use` error; any other exception aborts immediately. The Gateway serialises API handshakes, so a connect issued while the scheduled scans are claiming their own sockets times out, and that timeout was fatal to the whole request.

The sibling `ib_chain.py` (futures / index) already retries this exact class. The equity chain did not.

## Fix

Bounded connect retry: 3 attempts, 4s connect timeout, 1s backoff — 14s worst case, leaving room for the two 15s IB requests inside the endpoint's 45s budget. A test asserts that budget so it cannot silently drift.

## Verification

Red/green TDD, 3 new tests in `scripts/tests/test_ib_option_chain_connect_retry.py` (red on `AttributeError: module has no attribute 'time'`, green after).

```
$ python3.13 -m pytest scripts/tests/test_ib_option_chain*.py -q
10 passed
```

Live against the production Gateway (patched copy run from `/tmp` with `PYTHONPATH`; deployed tree untouched and verified clean):

```
NOW  -> {"symbol": "NOW",  "expirations": ["20260828", "20260904", ...]}
AAPL -> {"symbol": "AAPL", "expirations": ["20260828", "20260831", ...]}
SPX  -> {"symbol": "SPX",  "expirations": ["20260917", "20261015", ...]}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACU4Vg1SRnWeQ4DUWcjaAS