### PR TITLE
feat(leap): open the best mispriced LEAP in the order builder

### DIFF
--- a/scripts/leap_scanner_uw.py
+++ b/scripts/leap_scanner_uw.py
@@ -233,6 +233,9 @@ class ScanResult:
     leaps: List[LeapOption]
     best_gap: float
     is_mispriced: bool
+    # The single contract behind `best_gap` — the dashboard deep-links it into
+    # the chain order builder, which needs an expiry and a strike, not a gap.
+    best_leap: Optional[LeapOption] = None
 
 
 def get_uw_history(
@@ -437,6 +440,18 @@ def get_leap_options(ticker: str, min_year: int = 2027, _client: UWClient = None
     return leaps
 
 
+def pick_best_mispriced_leap(
+    leaps: List[LeapOption], hv_20: float
+) -> Optional[LeapOption]:
+    """The contract carrying the widest realized-vs-implied gap in a group.
+
+    Ties on IV go to the deeper open interest — same edge, better fill.
+    """
+    if not leaps:
+        return None
+    return max(leaps, key=lambda leap: (hv_20 - leap.iv, leap.oi))
+
+
 def approximate_delta(strike: float, price: float, iv: float, dte: int) -> float:
     """Rough delta approximation based on moneyness."""
     if price == 0 or dte == 0:
@@ -507,6 +522,7 @@ def scan_ticker(
     }
 
     best_gap = 0
+    best_leap: Optional[LeapOption] = None
     is_mispriced = False
 
     emit("\n  LEAP IV Analysis:")
@@ -523,6 +539,8 @@ def scan_ticker(
         if gap_20 >= min_gap or gap_60 >= min_gap:
             status = "🔥 MISPRICED"
             is_mispriced = True
+            if gap_20 > best_gap or best_leap is None:
+                best_leap = pick_best_mispriced_leap(group_leaps, vol_data.hv_20)
             if gap_20 > best_gap:
                 best_gap = gap_20
 
@@ -538,7 +556,8 @@ def scan_ticker(
         iv_rank=iv_rank,
         leaps=leaps,
         best_gap=best_gap,
-        is_mispriced=is_mispriced
+        is_mispriced=is_mispriced,
+        best_leap=best_leap,
     )
 
 
@@ -775,6 +794,23 @@ def resolve_scan_inputs(explicit_tickers=None, preset=None):
     return list(load_preset(preset).tickers), universe
 
 
+def best_leap_payload(leap: Optional[LeapOption], hv_20: float) -> Optional[dict]:
+    """Serialize the headline contract for the dashboard's order deep-link."""
+    if leap is None:
+        return None
+    return {
+        "symbol": leap.symbol,
+        "expiry": leap.expiry,
+        "strike": leap.strike,
+        "right": leap.right,
+        "iv": leap.iv,
+        "delta": round(leap.delta_approx, 2),
+        "gap": round(hv_20 - leap.iv, 1),
+        "oi": leap.oi,
+        "volume": leap.volume,
+    }
+
+
 def build_json_payload(results, min_gap, universe, requested_tickers):
     """Build the data/leap.json envelope, stamped with the scanned universe."""
     return {
@@ -794,6 +830,7 @@ def build_json_payload(results, min_gap, universe, requested_tickers):
                 "leap_count": len(r.leaps),
                 "best_gap": r.best_gap,
                 "is_mispriced": r.is_mispriced,
+                "best_leap": best_leap_payload(r.best_leap, r.vol_data.hv_20),
             }
             for r in results
         ],

--- a/scripts/tests/test_leap_scanner.py
+++ b/scripts/tests/test_leap_scanner.py
@@ -15,6 +15,8 @@ from leap_scanner_uw import (
     calculate_hv,
     approximate_delta,
     build_json_payload,
+    pick_best_mispriced_leap,
+    LeapOption,
     get_current_iv,
     get_leap_options,
     resolve_explicit_tickers,
@@ -206,6 +208,76 @@ class TestBuildJsonPayload:
     def test_indexes_universe_stamp(self):
         payload = build_json_payload([], 10.0, "preset:indexes", ["NVDA", "AAPL"])
         assert payload["universe"] == "preset:indexes"
+
+
+class TestPickBestMispricedLeap:
+    def _leap(self, strike, iv, oi=100, expiry="2027-01-15"):
+        return LeapOption(
+            symbol=f"NVDA{expiry.replace('-', '')[2:]}C{int(strike * 1000):08d}",
+            expiry=expiry,
+            strike=strike,
+            right="C",
+            iv=iv,
+            volume=10,
+            oi=oi,
+            delta_approx=0.5,
+        )
+
+    def test_picks_the_widest_gap_contract(self):
+        leaps = [self._leap(200, 30.0), self._leap(210, 22.0), self._leap(220, 26.0)]
+        assert pick_best_mispriced_leap(leaps, hv_20=45.0).strike == 210
+
+    def test_breaks_iv_ties_on_open_interest(self):
+        leaps = [self._leap(200, 22.0, oi=50), self._leap(210, 22.0, oi=900)]
+        assert pick_best_mispriced_leap(leaps, hv_20=45.0).strike == 210
+
+    def test_empty_group_has_no_contract(self):
+        assert pick_best_mispriced_leap([], hv_20=45.0) is None
+
+
+class TestBestLeapPayload:
+    """The scanner page deep-links its best row into the chain order builder,
+    so the payload has to name the contract — ticker + gap alone cannot."""
+
+    def _result(self, best_leap):
+        return ScanResult(
+            ticker="NVDA",
+            vol_data=VolData(
+                ticker="NVDA", price=180.0, hv_20=45.0, hv_60=40.0, hv_252=35.0, avg_hv=40.0
+            ),
+            current_iv=25.0,
+            iv_rank=30.0,
+            leaps=[best_leap] if best_leap else [],
+            best_gap=20.0,
+            is_mispriced=True,
+            best_leap=best_leap,
+        )
+
+    def test_emits_the_contract_the_order_builder_needs(self):
+        leap = LeapOption(
+            symbol="NVDA270115C00210000",
+            expiry="2027-01-15",
+            strike=210.0,
+            right="C",
+            iv=22.0,
+            volume=12,
+            oi=900,
+            delta_approx=0.42,
+        )
+        payload = build_json_payload([self._result(leap)], 10.0, "explicit", ["NVDA"])
+        best = payload["results"][0]["best_leap"]
+        assert best["expiry"] == "2027-01-15"
+        assert best["strike"] == 210.0
+        assert best["right"] == "C"
+        assert best["iv"] == 22.0
+        assert best["gap"] == 23.0  # hv_20 45 - iv 22
+        assert best["delta"] == 0.42
+        assert best["oi"] == 900
+        assert best["symbol"] == "NVDA270115C00210000"
+
+    def test_absent_contract_serializes_as_null(self):
+        payload = build_json_payload([self._result(None)], 10.0, "explicit", ["NVDA"])
+        assert payload["results"][0]["best_leap"] is None
 
 
 class TestResolveScanInputs:

--- a/scripts/tests/test_scan_service_health.py
+++ b/scripts/tests/test_scan_service_health.py
@@ -369,6 +369,7 @@ class TestLeapWiring:
             leaps=[],
             best_gap=15.0,
             is_mispriced=True,
+            best_leap=None,
         )
         monkeypatch.setattr(leap_scanner_uw, "UWClient", lambda: nullcontext(object()))
         monkeypatch.setattr(leap_scanner_uw, "scan_ticker", lambda *a, **kw: result)

--- a/web/components/LeapScanner.tsx
+++ b/web/components/LeapScanner.tsx
@@ -9,6 +9,8 @@ import SectionEmptyState from "./SectionEmptyState";
 import { SigMeter } from "./SigMeter";
 import SortTh from "./SortTh";
 import { useSort } from "@/lib/useSort";
+import { serializeLegsParam } from "@/lib/useChainUrlState";
+import { formatExpiry } from "@/lib/optionsChainUtils";
 import type { LeapData, LeapResult } from "@/lib/types";
 
 type LeapSortKey = "ticker" | "price" | "iv" | "iv_rank" | "hv_20" | "hv_252" | "leaps" | "best_gap" | "status";
@@ -25,6 +27,42 @@ type LeapScannerProps = {
 
 const LEAP_SECTION_HELP =
   "Long-dated IV mispricing scan: tickers where LEAP implied vol trades below realized vol. best_gap is the headline signal (HV − IV in vol points); MISPRICED rows clear the scan's own gap threshold.";
+
+/**
+ * Deep-link a row's headline LEAP into the chain order builder, prefilled as a
+ * long call. Mirrors `thetaOrderHref`: `?deck=c` opens the chain deck, `legs`
+ * seeds the builder. Null for scans written before the scanner emitted
+ * contract detail — a gap alone cannot address a strike.
+ */
+export function leapOrderHref(row: LeapResult): string | null {
+  const contract = row.best_leap;
+  if (!contract) return null;
+  const legs = serializeLegsParam([
+    { action: "BUY", quantity: 1, strike: contract.strike, right: contract.right },
+  ]);
+  if (!legs) return null;
+  const params = new URLSearchParams({
+    deck: "c",
+    expiry: formatExpiry(contract.expiry),
+    strikes: "100",
+    legs,
+    src: "leap",
+  });
+  return `/${encodeURIComponent(row.ticker.toUpperCase())}?${params.toString()}`;
+}
+
+function contractLabel(row: LeapResult): string {
+  const contract = row.best_leap;
+  if (!contract) return row.ticker.toUpperCase();
+  return `${row.ticker.toUpperCase()} ${contract.strike}${contract.right}`;
+}
+
+function widestMispriced(rows: LeapResult[]): LeapResult | null {
+  return rows.reduce<LeapResult | null>((best, row) => {
+    if (!row.is_mispriced || !row.best_leap) return best;
+    return best == null || row.best_gap > best.best_gap ? row : best;
+  }, null);
+}
 
 function extract(row: LeapResult, key: LeapSortKey): string | number | null {
   switch (key) {
@@ -62,6 +100,8 @@ export default function LeapScanner({
   const rows = data?.results ?? [];
   const { sorted, sort, toggle } = useSort(rows, extract, "best_gap", "desc");
   const mispricedCount = rows.filter((r) => r.is_mispriced).length;
+  const bestRow = widestMispriced(rows);
+  const bestHref = bestRow ? leapOrderHref(bestRow) : null;
 
   return (
     <ScannerInstrumentShell
@@ -79,6 +119,16 @@ export default function LeapScanner({
         <div className="theta-harvester__meta">
           {lastSync && <span className="report-meta">{new Date(lastSync).toLocaleTimeString()}</span>}
           <span className="pill defined">{mispricedCount} MISPRICED</span>
+          {bestRow && bestHref && (
+            <Link
+              href={bestHref}
+              className="theta-scan-button"
+              data-testid="leap-best-order-link"
+              title={`Open the ${contractLabel(bestRow)} LEAP in the order builder`}
+            >
+              TRADE BEST · {contractLabel(bestRow)}
+            </Link>
+          )}
           {onTickerScan && (
             <ScannerTickerSearch
               id="leap-ticker-search"
@@ -144,30 +194,46 @@ export default function LeapScanner({
                 </tr>
               </thead>
               <tbody>
-                {sorted.map((r) => (
-                  <tr key={r.ticker}>
-                    <td>
-                      <Link href={`/${encodeURIComponent(r.ticker)}`} className="ticker-link">
-                        {r.ticker}
-                      </Link>
-                    </td>
-                    <td className="right">{r.price != null ? `$${fmt(r.price, 2)}` : "---"}</td>
-                    <td className="right">{fmt(r.current_iv)}</td>
-                    <td className="right">
-                      {fmt(r.iv_rank)}
-                      <SigMeter value={r.iv_rank ?? null} tone={r.is_mispriced ? "pos" : "mut"} />
-                    </td>
-                    <td className="right">{fmt(r.hv_20)}</td>
-                    <td className="right">{fmt(r.hv_252)}</td>
-                    <td className="right">{r.leap_count}</td>
-                    <td className="right">{signed(r.best_gap)}</td>
-                    <td>
-                      <span className={`pill ${r.is_mispriced ? "defined" : "undefined"}`}>
-                        {r.is_mispriced ? "MISPRICED" : "FAIR"}
-                      </span>
-                    </td>
-                  </tr>
-                ))}
+                {sorted.map((r) => {
+                  const orderHref = leapOrderHref(r);
+                  return (
+                    <tr key={r.ticker}>
+                      <td>
+                        <Link href={`/${encodeURIComponent(r.ticker)}`} className="ticker-link">
+                          {r.ticker}
+                        </Link>
+                      </td>
+                      <td className="right">{r.price != null ? `$${fmt(r.price, 2)}` : "---"}</td>
+                      <td className="right">{fmt(r.current_iv)}</td>
+                      <td className="right">
+                        {fmt(r.iv_rank)}
+                        <SigMeter value={r.iv_rank ?? null} tone={r.is_mispriced ? "pos" : "mut"} />
+                      </td>
+                      <td className="right">{fmt(r.hv_20)}</td>
+                      <td className="right">{fmt(r.hv_252)}</td>
+                      <td className="right">{r.leap_count}</td>
+                      <td className="right">
+                        {orderHref ? (
+                          <Link
+                            href={orderHref}
+                            className="ticker-link"
+                            data-testid={`leap-order-link-${r.ticker}`}
+                            title={`Open the ${contractLabel(r)} LEAP in the order builder`}
+                          >
+                            {signed(r.best_gap)}
+                          </Link>
+                        ) : (
+                          signed(r.best_gap)
+                        )}
+                      </td>
+                      <td>
+                        <span className={`pill ${r.is_mispriced ? "defined" : "undefined"}`}>
+                          {r.is_mispriced ? "MISPRICED" : "FAIR"}
+                        </span>
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>

--- a/web/components/ticker-detail/OptionsChainTab.tsx
+++ b/web/components/ticker-detail/OptionsChainTab.tsx
@@ -73,6 +73,19 @@ function optionFetchErrorMessage(data: Record<string, unknown>, fallback: string
   return detail && detail !== error ? `${error}: ${detail}` : error;
 }
 
+/** Names the scanner that seeded `?legs=`. Unknown / absent stays on the
+ *  Theta Harvester wording it shipped with — that was the only seeder then. */
+function prefillLabelForSource(src: string | null | undefined): string {
+  switch (src) {
+    case "vol-cone":
+      return "PREFILLED FROM VOL CONE";
+    case "leap":
+      return "PREFILLED FROM LEAP SCAN";
+    default:
+      return "PREFILLED FROM THETA HARVESTER";
+  }
+}
+
 /* ─── Chain Strike Row ─── */
 
 function StrikeRow({
@@ -1141,11 +1154,7 @@ export default function OptionsChainTab({
     }));
 
     setOrderLegs(nextLegs);
-    setPrefillLabel(
-      searchParams?.get("src") === "vol-cone"
-        ? "PREFILLED FROM VOL CONE"
-        : "PREFILLED FROM THETA HARVESTER",
-    );
+    setPrefillLabel(prefillLabelForSource(searchParams?.get("src")));
     appliedLegsParamRef.current = signature;
   }, [ticker, selectedExpiry, chainUrl.legsParamRaw, chainUrl.urlExpiry, chainUrl.urlLegs, searchParams]);
 

--- a/web/e2e/leap-order-prefill.spec.ts
+++ b/web/e2e/leap-order-prefill.spec.ts
@@ -1,0 +1,180 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const LEAP_PAYLOAD = {
+  scan_time: "2026-08-27T18:02:30Z",
+  min_gap: 10,
+  universe: "preset:largecaps",
+  requested_tickers: [],
+  results: [
+    {
+      ticker: "MSFT",
+      price: 490.2,
+      hv_20: 18.3,
+      hv_60: 19.1,
+      hv_252: 21.4,
+      current_iv: 20.9,
+      iv_rank: 44,
+      leap_count: 5,
+      best_gap: 0,
+      is_mispriced: false,
+      best_leap: null,
+    },
+    {
+      ticker: "NVDA",
+      price: 181.4,
+      hv_20: 42.1,
+      hv_60: 38.7,
+      hv_252: 44.9,
+      current_iv: 31.2,
+      iv_rank: 12.5,
+      leap_count: 8,
+      best_gap: 13.7,
+      is_mispriced: true,
+      best_leap: {
+        symbol: "NVDA270115C00210000",
+        expiry: "2027-01-15",
+        strike: 210,
+        right: "C",
+        iv: 28.4,
+        delta: 0.42,
+        gap: 13.7,
+        oi: 900,
+        volume: 12,
+      },
+    },
+  ],
+};
+
+async function installMockWebSocket(page: Page) {
+  await page.addInitScript(() => {
+    class MockWebSocket {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+      readyState = MockWebSocket.CONNECTING;
+      onopen: ((event?: unknown) => void) | null = null;
+      onmessage: ((event: { data: string }) => void) | null = null;
+      onclose: ((event?: unknown) => void) | null = null;
+      constructor() {
+        setTimeout(() => {
+          this.readyState = MockWebSocket.OPEN;
+          this.onopen?.({});
+          this.onmessage?.({
+            data: JSON.stringify({
+              type: "batch",
+              updates: {
+                NVDA: {
+                  symbol: "NVDA",
+                  last: 181.4,
+                  lastIsCalculated: false,
+                  bid: 181.3,
+                  ask: 181.5,
+                  bidSize: 100,
+                  askSize: 100,
+                  volume: 1_000_000,
+                  high: null,
+                  low: null,
+                  open: null,
+                  close: 180,
+                  week52High: null,
+                  week52Low: null,
+                  avgVolume: null,
+                  delta: null,
+                  gamma: null,
+                  theta: null,
+                  vega: null,
+                  impliedVol: null,
+                  undPrice: null,
+                  timestamp: new Date().toISOString(),
+                },
+              },
+            }),
+          });
+        }, 0);
+      }
+      send() {}
+      close() {
+        this.readyState = MockWebSocket.CLOSED;
+        this.onclose?.({});
+      }
+    }
+    // Relay socket only — mocking Turbopack HMR too stalls hydration
+    // (see theta-harvester-prefill.spec.ts).
+    const NativeWebSocket = window.WebSocket;
+    const RelayAwareWebSocket = function (url: string | URL, protocols?: string | string[]) {
+      return String(url).includes("localhost:8765")
+        ? (new MockWebSocket() as unknown as WebSocket)
+        : new NativeWebSocket(url, protocols);
+    } as unknown as typeof WebSocket;
+    Object.assign(RelayAwareWebSocket, { CONNECTING: 0, OPEN: 1, CLOSING: 2, CLOSED: 3 });
+    window.WebSocket = RelayAwareWebSocket;
+  });
+}
+
+async function stubApis(page: Page) {
+  await page.route("**/api/**", async (route) => {
+    const url = new URL(route.request().url());
+    const path = url.pathname;
+    const json = (body: unknown) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+
+    if (path === "/api/leap") return json(LEAP_PAYLOAD);
+    if (path === "/api/scanner") {
+      return json({ scan_time: "2026-08-27T18:02:30Z", tickers_scanned: 0, signals_found: 0, top_signals: [] });
+    }
+    if (path === "/api/portfolio") {
+      return json({
+        bankroll: 100_000,
+        peak_value: 100_000,
+        last_sync: new Date().toISOString(),
+        positions: [],
+        total_deployed_pct: 0,
+        total_deployed_dollars: 0,
+        remaining_capacity_pct: 100,
+        position_count: 0,
+        defined_risk_count: 0,
+        undefined_risk_count: 0,
+        avg_kelly_optimal: null,
+      });
+    }
+    if (path === "/api/orders") return json({ open_orders: [], executed_orders: [], open_count: 0, executed_count: 0 });
+    if (path === "/api/service-health") return json({ services: [] });
+    if (path === "/api/profile") return json({ username: "Operator" });
+    if (path === "/api/watchlist") return json({ symbols: [] });
+    if (path === "/api/flex-token") return json({ remaining: 240 });
+    if (path === "/api/prices" || path === "/api/ib/ws-ticket") return json({ prices: {}, ticket: "test" });
+    if (path === "/api/regime") return json({ score: 15, cri: { score: 15 } });
+    if (path === "/api/risk-free-rate") return json({ rate: 0 });
+    if (path === "/api/ticker/info") return json({ stock_state: {}, uw_info: {}, profile: {}, stats: {} });
+    if (path === "/api/options/expirations") return json({ symbol: "NVDA", expirations: ["20270115"] });
+    if (path === "/api/options/chain") {
+      return json({ symbol: "NVDA", expiry: "20270115", strikes: [170, 180, 190, 200, 210, 220] });
+    }
+    return json({});
+  });
+}
+
+test.describe("LEAP IV mispricing order prefill", () => {
+  test("TRADE BEST opens the widest-gap LEAP in the chain order builder", async ({ page }) => {
+    await installMockWebSocket(page);
+    await stubApis(page);
+
+    await page.goto("/scanner?mode=leap");
+    await page.getByTestId("leap-scanner-section").waitFor();
+
+    await page.getByTestId("leap-best-order-link").click();
+
+    await expect(page).toHaveURL(/\/NVDA\?/);
+    const params = new URL(page.url()).searchParams;
+    expect(params.get("legs")).toBe("BUY:1x210C");
+    expect(params.get("expiry")).toBe("2027-01-15");
+    expect(params.get("deck")).toBe("c");
+
+    const builder = page.locator(".order-builder");
+    await expect(builder).toBeVisible();
+    await expect(builder).toContainText("PREFILLED FROM LEAP SCAN");
+    await expect(builder).toContainText("1x $210 Call");
+    await expect(builder).toContainText("2027-01-15");
+  });
+});

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -694,6 +694,21 @@ export type ScannerData = {
 // long-dated IV diverges from realized vol; `best_gap` is the headline
 // signal (HV − IV in vol points). `is_mispriced` is the script's own
 // boolean classification.
+/** The single contract behind `best_gap`, emitted by leap_scanner_uw.py so the
+ *  scanner can deep-link it into the chain order builder. Absent on scans
+ *  written before the field existed. */
+export type LeapBestContract = {
+  symbol: string;
+  expiry: string;
+  strike: number;
+  right: "C" | "P";
+  iv: number;
+  delta: number;
+  gap: number;
+  oi: number;
+  volume: number;
+};
+
 export type LeapResult = {
   ticker: string;
   price: number | null;
@@ -705,6 +720,7 @@ export type LeapResult = {
   leap_count: number;
   best_gap: number;
   is_mispriced: boolean;
+  best_leap?: LeapBestContract | null;
 };
 
 export type LeapData = {

--- a/web/tests/leap-garch-scanner.test.tsx
+++ b/web/tests/leap-garch-scanner.test.tsx
@@ -6,7 +6,7 @@ import React from "react";
 import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import LeapScanner from "../components/LeapScanner";
+import LeapScanner, { leapOrderHref } from "../components/LeapScanner";
 import GarchConvergenceScanner from "../components/GarchConvergenceScanner";
 import type { GarchConvergenceData, LeapData } from "../lib/types";
 
@@ -29,6 +29,17 @@ const leapData: LeapData = {
       leap_count: 8,
       best_gap: 13.7,
       is_mispriced: true,
+      best_leap: {
+        symbol: "NVDA270115C00210000",
+        expiry: "2027-01-15",
+        strike: 210,
+        right: "C",
+        iv: 28.4,
+        delta: 0.42,
+        gap: 13.7,
+        oi: 900,
+        volume: 12,
+      },
     },
     {
       ticker: "MSFT",
@@ -78,6 +89,28 @@ const garchData: GarchConvergenceData = {
   ],
 };
 
+describe("leapOrderHref", () => {
+  it("deep-links the contract into the chain order builder", () => {
+    expect(leapOrderHref(leapData.results[0])).toBe(
+      "/NVDA?deck=c&expiry=2027-01-15&strikes=100&legs=BUY%3A1x210C&src=leap",
+    );
+  });
+
+  it("keeps fractional strikes intact", () => {
+    expect(
+      leapOrderHref({
+        ...leapData.results[0],
+        ticker: "spy",
+        best_leap: { ...leapData.results[0].best_leap!, strike: 612.5, right: "P" },
+      }),
+    ).toBe("/SPY?deck=c&expiry=2027-01-15&strikes=100&legs=BUY%3A1x612.5P&src=leap");
+  });
+
+  it("has no destination for a row without a contract", () => {
+    expect(leapOrderHref(leapData.results[1])).toBeNull();
+  });
+});
+
 describe("LeapScanner", () => {
   it("renders result rows with the headline gap and mispriced status", () => {
     const onScan = vi.fn();
@@ -93,6 +126,53 @@ describe("LeapScanner", () => {
 
     fireEvent.click(within(section).getByRole("button", { name: /^scan$/i }));
     expect(onScan).toHaveBeenCalledTimes(1);
+  });
+
+  it("links the widest-gap mispriced row into the options order entry view", () => {
+    render(<LeapScanner data={leapData} />);
+
+    const section = screen.getByTestId("leap-scanner-section");
+    const best = within(section).getByTestId("leap-best-order-link");
+    expect(best.getAttribute("href")).toBe(
+      "/NVDA?deck=c&expiry=2027-01-15&strikes=100&legs=BUY%3A1x210C&src=leap",
+    );
+    expect(best.textContent).toContain("NVDA 210C");
+
+    const row = within(section).getByTestId("leap-order-link-NVDA");
+    expect(row.getAttribute("href")).toBe(
+      "/NVDA?deck=c&expiry=2027-01-15&strikes=100&legs=BUY%3A1x210C&src=leap",
+    );
+    expect(within(section).queryByTestId("leap-order-link-MSFT")).toBeNull();
+  });
+
+  it("picks the widest gap, not the first mispriced row", () => {
+    const wider = {
+      ...leapData,
+      results: [
+        leapData.results[0],
+        {
+          ...leapData.results[0],
+          ticker: "CRM",
+          best_gap: 44.8,
+          best_leap: { ...leapData.results[0].best_leap!, strike: 260, expiry: "2027-06-17" },
+        },
+      ],
+    };
+    render(<LeapScanner data={wider} />);
+    expect(
+      screen.getByTestId("leap-best-order-link").getAttribute("href"),
+    ).toBe("/CRM?deck=c&expiry=2027-06-17&strikes=100&legs=BUY%3A1x260C&src=leap");
+  });
+
+  it("omits the order action when the scan predates contract detail", () => {
+    const legacy = {
+      ...leapData,
+      results: leapData.results.map(({ best_leap: _ignored, ...rest }) => rest),
+    };
+    render(<LeapScanner data={legacy} />);
+    const section = screen.getByTestId("leap-scanner-section");
+    expect(within(section).queryByTestId("leap-best-order-link")).toBeNull();
+    expect(within(section).queryByTestId("leap-order-link-NVDA")).toBeNull();
   });
 
   it("renders the empty state when no scan is on file", () => {
@@ -166,9 +246,7 @@ describe("LeapScanner", () => {
     render(<LeapScanner data={three} />);
     const section = screen.getByTestId("leap-scanner-section");
     const tickers = () =>
-      within(section)
-        .getAllByRole("link")
-        .map((el) => el.textContent);
+      Array.from(section.querySelectorAll("tbody tr td:first-child a")).map((el) => el.textContent);
 
     expect(tickers()).toEqual(["NVDA", "AAPL", "MSFT"]);
     expect(within(section).getByRole("columnheader", { name: /best gap/i }).getAttribute("aria-sort")).toBe(


### PR DESCRIPTION
The LEAP IV Mispricing table ranked tickers by `best_gap` and dead-ended there: acting on the top row meant reading the gap, guessing which long-dated call produced it, and hand-building the ticket. The payload never named a contract, so no link could exist.

## What changed

- **`scripts/leap_scanner_uw.py`** — the scan payload now carries `best_leap`: the contract behind `best_gap` (symbol, expiry, strike, right, IV, delta, gap, OI). It is the widest realized-vs-implied gap inside the delta group that set `best_gap`, ties broken on open interest.
- **`web/components/LeapScanner.tsx`** — a `TRADE BEST · CRM 280C` action in the section header deep-links the widest-gap mispriced row into the chain order builder, and each mispriced row's Best Gap value links to its own contract. URL shape is the one Theta Harvester already uses: `/CRM?deck=c&expiry=2027-01-15&strikes=100&legs=BUY:1x280C&src=leap`.
- **`web/components/ticker-detail/OptionsChainTab.tsx`** — `src=leap` renders `PREFILLED FROM LEAP SCAN` instead of crediting every seeded ticket to the Theta Harvester.

Scans written before the field exists render exactly as they do today: no header action, Best Gap as plain text.

## Tests

- 5 new pytest cases: contract selection (widest gap, OI tie-break, empty group) and payload serialization (present / null).
- 4 new vitest cases asserting **exact href strings**, not link presence — a wrong ticker, expiry, strike, right, or deck fails.
- `web/e2e/leap-order-prefill.spec.ts` — clicks the header action and asserts the builder lands on `1x $280 Call` / `2027-01-15` with the LEAP SCAN banner.

Local gate: 76 leap-related pytest cases pass, full web vitest passes (7447), the new Playwright spec passes.

## Note

The action stays hidden until a fresh LEAP scan runs (`radon-leap.timer`, or SCAN on the page) — the cached `leap.json` / Turso snapshot predates `best_leap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177apGqsWaVFmiCkBvzNCSs
