### PR TITLE
feat(cloud): weekend disk cleanup timer for the VPS root filesystem

### DIFF
--- a/cloud/config/installed-units.sha256
+++ b/cloud/config/installed-units.sha256
@@ -132,3 +132,11 @@ d0c1ec2309131f1f1f311a864c6bfcb5088264ea456501b92091ccc6d937f4ee  radon-hhlev.se
 193ddc6b460b38ced6750ed0e6995fabdc5ce63bb37b4a898316ac5f5e3e1196  radon-hhlev.timer
 d25e52ea594eba7cd7421793dec6b0e6e554ea3055628b812e2d5b7508fd29f6  radon-vixts.service
 1735ba1cf04d7c7e42f734425eec6eb29eecc7923865742fa08d3c4be62abaf8  radon-vixts.timer
+
+# Weekend disk cleanup (2026-08-27 root-disk-usage P1). CONTROL-PLANE units:
+# `install-units` skips them by design, so the copy that clears these two
+# entries is the root `bootstrap-control-plane.sh` run, which the same commit's
+# CONTROL_PLANE_SOURCES growth already requires before the next deploy's
+# verify-control-plane preflight can pass.
+0213ae19e9bd1d51ae6c1c53eb871e10eac71546b013c2685228d8f174599b40  radon-disk-cleanup.service
+6d725a92326516355eda4486b5a8e77069681ed0acf7596f3170d3666c9fec06  radon-disk-cleanup.timer

