### PR TITLE
fix(portfolio): set avg entry from session fills when they cover live qty

### DIFF
--- a/scripts/ib_sync.py
+++ b/scripts/ib_sync.py
@@ -608,6 +608,7 @@ def collapse_positions(positions: list) -> list:
                 "entry_cost": leg['entry_cost'],
                 "avg_cost": leg['avgCost'],
                 "ib_avg_cost": leg.get('ibAvgCost'),
+                "basis_source": leg.get("basis_source"),
                 "market_price": leg.get('marketPrice'),
                 "market_value": leg.get('marketValue'),
                 "market_price_is_calculated": bool(leg.get('marketPriceIsCalculated'))
@@ -628,6 +629,13 @@ def collapse_positions(positions: list) -> list:
             "market_value": round(total_market_value, 2) if total_market_value is not None else None,
             "market_price_is_calculated": bool(is_market_price_calculated) if total_market_value is not None else False,
             "ib_daily_pnl": ib_daily_pnl,
+            "basis_source": (
+                "session_fills"
+                if formatted_legs and all(
+                    l.get("basis_source") == "session_fills" for l in formatted_legs
+                )
+                else None
+            ),
             "legs": formatted_legs,
             "kelly_optimal": None,
             "target": None,
@@ -782,11 +790,49 @@ def _with_net_qty(lookup: dict, net_qty_lookup: dict) -> "_BasisLookup":
     return enriched
 
 
-def fetch_positions(client: IBClient, journal_basis_lookup: Optional[dict[str, float]] = None) -> list:
+def _session_fill_cover(fill: dict, position_size: float):
+    """Newest same-sign session fills whose qty exactly equals live size.
+
+    Returns (entry_cost_dollars, avg_cost_per_contract) or None. An exact
+    cover is the blotter's current OPEN row; a miss (overnight inventory,
+    a reduce, an add) leaves IB/journal basis in place.
+    """
+    if not fill or position_size == 0:
+        return None
+    sign = 1 if position_size > 0 else -1
+    need = abs(float(position_size))
+    picked: list[tuple[float, float]] = []
+    picked_qty = 0.0
+    for lot in reversed(fill.get("lots") or []):
+        try:
+            signed = float(lot["signed_qty"])
+            price = float(lot["per_share"])
+        except (TypeError, ValueError, KeyError):
+            continue
+        if signed == 0 or (1 if signed > 0 else -1) != sign:
+            continue
+        qty = abs(signed)
+        picked.append((qty, price))
+        picked_qty += qty
+        if picked_qty >= need - 1e-9:
+            break
+    if abs(picked_qty - need) > 1e-9:
+        return None
+    vwap = sum(qty * price for qty, price in picked) / need
+    entry_cost = need * vwap * 100.0
+    return abs(entry_cost), entry_cost / need
+
+
+def fetch_positions(
+    client: IBClient,
+    journal_basis_lookup: Optional[dict[str, float]] = None,
+    fill_basis_lookup: Optional[dict] = None,
+) -> list:
     """Fetch all positions from IB"""
     positions = client.get_positions()
     journal_basis_lookup = journal_basis_lookup or {}
     journal_net_qty_lookup = getattr(journal_basis_lookup, "net_qty", {}) or {}
+    fill_basis_lookup = fill_basis_lookup or {}
 
     formatted = []
     for pos in positions:
