### PR TITLE
fix(portfolio): show leg quantity in the Qty column only

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -6342,7 +6342,9 @@ td.negative, .negative {
 /* ── Cell utility classes ── */
 
 .cell-muted { opacity: 0.7; font-size: 0.85em; }
-.cell-indent { padding-left: 1.5rem; }
+/* Leg descriptions sit in the narrow Structure column now that the contract
+   count moved to the Qty column, so keep them on one line. */
+.cell-indent { padding-left: 1.5rem; white-space: nowrap; }
 .section-message { padding: 12px 16px; }
 
 /* ─── Leg disclosure toggle ─── */

--- a/web/components/PositionTable.tsx
+++ b/web/components/PositionTable.tsx
@@ -272,23 +272,32 @@ function LegRow({
   const signedMarketPrice = marketPrice != null ? displaySign * marketPrice : null;
   const { direction: priceDirection, flashDirection } = usePriceDirection(signedMarketPrice);
 
-  // The leg-description cell spans across the columns to the right of Ticker
-  // up through Direction: Structure, optional Qty, Direction (each gated).
-  const descColSpan =
-    (columns.structure ? 1 : 0) + (columns.qty ? 1 : 0) + (columns.direction ? 1 : 0);
+  // The leg description takes the first visible of Structure, Direction, Qty;
+  // the contract count takes the Qty column so it lines up under the combo's
+  // own quantity instead of repeating inline in the description.
+  const descColumn = columns.structure
+    ? "structure"
+    : columns.direction
+      ? "direction"
+      : columns.qty
+        ? "qty"
+        : null;
+  const legDescription = (
+    <td
+      className={`cell-indent cell-muted ${onLegClick ? "leg-clickable" : ""}`}
+      onClick={onLegClick ? () => onLegClick(leg) : undefined}
+    >
+      {leg.direction} {leg.type}{leg.strike ? ` $${leg.strike}` : ""}
+    </td>
+  );
 
   return (
     <tr className={flashDirection ? `last-price-${flashDirection}` : undefined}>
       <td></td>
-      {descColSpan > 0 && (
-        <td
-          colSpan={descColSpan}
-          className={`cell-indent cell-muted ${onLegClick ? "leg-clickable" : ""}`}
-          onClick={onLegClick ? () => onLegClick(leg) : undefined}
-        >
-          {leg.direction} {leg.contracts}x {leg.type}{leg.strike ? ` $${leg.strike}` : ""}
-        </td>
-      )}
+      {columns.structure && legDescription}
+      {columns.qty &&
+        (descColumn === "qty" ? legDescription : <td className="right cell-muted">{leg.contracts}</td>)}
+      {columns.direction && (descColumn === "direction" ? legDescription : <td></td>)}
       {showUnderlying && <td></td>}
       {columns.avg_entry && (
         <td className="right cell-muted">{fmtPrice(displaySign * (Math.abs(leg.avg_cost) / mult))}</td>

--- a/web/e2e/order-ticket-quote-telemetry.spec.ts
+++ b/web/e2e/order-ticket-quote-telemetry.spec.ts
@@ -369,7 +369,7 @@ test.describe("Portfolio order ticket quote telemetry", () => {
 
     await expandLegs.click();
 
-    const legTrigger = page.locator(".leg-clickable", { hasText: "LONG 25x Call $105" }).first();
+    const legTrigger = page.locator(".leg-clickable", { hasText: "LONG Call $105" }).first();
     await legTrigger.waitFor({ timeout: 5_000 });
     await legTrigger.click();
 
@@ -423,7 +423,7 @@ test.describe("Portfolio order ticket quote telemetry", () => {
     await page.getByLabel("Expand legs for EWY").waitFor({ timeout: 10_000 });
 
     await page.getByLabel("Expand legs for EWY").click();
-    await page.locator(".leg-clickable", { hasText: "LONG 2500x Stock" }).click();
+    await page.locator(".leg-clickable", { hasText: "LONG Stock" }).click();
 
     const dialog = page.getByRole("dialog", { name: "EWY Stock" });
     await expect(dialog).toBeVisible();

--- a/web/e2e/portfolio-leg-row-runtime.spec.ts
+++ b/web/e2e/portfolio-leg-row-runtime.spec.ts
@@ -218,7 +218,7 @@ test("portfolio spread legs expand without rtLast runtime errors", async ({ page
 
   await croxRow.getByLabel("Expand legs for CROX").click();
 
-  await expect(page.locator("table tbody tr")).toContainText(["LONG 1x Call $80", "SHORT 1x Call $95"]);
+  await expect(page.locator("table tbody tr")).toContainText(["LONG Call $80", "SHORT Call $95"]);
   await expect(page.locator("table tbody tr")).toContainText(["$450", "$125"]);
   expect(pageErrors).not.toContain("rtLast is not defined");
 });
@@ -233,7 +233,7 @@ test("portfolio leg modal buy-to-cover keeps portfolio scope and close debit P&L
   await expect(muRow).toBeVisible();
 
   await muRow.getByLabel("Expand legs for MU").click();
-  await page.getByText("SHORT 5x Call $1250").click();
+  await page.getByText("SHORT Call $1250").click();
 
   const dialog = page.getByRole("dialog", { name: /MU \$1250 Call 2026-06-26/i });
   await expect(dialog).toBeVisible();

--- a/web/e2e/portfolio-ratio-risk-reversal-label.spec.ts
+++ b/web/e2e/portfolio-ratio-risk-reversal-label.spec.ts
@@ -121,6 +121,6 @@ test("portfolio shows raw long-short counts for ratio risk reversal labels", asy
   const undefinedRiskSection = page.locator(".section").filter({ hasText: "Undefined Risk Positions" }).first();
   await expect(undefinedRiskSection).toContainText("Ratio Risk Reversal 75x10 (P$400.0/C$410.0)");
   await expect(undefinedRiskSection).not.toContainText("Ratio Risk Reversal 2x15");
-  await expect(undefinedRiskSection).toContainText("LONG 75x Call $410");
-  await expect(undefinedRiskSection).toContainText("SHORT 10x Put $400");
+  await expect(undefinedRiskSection).toContainText("LONG Call $410");
+  await expect(undefinedRiskSection).toContainText("SHORT Put $400");
 });

--- a/web/lib/flowReportError.ts
+++ b/web/lib/flowReportError.ts
@@ -1,7 +1,7 @@
 /** Operator-facing copy for a per-ticker flow-report failure. */
 
 export function isSubprocessCapacityError(message: string | null | undefined): boolean {
-  return Boolean(message) && /subprocess capacity exhausted/i.test(message);
+  return message != null && /subprocess capacity exhausted/i.test(message);
 }
 
 export function flowReportErrorCopy(message: string | null | undefined): string {

--- a/web/tests/instrument-detail-buy-to-cover.test.tsx
+++ b/web/tests/instrument-detail-buy-to-cover.test.tsx
@@ -267,7 +267,7 @@ describe("InstrumentDetailModal buy-to-cover", () => {
     );
 
     fireEvent.click(screen.getByLabelText("Expand legs for MU"));
-    fireEvent.click(screen.getByText("SHORT 5x Call $1250"));
+    fireEvent.click(screen.getByText("SHORT Call $1250"));
     enterLimitAndReview("0.05");
 
     const text = summaryText();

--- a/web/tests/position-table-leg-qty-column.test.tsx
+++ b/web/tests/position-table-leg-qty-column.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Expanded leg rows carry their contract count in the Qty column, not inline in
+ * the leg description. "LONG 100x Call $300" duplicated the combo's Qty cell.
+ */
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import PositionTable from "../components/PositionTable";
+import type { PortfolioPosition } from "../lib/types";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock("../components/InstrumentDetailModal", () => ({ default: () => null }));
+
+afterEach(cleanup);
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+const BULL_CALL: PortfolioPosition = {
+  id: 41,
+  ticker: "ADBE",
+  structure: "Bull Call Spread $300.0/$350.0",
+  structure_type: "Bull Call Spread",
+  risk_profile: "defined",
+  expiry: "2099-05-01",
+  contracts: 100,
+  direction: "COMBO",
+  entry_cost: 120000,
+  max_risk: 120000,
+  market_value: 140000,
+  kelly_optimal: null,
+  target: null,
+  stop: null,
+  entry_date: "2026-04-15",
+  legs: [
+    {
+      direction: "LONG",
+      contracts: 100,
+      type: "Call",
+      strike: 300,
+      entry_cost: 250000,
+      avg_cost: 2500,
+      market_price: 28.0,
+      market_value: 280000,
+    },
+    {
+      direction: "SHORT",
+      contracts: 100,
+      type: "Call",
+      strike: 350,
+      entry_cost: -130000,
+      avg_cost: -1300,
+      market_price: 14.0,
+      market_value: -140000,
+    },
+  ],
+};
+
+function expandLegs() {
+  fireEvent.click(screen.getByLabelText("Expand legs for ADBE"));
+}
+
+describe("PositionTable expanded leg rows — quantity placement", () => {
+  it("drops the inline contract count from the leg description", () => {
+    render(<PositionTable positions={[BULL_CALL]} prices={{}} />);
+    expandLegs();
+
+    expect(screen.getByText("LONG Call $300")).toBeTruthy();
+    expect(screen.getByText("SHORT Call $350")).toBeTruthy();
+    expect(screen.queryByText(/100x/)).toBeNull();
+  });
+
+  it("renders each leg's contract count in the Qty column", () => {
+    render(<PositionTable positions={[BULL_CALL]} prices={{}} />);
+    expandLegs();
+
+    const header = screen.getByText("Qty").closest("th")!;
+    const headerCells = Array.from(header.parentElement!.children);
+    const qtyIndex = headerCells.indexOf(header);
+
+    const legRow = screen.getByText("LONG Call $300").closest("tr")!;
+    const cells = Array.from(legRow.children);
+    expect(cells[qtyIndex]!.textContent).toBe("100");
+  });
+});

--- a/web/tests/position-table-leg-row-runtime.test.ts
+++ b/web/tests/position-table-leg-row-runtime.test.ts
@@ -116,11 +116,11 @@ describe("PositionTable expanded leg rows", () => {
 
     fireEvent.click(screen.getByLabelText("Expand legs for CROX"));
 
-    const longLegRow = screen.getByText("LONG 1x Call $80").closest("tr");
+    const longLegRow = screen.getByText("LONG Call $80").closest("tr");
     expect(longLegRow).not.toBeNull();
     expect(longLegRow?.textContent).toContain("$450");
 
-    const shortLegRow = screen.getByText("SHORT 1x Call $95").closest("tr");
+    const shortLegRow = screen.getByText("SHORT Call $95").closest("tr");
     expect(shortLegRow).not.toBeNull();
     expect(shortLegRow?.textContent).toContain("$125");
   });

--- a/web/tests/position-table-short-leg-sign.test.tsx
+++ b/web/tests/position-table-short-leg-sign.test.tsx
@@ -116,7 +116,7 @@ describe("PositionTable expanded leg rows — SHORT option leg sign", () => {
     render(<PositionTable positions={[RATIO_RR]} prices={{}} />);
     expandLegs();
 
-    const shortRow = screen.getByText("SHORT 10x Put $400").closest("tr")!;
+    const shortRow = screen.getByText("SHORT Put $400").closest("tr")!;
     expect(shortRow.textContent).toContain("$-27.69");
     expect(shortRow.textContent).toContain("$-26.41");
   });
@@ -125,7 +125,7 @@ describe("PositionTable expanded leg rows — SHORT option leg sign", () => {
     render(<PositionTable positions={[RATIO_RR]} prices={{}} />);
     expandLegs();
 
-    const longRow = screen.getByText("LONG 75x Call $410").closest("tr")!;
+    const longRow = screen.getByText("LONG Call $410").closest("tr")!;
     expect(longRow.textContent).toContain("$19.45");
     expect(longRow.textContent).toContain("$10.45");
     expect(longRow.textContent).not.toContain("$-19.45");
@@ -145,7 +145,7 @@ describe("PositionTable expanded leg rows — SHORT option leg sign", () => {
 
     const T = yearsToExpiry(expiry, new Date())!;
     const putPerShare = bsPut(spot, 400, T, 0, sigma);
-    const shortRow = screen.getByText("SHORT 10x Put $400").closest("tr")!;
+    const shortRow = screen.getByText("SHORT Put $400").closest("tr")!;
     expect(shortRow.textContent).toContain(`$-${putPerShare.toFixed(2)}`);
   });
 });


### PR DESCRIPTION
Expanded leg rows repeated the combo's contract count inline (`LONG 100x Call $300`) right next to the same number in the Qty cell. The leg description now reads `LONG Call $300` and each leg's count renders in the Qty column, aligned under the combo row's quantity.

## Changes

- `web/components/PositionTable.tsx` — the leg description takes the Structure column and the contract count takes Qty; it falls back to Direction, then Qty, when Structure is hidden by the column toggle.
- `web/app/globals.css` — `.cell-indent` gets `white-space: nowrap` so the description stays on one line now that it no longer spans Structure through Direction.
- New `web/tests/position-table-leg-qty-column.test.tsx`; leg-text selectors updated in 3 vitest files and 3 Playwright specs.

## Verification

- Full vitest suite from repo root: 7832 passed, 10 failed. All 10 fail identically on `origin/main` without this change (`lib/tools/{runner,kelly,ib-wrappers-db-source}`, `web/tests/cta-percentile-reconcile`) and none touch PositionTable. The six PositionTable-related files pass 24/24.
- Live Chromium screenshot of both the full column set and the Structure + Qty set (the Defined Risk view), rendered through a temporary harness page that was removed after capture. Local Playwright portfolio specs cannot render `/portfolio` at all, before or after this change.

Also included: a one-line type-check fix in `web/lib/flowReportError.ts` (nullable message passed to `RegExp.test`) that landed on main in 3bfeff52 and was blocking the pre-commit type gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016XHuszj8x1R9z6Y99K4xDM