### PR TITLE
feat(cloud): push nightly Turso dumps off-box to Backblaze B2

### DIFF
--- a/cloud/scripts/db_backup.py
+++ b/cloud/scripts/db_backup.py
@@ -19,6 +19,23 @@ pattern as drift_audit.py) so a wedged libsql client can never block the
 liveness signal. libsql_experimental has no client-side timeouts (DUR-09),
 so the real bound is the unit's TimeoutStartSec.
 
+Off-box copy (B2): after the local dump lands, every ``*.sql.gz`` in
+BACKUP_DIR that is missing from the ``radon-archive`` bucket under
+``db_backups/`` is uploaded, so the first run backfills the whole local
+window and later runs push only the new night. Credentials default to
+``RADON_ARCHIVE_S3_*`` with optional ``RADON_DB_BACKUP_S3_*`` overrides,
+exactly like media_backup.py.
+
+DELIBERATE DIVERGENCE from media_backup.py, which fails CLOSED: here the
+local gzip is the critical path and the upload is not. A wedged or
+unconfigured B2 never deletes, truncates, or skips the on-box dump -- the
+run still writes the file, then reports the upload failure through the
+journal and an ``error`` service_health heartbeat (exit 1). Fail-degraded
+in that one direction only.
+
+Remote retention is REMOTE_RETENTION_DAYS, deliberately longer than the
+on-box RETENTION_DAYS; off-boxing a 30-day window would buy nothing.
+
 Restore runbook: main repo docs/cloud-services.md "DB backup & restore".
 """
 from __future__ import annotations
@@ -29,13 +46,31 @@ import os
 import sys
 import time
 import urllib.request
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
 SERVICE_NAME = "db-backup"
 RETENTION_DAYS = 30
+# Off-box copies outlive the on-box window by design -- a year of nightly
+# dumps in B2 is the whole reason for pushing them off a 75 GB root fs.
+# Local RETENTION_DAYS stays the operator's call and is untouched by this.
+REMOTE_RETENTION_DAYS = 365
+DEFAULT_S3_PREFIX = "db_backups/"
 TURSO_TIMEOUT = 10
 SUMMARY_CAP = 300
+# Wall-clock ceiling for the upload leg. The unit allows TimeoutStartSec
+# 19500s and a healthy dump eats ~1500s, so 3600s leaves ample headroom
+# while capping a slow first backfill (30 x ~530 MB): whatever does not fit
+# is deferred to tomorrow's run, which resumes where this one stopped.
+UPLOAD_BUDGET_SECS = 3600
+# Bounded transport: botocore has NO default socket timeout, so a wedged B2
+# would otherwise hang until TimeoutStartSec kills the whole unit.
+S3_CONNECT_TIMEOUT = 30
+S3_READ_TIMEOUT = 300
+S3_MAX_ATTEMPTS = 3
+MULTIPART_CHUNK_BYTES = 64 * 1024 * 1024
+MULTIPART_CONCURRENCY = 4
 # Rows per SELECT page. Direct-to-cloud throughput is ~1 MB/s and
 # portfolio_snapshots rows are ~12 KB, so 500 rows ≈ 6 MB / ~7 s per page —
 # bounded memory instead of a ~700 MB fetchall on the fattest table.
@@ -91,6 +126,112 @@ def select_prunable(entries, now_secs: float, retention_days: int = RETENTION_DA
         name
         for name, mtime in entries
         if name.endswith(".sql.gz") and mtime < cutoff
+    ]
+
+
+@dataclass(frozen=True)
+class RemoteObject:
+    """One object under the off-box dump prefix (size + mtime for compare)."""
+
+    key: str
+    size: int
+    mtime: float
+
+
+def normalize_endpoint(url: str) -> str:
+    """B2 console often copies host-only; boto3 requires a scheme."""
+    ep = (url or "").strip()
+    if ep and not ep.startswith(("http://", "https://")):
+        return "https://" + ep
+    return ep
+
+
+def s3_config_from_env(env: dict[str, str] | None = None) -> dict[str, str] | None:
+    """Resolve B2/S3 config for the off-box dump copy.
+
+    Preference order per field:
+      1. ``RADON_DB_BACKUP_S3_*`` when set (dedicated application key)
+      2. fall back to ``RADON_ARCHIVE_S3_*`` (shared radon-archive bucket)
+
+    Prefix: ``RADON_DB_BACKUP_PREFIX`` else ``db_backups/``. It never
+    inherits ``RADON_ARCHIVE_S3_PREFIX`` -- dumps must not land in the
+    portfolio_snapshots tree.
+
+    Returns ``None`` when endpoint/bucket/key/secret are incomplete.
+    """
+    env = env if env is not None else dict(os.environ)
+
+    def pick(db_key: str, archive_key: str) -> str:
+        return (env.get(db_key) or env.get(archive_key) or "").strip()
+
+    cfg = {
+        "endpoint_url": normalize_endpoint(
+            pick("RADON_DB_BACKUP_S3_ENDPOINT", "RADON_ARCHIVE_S3_ENDPOINT")
+        ),
+        "bucket": pick("RADON_DB_BACKUP_S3_BUCKET", "RADON_ARCHIVE_S3_BUCKET"),
+        "access_key": pick(
+            "RADON_DB_BACKUP_S3_ACCESS_KEY_ID", "RADON_ARCHIVE_S3_ACCESS_KEY_ID"
+        ),
+        "secret_key": pick(
+            "RADON_DB_BACKUP_S3_SECRET_ACCESS_KEY",
+            "RADON_ARCHIVE_S3_SECRET_ACCESS_KEY",
+        ),
+    }
+    if not all(cfg.values()):
+        return None
+
+    prefix = (env.get("RADON_DB_BACKUP_PREFIX") or DEFAULT_S3_PREFIX).strip()
+    if prefix and not prefix.endswith("/"):
+        prefix += "/"
+    cfg["region"] = pick("RADON_DB_BACKUP_S3_REGION", "RADON_ARCHIVE_S3_REGION") or "auto"
+    cfg["prefix"] = prefix or DEFAULT_S3_PREFIX
+    return cfg
+
+
+def object_key_for(prefix: str, name: str) -> str:
+    """Join the S3 prefix with a dump basename (no leading slash)."""
+    clean = prefix.lstrip("/")
+    if clean and not clean.endswith("/"):
+        clean += "/"
+    return clean + name.lstrip("/")
+
+
+def is_dump_name(name: str) -> bool:
+    """Only completed dumps ship off-box (never the ``.tmp`` in-progress
+    file, which starts with a dot and ends ``.tmp``)."""
+    return name.endswith(".sql.gz") and not name.startswith(".")
+
+
+def select_uploadable(local_entries, remote_by_key, prefix: str) -> list[str]:
+    """Dump names missing off-box or differing in size, NEWEST FIRST.
+
+    ``local_entries`` is an iterable of ``(name, size_bytes)``. Newest-first
+    means tonight's dump is uploaded before any backfill of the older
+    window, so a budget-truncated run always protects the newest data.
+    Size compare is enough: a dump filename carries its UTC timestamp and is
+    never rewritten once ``os.replace`` has landed it.
+    """
+    planned = []
+    for name, size in local_entries:
+        if not is_dump_name(name):
+            continue
+        remote = remote_by_key.get(object_key_for(prefix, name))
+        if remote is None or remote.size != size:
+            planned.append(name)
+    return sorted(planned, reverse=True)
+
+
+def select_remote_prunable(
+    entries, now_secs: float, retention_days: int = REMOTE_RETENTION_DAYS
+) -> list[str]:
+    """Off-box object keys (``*.sql.gz`` ONLY) past the remote window.
+
+    ``entries`` is an iterable of ``(key, mtime_secs)``. Separate from
+    :func:`select_prunable` on purpose: remote keeps a far longer tail.
+    """
+    cutoff = now_secs - retention_days * 86400
+    return [
+        key for key, mtime in entries if key.endswith(".sql.gz") and mtime < cutoff
     ]
 
 
@@ -216,6 +357,160 @@ def dump_database(db, out, batch_size: int = BATCH_SIZE) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Off-box copy to Backblaze B2 (S3 API) -- never the critical path
+# ---------------------------------------------------------------------------
+
+
+def _s3_client(cfg: dict[str, str]):
+    import boto3  # lazy: unit tests and credential-less runs never import it
+    from botocore.config import Config
+
+    return boto3.client(
+        "s3",
+        endpoint_url=cfg["endpoint_url"],
+        aws_access_key_id=cfg["access_key"],
+        aws_secret_access_key=cfg["secret_key"],
+        region_name=cfg["region"],
+        config=Config(
+            connect_timeout=S3_CONNECT_TIMEOUT,
+            read_timeout=S3_READ_TIMEOUT,
+            retries={"max_attempts": S3_MAX_ATTEMPTS, "mode": "standard"},
+        ),
+    )
+
+
+def _transfer_config():
+    """Multipart so a ~500 MB dump uploads in bounded, retryable chunks."""
+    from boto3.s3.transfer import TransferConfig
+
+    return TransferConfig(
+        multipart_threshold=MULTIPART_CHUNK_BYTES,
+        multipart_chunksize=MULTIPART_CHUNK_BYTES,
+        max_concurrency=MULTIPART_CONCURRENCY,
+        use_threads=True,
+    )
+
+
+def _object_mtime(obj) -> float:
+    stamp = obj.get("LastModified")
+    try:
+        return float(stamp.timestamp())
+    except Exception:  # noqa: BLE001 - an unparseable stamp must never prune
+        return float("inf")
+
+
+def list_remote_dumps(client, bucket: str, prefix: str) -> dict[str, RemoteObject]:
+    """Index every object under ``prefix`` as ``{key: RemoteObject}``."""
+    out: dict[str, RemoteObject] = {}
+    token = None
+    while True:
+        kwargs = {"Bucket": bucket, "Prefix": prefix}
+        if token:
+            kwargs["ContinuationToken"] = token
+        resp = client.list_objects_v2(**kwargs)
+        for obj in resp.get("Contents") or []:
+            key = obj["Key"]
+            out[key] = RemoteObject(
+                key=key, size=int(obj["Size"]), mtime=_object_mtime(obj)
+            )
+        if not resp.get("IsTruncated"):
+            break
+        token = resp.get("NextContinuationToken")
+        if not token:
+            break
+    return out
+
+
+def sync_offbox(
+    backup_dir: Path,
+    cfg: dict[str, str],
+    *,
+    client=None,
+    now: float | None = None,
+    budget_secs: float = UPLOAD_BUDGET_SECS,
+    clock=time.monotonic,
+) -> dict:
+    """Push every local dump missing from B2, then prune the remote tail.
+
+    Idempotent: an object already present at the same size is skipped, so a
+    re-run costs one LIST. Resumable: uploads run newest-first and stop when
+    ``budget_secs`` is spent, leaving the rest for the next nightly run --
+    that is how the existing 30-dump local window backfills without any one
+    run overrunning TimeoutStartSec.
+    """
+    transfer = None
+    if client is None:
+        # Real transport only: an injected client is a test double, and
+        # building a TransferConfig would import boto3 for nothing.
+        client = _s3_client(cfg)
+        transfer = _transfer_config()
+
+    bucket = cfg["bucket"]
+    prefix = cfg["prefix"]
+    local = [
+        (path.name, path.stat().st_size)
+        for path in backup_dir.iterdir()
+        if path.is_file()
+    ]
+    remote = list_remote_dumps(client, bucket, prefix)
+    planned = select_uploadable(local, remote, prefix)
+
+    started = clock()
+    uploaded = 0
+    bytes_uploaded = 0
+    deferred = 0
+    for index, name in enumerate(planned):
+        if clock() - started >= budget_secs:
+            deferred = len(planned) - index
+            break
+        path = backup_dir / name
+        kwargs = {"Config": transfer} if transfer is not None else {}
+        client.upload_file(str(path), bucket, object_key_for(prefix, name), **kwargs)
+        uploaded += 1
+        bytes_uploaded += path.stat().st_size
+
+    prune_now = time.time() if now is None else now
+    prunable = select_remote_prunable(
+        [(obj.key, obj.mtime) for obj in remote.values()], prune_now
+    )
+    for key in prunable:
+        client.delete_object(Bucket=bucket, Key=key)
+
+    dumps = [name for name, _size in local if is_dump_name(name)]
+    return {
+        "bucket": bucket,
+        "prefix": prefix,
+        "local_dumps": len(dumps),
+        "planned": len(planned),
+        "uploaded": uploaded,
+        "bytes_uploaded": bytes_uploaded,
+        "deferred": deferred,
+        "skipped_present": len(dumps) - len(planned),
+        "remote_pruned": len(prunable),
+    }
+
+
+def run_offbox(backup_dir: Path) -> tuple[dict | None, str | None]:
+    """Best-effort off-box leg. Returns ``(summary, error)``; NEVER raises.
+
+    The local dump has already landed by the time this runs, and nothing
+    here may remove or rewrite it. A failure is reported, not fatal to the
+    artifact -- see the module docstring on the deliberate divergence from
+    media_backup.py.
+    """
+    cfg = s3_config_from_env()
+    if cfg is None:
+        return None, (
+            "off-box upload skipped: B2 credentials missing (set "
+            "RADON_ARCHIVE_S3_* or RADON_DB_BACKUP_S3_*)"
+        )
+    try:
+        return sync_offbox(backup_dir, cfg), None
+    except Exception as exc:  # noqa: BLE001 - upload is not the critical path
+        return None, f"{exc.__class__.__name__}: {exc}"
+
+
+# ---------------------------------------------------------------------------
 # service_health heartbeat (stdlib libSQL HTTP pipeline -- bounded, no libsql)
 # ---------------------------------------------------------------------------
 
@@ -322,19 +617,45 @@ def run_backup() -> dict:
         (BACKUP_DIR / name).unlink(missing_ok=True)
 
     size = final_path.stat().st_size
+
+    # Off-box leg LAST and non-fatal: the artifact above is already durable.
+    offbox, offbox_error = run_offbox(BACKUP_DIR)
+
     duration = round(time.monotonic() - started, 1)
-    return {
-        "summary": (
-            f"dumped {stats['tables']} tables / {stats['rows']} rows -> "
-            f"{final_path.name} ({size} bytes) in {duration}s; pruned {len(pruned)}"
-        )[:SUMMARY_CAP],
+    summary = (
+        f"dumped {stats['tables']} tables / {stats['rows']} rows -> "
+        f"{final_path.name} ({size} bytes) in {duration}s; pruned {len(pruned)}"
+    )
+    if offbox_error:
+        summary += f"; b2 FAILED: {offbox_error[:160]}"
+    else:
+        summary += (
+            f"; b2 {offbox['uploaded']}/{offbox['planned']} "
+            f"({offbox['bytes_uploaded']} B), deferred {offbox['deferred']}, "
+            f"remote pruned {offbox['remote_pruned']}"
+        )
+    detail = {
+        "summary": summary[:SUMMARY_CAP],
         "path": str(final_path),
         "size_bytes": size,
         "duration_secs": duration,
         "tables": stats["tables"],
         "rows": stats["rows"],
         "pruned": len(pruned),
+        "offbox_error": offbox_error,
     }
+    if offbox:
+        detail.update(
+            {
+                "offbox_bucket": offbox["bucket"],
+                "offbox_prefix": offbox["prefix"],
+                "offbox_uploaded": offbox["uploaded"],
+                "offbox_bytes_uploaded": offbox["bytes_uploaded"],
+                "offbox_deferred": offbox["deferred"],
+                "offbox_remote_pruned": offbox["remote_pruned"],
+            }
+        )
+    return detail
 
 
 def main() -> int:
@@ -350,14 +671,19 @@ def main() -> int:
             print(f"service_health write failed: {write_exc}", file=sys.stderr)
         return 1
 
-    print(f"db-backup: {detail['summary']}")
+    # The dump itself succeeded; only the off-box copy can still be red.
+    state = "error" if detail.get("offbox_error") else "ok"
+    print(
+        f"db-backup: {detail['summary']}",
+        file=sys.stderr if state == "error" else sys.stdout,
+    )
     try:
-        write_service_health("ok", detail, started_at)
+        write_service_health(state, detail, started_at)
     except Exception as exc:  # noqa: BLE001 - bounded write, surface the failure
         print(f"service_health write failed: {exc}", file=sys.stderr)
         return 1
-    print("service_health row written: db-backup = ok")
-    return 0
+    print(f"service_health row written: db-backup = {state}")
+    return 1 if state == "error" else 0
 
 
 if __name__ == "__main__":

--- a/cloud/tests/test_db_backup.py
+++ b/cloud/tests/test_db_backup.py
@@ -4,6 +4,7 @@ import importlib.util
 import io
 import pathlib
 import sqlite3
+import sys
 
 import pytest
 
@@ -11,10 +12,14 @@ ROOT = pathlib.Path(__file__).resolve().parent.parent
 
 
 def _load_module():
+    name = "db_backup"
     spec = importlib.util.spec_from_file_location(
-        "db_backup", ROOT / "scripts" / "db_backup.py"
+        name, ROOT / "scripts" / "db_backup.py"
     )
     module = importlib.util.module_from_spec(spec)
+    # dataclasses require the module to be present in sys.modules during class
+    # creation when loaded via spec_from_file_location.
+    sys.modules[name] = module
     spec.loader.exec_module(module)
     return module
 

--- a/cloud/tests/test_db_backup_offbox.py
+++ b/cloud/tests/test_db_backup_offbox.py
@@ -1,0 +1,370 @@
+"""Tests for the off-box (Backblaze B2) leg of scripts/db_backup.py.
+
+No live B2, no boto3 import: the S3 client is always stubbed. The local
+gzip dump is the critical path — every failure mode here must leave it on
+disk and still heartbeat.
+"""
+
+import gzip
+import importlib.util
+import pathlib
+import sqlite3
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _load_module():
+    name = "db_backup_offbox"
+    spec = importlib.util.spec_from_file_location(
+        name, ROOT / "scripts" / "db_backup.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    # dataclasses require the module to be present in sys.modules during class
+    # creation when loaded via spec_from_file_location.
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+db_backup = _load_module()
+
+DAY = 86400
+
+FULL_ARCHIVE_ENV = {
+    "RADON_ARCHIVE_S3_ENDPOINT": "https://s3.us-west-004.backblazeb2.com",
+    "RADON_ARCHIVE_S3_BUCKET": "radon-archive",
+    "RADON_ARCHIVE_S3_ACCESS_KEY_ID": "key",
+    "RADON_ARCHIVE_S3_SECRET_ACCESS_KEY": "secret",
+}
+
+
+class _StubClient:
+    """Minimal S3 surface: list_objects_v2 / upload_file / delete_object."""
+
+    def __init__(self, objects=None, fail_on=None):
+        # objects: {key: (size, mtime_epoch_secs)}
+        self.objects = dict(objects or {})
+        self.fail_on = fail_on
+        self.uploaded: list[tuple[str, str]] = []
+        self.deleted: list[str] = []
+
+    def list_objects_v2(self, **kwargs):
+        prefix = kwargs.get("Prefix", "")
+        contents = [
+            {"Key": k, "Size": v[0], "LastModified": _Stamp(v[1])}
+            for k, v in sorted(self.objects.items())
+            if k.startswith(prefix)
+        ]
+        return {"Contents": contents, "IsTruncated": False}
+
+    def upload_file(self, path, bucket, key, **kwargs):
+        if self.fail_on is not None and self.fail_on in key:
+            raise RuntimeError("b2 wedged")
+        self.uploaded.append((str(path), key))
+        self.objects[key] = (pathlib.Path(path).stat().st_size, 0.0)
+
+    def delete_object(self, Bucket, Key):  # noqa: N803 — boto3 kwarg casing
+        self.deleted.append(Key)
+        self.objects.pop(Key, None)
+
+
+class _Stamp:
+    """Stand-in for the datetime boto3 returns as ``LastModified``."""
+
+    def __init__(self, epoch: float):
+        self._epoch = epoch
+
+    def timestamp(self) -> float:
+        return self._epoch
+
+
+class TestNoBoto3AtImport:
+    def test_boto3_is_never_imported_by_the_module(self):
+        assert "boto3" not in sys.modules
+
+
+class TestS3ConfigFromEnv:
+    def test_reads_archive_keys_with_db_backup_prefix(self):
+        cfg = db_backup.s3_config_from_env(dict(FULL_ARCHIVE_ENV))
+        assert cfg["bucket"] == "radon-archive"
+        assert cfg["endpoint_url"] == "https://s3.us-west-004.backblazeb2.com"
+        assert cfg["access_key"] == "key"
+        assert cfg["secret_key"] == "secret"
+        assert cfg["region"] == "auto"
+        assert cfg["prefix"] == "db_backups/"
+
+    def test_host_only_endpoint_gets_https_scheme(self):
+        env = dict(FULL_ARCHIVE_ENV, RADON_ARCHIVE_S3_ENDPOINT="s3.us-west-004.backblazeb2.com")
+        cfg = db_backup.s3_config_from_env(env)
+        assert cfg["endpoint_url"] == "https://s3.us-west-004.backblazeb2.com"
+
+    def test_http_endpoint_is_left_alone(self):
+        env = dict(FULL_ARCHIVE_ENV, RADON_ARCHIVE_S3_ENDPOINT="http://localhost:9000")
+        assert db_backup.s3_config_from_env(env)["endpoint_url"] == "http://localhost:9000"
+
+    def test_db_backup_overrides_win_over_archive(self):
+        env = dict(
+            FULL_ARCHIVE_ENV,
+            RADON_DB_BACKUP_S3_BUCKET="radon-db",
+            RADON_DB_BACKUP_S3_ACCESS_KEY_ID="dbkey",
+            RADON_DB_BACKUP_S3_SECRET_ACCESS_KEY="dbsecret",
+            RADON_DB_BACKUP_S3_REGION="us-west-004",
+        )
+        cfg = db_backup.s3_config_from_env(env)
+        assert cfg["bucket"] == "radon-db"
+        assert cfg["access_key"] == "dbkey"
+        assert cfg["secret_key"] == "dbsecret"
+        assert cfg["region"] == "us-west-004"
+
+    def test_never_inherits_the_portfolio_snapshot_prefix(self):
+        env = dict(FULL_ARCHIVE_ENV, RADON_ARCHIVE_S3_PREFIX="portfolio_snapshots/")
+        assert db_backup.s3_config_from_env(env)["prefix"] == "db_backups/"
+
+    def test_prefix_override_gets_a_trailing_slash(self):
+        env = dict(FULL_ARCHIVE_ENV, RADON_DB_BACKUP_PREFIX="nightly/db")
+        assert db_backup.s3_config_from_env(env)["prefix"] == "nightly/db/"
+
+    @pytest.mark.parametrize(
+        "missing",
+        [
+            "RADON_ARCHIVE_S3_ENDPOINT",
+            "RADON_ARCHIVE_S3_BUCKET",
+            "RADON_ARCHIVE_S3_ACCESS_KEY_ID",
+            "RADON_ARCHIVE_S3_SECRET_ACCESS_KEY",
+        ],
+    )
+    def test_missing_credential_disables_upload(self, missing):
+        env = dict(FULL_ARCHIVE_ENV)
+        env.pop(missing)
+        assert db_backup.s3_config_from_env(env) is None
+
+    def test_blank_credential_disables_upload(self):
+        env = dict(FULL_ARCHIVE_ENV, RADON_ARCHIVE_S3_SECRET_ACCESS_KEY="   ")
+        assert db_backup.s3_config_from_env(env) is None
+
+
+class TestObjectKey:
+    def test_joins_prefix_and_name(self):
+        assert (
+            db_backup.object_key_for("db_backups/", "radon-2026-08-27T090000Z.sql.gz")
+            == "db_backups/radon-2026-08-27T090000Z.sql.gz"
+        )
+
+    def test_adds_missing_separator_and_strips_leading_slash(self):
+        assert db_backup.object_key_for("/db_backups", "x.sql.gz") == "db_backups/x.sql.gz"
+
+
+class TestSelectUploadable:
+    def test_skips_objects_already_present_with_the_same_size(self):
+        local = [("radon-a.sql.gz", 100)]
+        remote = {"db_backups/radon-a.sql.gz": db_backup.RemoteObject(
+            key="db_backups/radon-a.sql.gz", size=100, mtime=0.0
+        )}
+        assert db_backup.select_uploadable(local, remote, "db_backups/") == []
+
+    def test_reuploads_when_remote_size_differs(self):
+        local = [("radon-a.sql.gz", 100)]
+        remote = {"db_backups/radon-a.sql.gz": db_backup.RemoteObject(
+            key="db_backups/radon-a.sql.gz", size=7, mtime=0.0
+        )}
+        assert db_backup.select_uploadable(local, remote, "db_backups/") == ["radon-a.sql.gz"]
+
+    def test_uploads_everything_missing_newest_first(self):
+        local = [
+            ("radon-2026-08-01T090000Z.sql.gz", 10),
+            ("radon-2026-08-27T090000Z.sql.gz", 10),
+            ("radon-2026-08-14T090000Z.sql.gz", 10),
+        ]
+        assert db_backup.select_uploadable(local, {}, "db_backups/") == [
+            "radon-2026-08-27T090000Z.sql.gz",
+            "radon-2026-08-14T090000Z.sql.gz",
+            "radon-2026-08-01T090000Z.sql.gz",
+        ]
+
+    def test_ignores_non_dump_files(self):
+        local = [("README.md", 1), (".radon-x.sql.gz.tmp", 1), ("dump.sql", 1)]
+        assert db_backup.select_uploadable(local, {}, "db_backups/") == []
+
+
+class TestRemoteRetention:
+    def test_remote_retention_is_longer_than_local(self):
+        assert db_backup.REMOTE_RETENTION_DAYS > db_backup.RETENTION_DAYS
+
+    def test_prunes_remote_objects_past_the_remote_window(self):
+        now = 1_000_000 * DAY
+        entries = [
+            ("db_backups/radon-old.sql.gz", now - (db_backup.REMOTE_RETENTION_DAYS + 1) * DAY),
+            ("db_backups/radon-new.sql.gz", now - 40 * DAY),
+        ]
+        assert db_backup.select_remote_prunable(entries, now) == ["db_backups/radon-old.sql.gz"]
+
+    def test_keeps_objects_local_retention_would_have_dropped(self):
+        now = 1_000_000 * DAY
+        entries = [("db_backups/radon-x.sql.gz", now - 31 * DAY)]
+        assert db_backup.select_remote_prunable(entries, now) == []
+
+    def test_never_touches_non_dump_keys(self):
+        now = 1_000_000 * DAY
+        entries = [("db_backups/notes.txt", now - 5000 * DAY)]
+        assert db_backup.select_remote_prunable(entries, now) == []
+
+
+def _seed_dumps(tmp_path, names, size=32):
+    for name in names:
+        (tmp_path / name).write_bytes(b"x" * size)
+    return tmp_path
+
+
+class TestSyncOffbox:
+    def test_backfills_every_local_dump_on_first_run(self, tmp_path):
+        _seed_dumps(tmp_path, [f"radon-2026-08-{d:02d}T090000Z.sql.gz" for d in range(1, 31)])
+        client = _StubClient()
+        cfg = db_backup.s3_config_from_env(dict(FULL_ARCHIVE_ENV))
+
+        summary = db_backup.sync_offbox(tmp_path, cfg, client=client)
+
+        assert summary["uploaded"] == 30
+        assert summary["deferred"] == 0
+        assert len(client.uploaded) == 30
+
+    def test_second_run_is_a_no_op(self, tmp_path):
+        _seed_dumps(tmp_path, ["radon-a.sql.gz", "radon-b.sql.gz"])
+        client = _StubClient()
+        cfg = db_backup.s3_config_from_env(dict(FULL_ARCHIVE_ENV))
+
+        db_backup.sync_offbox(tmp_path, cfg, client=client)
+        client.uploaded.clear()
+        summary = db_backup.sync_offbox(tmp_path, cfg, client=client)
+
+        assert summary["uploaded"] == 0
+        assert summary["skipped_present"] == 2
+        assert client.uploaded == []
+
+    def test_budget_defers_the_tail_newest_first(self, tmp_path):
+        _seed_dumps(tmp_path, ["radon-a.sql.gz", "radon-b.sql.gz", "radon-c.sql.gz"])
+        client = _StubClient()
+        cfg = db_backup.s3_config_from_env(dict(FULL_ARCHIVE_ENV))
+        ticks = iter([0, 0, 10, 999_999])
+
+        summary = db_backup.sync_offbox(
+            tmp_path, cfg, client=client, budget_secs=100, clock=lambda: next(ticks)
+        )
+
+        assert summary["uploaded"] == 2
+        assert summary["deferred"] == 1
+        assert [k for _p, k in client.uploaded] == [
+            "db_backups/radon-c.sql.gz",
+            "db_backups/radon-b.sql.gz",
+        ]
+
+    def test_prunes_only_past_the_remote_window(self, tmp_path):
+        _seed_dumps(tmp_path, ["radon-a.sql.gz"])
+        now = 1_000_000 * DAY
+        client = _StubClient(
+            {
+                "db_backups/radon-ancient.sql.gz": (
+                    5,
+                    now - (db_backup.REMOTE_RETENTION_DAYS + 5) * DAY,
+                ),
+                "db_backups/radon-recent.sql.gz": (5, now - 60 * DAY),
+            }
+        )
+        cfg = db_backup.s3_config_from_env(dict(FULL_ARCHIVE_ENV))
+
+        summary = db_backup.sync_offbox(tmp_path, cfg, client=client, now=now)
+
+        assert client.deleted == ["db_backups/radon-ancient.sql.gz"]
+        assert summary["remote_pruned"] == 1
+
+    def test_upload_failure_propagates(self, tmp_path):
+        _seed_dumps(tmp_path, ["radon-a.sql.gz"])
+        cfg = db_backup.s3_config_from_env(dict(FULL_ARCHIVE_ENV))
+        with pytest.raises(RuntimeError, match="b2 wedged"):
+            db_backup.sync_offbox(tmp_path, cfg, client=_StubClient(fail_on="radon-a"))
+
+
+def _fake_source_db():
+    conn = sqlite3.connect(":memory:")
+    conn.executescript("CREATE TABLE journal (id INTEGER PRIMARY KEY, ticker TEXT);")
+    conn.execute("INSERT INTO journal VALUES (1, 'AAPL')")
+    conn.commit()
+    return conn
+
+
+@pytest.fixture
+def backup_env(monkeypatch, tmp_path):
+    monkeypatch.setattr(db_backup, "BACKUP_DIR", tmp_path)
+    monkeypatch.setattr(db_backup, "_open_cloud_db", _fake_source_db)
+    for key, value in FULL_ARCHIVE_ENV.items():
+        monkeypatch.setenv(key, value)
+    return tmp_path
+
+
+class TestLocalDumpSurvivesUploadFailure:
+    def test_dump_is_written_and_kept_when_b2_upload_raises(self, backup_env, monkeypatch):
+        monkeypatch.setattr(
+            db_backup, "_s3_client", lambda cfg: _StubClient(fail_on="radon-")
+        )
+
+        detail = db_backup.run_backup()
+
+        dumps = sorted(backup_env.glob("*.sql.gz"))
+        assert len(dumps) == 1
+        assert dumps[0].stat().st_size > 0
+        with gzip.open(dumps[0], "rt", encoding="utf-8") as fh:
+            assert 'INSERT INTO "journal"' in fh.read()
+        assert detail["offbox_error"]
+        assert "b2 wedged" in detail["offbox_error"]
+
+    def test_missing_credentials_still_write_the_local_dump(self, backup_env, monkeypatch):
+        for key in FULL_ARCHIVE_ENV:
+            monkeypatch.delenv(key, raising=False)
+
+        detail = db_backup.run_backup()
+
+        assert len(sorted(backup_env.glob("*.sql.gz"))) == 1
+        assert "credential" in detail["offbox_error"].lower()
+
+    def test_upload_failure_heartbeats_error_and_exits_nonzero(self, backup_env, monkeypatch):
+        monkeypatch.setattr(
+            db_backup, "_s3_client", lambda cfg: _StubClient(fail_on="radon-")
+        )
+        beats: list[tuple] = []
+        monkeypatch.setattr(
+            db_backup,
+            "write_service_health",
+            lambda state, detail, started_at: beats.append((state, detail)),
+        )
+
+        rc = db_backup.main()
+
+        assert rc == 1
+        assert len(beats) == 1
+        state, detail = beats[0]
+        assert state == "error"
+        assert "b2 wedged" in detail["summary"]
+        # The dump itself succeeded — the summary must still say so.
+        assert detail["size_bytes"] > 0
+        assert len(sorted(backup_env.glob("*.sql.gz"))) == 1
+
+    def test_successful_upload_heartbeats_ok_with_bytes_uploaded(self, backup_env, monkeypatch):
+        client = _StubClient()
+        monkeypatch.setattr(db_backup, "_s3_client", lambda cfg: client)
+        beats: list[tuple] = []
+        monkeypatch.setattr(
+            db_backup,
+            "write_service_health",
+            lambda state, detail, started_at: beats.append((state, detail)),
+        )
+
+        rc = db_backup.main()
+
+        assert rc == 0
+        state, detail = beats[0]
+        assert state == "ok"
+        assert detail["offbox_uploaded"] == 1
+        assert detail["offbox_bytes_uploaded"] == detail["size_bytes"]
+        assert "b2 1/1" in detail["summary"]

--- a/cloud/tests/test_db_backup_offbox.py
+++ b/cloud/tests/test_db_backup_offbox.py
@@ -1,8 +1,15 @@
 """Tests for the off-box (Backblaze B2) leg of scripts/db_backup.py.
 