@@ -809,6 +855,7 @@ def fetch_positions(client: IBClient, journal_basis_lookup: Optional[dict[str, f
             getattr(contract, 'right', None),
             getattr(contract, 'strike', None),
         )
+        basis_source = "ib"
         if journal_key and journal_key in journal_basis_lookup and position_size != 0:
             journal_net = journal_net_qty_lookup.get(journal_key)
             # SIGNED equality: |+10| == |-10| let a sign-flipped journal
@@ -822,12 +869,22 @@ def fetch_positions(client: IBClient, journal_basis_lookup: Optional[dict[str, f
             if basis_is_complete:
                 entry_cost = abs(float(journal_basis_lookup[journal_key]))
                 avg_cost = entry_cost / abs(position_size)
+                basis_source = "journal"
             else:
                 print(
                     f"  Warning: journal basis SKIPPED for {journal_key}: "
                     f"journal_net_qty={journal_net} != position_qty={position_size} "
                     f"— keeping IB avgCost (incomplete journal)"
                 )
+
+        # Session fills whose newest same-sign qty exactly covers live size
+        # beat IB avgCost and a same-sized stale journal lot (META 575C
+        # 2026-08-27: blotter $5.55, AVG ENTRY $4.69).
+        fill = fill_basis_lookup.get(journal_key) if journal_key else None
+        fill_cover = _session_fill_cover(fill, position_size) if fill else None
+        if fill_cover is not None:
+            entry_cost, avg_cost = fill_cover
+            basis_source = "session_fills"
         
         formatted.append({
             "account_id": getattr(pos, 'account', '') or '',
@@ -836,6 +893,7 @@ def fetch_positions(client: IBClient, journal_basis_lookup: Optional[dict[str, f
             "position": position_size,
             "avgCost": avg_cost,
             "ibAvgCost": ib_avg_cost,
+            "basis_source": basis_source,
             "entry_cost": round(entry_cost, 2),
             "expiry": parse_expiry(contract),
             "strike": getattr(contract, 'strike', None),
@@ -1140,17 +1198,93 @@ def build_account_summary(account: dict, pnl_data: dict) -> dict:
     }
 
 
-def build_fill_dates(client) -> dict:
+def _fill_exec_time(fill) -> datetime:
+    raw = getattr(getattr(fill, "execution", None), "time", None)
+    if raw is None:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    if isinstance(raw, datetime):
+        return raw if raw.tzinfo else raw.replace(tzinfo=timezone.utc)
+    try:
+        parsed = datetime.fromisoformat(str(raw)[:19])
+    except ValueError:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _fill_signed_qty(side, shares) -> float:
+    label = str(side or "").strip().upper()
+    try:
+        qty = abs(float(shares or 0))
+    except (TypeError, ValueError):
+        return 0.0
+    if label in {"BOT", "BUY", "B"}:
+        return qty
+    if label in {"SLD", "SELL", "S"}:
+        return -qty
+    return 0.0
+
+
+def build_fill_basis(fills) -> dict[str, dict]:
+    """FIFO remaining inventory from this session's option fills.
+
+    Keyed like journal basis (``TICKER|YYYYMMDD|R|STRIKE``). Used when IB
+    avgCost is a lagged VWAP and the journal still holds a same-sized stale
+    open lot — Today's Executed Orders already shows the live fill price.
+    """
+    buckets: dict[str, list[tuple[datetime, float, float]]] = {}
+    for fill in fills or []:
+        contract = getattr(fill, "contract", None)
+        execution = getattr(fill, "execution", None)
+        if contract is None or execution is None:
+            continue
+        if getattr(contract, "secType", None) != "OPT":
+            continue
+        key = _journal_basis_key(
+            getattr(contract, "symbol", None),
+            getattr(contract, "lastTradeDateOrContractMonth", None),
+            getattr(contract, "right", None),
+            getattr(contract, "strike", None),
+        )
+        if not key:
+            continue
+        signed = _fill_signed_qty(
+            getattr(execution, "side", None), getattr(execution, "shares", 0)
+        )
+        price = getattr(execution, "avgPrice", None)
+        if price is None:
+            price = getattr(execution, "price", None)
+        try:
+            price_f = float(price)
+        except (TypeError, ValueError):
+            continue
+        if signed == 0 or not math.isfinite(price_f):
+            continue
+        buckets.setdefault(key, []).append((_fill_exec_time(fill), signed, price_f))
+
+    out: dict[str, dict] = {}
+    for key, rows in buckets.items():
+        rows.sort(key=lambda row: row[0])
+        out[key] = {
+            "lots": [
+                {"signed_qty": signed, "per_share": price}
+                for _when, signed, price in rows
+            ]
+        }
+    return out
+
+
+def build_fill_dates(client, fills=None) -> dict:
     """Extract earliest execution date per contract from IB session fills.
 
     Returns dict keyed by "TICKER|EXPIRY|RIGHT|STRIKE" → "YYYY-MM-DD".
     Covers same-session trades that haven't appeared in Flex Query (blotter) yet.
     """
     fill_dates: dict[str, str] = {}
-    try:
-        fills = client.get_fills()
-    except Exception:
-        return fill_dates
+    if fills is None:
+        try:
+            fills = client.get_fills()
+        except Exception:
+            return fill_dates
 
     for fill in fills:
         contract = fill.contract
@@ -1330,9 +1464,11 @@ def convert_to_portfolio_format(account: dict, collapsed_positions: list, pnl_da
             journal_corrected = (
                 ac is not None and ibc is not None and abs(float(ac) - float(ibc)) > 1e-6
             )
+            session_fill_basis = pos.get("basis_source") == "session_fills"
             drifted = ibc is not None and abs(pb["per_unit"] - float(ibc)) > 1e-6
             if (
                 not journal_corrected
+                and not session_fill_basis
                 and drifted
                 and cur_dir == pb["direction"]
                 and 0 < cur_contracts <= pb["contracts"]
@@ -1588,9 +1724,18 @@ def main():
 
         # Fetch positions while PnL streams
         journal_basis_lookup = build_journal_basis_lookup(client)
+        try:
+            session_fills = client.get_fills()
+        except Exception:
+            session_fills = []
+        fill_basis_lookup = build_fill_basis(session_fills)
         positions = [
             position
-            for position in fetch_positions(client, journal_basis_lookup=journal_basis_lookup)
+            for position in fetch_positions(
+                client,
+                journal_basis_lookup=journal_basis_lookup,
+                fill_basis_lookup=fill_basis_lookup,
+            )
             if not position.get("account_id") or position.get("account_id") == ib_account
         ]
         margin_observed_through = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
@@ -1718,7 +1863,7 @@ def main():
 
         # Sync or emit JSON if requested
         if args.sync or args.json_output:
-            fill_dates = build_fill_dates(client)
+            fill_dates = build_fill_dates(client, fills=session_fills)
             portfolio = convert_to_portfolio_format(account, collapsed, pnl_data, fill_dates=fill_dates)
 
         if args.sync and portfolio is not None:

--- a/scripts/tests/test_ib_sync_fill_basis.py
+++ b/scripts/tests/test_ib_sync_fill_basis.py
@@ -1,0 +1,121 @@
+"""Session-fill remaining inventory must set option avg entry.
+
+2026-08-27: META Long Call $575 25x showed AVG ENTRY $4.69 while Today's
+Executed Orders had the same contract OPEN 25 @ $5.55. ib_sync used IB's
+lagged avgCost (finite, so the 1s wait returned) and, when the journal
+still held a same-sized open lot, treated that stale basis as complete.
+Session fills already feed entry_date; they must also replace basis when
+FIFO remaining inventory qty equals the live position.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import ib_sync  # noqa: E402
+
+
+def _position(*, symbol="META", position=25, avg_cost=469.0, strike=575.0, right="C", expiry="20260828"):
+    contract = SimpleNamespace(
+        symbol=symbol,
+        secType="OPT",
+        strike=strike,
+        right=right,
+        conId=77001,
+        lastTradeDateOrContractMonth=expiry,
+        multiplier="100",
+        currency="USD",
+    )
+    return SimpleNamespace(contract=contract, position=position, avgCost=avg_cost, account="U123")
+
+
+def _fill(*, side, shares, price, time="2026-08-27T14:49:55", strike=575.0, expiry="20260828", right="C"):
+    contract = SimpleNamespace(
+        symbol="META",
+        secType="OPT",
+        strike=strike,
+        right=right,
+        lastTradeDateOrContractMonth=expiry,
+    )
+    execution = SimpleNamespace(
+        side=side,
+        shares=shares,
+        avgPrice=price,
+        price=price,
+        time=datetime.fromisoformat(time),
+    )
+    return SimpleNamespace(contract=contract, execution=execution)
+
+
+def test_session_open_overrides_stale_ib_avg_cost():
+    """Fresh 25-lot at $5.55; IB still reporting $4.69/share (469/contract)."""
+    fills = [_fill(side="BOT", shares=25, price=5.55)]
+    lookup = ib_sync.build_fill_basis(fills)
+    client = SimpleNamespace(get_positions=lambda: [_position()])
+
+    positions = ib_sync.fetch_positions(client, fill_basis_lookup=lookup)
+    pos = positions[0]
+
+    assert pos["entry_cost"] == pytest.approx(13875.0, abs=0.01)
+    assert pos["avgCost"] == pytest.approx(555.0, abs=0.0001)
+    assert pos["ibAvgCost"] == pytest.approx(469.0, abs=0.0001)
+    assert pos["basis_source"] == "session_fills"
+
+
+def test_session_fills_win_over_stale_same_qty_journal():
+    """Journal still shows yesterday's 25-lot at $4.69; today reopened at $5.55."""
+    fills = [_fill(side="BOT", shares=25, price=5.55)]
+    journal = ib_sync._with_net_qty(
+        {"META|20260828|C|575.0": 11725.0},
+        {"META|20260828|C|575.0": 25.0},
+    )
+    client = SimpleNamespace(get_positions=lambda: [_position()])
+
+    positions = ib_sync.fetch_positions(
+        client, journal_basis_lookup=journal, fill_basis_lookup=ib_sync.build_fill_basis(fills)
+    )
+    pos = positions[0]
+    assert pos["avgCost"] == pytest.approx(555.0, abs=0.0001)
+    assert pos["entry_cost"] == pytest.approx(13875.0, abs=0.01)
+
+
+def test_close_then_reopen_uses_new_fill_price():
+    fills = [
+        _fill(side="SLD", shares=25, price=4.69, time="2026-08-27T13:00:00"),
+        _fill(side="BOT", shares=25, price=5.55, time="2026-08-27T14:49:55"),
+    ]
+    client = SimpleNamespace(get_positions=lambda: [_position()])
+    pos = ib_sync.fetch_positions(
+        client, fill_basis_lookup=ib_sync.build_fill_basis(fills)
+    )[0]
+    assert pos["avgCost"] == pytest.approx(555.0, abs=0.0001)
+
+
+def test_partial_session_fill_does_not_override():
+    """Overnight 25 + today add 10: session remaining 10 != live 35."""
+    fills = [_fill(side="BOT", shares=10, price=5.55)]
+    client = SimpleNamespace(get_positions=lambda: [_position(position=35, avg_cost=469.0)])
+    pos = ib_sync.fetch_positions(
+        client, fill_basis_lookup=ib_sync.build_fill_basis(fills)
+    )[0]
+    assert pos["avgCost"] == pytest.approx(469.0, abs=0.0001)
+    assert pos.get("basis_source") != "session_fills"
+
+
+def test_no_fills_keeps_journal_override():
+    journal = ib_sync._with_net_qty(
+        {"META|20260828|C|575.0": 11725.0},
+        {"META|20260828|C|575.0": 25.0},
+    )
+    client = SimpleNamespace(get_positions=lambda: [_position()])
+    pos = ib_sync.fetch_positions(client, journal_basis_lookup=journal)[0]
+    assert pos["entry_cost"] == pytest.approx(11725.0, abs=0.01)
+    assert pos["avgCost"] == pytest.approx(469.0, abs=0.0001)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,24 @@
+# Task: META avg entry lagged IB VWAP vs fill (2026-08-27)
+
+## Dependency graph
+
+- A1 depends_on: [] - Red: session-fill cover overrides stale IB/journal avgCost
+- A2 depends_on: [A1] - build_fill_basis + fetch_positions cover; skip carry-forward
+- A3 depends_on: [A2] - Focused pytest + avg-entry vitest
+
+## Checklist
+
+- [x] A1 Red tests
+- [x] A2 Session-fill exact cover
+- [x] A3 Green
+
+## Review
+
+- pytest `test_ib_sync_fill_basis.py` 5 passed
+- vitest `position-table-short-stock-avg-entry` 10 passed
+
+---
+
 # Task: P1 radon-bpi Result=timeout (page bbaa065b, 2026-08-24 23:30Z)
 
 ## Dependency graph

--- a/web/tests/position-table-short-stock-avg-entry.test.tsx
+++ b/web/tests/position-table-short-stock-avg-entry.test.tsx
@@ -165,6 +165,25 @@ describe("getAvgEntry — pure", () => {
   it("SHORT single-leg option returns a NEGATIVE per-contract entry (premium is a credit)", () => {
     expect(getAvgEntry(META_SHORT_CALL)).toBeCloseTo(-1.74, 2);
   });
+
+  it("same-day long call avg entry is fill dollars / (qty × 100), not IB's lagged VWAP", () => {
+    // 25 META 575C @ $5.55 fill → $13,875 debit. IB avgCost still $4.69/share
+    // would display $4.69 if we used it; blotter net price is $5.55.
+    const metaLong: PortfolioPosition = {
+      ...AMD_LONG_PUT,
+      ticker: "META",
+      structure: "Long Call $575.0",
+      structure_type: "Long Call",
+      contracts: 25,
+      entry_cost: 13875,
+      max_risk: 13875,
+      legs: [
+        { direction: "LONG", contracts: 25, type: "Call", strike: 575,
+          entry_cost: 13875, avg_cost: 555, market_price: 5.78, market_value: 14450 },
+      ],
+    };
+    expect(getAvgEntry(metaLong)).toBeCloseTo(5.55, 2);
+  });
 });
 
 /* ─── rendered cell ────────────────────────────────────── */
@@ -214,5 +233,29 @@ describe("PositionTable — Avg Entry never negative for SHORT stock", () => {
       />,
     );
     expect(avgEntryCellText("META")).toBe("$-1.74");
+  });
+
+  it("renders $5.55 for a 25-lot long call whose entry is the $5.55 fill", () => {
+    const metaLong: PortfolioPosition = {
+      ...AMD_LONG_PUT,
+      ticker: "META",
+      structure: "Long Call $575.0",
+      structure_type: "Long Call",
+      contracts: 25,
+      entry_cost: 13875,
+      max_risk: 13875,
+      legs: [
+        { direction: "LONG", contracts: 25, type: "Call", strike: 575,
+          entry_cost: 13875, avg_cost: 555, market_price: 5.78, market_value: 14450 },
+      ],
+    };
+    render(
+      <PositionTable
+        positions={[metaLong]}
+        prices={{}}
+        columnVisibility={makeVisibility({ avg_entry: true })}
+      />,
+    );
+    expect(avgEntryCellText("META")).toBe("$5.55");
   });
 });


### PR DESCRIPTION
## Why
Defined-risk META Long Call \$575 25x showed AVG ENTRY **\$4.69**. Today's Executed Orders had the same contract OPEN 25 @ **\$5.55**.

## Cause
\`ib_sync.fetch_positions\` used IB \`avgCost\` (lags after a fill; 1s wait only checks finite). Journal override also fired on a same-sized *stale* open lot. Session fills already drove entry_date, not basis.

## Fix
Newest same-sign session fills whose qty exactly equals live size set \`entry_cost\` / \`avgCost\`. Beats IB and a same-sized stale journal lot. Reduce/add (qty mismatch) still uses journal/IB/carry-forward.

## Verify
- \`test_ib_sync_fill_basis.py\` 5 passed
- \`test_ib_sync_basis_guard.py\` + \`test_cover_basis_carry_forward.py\` 15 passed
- vitest avg-entry 10 passed (\`\$5.55\` for 25 × \$5.55 fill)

Next \`ib_sync --sync\` restamps the snapshot. AVG ENTRY then matches Net Price; same-day P&amp;L uses the fill basis.