--- a/cloud/scripts/bootstrap-control-plane.sh
+++ b/cloud/scripts/bootstrap-control-plane.sh
@@ -112,6 +112,7 @@ readonly -a SOURCES=(
   scripts/ib-gateway-control.sh
   scripts/operator-radon.sh
   scripts/drift_audit.py
+  scripts/disk_cleanup.py
   scripts/radon-app-runtime.sh
   config/sudoers.d/radon-deploy
   config/sudoers.d/radon-monitor
@@ -132,6 +133,8 @@ readonly -a SOURCES=(
   services/radon-refresh.timer
   services/radon-db-backup.service
   services/radon-db-backup.timer
+  services/radon-disk-cleanup.service
+  services/radon-disk-cleanup.timer
   services/radon-drift-audit.service
   services/radon-drift-audit.timer
   services/radon-nextjs-db-watchdog.service
@@ -142,6 +145,7 @@ readonly -a LOGICAL_TARGETS=(
   /usr/local/bin/radon-ib-gateway-control
   /usr/local/bin/radon
   /usr/local/lib/radon/drift_audit.py
+  /usr/local/lib/radon/disk_cleanup.py
   /usr/local/sbin/radon-app-runtime
   /etc/sudoers.d/radon-deploy
   /etc/sudoers.d/radon-monitor
@@ -162,24 +166,26 @@ readonly -a LOGICAL_TARGETS=(
   /etc/systemd/system/radon-refresh.timer
   /etc/systemd/system/radon-db-backup.service
   /etc/systemd/system/radon-db-backup.timer
+  /etc/systemd/system/radon-disk-cleanup.service
+  /etc/systemd/system/radon-disk-cleanup.timer
   /etc/systemd/system/radon-drift-audit.service
   /etc/systemd/system/radon-drift-audit.timer
   /etc/systemd/system/radon-nextjs-db-watchdog.service
   /etc/systemd/system/radon-nextjs-db-watchdog.timer
 )
 readonly -a MODES=(
-  0755 0755 0755 0644 0755
+  0755 0755 0755 0644 0644 0755
   0440 0440 0440 0440
   0644
   0644 0644 0644 0644 0644 0644 0644 0644 0644 0644 0644 0644 0644 0644 0644
-  0644 0644 0644
+  0644 0644 0644 0644 0644
 )
 readonly -a KINDS=(
-  shell shell shell python shell
+  shell shell shell python python shell
   sudoers sudoers sudoers sudoers
   polkit
-  systemd systemd systemd systemd systemd systemd systemd systemd systemd
-  systemd systemd systemd systemd systemd systemd systemd systemd systemd
+  systemd systemd systemd systemd systemd systemd systemd systemd systemd systemd
+  systemd systemd systemd systemd systemd systemd systemd systemd systemd systemd
 )
 
 [[ "${#SOURCES[@]}" -eq "${#LOGICAL_TARGETS[@]}" && \

--- a/cloud/scripts/deploy-root-helper.sh
+++ b/cloud/scripts/deploy-root-helper.sh
@@ -16,6 +16,7 @@ readonly -a CONTROL_PLANE_SOURCES=(
   scripts/ib-gateway-control.sh
   scripts/operator-radon.sh
   scripts/drift_audit.py
+  scripts/disk_cleanup.py
   scripts/radon-app-runtime.sh
   config/sudoers.d/radon-deploy
   config/sudoers.d/radon-monitor
@@ -36,6 +37,8 @@ readonly -a CONTROL_PLANE_SOURCES=(
   services/radon-refresh.timer
   services/radon-db-backup.service
   services/radon-db-backup.timer
+  services/radon-disk-cleanup.service
+  services/radon-disk-cleanup.timer
   services/radon-drift-audit.service
   services/radon-drift-audit.timer
   services/radon-nextjs-db-watchdog.service
@@ -46,6 +49,7 @@ readonly -a CONTROL_PLANE_TARGETS=(
   /usr/local/bin/radon-ib-gateway-control
   /usr/local/bin/radon
   /usr/local/lib/radon/drift_audit.py
+  /usr/local/lib/radon/disk_cleanup.py
   /usr/local/sbin/radon-app-runtime
   /etc/sudoers.d/radon-deploy
   /etc/sudoers.d/radon-monitor
@@ -66,16 +70,18 @@ readonly -a CONTROL_PLANE_TARGETS=(
   /etc/systemd/system/radon-refresh.timer
   /etc/systemd/system/radon-db-backup.service
   /etc/systemd/system/radon-db-backup.timer
+  /etc/systemd/system/radon-disk-cleanup.service
+  /etc/systemd/system/radon-disk-cleanup.timer
   /etc/systemd/system/radon-drift-audit.service
   /etc/systemd/system/radon-drift-audit.timer
   /etc/systemd/system/radon-nextjs-db-watchdog.service
   /etc/systemd/system/radon-nextjs-db-watchdog.timer
 )
 readonly -a CONTROL_PLANE_MODES=(
-  755 755 755 644 755
+  755 755 755 644 644 755
   440 440 440 440
   644
-  644 644 644 644 644 644 644 644 644 644 644 644 644 644 644 644 644 644
+  644 644 644 644 644 644 644 644 644 644 644 644 644 644 644 644 644 644 644 644
 )
 
 if [[ "${RADON_DEPLOY_HELPER_TEST_MODE:-0}" == "1" ]]; then

--- a/cloud/scripts/disk_cleanup.py
+++ b/cloud/scripts/disk_cleanup.py
@@ -1,0 +1,638 @@
+#!/usr/bin/env python3
+"""Weekly reclaim of the VPS root filesystem (2026-08-27 P1).
+
+The watchdog `root-disk-usage` check paged P1 when root hit 98% (1.7 GiB free
+on a 75G disk). Four consumers had unbounded growth and no pruner anywhere in
+cloud/ or scripts/:
+
+  * per-SHA ``ghcr.io/joemccann/radon-{node,python}`` image pairs (~5.8G per
+    deploy) pulled by radon-app-runtime -- nothing ever ran `docker image rm`;
+  * ``stage.<sha>.XXXXXX`` / ``backup.<sha>.XXXXXX`` deploy worktrees under
+    /home/radon/.radon-releases -- deploy.sh's cleanup_staged_release_path is
+    best-effort and logs "leaving for root cleanup" when it gives up;
+  * ~/.npm/_cacache (8.9G) and ~/.cache/pip (989M) -- pure caches;
+  * journald (1.0G).
+
+DELIBERATELY OUT OF SCOPE: /home/radon/radon-cloud/backups/db. Retention there
+is db_backup.py's RETENTION_DAYS=30, it is real data with no offsite copy in
+that script, and shrinking it is an operator policy call. It is in
+PROTECTED_PATHS so no category here can reach it.
+
+Every destructive decision is a PURE selector (tests/test_disk_cleanup.py), so
+the retention rules are provable without a live docker daemon. The running
+broker image (ghcr.io/gnzsnz/ib-gateway) and the autoheal sidecar are outside
+MANAGED_IMAGE_REPOSITORIES and additionally named in
+PROTECTED_IMAGE_REPOSITORIES -- the same belt-and-braces posture as
+radon-app-runtime.sh's refuse_host_plane(). /home/radon/radon (the live tree,
+the only non-detached entry in `git worktree list`) can never be selected as
+an orphaned release.
+
+This job runs as ROOT: the docker engine socket is root-only (radon is
+deliberately not in group docker) and journald vacuuming is root-only. Root
+therefore executes the control-plane copy at /usr/local/lib/radon/, never the
+radon-writable checkout, and never runs `git` inside /home/radon/radon --
+git reads repo-local config the radon account owns, which would turn a
+`core.fsmonitor` line into a root shell. HEAD is resolved by READING
+.git/HEAD, and stale worktree admin dirs are removed by filesystem ops
+instead of `git worktree prune`.
+
+Heartbeats the ``service_health`` row ``disk-cleanup`` on EVERY run -- ok with
+per-category bytes, error with the failing categories -- because a cleanup
+timer with no liveness signal is a silently-dead cleanup timer
+(feedback_service_health_heartbeat). A category that finds nothing is a normal
+outcome and never fails the unit; a category that RAISES flips the heartbeat
+to error (visible on the dashboard + the watchdog daily bucket) while the
+remaining categories still run and the unit still exits 0, the same shape as
+drift_audit.py reporting drift.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Iterable, NamedTuple
+
+SERVICE_NAME = "disk-cleanup"
+SUMMARY_CAP = 900
+TURSO_TIMEOUT = 10
+SUBPROCESS_TIMEOUT = 300
+
+# Retention constants -- the only knobs an operator should need.
+KEEP_IMAGE_PAIRS = 2
+RELEASE_MAX_AGE_DAYS = 3
+JOURNAL_VACUUM_SIZE = "200M"
+
+DOCKER_BIN = "/usr/bin/docker"
+JOURNALCTL_BIN = "/usr/bin/journalctl"
+
+LIVE_TREE = Path("/home/radon/radon")
+RELEASES_DIR = Path("/home/radon/.radon-releases")
+WORKTREE_ADMIN_DIR = LIVE_TREE / ".git" / "worktrees"
+
+# Ours to prune: one pair per deployed SHA, pulled by radon-app-runtime.
+MANAGED_IMAGE_REPOSITORIES = (
+    "ghcr.io/joemccann/radon-node",
+    "ghcr.io/joemccann/radon-python",
+)
+# Never ours: the live broker container and its autoheal sidecar. Redundant
+# with the allowlist above on purpose (radon-app-runtime.sh:refuse_host_plane).
+PROTECTED_IMAGE_REPOSITORIES = (
+    "ghcr.io/gnzsnz/ib-gateway",
+    "willfarrell/autoheal",
+)
+
+CACHE_TARGETS = (
+    Path("/home/radon/.npm/_cacache"),
+    Path("/home/radon/.cache/pip"),
+)
+
+# Deleting any of these breaks a running service or forces a slow re-download:
+# ms-playwright is the browser radon-newsfeed drives, huggingface holds the
+# Chronos-2 forecast weights, radon-wheels is the deploy wheel cache, and the
+# db backup tree is real data governed by db_backup.py's own retention.
+PROTECTED_PATHS = (
+    LIVE_TREE,
+    Path("/home/radon/radon-cloud/backups"),
+    Path("/home/radon/.cache/ms-playwright"),
+    Path("/home/radon/.cache/huggingface"),
+    Path("/home/radon/.cache/fastembed"),
+    Path("/home/radon/.cache/radon-wheels"),
+)
+
+# deploy.sh:RELEASES_DIR mktemp templates -- `stage.<sha12>.XXXXXX` and
+# `backup.<sha12>.XXXXXX`. Anything else under the releases dir is left alone.
+RELEASE_NAME_RE = re.compile(r"^(?:stage|backup)\.[0-9a-f]{7,40}\.[A-Za-z0-9]{6}$")
+
+_SIZE_UNITS = {
+    "b": 1,
+    "kb": 1_000,
+    "mb": 1_000_000,
+    "gb": 1_000_000_000,
+    "tb": 1_000_000_000_000,
+}
+_SIZE_RE = re.compile(r"^([0-9]+(?:\.[0-9]+)?)\s*([kmgt]?b)$", re.IGNORECASE)
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+class Image(NamedTuple):
+    repository: str
+    tag: str
+    image_id: str
+    created_at: float
+    size_bytes: int
+
+
+# ---------------------------------------------------------------------------
+# Pure selectors and parsers (unit-tested in tests/test_disk_cleanup.py)
+# ---------------------------------------------------------------------------
+
+
+def parse_docker_size(text: str) -> int:
+    """``4.69GB`` -> bytes. Docker reports decimal units."""
+    match = _SIZE_RE.match((text or "").strip())
+    if not match:
+        return 0
+    return int(float(match.group(1)) * _SIZE_UNITS[match.group(2).lower()])
+
+
+def parse_reclaimed_space(output: str) -> int:
+    """Bytes from `docker image prune`'s ``Total reclaimed space:`` line."""
+    for line in (output or "").splitlines():
+        _, sep, tail = line.partition("Total reclaimed space:")
+        if sep:
+            return parse_docker_size(tail.strip())
+    return 0
+
+
+def parse_docker_created(text: str) -> float:
+    """``2026-08-20 03:11:22 +0000 UTC`` -> epoch seconds (0.0 if unparseable)."""
+    cleaned = re.sub(r"\s+[A-Z]{2,5}$", "", (text or "").strip())
+    try:
+        return datetime.strptime(cleaned, "%Y-%m-%d %H:%M:%S %z").timestamp()
+    except ValueError:
+        return 0.0
+
+
+def parse_image_lines(output: str) -> list[Image]:
+    """Tab-separated `docker image ls` rows; malformed rows are dropped."""
+    images = []
+    for line in (output or "").splitlines():
+        fields = line.split("\t")
+        if len(fields) != 5:
+            continue
+        repository, tag, image_id, created, size = (f.strip() for f in fields)
+        images.append(
+            Image(
+                repository=repository,
+                tag=tag,
+                image_id=image_id,
+                created_at=parse_docker_created(created),
+                size_bytes=parse_docker_size(size),
+            )
+        )
+    return images
+
+
+def select_prunable_images(
+    images: Iterable[Image], head_tag: str, keep_pairs: int = KEEP_IMAGE_PAIRS
+) -> list[Image]:
+    """Managed radon app images safe to remove.
+
+    Keeps the pair matching the live checkout's HEAD plus the ``keep_pairs``
+    newest pairs. An unresolvable HEAD prunes NOTHING: without it any tag
+    could be the one the running containers were started from.
+    """
+    if not head_tag:
+        return []
+    managed = [
+        image
+        for image in images
+        if image.repository in MANAGED_IMAGE_REPOSITORIES
+        and image.repository not in PROTECTED_IMAGE_REPOSITORIES
+        and image.tag
+        and image.tag != "<none>"
+    ]
+    newest_per_tag: dict[str, float] = {}
+    for image in managed:
+        newest_per_tag[image.tag] = max(
+            newest_per_tag.get(image.tag, image.created_at), image.created_at
+        )
+    ordered = sorted(newest_per_tag, key=lambda tag: (newest_per_tag[tag], tag), reverse=True)
+    keep = set(ordered[:keep_pairs])
+    keep.add(head_tag)
+    return sorted(
+        (image for image in managed if image.tag not in keep),
+        key=lambda image: (image.repository, image.tag),
+    )
+
+
+def is_protected_path(path: Path) -> bool:
+    """True for anything this job must never delete.
+
+    A protected path's ANCESTORS are protected too: removing /home/radon/.cache
+    would take ms-playwright and the Chronos weights with it.
+    """
+    candidate = Path(path)
+    for protected in PROTECTED_PATHS:
+        if candidate == protected:
+            return True
+        if protected in candidate.parents or candidate in protected.parents:
+            return True
+    return False
+
+
+def select_prunable_releases(
+    entries: Iterable[tuple[Path, float]],
+    now_secs: float,
+    max_age_days: int = RELEASE_MAX_AGE_DAYS,
+    releases_dir: Path = RELEASES_DIR,
+) -> list[Path]:
+    """Leaked deploy worktrees older than the age threshold.
+
+    ``entries`` is an iterable of (path, mtime_secs). A path is eligible only
+    when it is a DIRECT child of the releases dir AND its name matches one of
+    deploy.sh's two mktemp templates, so /home/radon/radon -- the live tree --
+    is unreachable by construction as well as by is_protected_path.
+    """
+    cutoff = now_secs - max_age_days * 86400
+    selected = []
+    for path, mtime in entries:
+        candidate = Path(path)
+        if candidate.parent != Path(releases_dir):
+            continue
+        if not RELEASE_NAME_RE.match(candidate.name):
+            continue
+        if is_protected_path(candidate):
+            continue
+        if mtime >= cutoff:
+            continue
+        selected.append(candidate)
+    return sorted(selected)
+
+
+def select_stale_worktree_admin_dirs(
+    entries: Iterable[tuple[Path, bool]],
+) -> list[Path]:
+    """`.git/worktrees/<name>` admin dirs whose worktree no longer exists.
+
+    ``entries`` is (admin_dir, worktree_still_exists). This is what
+    `git worktree prune` would remove, done with filesystem ops so root never
+    executes git inside a repository the radon account can configure.
+    """
+    return sorted(admin for admin, exists in entries if not exists)
+
+
+def resolve_head_sha(git_dir: Path) -> str:
+    """The live checkout's HEAD commit, read as DATA from .git.
+
+    Never shells out to git: repo-local config is radon-writable and git
+    honours it (aliases, core.fsmonitor) in a root process.
+    """
+    try:
+        head = (Path(git_dir) / "HEAD").read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+    if not head.startswith("ref: "):
+        return head if _SHA_RE.match(head) else ""
+    ref = head[len("ref: "):].strip()
+    loose = Path(git_dir) / ref
+    try:
+        candidate = loose.read_text(encoding="utf-8").strip()
+    except OSError:
+        candidate = ""
+    if not _SHA_RE.match(candidate):
+        candidate = ""
+        try:
+            packed = (Path(git_dir) / "packed-refs").read_text(encoding="utf-8")
+        except OSError:
+            packed = ""
+        for line in packed.splitlines():
+            if line.startswith("#") or line.startswith("^"):
+                continue
+            sha, _, name = line.partition(" ")
+            if name.strip() == ref:
+                candidate = sha.strip()
+                break
+    return candidate if _SHA_RE.match(candidate) else ""
+
+
+def human_bytes(count: int) -> str:
+    value = float(count)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if abs(value) < 1024 or unit == "TiB":
+            return f"{int(value)} {unit}" if unit == "B" else f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{value:.1f} TiB"
+
+
+def build_summary(categories: dict[str, int], errors: dict[str, str], before: int, after: int) -> str:
+    parts = [f"{name} {human_bytes(size)}" for name, size in sorted(categories.items())]
+    summary = (
+        f"free {human_bytes(before)} -> {human_bytes(after)} "
+        f"(reclaimed {human_bytes(sum(categories.values()))}); " + ", ".join(parts)
+    )
+    if errors:
+        summary += "; failed: " + ", ".join(sorted(errors))
+    return summary[:SUMMARY_CAP]
+
+
+# ---------------------------------------------------------------------------
+# Filesystem + docker actions
+# ---------------------------------------------------------------------------
+
+
+def _run(argv: list[str]) -> str:
+    return subprocess.run(
+        argv,
+        capture_output=True,
+        text=True,
+        timeout=SUBPROCESS_TIMEOUT,
+        check=True,
+    ).stdout
+
+
+def dir_size(path: Path) -> int:
+    total = 0
+    for root, dirs, files in os.walk(path, onerror=lambda _exc: None):
+        dirs[:] = [d for d in dirs if not os.path.islink(os.path.join(root, d))]
+        for name in files:
+            try:
+                total += os.lstat(os.path.join(root, name)).st_size
+            except OSError:
+                continue
+    return total
+
+
+def remove_tree(path: Path) -> int:
+    """Delete a directory tree and return the bytes it held.
+
+    Refuses protected paths and symlinks: root following a symlink the radon
+    account planted is how an rm -rf becomes an incident.
+    """
+    if is_protected_path(path):
+        raise ValueError(f"refusing to remove protected path: {path}")
+    if path.is_symlink() or not path.is_dir():
+        return 0
+    size = dir_size(path)
+    shutil.rmtree(path)
+    return size
+
+
+def cleanup_docker_images() -> tuple[int, str]:
+    head = resolve_head_sha(LIVE_TREE / ".git")
+    if not head:
+        return 0, "HEAD unresolvable; refused to prune any image"
+    images = parse_image_lines(
+        _run([
+            DOCKER_BIN, "image", "ls", "--no-trunc",
+            "--format", "{{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.CreatedAt}}\t{{.Size}}",
+        ])
+    )
+    prunable = select_prunable_images(images, head)
+    reclaimed = 0
+    removed = 0
+    for image in prunable:
+        _run([DOCKER_BIN, "image", "rm", f"{image.repository}:{image.tag}"])
+        reclaimed += image.size_bytes
+        removed += 1
+    return reclaimed, f"removed {removed} image(s), keeping HEAD {head[:12]} + {KEEP_IMAGE_PAIRS} newest pairs"
+
+
+def cleanup_dangling_images() -> tuple[int, str]:
+    output = _run([DOCKER_BIN, "image", "prune", "-f"])
+    return parse_reclaimed_space(output), "dangling/untagged layers pruned"
+
+
+def cleanup_release_worktrees() -> tuple[int, str]:
+    if not RELEASES_DIR.is_dir():
+        return 0, "no releases dir"
+    entries = []
+    for child in RELEASES_DIR.iterdir():
+        try:
+            entries.append((child, child.lstat().st_mtime))
+        except OSError:
+            continue
+    import time
+
+    reclaimed = 0
+    removed = 0
+    for path in select_prunable_releases(entries, time.time()):
+        reclaimed += remove_tree(path)
+        removed += 1
+
+    admin_entries = []
+    if WORKTREE_ADMIN_DIR.is_dir():
+        for admin in WORKTREE_ADMIN_DIR.iterdir():
+            if not admin.is_dir():
+                continue
+            try:
+                gitdir = (admin / "gitdir").read_text(encoding="utf-8").strip()
+            except OSError:
+                gitdir = ""
+            admin_entries.append((admin, bool(gitdir) and Path(gitdir).exists()))
+    pruned_admin = 0
+    for admin in select_stale_worktree_admin_dirs(admin_entries):
+        shutil.rmtree(admin, ignore_errors=True)
+        pruned_admin += 1
+    return (
+        reclaimed,
+        f"removed {removed} orphan(s) older than {RELEASE_MAX_AGE_DAYS}d, "
+        f"pruned {pruned_admin} stale worktree record(s)",
+    )
+
+
+def cleanup_caches() -> tuple[int, str]:
+    reclaimed = 0
+    removed = []
+    for target in CACHE_TARGETS:
+        freed = remove_tree(target)
+        if freed:
+            reclaimed += freed
+            removed.append(target.name)
+    return reclaimed, f"cleared {', '.join(removed) or 'nothing'}"
+
+
+def cleanup_journal() -> tuple[int, str]:
+    journal_dir = Path("/var/log/journal")
+    before = dir_size(journal_dir) if journal_dir.is_dir() else 0
+    _run([JOURNALCTL_BIN, f"--vacuum-size={JOURNAL_VACUUM_SIZE}"])
+    after = dir_size(journal_dir) if journal_dir.is_dir() else 0
+    return max(before - after, 0), f"vacuumed to {JOURNAL_VACUUM_SIZE}"
+
+
+CATEGORIES: tuple[tuple[str, Callable[[], tuple[int, str]]], ...] = (
+    ("docker-images", cleanup_docker_images),
+    ("docker-dangling", cleanup_dangling_images),
+    ("release-worktrees", cleanup_release_worktrees),
+    ("caches", cleanup_caches),
+    ("journal", cleanup_journal),
+)
+
+
+def _free_space() -> int:
+    return shutil.disk_usage("/").free
+
+
+def run_cleanup(categories=None, free_space=None) -> dict:
+    """Run every category, isolating failures, and return the heartbeat payload."""
+    categories = CATEGORIES if categories is None else categories
+    free_space = _free_space if free_space is None else free_space
+
+    before = free_space()
+    reclaimed: dict[str, int] = {}
+    notes: dict[str, str] = {}
+    errors: dict[str, str] = {}
+    for name, action in categories:
+        try:
+            freed, note = action()
+        except Exception as exc:  # noqa: BLE001 - one bad category must not stop the sweep
+            errors[name] = f"{exc.__class__.__name__}: {exc}"[:200]
+            reclaimed[name] = 0
+            continue
+        reclaimed[name] = freed
+        notes[name] = note
+    after = free_space()
+
+    return {
+        "state": "error" if errors else "ok",
+        "detail": {
+            "summary": build_summary(reclaimed, errors, before, after),
+            "free_before_bytes": before,
+            "free_after_bytes": after,
+            "reclaimed_bytes": sum(reclaimed.values()),
+            "categories": reclaimed,
+            "notes": notes,
+            "errors": errors,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# service_health heartbeat (stdlib libSQL HTTP pipeline -- bounded, no libsql)
+# ---------------------------------------------------------------------------
+
+_UPSERT_SQL = (
+    "INSERT INTO service_health (service, state, last_attempt_started_at, "
+    "last_attempt_finished_at, last_error, updated_at) VALUES (?, ?, ?, ?, ?, ?) "
+    "ON CONFLICT(service) DO UPDATE SET state = excluded.state, "
+    "last_attempt_started_at = COALESCE(excluded.last_attempt_started_at, service_health.last_attempt_started_at), "
+    "last_attempt_finished_at = COALESCE(excluded.last_attempt_finished_at, service_health.last_attempt_finished_at), "
+    "last_error = excluded.last_error, "
+    "updated_at = excluded.updated_at"
+)
+
+DB_CREDENTIAL_KEYS = ("TURSO_DB_URL", "TURSO_AUTH_TOKEN")
+
+
+def http_url_from_libsql(url: str) -> str:
+    if url.startswith("libsql://"):
+        return "https://" + url[len("libsql://"):]
+    if url.startswith("wss://"):
+        return "https://" + url[len("wss://"):]
+    return url
+
+
+def load_env_keys(path: Path, keys: tuple[str, ...]) -> dict[str, str]:
+    """Read an allowlisted set of keys out of an env file, as DATA.
+
+    Same contract as drift_audit.load_env_keys: this process is root while the
+    file is 0600 radon:radon, so nothing here touches os.environ and an
+    appended LD_PRELOAD or PATH line is read past, not applied.
+    """
+    values: dict[str, str] = {}
+    try:
+        text = Path(path).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return values
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        key, sep, value = stripped.partition("=")
+        if not sep or key.strip() not in keys:
+            continue
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+            value = value[1:-1]
+        values[key.strip()] = value
+    return values
+
+
+def resolve_db_credentials(environ) -> dict[str, str]:
+    resolved = {
+        key: environ.get(key, "") for key in DB_CREDENTIAL_KEYS if environ.get(key)
+    }
+    missing = [key for key in DB_CREDENTIAL_KEYS if key not in resolved]
+    env_file = environ.get("RADON_ENV_FILE")
+    if missing and env_file:
+        resolved.update(load_env_keys(Path(env_file), tuple(missing)))
+    return resolved
+
+
+def _hrana_arg(value):
+    return {"type": "null"} if value is None else {"type": "text", "value": value}
+
+
+def write_service_health(state: str, detail: dict | None, started_at: str) -> None:
+    credentials = resolve_db_credentials(os.environ)
+    origin = http_url_from_libsql(credentials.get("TURSO_DB_URL", ""))
+    token = credentials.get("TURSO_AUTH_TOKEN", "")
+    if not origin or not token:
+        raise RuntimeError("TURSO_DB_URL / TURSO_AUTH_TOKEN missing from environment")
+    now = datetime.now(timezone.utc).isoformat()
+    payload = json.dumps(
+        {
+            "requests": [
+                {
+                    "type": "execute",
+                    "stmt": {
+                        "sql": _UPSERT_SQL,
+                        "args": [
+                            _hrana_arg(SERVICE_NAME),
+                            _hrana_arg(state),
+                            _hrana_arg(started_at),
+                            _hrana_arg(now),
+                            _hrana_arg(json.dumps(detail) if detail else None),
+                            _hrana_arg(now),
+                        ],
+                    },
+                },
+                {"type": "close"},
+            ]
+        }
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        origin.rstrip("/") + "/v2/pipeline",
+        data=payload,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": "Bearer " + token,
+        },
+    )
+    with urllib.request.urlopen(req, timeout=TURSO_TIMEOUT) as resp:
+        body = json.loads(resp.read(1_048_576).decode("utf-8"))
+    first = body["results"][0]
+    if first.get("type") != "ok":
+        raise RuntimeError(f"service_health upsert rejected: {json.dumps(first)[:300]}")
+
+
+def main() -> int:
+    started_at = datetime.now(timezone.utc).isoformat()
+    try:
+        outcome = run_cleanup()
+    except Exception as exc:  # noqa: BLE001 - a crash must still heartbeat
+        crash = {"summary": f"disk cleanup crashed: {exc.__class__.__name__}: {exc}"[:SUMMARY_CAP]}
+        print(crash["summary"], file=sys.stderr)
+        try:
+            write_service_health("error", crash, started_at)
+        except Exception as write_exc:  # noqa: BLE001
+            print(f"service_health write failed: {write_exc}", file=sys.stderr)
+        return 1
+
+    detail = outcome["detail"]
+    print(f"disk-cleanup: {detail['summary']}")
+    for name, note in sorted(detail["notes"].items()):
+        print(f"  {name}: {human_bytes(detail['categories'][name])} -- {note}")
+    for name, message in sorted(detail["errors"].items()):
+        print(f"  FAILED {name}: {message}", file=sys.stderr)
+
+    try:
+        write_service_health(outcome["state"], detail, started_at)
+    except Exception as exc:  # noqa: BLE001 - bounded write, surface the failure
+        print(f"service_health write failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"service_health row written: {SERVICE_NAME} = {outcome['state']}")
+    # A failing category is reported through the heartbeat, not by failing the
+    # unit: a wedged docker daemon must not also park the timer (DUR-02).
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cloud/scripts/setup-vps.sh
+++ b/cloud/scripts/setup-vps.sh
@@ -72,6 +72,8 @@ readonly SERVICE_FILES=(
   radon-drift-audit.timer
   radon-db-backup.service
   radon-db-backup.timer
+  radon-disk-cleanup.service
+  radon-disk-cleanup.timer
   radon-portfolio-archive.service
   radon-portfolio-archive.timer
   radon-media-backup.service

--- a/cloud/services/radon-disk-cleanup.service
+++ b/cloud/services/radon-disk-cleanup.service
@@ -1,0 +1,45 @@
+[Unit]
+Description=Radon weekend disk cleanup (stale deploy images, leaked release worktrees, caches, journald)
+Wants=network-online.target
+After=network-online.target docker.service
+# DUR-02 pattern: brake crash loops -- after StartLimitBurst starts inside
+# StartLimitIntervalSec, systemd parks the unit as failed instead of
+# restarting forever. The disk-cleanup service_health heartbeat (8-day
+# window) surfaces a parked/silent sweep on the dashboard + watchdog daily
+# bucket.
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
+[Service]
+Type=oneshot
+# Root on purpose: the docker engine socket is root-only (radon is
+# deliberately NOT in group docker, see radon-app-runtime.sh) and journald
+# vacuuming is root-only. The leaked stage./backup. worktrees also outlive
+# the radon processes that created them.
+User=root
+WorkingDirectory=/
+# This unit deliberately declares NO environment-file directive, for the same
+# reason radon-drift-audit.service does not: the stable secret file is 0600
+# radon:radon and systemd merges every KEY=VALUE line of such a file into the
+# process environment unfiltered, so one appended LD_PRELOAD line would load
+# radon-authored code into root and PATH= would redirect the bare binary names
+# below. The two Turso keys the heartbeat needs are READ out of that file as
+# data (disk_cleanup.load_env_keys).
+Environment=RADON_ENV_FILE=/home/radon/radon-cloud/.env
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+# Root runs the control-plane copy installed root-owned by
+# cloud/scripts/bootstrap-control-plane.sh, never the radon-writable checkout
+# (cloud/tests/test_root_execution_paths.py).
+# -I (isolated): CPython otherwise prepends the script's own directory to
+# sys.path, so a module dropped beside it would be imported by root.
+ExecStart=/usr/bin/python3 -I /usr/local/lib/radon/disk_cleanup.py
+StandardOutput=journal
+StandardError=journal
+# A oneshot with no runtime ceiling can hang forever and freeze its timer
+# (the ib-watchdog self-hang, 2026-06-10). The dominant cost is walking
+# ~9 GB of cache trees and a handful of `docker image rm` calls; 900s is far
+# above the observed manual reclaim and still finite.
+TimeoutStartSec=900
+
+[Install]
+WantedBy=multi-user.target

--- a/cloud/services/radon-disk-cleanup.timer
+++ b/cloud/services/radon-disk-cleanup.timer
@@ -1,0 +1,16 @@
+[Unit]
+Description=Radon disk cleanup -- weekly, Sunday off-hours
+
+[Timer]
+# Sunday 03:20 UTC: the weekend slot the operator asked for, and deliberately
+# clear of every DB-maintenance window -- portfolio-archive (05:40 + 2h),
+# db-retention (08:10), db-backup (09:00) -- and of the 02:15/02:20/02:35
+# nightly cluster above it. Not :00/:30 to stay off the top-of-hour scheduler
+# herd. Persistent so a missed firing (host down) replays on the next boot
+# instead of skipping a whole week; the disk fills either way.
+OnCalendar=Sun *-*-* 03:20:00 UTC
+RandomizedDelaySec=300
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/cloud/tests/test_bootstrap_control_plane.py
+++ b/cloud/tests/test_bootstrap_control_plane.py
@@ -34,6 +34,7 @@ ARTIFACTS = (
     # Root runs the audit, so its payload cannot live in the radon-writable
     # checkout. It is data for a root-owned interpreter, hence 0644 not 0755.
     Artifact("scripts/drift_audit.py", "/usr/local/lib/radon/drift_audit.py", 0o644),
+    Artifact("scripts/disk_cleanup.py", "/usr/local/lib/radon/disk_cleanup.py", 0o644),
     Artifact("scripts/radon-app-runtime.sh", "/usr/local/sbin/radon-app-runtime", 0o755),
     Artifact("config/sudoers.d/radon-deploy", "/etc/sudoers.d/radon-deploy", 0o440),
     Artifact("config/sudoers.d/radon-monitor", "/etc/sudoers.d/radon-monitor", 0o440),
@@ -96,6 +97,16 @@ ARTIFACTS = (
     Artifact(
         "services/radon-db-backup.timer",
         "/etc/systemd/system/radon-db-backup.timer",
+        0o644,
+    ),
+    Artifact(
+        "services/radon-disk-cleanup.service",
+        "/etc/systemd/system/radon-disk-cleanup.service",
+        0o644,
+    ),
+    Artifact(
+        "services/radon-disk-cleanup.timer",
+        "/etc/systemd/system/radon-disk-cleanup.timer",
         0o644,
     ),
     Artifact(

--- a/cloud/tests/test_disk_cleanup.py
+++ b/cloud/tests/test_disk_cleanup.py
@@ -1,0 +1,336 @@
+"""Tests for scripts/disk_cleanup.py pure logic (no docker, no host, no Turso).
+
+2026-08-27: the watchdog `root-disk-usage` check paged P1 when the VPS root
+filesystem reached 98% (1.7 GiB free on a 75G disk). Nothing on the box ever
+pruned the per-SHA ``ghcr.io/joemccann/radon-{node,python}`` image pairs
+(~5.8G per deploy), and ``deploy.sh``'s best-effort
+``cleanup_staged_release_path`` had leaked seven ``stage.``/``backup.``
+worktrees under /home/radon/.radon-releases going back to Jul 11.
+
+Every destructive decision this job makes is a PURE selector tested here, so
+the retention rules are provable without a live docker daemon: the running
+broker image and the autoheal sidecar can never be selected, and the live
+/home/radon/radon checkout can never be selected as an orphaned worktree.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+DAY = 86400
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "disk_cleanup", ROOT / "scripts" / "disk_cleanup.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+disk_cleanup = _load_module()
+
+HEAD = "a" * 40
+NEWER = "b" * 40
+NEWEST = "c" * 40
+OLD = "d" * 40
+OLDEST = "e" * 40
+
+
+def _image(repo: str, tag: str, created: float, size: int = 1, image_id: str = "sha256:x"):
+    return disk_cleanup.Image(
+        repository=repo, tag=tag, image_id=image_id, created_at=created, size_bytes=size
+    )
+
+
+def _pair(tag: str, created: float):
+    return [
+        _image("ghcr.io/joemccann/radon-node", tag, created, 4_690_000_000),
+        _image("ghcr.io/joemccann/radon-python", tag, created, 1_110_000_000),
+    ]
+
+
+class TestImageRetention:
+    def test_keeps_head_pair_plus_the_newest_n_pairs(self):
+        images = (
+            _pair(HEAD, 100)
+            + _pair(NEWER, 300)
+            + _pair(NEWEST, 400)
+            + _pair(OLD, 200)
+        )
+        removed = disk_cleanup.select_prunable_images(images, HEAD, keep_pairs=2)
+        removed_tags = {img.tag for img in removed}
+        assert removed_tags == {OLD}, (
+            "must retain the HEAD pair plus the two newest pairs and remove the rest"
+        )
+        assert len(removed) == 2, "both halves of a superseded pair go"
+
+    def test_head_pair_survives_even_when_it_is_the_oldest(self):
+        images = _pair(HEAD, 1) + _pair(NEWER, 300) + _pair(NEWEST, 400)
+        removed = disk_cleanup.select_prunable_images(images, HEAD, keep_pairs=2)
+        assert removed == [], "the pair matching /home/radon/radon HEAD is never removable"
+
+    def test_never_returns_the_running_broker_or_autoheal_images(self):
+        images = [
+            _image("ghcr.io/gnzsnz/ib-gateway", "10.45.1b", 1),
+            _image("willfarrell/autoheal", "latest", 1),
+        ] + _pair(HEAD, 500) + _pair(OLDEST, 1)
+        removed = disk_cleanup.select_prunable_images(images, HEAD, keep_pairs=1)
+        repos = {img.repository for img in removed}
+        assert "ghcr.io/gnzsnz/ib-gateway" not in repos, "the live broker image is not ours to prune"
+        assert "willfarrell/autoheal" not in repos
+        assert repos == {
+            "ghcr.io/joemccann/radon-node",
+            "ghcr.io/joemccann/radon-python",
+        }
+
+    def test_never_returns_an_unmanaged_repository(self):
+        images = [_image("postgres", "16", 1), _image("caddy", "2", 1)] + _pair(HEAD, 5)
+        assert disk_cleanup.select_prunable_images(images, HEAD, keep_pairs=1) == []
+
+    def test_is_a_no_op_below_the_retention_count(self):
+        images = _pair(HEAD, 100) + _pair(NEWER, 200)
+        assert disk_cleanup.select_prunable_images(images, HEAD, keep_pairs=2) == []
+
+    def test_untagged_images_are_left_to_the_dangling_prune(self):
+        images = _pair(HEAD, 400) + [
+            _image("ghcr.io/joemccann/radon-node", "<none>", 1),
+            _image("ghcr.io/joemccann/radon-python", "", 1),
+        ]
+        assert disk_cleanup.select_prunable_images(images, HEAD, keep_pairs=1) == []
+
+    def test_an_unresolvable_head_prunes_nothing(self):
+        """If HEAD cannot be read, every tag is potentially the running one."""
+        images = _pair(HEAD, 100) + _pair(NEWER, 200) + _pair(OLD, 50)
+        assert disk_cleanup.select_prunable_images(images, "", keep_pairs=1) == []
+
+
+class TestReleaseWorktreeSelection:
+    RELEASES = pathlib.Path("/home/radon/.radon-releases")
+    NOW = 10 * DAY
+
+    def _entries(self, *pairs):
+        return [(self.RELEASES / name, mtime) for name, mtime in pairs]
+
+    def test_never_returns_the_live_checkout(self):
+        entries = [(pathlib.Path("/home/radon/radon"), 0.0)]
+        assert disk_cleanup.select_prunable_releases(entries, self.NOW) == []
+
+    def test_never_returns_a_path_outside_the_releases_dir(self):
+        entries = [(pathlib.Path("/home/radon/stage.abc1234.AbCdEf"), 0.0)]
+        assert disk_cleanup.select_prunable_releases(entries, self.NOW) == []
+
+    def test_selects_stage_and_backup_orphans_past_the_age_threshold(self):
+        entries = self._entries(
+            ("stage.abc1234.AbCdEf", self.NOW - 9 * DAY),
+            ("backup.abc1234.ZzYyXx", self.NOW - 4 * DAY),
+        )
+        removed = disk_cleanup.select_prunable_releases(entries, self.NOW, max_age_days=3)
+        assert removed == [
+            self.RELEASES / "backup.abc1234.ZzYyXx",
+            self.RELEASES / "stage.abc1234.AbCdEf",
+        ]
+
+    def test_retains_a_worktree_younger_than_the_threshold(self):
+        entries = self._entries(("stage.abc1234.AbCdEf", self.NOW - 2 * DAY))
+        assert disk_cleanup.select_prunable_releases(entries, self.NOW, max_age_days=3) == []
+
+    def test_ignores_names_deploy_sh_never_creates(self):
+        entries = self._entries(
+            ("notes.txt", 0.0),
+            ("radon", 0.0),
+            ("stage", 0.0),
+        )
+        assert disk_cleanup.select_prunable_releases(entries, self.NOW) == []
+
+    def test_is_a_no_op_on_an_empty_releases_dir(self):
+        assert disk_cleanup.select_prunable_releases([], self.NOW) == []
+
+
+class TestProtectedPaths:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/home/radon/radon",
+            "/home/radon/radon/data",
+            "/home/radon/radon-cloud/backups/db",
+            "/home/radon/.cache/ms-playwright",
+            "/home/radon/.cache/huggingface",
+            "/home/radon/.cache/fastembed",
+            "/home/radon/.cache/radon-wheels",
+            # An ancestor of a protected path is protected: removing it takes
+            # the protected tree with it.
+            "/home/radon/.cache",
+            "/home/radon",
+            "/",
+        ],
+    )
+    def test_protected(self, path):
+        assert disk_cleanup.is_protected_path(pathlib.Path(path)) is True
+
+    @pytest.mark.parametrize(
+        "path",
+        ["/home/radon/.npm/_cacache", "/home/radon/.cache/pip", "/home/radon/.radon-releases/stage.a.b"],
+    )
+    def test_not_protected(self, path):
+        assert disk_cleanup.is_protected_path(pathlib.Path(path)) is False
+
+    def test_the_configured_cache_targets_are_all_removable(self):
+        for target in disk_cleanup.CACHE_TARGETS:
+            assert disk_cleanup.is_protected_path(target) is False
+
+    def test_the_db_backup_tree_is_out_of_scope(self):
+        """Retention there is db_backup.py's RETENTION_DAYS, not ours."""
+        assert disk_cleanup.is_protected_path(
+            pathlib.Path("/home/radon/radon-cloud/backups/db/radon-2026-08-01T090000Z.sql.gz")
+        )
+
+
+class TestStaleWorktreeAdminDirs:
+    ADMIN = pathlib.Path("/home/radon/radon/.git/worktrees")
+
+    def test_selects_only_admin_dirs_whose_worktree_is_gone(self):
+        entries = [
+            (self.ADMIN / "stage.abc1234.AbCdEf", False),
+            (self.ADMIN / "stage.def5678.GhIjKl", True),
+        ]
+        assert disk_cleanup.select_stale_worktree_admin_dirs(entries) == [
+            self.ADMIN / "stage.abc1234.AbCdEf"
+        ]
+
+    def test_is_a_no_op_when_every_worktree_is_live(self):
+        entries = [(self.ADMIN / "stage.abc1234.AbCdEf", True)]
+        assert disk_cleanup.select_stale_worktree_admin_dirs(entries) == []
+
+
+class TestParsers:
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("0B", 0),
+            ("512B", 512),
+            ("989MB", 989_000_000),
+            ("4.69GB", 4_690_000_000),
+            ("1.1kB", 1_100),
+            ("", 0),
+            ("N/A", 0),
+        ],
+    )
+    def test_parse_docker_size(self, text, expected):
+        assert disk_cleanup.parse_docker_size(text) == expected
+
+    def test_parse_reclaimed_space(self):
+        output = "deleted: sha256:abc\n\nTotal reclaimed space: 1.234GB\n"
+        assert disk_cleanup.parse_reclaimed_space(output) == 1_234_000_000
+
+    def test_parse_reclaimed_space_when_nothing_was_reclaimed(self):
+        assert disk_cleanup.parse_reclaimed_space("Total reclaimed space: 0B\n") == 0
+        assert disk_cleanup.parse_reclaimed_space("") == 0
+
+    def test_parse_docker_created(self):
+        stamp = disk_cleanup.parse_docker_created("2026-08-20 03:11:22 +0000 UTC")
+        assert stamp == pytest.approx(1787195482.0, abs=86400)
+
+    def test_parse_docker_created_is_zero_when_unparseable(self):
+        assert disk_cleanup.parse_docker_created("who knows") == 0.0
+
+    def test_parse_image_lines(self):
+        line = "ghcr.io/joemccann/radon-node\t" + HEAD + "\tsha256:1\t2026-08-20 03:11:22 +0000 UTC\t4.69GB"
+        images = disk_cleanup.parse_image_lines(line + "\nmalformed line\n")
+        assert len(images) == 1
+        assert images[0].repository == "ghcr.io/joemccann/radon-node"
+        assert images[0].tag == HEAD
+        assert images[0].size_bytes == 4_690_000_000
+
+    def test_human_bytes(self):
+        assert disk_cleanup.human_bytes(0) == "0 B"
+        assert disk_cleanup.human_bytes(1536) == "1.5 KiB"
+        assert disk_cleanup.human_bytes(12_900_000_000).endswith("GiB")
+
+
+class TestResolveHeadSha:
+    def test_reads_a_symbolic_head_through_a_loose_ref(self, tmp_path):
+        git_dir = tmp_path / ".git"
+        (git_dir / "refs" / "heads").mkdir(parents=True)
+        (git_dir / "HEAD").write_text("ref: refs/heads/main\n")
+        (git_dir / "refs" / "heads" / "main").write_text(HEAD + "\n")
+        assert disk_cleanup.resolve_head_sha(git_dir) == HEAD
+
+    def test_falls_back_to_packed_refs(self, tmp_path):
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        (git_dir / "HEAD").write_text("ref: refs/heads/main\n")
+        (git_dir / "packed-refs").write_text(
+            "# pack-refs with: peeled fully-peeled sorted\n"
+            f"{HEAD} refs/heads/main\n"
+        )
+        assert disk_cleanup.resolve_head_sha(git_dir) == HEAD
+
+    def test_reads_a_detached_head(self, tmp_path):
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        (git_dir / "HEAD").write_text(HEAD + "\n")
+        assert disk_cleanup.resolve_head_sha(git_dir) == HEAD
+
+    def test_returns_empty_when_head_is_unreadable_or_bogus(self, tmp_path):
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        assert disk_cleanup.resolve_head_sha(git_dir) == ""
+        (git_dir / "HEAD").write_text("ref: refs/heads/gone\n")
+        assert disk_cleanup.resolve_head_sha(git_dir) == ""
+
+
+class TestRunCleanup:
+    def test_a_clean_box_reports_ok_with_zero_reclaimed(self):
+        outcome = disk_cleanup.run_cleanup(
+            categories=(("docker-images", lambda: (0, "nothing to remove")),),
+            free_space=lambda: 30_000_000_000,
+        )
+        assert outcome["state"] == "ok"
+        assert outcome["detail"]["reclaimed_bytes"] == 0
+        assert outcome["detail"]["errors"] == {}
+
+    def test_one_failing_category_does_not_stop_the_others(self):
+        def boom():
+            raise RuntimeError("docker is down")
+
+        outcome = disk_cleanup.run_cleanup(
+            categories=(
+                ("docker-images", boom),
+                ("npm-cache", lambda: (8_900_000_000, "removed")),
+            ),
+            free_space=iter([1_700_000_000, 10_600_000_000]).__next__,
+        )
+        assert outcome["state"] == "error"
+        assert "docker is down" in outcome["detail"]["errors"]["docker-images"]
+        assert outcome["detail"]["categories"]["npm-cache"] == 8_900_000_000
+        assert outcome["detail"]["reclaimed_bytes"] == 8_900_000_000
+
+    def test_free_space_before_and_after_are_reported(self):
+        outcome = disk_cleanup.run_cleanup(
+            categories=(("journal", lambda: (900_000_000, "vacuumed")),),
+            free_space=iter([1_700_000_000, 2_600_000_000]).__next__,
+        )
+        detail = outcome["detail"]
+        assert detail["free_before_bytes"] == 1_700_000_000
+        assert detail["free_after_bytes"] == 2_600_000_000
+        assert "journal" in detail["summary"]
+
+
+class TestUnitFiles:
+    def test_timer_fires_on_the_weekend_clear_of_the_db_maintenance_window(self, services_dir):
+        text = (services_dir / "radon-disk-cleanup.timer").read_text()
+        assert "OnCalendar=Sun *-*-* 03:20:00 UTC" in text
+        assert "Persistent=true" in text
+
+    def test_service_runs_the_root_owned_control_plane_copy(self, services_dir):
+        text = (services_dir / "radon-disk-cleanup.service").read_text()
+        assert "User=root" in text
+        assert "ExecStart=/usr/bin/python3 -I /usr/local/lib/radon/disk_cleanup.py" in text
+        assert "EnvironmentFile=" not in text
+        assert "Environment=PATH=" in text

--- a/cloud/tests/test_sync_scheduled_units.py
+++ b/cloud/tests/test_sync_scheduled_units.py
@@ -41,6 +41,8 @@ CONTROL_PLANE_UNITS = {
     "radon-refresh.timer",
     "radon-db-backup.service",
     "radon-db-backup.timer",
+    "radon-disk-cleanup.service",
+    "radon-disk-cleanup.timer",
     "radon-drift-audit.service",
     "radon-drift-audit.timer",
     "radon-nextjs-db-watchdog.service",

--- a/cloud/tests/test_systemd_services.py
+++ b/cloud/tests/test_systemd_services.py
@@ -33,6 +33,8 @@ EXPECTED_SERVICE_FILES = [
     "radon-watchdog-error.timer",
     "radon-db-backup.service",
     "radon-db-backup.timer",
+    "radon-disk-cleanup.service",
+    "radon-disk-cleanup.timer",
     "radon-portfolio-archive.service",
     "radon-portfolio-archive.timer",
     "radon-media-backup.service",
@@ -153,8 +155,13 @@ STATIC_SERVICES = {
 # The drift audit must read 0440 root sudoers and run `docker inspect`, so it
 # stays root -- but it executes a root-owned control-plane copy of the audit,
 # never the radon-writable checkout (cloud/tests/test_root_execution_paths.py).
+# The weekend disk sweep must talk to the root-only docker engine socket
+# (radon is deliberately not in group docker) and vacuum journald -- so it
+# stays root, and like the drift audit it executes a root-owned
+# control-plane copy, never the radon-writable checkout.
 ROOT_REQUIRED_SERVICES = {
     "radon-drift-audit.service",
+    "radon-disk-cleanup.service",
 }
 
 

--- a/docs/cloud-services.md
+++ b/docs/cloud-services.md
@@ -501,6 +501,47 @@ Re-check with `turso plan show` after any plan change. Nightly dumps remain mand
 | `radon-db-backup.timer` | **09:00** | Full Turso dump after archive + retention. |
 | `radon-media-backup.timer` | **10:15** | Mirror `media.radon.run` tree (`/home/radon/radon-cloud/media`) → B2 prefix `media/`. Heartbeat: `media-backup`. `TimeoutStartSec=3600`. |
 
+## Disk cleanup (weekly)
+
+2026-08-27: the watchdog `root-disk-usage` check paged P1 at 98% of the 75G
+root filesystem (1.7 GiB free). Nothing on the box pruned the per-SHA
+`ghcr.io/joemccann/radon-{node,python}` image pairs (~5.8G per deploy), and
+`deploy.sh`'s best-effort `cleanup_staged_release_path` had leaked seven
+`stage.`/`backup.` worktrees under `/home/radon/.radon-releases` going back to
+Jul 11. `radon-disk-cleanup` automates the manual reclaim.
+
+| Piece | Where | What |
+|---|---|---|
+| `radon-disk-cleanup.timer` | VPS | Weekly **Sun 03:20 UTC**, `RandomizedDelaySec=300`, `Persistent=true`. Clear of portfolio-archive (05:40), db-retention (08:10) and db-backup (09:00). |
+| `radon-disk-cleanup.service` | VPS | Oneshot, `User=root` (root-only docker socket + journald vacuum), `TimeoutStartSec=900`. Runs the control-plane copy at `/usr/local/lib/radon/disk_cleanup.py` under `python3 -I`, never the radon-writable checkout. |
+| `cloud/scripts/disk_cleanup.py` | VPS | Five categories: stale app images, dangling layers, leaked release worktrees, npm/pip caches, journald. |
+| `service_health` heartbeat | row `disk-cleanup` | Written on EVERY run — `ok` with per-category bytes plus free-space before/after, `error` naming the failing categories. 8-day freshness window. |
+
+Retention constants (`cloud/scripts/disk_cleanup.py`):
+
+- `KEEP_IMAGE_PAIRS = 2` — keeps the `radon-node` / `radon-python` pair matching
+  the live checkout's HEAD **plus** the two newest pairs. An unresolvable HEAD
+  prunes nothing.
+- `RELEASE_MAX_AGE_DAYS = 3` — removes `stage.<sha>.XXXXXX` / `backup.<sha>.XXXXXX`
+  worktrees older than that, then drops their stale `.git/worktrees/<name>`
+  records by filesystem op (root never runs `git` inside a repo the radon
+  account can configure).
+- `JOURNAL_VACUUM_SIZE = "200M"`.
+
+Never touched: the running `ghcr.io/gnzsnz/ib-gateway` and
+`willfarrell/autoheal` images, `/home/radon/radon` (the live tree),
+`~/.cache/{ms-playwright,huggingface,fastembed,radon-wheels}`, and
+`/home/radon/radon-cloud/backups` — DB backup retention is `db_backup.py`'s
+`RETENTION_DAYS = 30` and shrinking it is an operator policy call.
+
+A category that finds nothing is a normal run. A category that RAISES flips
+the heartbeat to `error` but does not fail the unit: a wedged docker daemon
+must not also park the timer.
+
+Both units are **control-plane**, so `install-units` skips them by design and
+the root `bootstrap-control-plane.sh` run is what installs them and clears
+their `config/installed-units.sha256` entries.
+
 ### CREDIT spread (`radon-credit-spread.timer`)
 
 Daily `21:45 UTC` (`RandomizedDelaySec=300`), oneshot

--- a/scripts/tests/test_watchdog_catalog_parity.py
+++ b/scripts/tests/test_watchdog_catalog_parity.py
@@ -304,10 +304,17 @@ class TestDur02BrakeAndFlapReach:
 # real gap or a real exemption; a NEW unit in neither fails the test, so the
 # class cannot grow silently while it is worked down.
 
-# Units whose job DOES call record_service_health, under a name this static
-# parser cannot resolve (built at runtime, or passed in by a caller). Not a
-# reliability gap — a parser limitation, tracked so it is not mistaken for one.
+# Units whose job DOES write a service_health row, under a name this static
+# parser cannot resolve (built at runtime, passed in by a caller, or written
+# through the cloud tree's own bounded stdlib libSQL pipeline rather than
+# record_service_health). Not a reliability gap — a parser limitation, tracked
+# so it is not mistaken for one.
 HEALTH_NAME_UNRESOLVED = {
+    # cloud/scripts/disk_cleanup.py heartbeats `disk-cleanup` on every run via
+    # its own write_service_health (same bounded stdlib shape as db_backup.py /
+    # drift_audit.py, which never touch the libsql bindings). The name is
+    # registered in BOTH catalogs; only this literal scan cannot see it.
+    "radon-disk-cleanup",
     "radon-ib-watchdog",
     "radon-nextjs-db-watchdog",
     "radon-perf-twr",

--- a/scripts/watchdog/services.py
+++ b/scripts/watchdog/services.py
@@ -346,6 +346,12 @@ SCHEDULED_SERVICES: dict[str, FreshnessWindow] = {
     # event-odds — laptop launchd 3x weekday, holiday-aware. Windows
     # match catalysts (7h open / 4d closed). Polymarket only — no IB.
     "event-odds": {"open": 7 * _HOUR, "closed": 4 * _DAY, "requires_ib": False},
+    # disk-cleanup — WEEKLY root-filesystem reclaim on the VPS
+    # (cloud/scripts/disk_cleanup.py via radon-disk-cleanup.timer, Sun 03:20
+    # UTC). Heartbeats ok/error every run. 8-day window uses the
+    # preset-rebalance weekly precedent (cadence + timer jitter). Docker +
+    # local disk + journald only — no IB dependency.
+    "disk-cleanup": {"open": 8 * _DAY, "closed": 8 * _DAY, "requires_ib": False},
 }
 
 
@@ -514,6 +520,9 @@ BUCKETS: dict[str, list[str]] = {
         "db-retention",
         # Nightly media.radon.run tree backup to B2 — 48h window.
         "media-backup",
+        # Weekly weekend disk cleanup on the VPS — hourly check surfaces a
+        # missed sweep within 1h of the 8-day window expiring.
+        "disk-cleanup",
         # Equibles daily + weekly + event-odds. Hourly check surfaces a
         # missed fire within 1h of the window expiring (preset-rebalance
         # weekly precedent).

--- a/web/lib/serviceHealthWindows.ts
+++ b/web/lib/serviceHealthWindows.ts
@@ -534,6 +534,14 @@ export const SERVICE_FRESHNESS_WINDOWS: Record<string, Window> = {
   // Polymarket only — no IB.
   "event-odds": { open: 7 * HOUR, extended: 7 * HOUR, closed: 4 * DAY, category: "scheduled", requires_ib: false },
 
+  // ``disk-cleanup`` is the WEEKLY root-filesystem reclaim on the VPS
+  // (cloud/scripts/disk_cleanup.py via radon-disk-cleanup.timer, Sun 03:20
+  // UTC) — stale deploy images, leaked release worktrees, npm/pip caches,
+  // journald. Heartbeats ok/error on every run. Uniform 8d window on the
+  // preset-rebalance weekly precedent: weekly cadence plus timer jitter, so
+  // one missed Sunday surfaces before the second. Docker + local disk only.
+  "disk-cleanup": { open: 8 * DAY, extended: 8 * DAY, closed: 8 * DAY, category: "scheduled", requires_ib: false },
+
 };
 
 const DEFAULT_WINDOW: Window = {


### PR DESCRIPTION
## Why

The watchdog `root-disk-usage` check (`scripts/watchdog/disk.py`, P1 at 95%) paged tonight: root hit **98% / 1.7 GiB free** on the 75G disk. The incident itself is resolved by hand (~27G reclaimed, now 58%). This PR is prevention only.

Verified consumers, none of which had a pruner anywhere in `cloud/` or `scripts/`:

1. **Docker images (~12.9G).** One `ghcr.io/joemccann/radon-node` (~4.69G) + `radon-python` (~1.11G) pair accumulates per SHA. No `docker image prune` / `system prune` / `rmi` existed.
2. **Orphaned deploy worktrees (5.8G).** `deploy.sh`'s `cleanup_staged_release_path` is best-effort and logs *"Could not fully remove release backup ...; leaving for root cleanup"*. Seven orphans found, oldest Jul 11.
3. **Caches (~9.9G).** `~/.npm/_cacache` + `~/.cache/pip`.
4. **journald (0.9G).**

## What

`radon-disk-cleanup.{service,timer}` + `cloud/scripts/disk_cleanup.py`.

| | |
|---|---|
| Schedule | `OnCalendar=Sun *-*-* 03:20:00 UTC`, `RandomizedDelaySec=300`, `Persistent=true` |
| Collisions | Clear of portfolio-archive (05:40 +2h), db-retention (08:10), db-backup (09:00), drift-audit (06:40) and the 02:15/02:20/02:35 cluster |
| `KEEP_IMAGE_PAIRS` | `2` — keeps the pair matching live-checkout HEAD **plus** the 2 newest pairs |
| `RELEASE_MAX_AGE_DAYS` | `3` |
| `JOURNAL_VACUUM_SIZE` | `200M` |
| Heartbeat | `service_health` row `disk-cleanup`, every run, per-category bytes + free space before/after. 8-day window in both catalogs. |

### Safety

Every destructive decision is a **pure selector**, unit-tested with no docker/host:

- `select_prunable_images` only ever considers `MANAGED_IMAGE_REPOSITORIES`; `ghcr.io/gnzsnz/ib-gateway` (the live broker) and `willfarrell/autoheal` are additionally named in `PROTECTED_IMAGE_REPOSITORIES` — the same belt-and-braces posture as `radon-app-runtime.sh:refuse_host_plane()`. An unresolvable HEAD prunes **nothing**.
- `select_prunable_releases` requires a direct child of `/home/radon/.radon-releases` matching deploy.sh's two mktemp templates, so `/home/radon/radon` is unreachable by construction *and* by `is_protected_path`.
- `PROTECTED_PATHS` covers the live tree, `~/.cache/{ms-playwright,huggingface,fastembed,radon-wheels}` and `/home/radon/radon-cloud/backups` — **out of scope by design**: retention there is `db_backup.py`'s `RETENTION_DAYS = 30`, it is real data with no offsite copy in that script, and shrinking it is an operator policy call.
- `remove_tree` refuses symlinks and protected paths.
- Root runs the control-plane copy at `/usr/local/lib/radon/disk_cleanup.py` under `python3 -I`, declares no `EnvironmentFile`, pins `PATH`, and reads the two Turso keys as data (`load_env_keys`) — `cloud/tests/test_root_execution_paths.py` contract.
- Root never runs `git` inside `/home/radon/radon`: HEAD is read from `.git/HEAD`, and stale `.git/worktrees/<name>` records are dropped by filesystem op instead of `git worktree prune`. Repo-local config is radon-writable, and git honours it.
- Idempotent. A category that finds nothing is a normal run; a category that **raises** flips the heartbeat to `error` but does not fail the unit (a wedged docker daemon must not also park the timer).

### Registration

`setup-vps.sh` · `bootstrap-control-plane.sh` (SOURCES/LOGICAL_TARGETS/MODES/KINDS) · `deploy-root-helper.sh` (CONTROL_PLANE_SOURCES/TARGETS/MODES) · `config/installed-units.sha256` · `scripts/watchdog/services.py` (window + daily bucket) · `web/lib/serviceHealthWindows.ts` · `docs/cloud-services.md`.

## ⚠️ Operator action required before merge

Both units are **control-plane**, so the artifact table grew from 28 to 31. `verify-control-plane` compares the root-written manifest length against `CONTROL_PLANE_TARGETS`, so the root install-copy must run on the host or the next deploy preflight fails on manifest length (same as REL-039):

```bash
cd /home/radon/radon && bash cloud/scripts/bootstrap-control-plane.sh
```

`install-units` skips control-plane units by design, so that run is also what clears the two new `installed-units.sha256` entries.

## Tests

Red/green. `cloud/tests/test_disk_cleanup.py` — 52 new tests, written failing first (collection error, then 2 unit-file failures) before the implementation.

Rebased onto `origin/main` (`a3b90393`, 87 commits ahead of the original base); baselines re-measured against that base.

| Gate | Branch | `origin/main` baseline |
|---|---|---|
| `pytest cloud/tests -q` | 37 failed, 1163 passed, 7 skipped | 37 failed, 1126 passed, 7 skipped |
| `pytest scripts/tests tests -q` | **7594 passed, 1 skipped, 0 failed** | — |
| `vitest web/tests` | 1076 failed, 4313 passed | 1076 failed, 4313 passed |

The 37 cloud failures (`test_bootstrap_control_plane.py`, `test_caddy_edge_timeouts.py`, `test_ib_gateway_control.py`) and every vitest failure are the pre-existing local macOS baseline — **failure-ID sets are byte-identical** between branch and `origin/main`, verified by diffing the captured `FAILED` lists. CI runs these on Linux.

The rebase pulled in `scripts/tests/test_watchdog_catalog_parity.py` (R-277), which requires every timer-backed unit to contribute a catalogued health name. `radon-disk-cleanup` is registered in `HEALTH_NAME_UNRESOLVED`: it *does* heartbeat every run, through the cloud tree's own bounded stdlib libSQL pipeline (`write_service_health`, same shape as `db_backup.py` / `drift_audit.py`) rather than `record_service_health`, which is the only form that literal scan resolves. The name is registered in **both** catalogs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tL6SCTsyQuEFAoVwfzj8r

