### PR TITLE
fix(portfolio): stamp entry_date from session fills that cover the position

### DIFF
--- a/scripts/ib_sync.py
+++ b/scripts/ib_sync.py
@@ -586,6 +586,14 @@ def collapse_positions(positions: list) -> list:
         else:
             ib_daily_pnl = None
 
+        # Session-open date: only when EVERY leg was opened this session. One
+        # overnight leg (or a stock leg, which has no per-contract fill key)
+        # means the structure is not same-day.
+        leg_session_dates = [leg.get("session_fill_date") for leg in legs]
+        session_fill_date = (
+            min(leg_session_dates) if leg_session_dates and all(leg_session_dates) else None
+        )
+
         # Format legs for subtree
         formatted_legs = []
         for leg in sorted(legs, key=lambda x: (x.get('right', 'Z'), x.get('strike', 0))):
@@ -629,6 +637,7 @@ def collapse_positions(positions: list) -> list:
             "market_value": round(total_market_value, 2) if total_market_value is not None else None,
             "market_price_is_calculated": bool(is_market_price_calculated) if total_market_value is not None else False,
             "ib_daily_pnl": ib_daily_pnl,
+            "session_fill_date": session_fill_date,
             "basis_source": (
                 "session_fills"
                 if formatted_legs and all(
@@ -823,6 +832,37 @@ def _session_fill_cover(fill: dict, position_size: float):
     return abs(entry_cost), entry_cost / need
 
 
+def _session_fill_open_date(fill: dict, position_size: float) -> Optional[str]:
+    """ET date the live position was opened, when this session's fills are ALL
+    of it. Otherwise None.
+
+    Net signed session qty == live size means the contract was flat when the
+    session began: every unit held now was filled today, so the position is
+    same-day and yesterday's close is not a baseline for it. This has to beat
+    the journal, which keeps the EARLIEST date per contract and therefore hands
+    back a prior round-trip's date when a contract is reopened (META 575C
+    2026-08-28: closed 2026-08-26, reopened 2026-08-27, Today P&L rendered
+    -$9,425 against a -$1,750 total). Overnight inventory or a partial add
+    leaves the net short of the live size and returns None.
+    """
+    lots = (fill or {}).get("lots") or []
+    if not lots or not position_size:
+        return None
+    net = 0.0
+    dates: list[str] = []
+    for lot in lots:
+        try:
+            net += float(lot["signed_qty"])
+        except (TypeError, ValueError, KeyError):
+            return None
+        date = lot.get("date")
+        if date:
+            dates.append(date)
+    if abs(net - float(position_size)) > 1e-9 or not dates:
+        return None
+    return min(dates)
+
+
 def fetch_positions(
     client: IBClient,
     journal_basis_lookup: Optional[dict[str, float]] = None,
@@ -885,6 +925,7 @@ def fetch_positions(
         if fill_cover is not None:
             entry_cost, avg_cost = fill_cover
             basis_source = "session_fills"
+        session_fill_date = _session_fill_open_date(fill, position_size) if fill else None
         
         formatted.append({
             "account_id": getattr(pos, 'account', '') or '',
@@ -894,6 +935,7 @@ def fetch_positions(
             "avgCost": avg_cost,
             "ibAvgCost": ib_avg_cost,
             "basis_source": basis_source,
+            "session_fill_date": session_fill_date,
             "entry_cost": round(entry_cost, 2),
             "expiry": parse_expiry(contract),
             "strike": getattr(contract, 'strike', None),
@@ -1211,6 +1253,16 @@ def _fill_exec_time(fill) -> datetime:
     return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
 
 
+def _et_date(when: datetime) -> Optional[str]:
+    """ET calendar day for a fill timestamp, or None when there isn't one.
+    `_fill_exec_time` returns `datetime.min` for a missing/unparsable time, and
+    shifting that back to ET underflows."""
+    try:
+        return when.astimezone(ZoneInfo("America/New_York")).strftime("%Y-%m-%d")
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
 def _fill_signed_qty(side, shares) -> float:
     label = str(side or "").strip().upper()
     try:
@@ -1266,8 +1318,15 @@ def build_fill_basis(fills) -> dict[str, dict]:
         rows.sort(key=lambda row: row[0])
         out[key] = {
             "lots": [
-                {"signed_qty": signed, "per_share": price}
-                for _when, signed, price in rows
+                {
+                    "signed_qty": signed,
+                    "per_share": price,
+                    # ET trading day, not the host's — a 20:00 ET fill is
+                    # already tomorrow in UTC, and `entry_date` is compared
+                    # against an ET `today`.
+                    "date": _et_date(when),
+                }
+                for when, signed, price in rows
             ]
         }
     return out
@@ -1429,6 +1488,9 @@ def convert_to_portfolio_format(account: dict, collapsed_positions: list, pnl_da
         # Reversal P$320/C$330 was assigned 2026-04-22 because an unrelated
         # AMD 295P existed in the blotter — see test_combo_entry_date.py).
         #
+        #   0. session fills that account for the WHOLE live position — the
+        #      contract was flat at the session open, so nothing older can be
+        #      this lot's entry (see `_session_fill_open_date`)
         #   1. journal (per-contract: ticker|expiry|right|strike)
         #   2. journal (ticker|structure)
         #   3. IB fills (per-contract, same-session)
@@ -1437,7 +1499,8 @@ def convert_to_portfolio_format(account: dict, collapsed_positions: list, pnl_da
         #              same-day P&L branch fires correctly. We deliberately
         #              do NOT use a per-ticker blotter fallback or "unknown".
         pos['entry_date'] = (
-            blotter_contract_date
+            pos.get("session_fill_date")
+            or blotter_contract_date
             or trade_log_dates.get(f"{ticker}|{structure}")
             or fill_contract_date
             or prev_dates.get(key)

--- a/scripts/tests/test_session_open_entry_date.py
+++ b/scripts/tests/test_session_open_entry_date.py
@@ -1,0 +1,153 @@
+"""A position opened during the current session must carry today's entry_date.
+
+2026-08-27: META Long Call $575 2026-08-28 25x was opened today, but the same
+contract had been traded (and closed) on 2026-08-26 as the short leg of a
+spread. `read_journal_entry_date_maps` keeps the EARLIEST date per contract, so
+entry_date resolved to 2026-08-26, `isSameDay` missed, and Today P&L fell back
+to yesterday's close: -$9,425 against a total P&L of -$1,750.
+
+The session's own fills are the authority on this. When the net signed session
+qty for a contract equals the live position, the contract was flat at the
+session open — every unit held now was filled today, so entry_date is today and
+yesterday's close is not a baseline for it.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import ib_sync  # noqa: E402
+
+TODAY_ET = datetime.now(ZoneInfo("America/New_York")).strftime("%Y-%m-%d")
+
+
+def _position(*, position=25, avg_cost=555.0, strike=575.0, right="C", expiry="20260828"):
+    contract = SimpleNamespace(
+        symbol="META",
+        secType="OPT",
+        strike=strike,
+        right=right,
+        conId=77001,
+        lastTradeDateOrContractMonth=expiry,
+        multiplier="100",
+        currency="USD",
+    )
+    return SimpleNamespace(contract=contract, position=position, avgCost=avg_cost, account="U123")
+
+
+def _fill(*, side, shares, price=5.55, when=None, strike=575.0, expiry="20260828", right="C"):
+    contract = SimpleNamespace(
+        symbol="META",
+        secType="OPT",
+        strike=strike,
+        right=right,
+        lastTradeDateOrContractMonth=expiry,
+    )
+    execution = SimpleNamespace(
+        side=side,
+        shares=shares,
+        avgPrice=price,
+        price=price,
+        time=when or datetime.now(ZoneInfo("America/New_York")).replace(hour=11, minute=0, second=0, microsecond=0),
+    )
+    return SimpleNamespace(contract=contract, execution=execution)
+
+
+def _fetch(fills, position):
+    client = SimpleNamespace(get_positions=lambda: [position])
+    return ib_sync.fetch_positions(
+        client, fill_basis_lookup=ib_sync.build_fill_basis(fills)
+    )[0]
+
+
+def test_session_fills_covering_live_qty_stamp_todays_date():
+    leg = _fetch([_fill(side="BOT", shares=25)], _position())
+    assert leg["session_fill_date"] == TODAY_ET
+
+
+def test_same_day_open_then_partial_close_is_still_same_day():
+    """Bought 25, sold 10 — the remaining 15 was still all filled today."""
+    fills = [_fill(side="BOT", shares=25), _fill(side="SLD", shares=10, price=4.90)]
+    leg = _fetch(fills, _position(position=15))
+    assert leg["session_fill_date"] == TODAY_ET
+
+
+def test_overnight_inventory_is_not_session_dated():
+    """Held 25 overnight, added 10 today: session net 10 != live 35."""
+    leg = _fetch([_fill(side="BOT", shares=10)], _position(position=35))
+    assert leg["session_fill_date"] is None
+
+
+def test_no_session_fills_leaves_date_unresolved():
+    leg = _fetch([], _position())
+    assert leg["session_fill_date"] is None
+
+
+def test_collapse_promotes_session_date_only_when_every_leg_has_one():
+    def _leg(session_fill_date, strike, right):
+        return {
+            "account_id": "U123", "symbol": "META", "secType": "OPT", "position": 25,
+            "avgCost": 555.0, "ibAvgCost": 555.0, "basis_source": "session_fills",
+            "entry_cost": 13875.0, "expiry": "2026-08-28", "strike": strike, "right": right,
+            "structure": "Long Call", "conId": 1, "currency": "USD", "multiplier": 100.0,
+            "contract": None, "session_fill_date": session_fill_date,
+        }
+
+    both = ib_sync.collapse_positions([_leg(TODAY_ET, 575.0, "C"), _leg(TODAY_ET, 580.0, "C")])
+    assert both[0]["session_fill_date"] == TODAY_ET
+
+    mixed = ib_sync.collapse_positions([_leg(TODAY_ET, 575.0, "C"), _leg(None, 580.0, "C")])
+    assert mixed[0]["session_fill_date"] is None
+
+
+def _collapsed(session_fill_date):
+    return [{
+        "id": 1, "ticker": "META", "structure": "Long Call $575.0",
+        "structure_type": "Long Call", "risk_profile": "defined", "expiry": "2026-08-28",
+        "contracts": 25, "direction": "LONG", "entry_cost": 13875.0, "max_risk": 13875.0,
+        "market_value": 12125.0, "market_price_is_calculated": False, "ib_daily_pnl": None,
+        "session_fill_date": session_fill_date,
+        "legs": [{
+            "direction": "LONG", "contracts": 25, "type": "Call", "strike": 575.0,
+            "entry_cost": 13875.0, "avg_cost": 555.0, "market_price": 4.85,
+            "market_value": 12125.0, "market_price_is_calculated": False,
+        }],
+        "kelly_optimal": None, "target": None, "stop": None,
+    }]
+
+
+def test_reopened_contract_does_not_inherit_prior_round_trip_date():
+    """The 575C traded on 2026-08-26 as a spread leg and was flat overnight.
+    Today's reopen must not inherit that journal date."""
+    with patch.multiple(
+        ib_sync,
+        read_journal_entry_date_maps=lambda: (
+            {"META|Long Call $575.0": "2026-08-26"},
+            {"META|2026-08-28|C|575.0": "2026-08-26"},
+        ),
+        read_latest_portfolio_snapshot=lambda: None,
+    ):
+        result = ib_sync.convert_to_portfolio_format(
+            {"NetLiquidation": 1_000_000}, _collapsed(TODAY_ET), {}
+        )
+    assert result["positions"][0]["entry_date"] == TODAY_ET
+
+
+def test_without_session_coverage_the_journal_date_still_wins():
+    with patch.multiple(
+        ib_sync,
+        read_journal_entry_date_maps=lambda: ({}, {"META|2026-08-28|C|575.0": "2026-08-26"}),
+        read_latest_portfolio_snapshot=lambda: None,
+    ):
+        result = ib_sync.convert_to_portfolio_format(
+            {"NetLiquidation": 1_000_000}, _collapsed(None), {}
+        )
+    assert result["positions"][0]["entry_date"] == "2026-08-26"

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -102,6 +102,7 @@ Per-leg: `sign × (last - close) × contracts × 100`. Impl: `getOptionDailyChg(
 ### Entry-Date Resolution (`ib_sync.py`)
 
 Strict ordered fallback, MOST → LEAST specific:
+0. **session fills covering the WHOLE live position** — net signed session-fill qty == live size means the contract was flat at the session open, so nothing older can be this lot's entry
 1. blotter (per-contract: `ticker|expiry|right|strike`)
 2. trade_log (`ticker|structure`)
 3. IB fills (per-contract, same-session)
@@ -109,6 +110,8 @@ Strict ordered fallback, MOST → LEAST specific:
 5. **today** ← brand-new positions land here
 
 **Never use per-ticker blotter fallback.** Test: `test_combo_entry_date.py`.
+
+Step 0 outranks the journal because the journal keeps the EARLIEST date per contract and hands back a prior round-trip's date when a contract is reopened. META 575C 2026-08-28 was closed 2026-08-26, reopened 2026-08-27, and rendered Today P&L -$9,425 against a -$1,750 total. Test: `test_session_open_entry_date.py`.
 
 ### Position Cache Refresh
 


### PR DESCRIPTION
A contract reopened after a prior round trip inherited the journal's earliest date for that contract, so `isSameDay` missed and Today P&L fell back to yesterday's close.

Production: META Long Call $575 2026-08-28, 25x opened this session, showed **Today P&L -$9,425** against a **total P&L of -$1,750**. The same contract had traded on 2026-08-19 and again on 2026-08-26 as a spread leg; `read_journal_entry_date_maps` keeps the earliest date per contract key, so `entry_date` resolved to 2026-08-19 and `getTodayPnlDollars` priced the day off an $8.62 close.

## Fix

`_session_fill_open_date()` — when the net signed session-fill qty for a contract equals the live position size, the contract was flat at the session open, so every unit held now was filled today. That date wins the `entry_date` fallback chain outright, ahead of the journal and blotter maps.

- Promoted to the collapsed position only when *every* leg qualifies (an overnight leg, or a stock leg with no per-contract fill key, disqualifies the structure).
- Fill lots now carry an ET date, not the host's day — a 20:00 ET fill is already tomorrow in UTC.

## Tests

`scripts/tests/test_session_open_entry_date.py`, 7 cases, red before / green after:

- reopened contract does not inherit the prior round trip's journal date (the production case)
- open-then-partial-close today is still same-day
- overnight inventory plus a same-day add is not
- mixed-leg structures do not promote
- without session coverage the journal date still wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112BK4uxmymsUYSU8XpuBjj