-No live B2, no boto3 import: the S3 client is always stubbed. The local
-gzip dump is the critical path — every failure mode here must leave it on
-disk and still heartbeat.
+No live B2 and NO boto3 dependency: the CI cloud-tests job installs only
+requirements-dev.txt + cloud/requirements-test.txt, neither of which
+carries boto3, and db_backup.py imports it lazily precisely so these tests
+never need it. Tests that must reach the transport install a fake ``boto3``
+/ ``botocore`` module tree in ``sys.modules`` (see _install_fake_boto3), so
+the real lazy-import path in ``_s3_client`` / ``_transfer_config`` is
+exercised and the stub client is what actually gets driven.
+
+The local gzip dump is the critical path — every failure mode here must
+leave it on disk and still heartbeat.
 """
 
 import gzip
@@ -10,6 +17,7 @@ import importlib.util
 import pathlib
 import sqlite3
 import sys
+import types
 
 import pytest
 
@@ -81,9 +89,61 @@ class _Stamp:
         return self._epoch
 
 
+def _install_fake_boto3(monkeypatch, client):
+    """Put a minimal fake boto3/botocore in sys.modules and return the kwargs
+    db_backup passes into them.
+
+    Stubbing beats adding the dependency: cloud/requirements-test.txt is a
+    deliberately minimal three-line file, and the module documents its
+    import as lazy so unit runs never pull botocore/s3transfer. monkeypatch
+    restores sys.modules after each test.
+    """
+    seen: dict = {}
+
+    class _TransferConfig:
+        def __init__(self, **kwargs):
+            seen["transfer"] = kwargs
+
+    class _Config:
+        def __init__(self, **kwargs):
+            seen["botocore_config"] = kwargs
+
+    def _make_client(service, **kwargs):
+        seen["service"] = service
+        seen["client"] = kwargs
+        return client
+
+    boto3_mod = types.ModuleType("boto3")
+    s3_mod = types.ModuleType("boto3.s3")
+    transfer_mod = types.ModuleType("boto3.s3.transfer")
+    botocore_mod = types.ModuleType("botocore")
+    botocore_config_mod = types.ModuleType("botocore.config")
+
+    boto3_mod.client = _make_client
+    boto3_mod.s3 = s3_mod
+    s3_mod.transfer = transfer_mod
+    transfer_mod.TransferConfig = _TransferConfig
+    botocore_mod.config = botocore_config_mod
+    botocore_config_mod.Config = _Config
+
+    for name, module in (
+        ("boto3", boto3_mod),
+        ("boto3.s3", s3_mod),
+        ("boto3.s3.transfer", transfer_mod),
+        ("botocore", botocore_mod),
+        ("botocore.config", botocore_config_mod),
+    ):
+        monkeypatch.setitem(sys.modules, name, module)
+    return seen
+
+
 class TestNoBoto3AtImport:
-    def test_boto3_is_never_imported_by_the_module(self):
-        assert "boto3" not in sys.modules
+    def test_module_import_does_not_pull_boto3(self):
+        """The lazy import is load-bearing: the CI cloud-tests job has no
+        boto3, so an eager import would break the whole module."""
+        before = "boto3" in sys.modules
+        _load_module()
+        assert ("boto3" in sys.modules) is before
 
 
 class TestS3ConfigFromEnv:
@@ -305,9 +365,7 @@ def backup_env(monkeypatch, tmp_path):
 
 class TestLocalDumpSurvivesUploadFailure:
     def test_dump_is_written_and_kept_when_b2_upload_raises(self, backup_env, monkeypatch):
-        monkeypatch.setattr(
-            db_backup, "_s3_client", lambda cfg: _StubClient(fail_on="radon-")
-        )
+        _install_fake_boto3(monkeypatch, _StubClient(fail_on="radon-"))
 
         detail = db_backup.run_backup()
 
@@ -329,9 +387,7 @@ class TestLocalDumpSurvivesUploadFailure:
         assert "credential" in detail["offbox_error"].lower()
 
     def test_upload_failure_heartbeats_error_and_exits_nonzero(self, backup_env, monkeypatch):
-        monkeypatch.setattr(
-            db_backup, "_s3_client", lambda cfg: _StubClient(fail_on="radon-")
-        )
+        _install_fake_boto3(monkeypatch, _StubClient(fail_on="radon-"))
         beats: list[tuple] = []
         monkeypatch.setattr(
             db_backup,
@@ -352,7 +408,7 @@ class TestLocalDumpSurvivesUploadFailure:
 
     def test_successful_upload_heartbeats_ok_with_bytes_uploaded(self, backup_env, monkeypatch):
         client = _StubClient()
-        monkeypatch.setattr(db_backup, "_s3_client", lambda cfg: client)
+        _install_fake_boto3(monkeypatch, client)
         beats: list[tuple] = []
         monkeypatch.setattr(
             db_backup,
@@ -368,3 +424,21 @@ class TestLocalDumpSurvivesUploadFailure:
         assert detail["offbox_uploaded"] == 1
         assert detail["offbox_bytes_uploaded"] == detail["size_bytes"]
         assert "b2 1/1" in detail["summary"]
+
+    def test_transport_is_bounded_and_multipart(self, backup_env, monkeypatch):
+        """A wedged B2 must not hang the unit past TimeoutStartSec, so the
+        socket timeouts / retries / multipart chunking have to reach boto3."""
+        seen = _install_fake_boto3(monkeypatch, _StubClient())
+        monkeypatch.setattr(db_backup, "write_service_health", lambda *a, **k: None)
+
+        assert db_backup.main() == 0
+
+        assert seen["service"] == "s3"
+        assert seen["client"]["endpoint_url"] == FULL_ARCHIVE_ENV[
+            "RADON_ARCHIVE_S3_ENDPOINT"
+        ]
+        assert seen["botocore_config"]["connect_timeout"] == db_backup.S3_CONNECT_TIMEOUT
+        assert seen["botocore_config"]["read_timeout"] == db_backup.S3_READ_TIMEOUT
+        assert seen["botocore_config"]["retries"]["max_attempts"] == db_backup.S3_MAX_ATTEMPTS
+        assert seen["transfer"]["multipart_chunksize"] == db_backup.MULTIPART_CHUNK_BYTES
+        assert seen["transfer"]["max_concurrency"] == db_backup.MULTIPART_CONCURRENCY

--- a/docs/cloud-services.md
+++ b/docs/cloud-services.md
@@ -821,3 +821,60 @@ sudo systemctl daemon-reload
 | 5 | ~~Verify Turso plan PITR~~ | **Verified 2026-07-13** — org Pro, **90d PITR**; `turso plan show` (not `org show`) |
 | 6 | ~~Off-box portfolio archive (`RADON_ARCHIVE_S3_*`)~~ | **Done** — Backblaze B2 `radon-archive` (2026-07-13) |
 | 7 | Continuous journal-gap SLI | **Done** — `journal-gap-sli` monitor handler (5m) |
+
+## DB backup off-box copy (B2 `db_backups/`)
+
+Closes the single-copy risk in "DB backup & restore" above: until 2026-08-27
+the only copy of the nightly Turso dumps lived on the VPS root filesystem
+(`/home/radon/radon-cloud/backups/db`, 13G and growing ~55%/month at
+`RETENTION_DAYS = 30`), on the same 75G disk that hit 98% that night.
+`scripts/db_backup_pull.sh` is a manual laptop-initiated rsync pull, not an
+automated off-box push, and is not a backup strategy.
+
+| Piece | Value |
+|---|---|
+| Owner | `cloud/scripts/db_backup.py` — the SAME oneshot that writes the dump. No new systemd unit, no new `service_health` row. |
+| Unit | Unchanged `radon-db-backup.service` + `.timer` (09:00 UTC). `TimeoutStartSec=19500` already covers dump + upload. |
+| Target | S3-compatible API to the existing B2 bucket `radon-archive`, prefix **`db_backups/`** (never collides with `portfolio_snapshots/` or `media/`). |
+| Credentials | `RADON_ARCHIVE_S3_*` from `/etc/radon/env` (already required-env). Optional per-field overrides `RADON_DB_BACKUP_S3_{ENDPOINT,BUCKET,ACCESS_KEY_ID,SECRET_ACCESS_KEY,REGION}` and `RADON_DB_BACKUP_PREFIX`, same shape as `RADON_MEDIA_BACKUP_S3_*`. |
+| Local retention | `RETENTION_DAYS = 30` — **unchanged**, operator policy. |
+| Remote retention | `REMOTE_RETENTION_DAYS = 365`. Off-boxing a 30-day window would buy nothing; a year of nightly dumps is ~190 GB in B2 at current sizes. |
+| Transport bound | Multipart at 64 MB chunks, 4 threads, botocore `connect_timeout=30` / `read_timeout=300` / 3 attempts, plus a `UPLOAD_BUDGET_SECS = 3600` wall-clock ceiling. |
+| Heartbeat | Existing `db-backup` row, extended detail: `offbox_bucket`, `offbox_prefix`, `offbox_uploaded`, `offbox_bytes_uploaded`, `offbox_deferred`, `offbox_remote_pruned`, and `offbox_error`. Summary gains `; b2 <uploaded>/<planned> (<bytes> B), deferred N, remote pruned N`. |
+
+### Fail-degraded, deliberately
+
+`media_backup.py` fails **closed** — no credentials, unit fails, nothing
+written. `db_backup.py` is the opposite by design and says so in its
+docstring: the local gzip is the critical path and the upload is not. A
+wedged, misconfigured, or credential-less B2 never deletes, truncates, or
+skips the on-box dump. The run still writes the file, then reports the
+upload failure to the journal and flips the `db-backup` heartbeat to
+`error` (exit 1). A red `db-backup` row therefore means "check whether the
+dump or only the upload failed" — `offbox_error` in the detail distinguishes
+them, and `size_bytes` is still populated when the dump itself was fine.
+
+### Idempotent, resumable, and the first-run backfill
+
+Each run lists `db_backups/` once and uploads only dumps that are absent
+remotely or present at a different size. Uploads run **newest first**, so
+tonight's dump always goes before any backfill of the older window.
+
+The first run after deploy therefore backfills the whole local retention
+window (~30 dumps, ~13 GB) rather than only that night's file. If the
+`UPLOAD_BUDGET_SECS` ceiling is reached the remainder is reported as
+`offbox_deferred` and the next night resumes exactly where this one
+stopped — no re-upload of what already landed. Expect the backlog to clear
+over the first one to three nights; steady state is one ~530 MB object per
+night.
+
+### Verify
+
+```bash
+journalctl -u radon-db-backup -n 50 --no-pager | grep ' b2 '
+# object listing (from a host with the B2 credentials)
+aws s3 ls "s3://radon-archive/db_backups/" --endpoint-url "$RADON_ARCHIVE_S3_ENDPOINT" | tail
+```
+
+Restore is unchanged: pull the object, then follow the "Restore runbook"
+above against the downloaded `radon-<stamp>.sql.gz`.


### PR DESCRIPTION
## Why

The Hetzner root fs hit 98% tonight. Triage surfaced the structural risk behind it: `/home/radon/radon-cloud/backups/db` is **13G and compounding** (344M on 2026-07-29 → 533M on 2026-08-27, ~+55%/month at a correct `RETENTION_DAYS = 30`), and `cloud/scripts/db_backup.py` wrote **no off-box copy at all**. The only copy of the production DB history lived on the single 75G box that just ran out of space.

`scripts/db_backup_pull.sh` is a manual, laptop-initiated rsync pull. It is not a backup strategy.

## What

`db_backup.py` now pushes every local `*.sql.gz` missing from the existing `radon-archive` B2 bucket, under a distinct `db_backups/` prefix (never collides with `portfolio_snapshots/` or `media/`).

Reuses the proven pattern rather than inventing one:
- credential shape from `media_backup.py` — `RADON_ARCHIVE_S3_*` with optional per-field `RADON_DB_BACKUP_S3_*` overrides plus `RADON_DB_BACKUP_PREFIX`
- `https://` scheme fixup for host-only B2 endpoints, and the **lazy `import boto3`** from `archive_portfolio_snapshots.py`, so unit tests and credential-less runs never import it
- `boto3==1.43.36` is already declared in `requirements.txt` and already used by `radon-portfolio-archive`; nothing to add

### No new systemd unit

`radon-db-backup.service` already runs nightly at 09:0x UTC with `EnvironmentFile=/etc/radon/env` (which already carries `RADON_ARCHIVE_S3_*` as required-env) and `TimeoutStartSec=19500`. Uploading at the end of the dump it just produced needs no new unit, **no manifest change, and no `installed-units.sha256` churn**. No second `service_health` row either — the existing `db-backup` heartbeat carries the upload outcome.

### Fail-degraded, deliberately

`media_backup.py` fails **closed**. This one is the opposite by design, and the docstring says so: the local gzip is the critical path, the upload is not. A wedged, misconfigured, or credential-less B2 never deletes, truncates, or skips the on-box dump. The dump still lands; the run then reports the failure to the journal, flips the `db-backup` heartbeat to `error`, and exits 1. `offbox_error` in the detail distinguishes "dump failed" from "only the upload failed", and `size_bytes` is still populated in the latter case.

### Idempotent, resumable, bounded

- one LIST per run; anything already present at the same size is skipped
- uploads run **newest-first**, so tonight's dump always precedes backfill
- `UPLOAD_BUDGET_SECS = 3600` wall-clock ceiling; the remainder is reported as `offbox_deferred` and the next night resumes exactly where this one stopped
- multipart at 64 MB / 4 threads, botocore `connect_timeout=30`, `read_timeout=300`, 3 attempts

First run after deploy therefore **backfills the whole existing 30-dump local window (~13G)**, not just that night's file, clearing over roughly one to three nights.

### Retention

`REMOTE_RETENTION_DAYS = 365`, a separate explicitly-named constant. Local `RETENTION_DAYS = 30` is unchanged and nothing is deleted from `backups/db` — local retention stays the operator's policy call.

## Tests

Red/green. New `cloud/tests/test_db_backup_offbox.py` (31 tests, no live B2, stubbed client): `s3_config_from_env` parsing incl. scheme fixup / overrides / prefix isolation / each missing-credential path; the reconcile selector (skip-already-uploaded, size mismatch, newest-first, non-dump files); remote-vs-local retention constants; the 30-dump backfill, the second-run no-op, budget deferral, and remote prune; and that an upload exception still leaves the local dump on disk, still heartbeats `error`, and still reports `size_bytes`. Also asserts `boto3` is never imported at module load.

One-line fix to `test_db_backup.py`'s loader (register the module in `sys.modules` before `exec_module`, the pattern already used by `test_media_backup.py`) — required now that the module defines a dataclass.

```
python -m pytest cloud/tests -q         37 failed, 1157 passed, 7 skipped
python -m pytest scripts/tests tests -q 7594 passed, 1 skipped, 90 deselected
```

Baseline measured on the base commit `a3b90393` with a clean tree: `cloud/tests` 37 failed, 1126 passed, 7 skipped (known local macOS failures in `test_ib_gateway_control.py` / `test_bootstrap_control_plane.py`); `scripts/tests tests` 7594 passed, 1 skipped, 90 deselected. Same 37 failures before and after; +31 passing.

## PR #123 overlap

Only `docs/cloud-services.md`, and only as a **new section appended at EOF** — existing sections untouched, so the merge stays trivial. No `cloud/services/*`, no `cloud/config/installed-units.sha256`, no `cloud/scripts/*.sh`, no `scripts/watchdog/services.py`, no `web/lib/serviceHealthWindows.ts`.

## Not done

Nothing was run against the live host or against real B2 credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tL6SCTsyQuEFAoVwfzj8r