### PR TITLE
fix(chain): make the order ticket scroll itself inside the chain deck

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -12763,12 +12763,35 @@ body[data-mobile="true"] .vol-cone-analysis .vol-cone-analysis-metrics {
 
 /* Docked ticket rail — chain keeps its column, the ticket sits beside it so
    legs, price, risk and CTA are readable without scrolling. Below the
-   breakpoint the rail unstacks and the ticket returns to full width. */
+   breakpoint the rail unstacks and the ticket returns to full width.
+
+   The deck is height-locked, so the chain is the deck body's only child and
+   fills it exactly: chain table and ticket are then the ONLY scroll
+   containers. Without this the deck body scrolls too, and a ticket sized off
+   the viewport (`100dvh`) overflows its much shorter scrollport — the risk
+   block and transmit CTA are reachable only by scrolling the panel AROUND the
+   form, never the form. */
+.asset-deck-body:has(.chain-tab) {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.chain-tab {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 8px 0 0;
+}
+
 .chain-rail {
+  flex: 1;
+  min-height: 0;
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   gap: 12px;
-  align-items: start;
+  align-items: stretch;
 }
 
 .chain-rail[data-docked="true"] {
@@ -12777,32 +12800,55 @@ body[data-mobile="true"] .vol-cone-analysis .vol-cone-analysis-metrics {
 
 .chain-rail-main {
   min-width: 0;
+  min-height: 0;
   display: flex;
   flex-direction: column;
 }
 
+/* The chain takes whatever height the toolbar and hint leave it — a fixed box
+   would either strand empty deck below it or clip rows on a short window.
+   `0 1 auto` hugs a short chain and shrinks-to-scroll a long one. */
 .chain-rail .chain-grid-wrapper {
+  flex: 0 1 auto;
   min-width: 0;
+  min-height: 0;
+  max-height: none;
 }
 
+/* Hugs its content, caps at the deck and scrolls itself past that — so the
+   risk block and TRANSMIT are always reachable from inside the ticket. */
 .order-builder--rail {
-  position: sticky;
-  top: 8px;
-  /* Never taller than the viewport: the ticket scrolls internally so the
-     transmit CTA stays reachable on a short window. */
-  max-height: calc(100dvh - 96px);
+  align-self: start;
+  max-height: 100%;
+  margin-top: 0;
   overflow-y: auto;
   overscroll-behavior: contain;
 }
 
+/* Narrow: the rail unstacks, so the deck body goes back to being the single
+   scroll container and both panes size to content. */
 @media (max-width: 1180px) {
-  .chain-rail[data-docked="true"] {
-    grid-template-columns: minmax(0, 1fr);
+  .asset-deck-body:has(.chain-tab) {
+    overflow-y: auto;
+    display: block;
+  }
+
+  .chain-tab {
+    display: block;
+  }
+
+  .chain-rail,
+  .chain-rail-main {
+    display: block;
+  }
+
+  .chain-rail .chain-grid-wrapper {
+    max-height: 520px;
   }
 
   .order-builder--rail {
-    position: static;
-    max-height: none;
+    height: auto;
+    margin-top: 12px;
     overflow-y: visible;
   }
 }

--- a/web/components/ticker-detail/OptionsChainTab.tsx
+++ b/web/components/ticker-detail/OptionsChainTab.tsx
@@ -1441,7 +1441,14 @@ export default function OptionsChainTab({
   }
 
   return (
-    <div className="chain-tab" style={{ padding: "8px 0" }}>
+    <div className="chain-tab">
+      {/* Chain column + docked ticket rail. The rail owns the whole deck
+          height: the toolbar, chain and hint ride in the left column so the
+          ticket starts level with them instead of below a full-width bar. */}
+      <div className="chain-rail" data-docked={orderLegs.length > 0 ? "true" : "false"}>
+      {/* One grid child per column: toolbar, chain and hint travel together,
+          otherwise the hint becomes a third child and wraps the dock below. */}
+      <div className="chain-rail-main">
       {/* Expiry selector */}
       <div className="chain-expiry-bar">
         <label
@@ -1505,13 +1512,6 @@ export default function OptionsChainTab({
         </div>
       </div>
 
-      {/* Chain grid + docked ticket rail. The ticket sits BESIDE the chain
-          rather than under it, so legs, price, risk and CTA stay readable
-          without scrolling and the chain keeps its full height. */}
-      <div className="chain-rail" data-docked={orderLegs.length > 0 ? "true" : "false"}>
-      {/* One grid child per column: the chain and its hint row travel together,
-          otherwise the hint becomes a third child and wraps the dock below. */}
-      <div className="chain-rail-main">
       {loadingStrikes ? (
         <div style={{ padding: "24px 0", textAlign: "center" }}>
           <SpectralLoader label="Loading chain" />

--- a/web/e2e/chain-deck-ticket-scroll.spec.ts
+++ b/web/e2e/chain-deck-ticket-scroll.spec.ts
@@ -1,0 +1,251 @@
+/**
+ * E2E: the chain deck's order ticket scrolls ITSELF.
+ *
+ * Repro: open the chain deck, stage legs until the ticket is taller than the
+ * deck. The ticket used to be sized off the viewport (`100dvh`) while its
+ * scrollport was the much shorter deck body, so it overflowed without ever
+ * growing its own scrollbar — the risk block and TRANSMIT CTA were reachable
+ * only by scrolling the panel AROUND the form.
+ */
+
+import { test, expect } from "@playwright/test";
+
+const TICKER = "MU";
+
+function fridayInDays(days: number): string {
+  const d = new Date();
+  d.setUTCHours(0, 0, 0, 0);
+  d.setUTCDate(d.getUTCDate() + days);
+  while (d.getUTCDay() !== 5) d.setUTCDate(d.getUTCDate() + 1);
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}${m}${day}`;
+}
+
+const NEAR = fridayInDays(14);
+
+const PORTFOLIO_EMPTY = {
+  bankroll: 1_000_000,
+  peak_value: 1_000_000,
+  last_sync: new Date().toISOString(),
+  total_deployed_pct: 0,
+  total_deployed_dollars: 0,
+  remaining_capacity_pct: 100,
+  position_count: 0,
+  defined_risk_count: 0,
+  undefined_risk_count: 0,
+  avg_kelly_optimal: null,
+  exposure: {},
+  violations: [],
+  positions: [],
+};
+
+const ORDERS_EMPTY = {
+  last_sync: new Date().toISOString(),
+  open_orders: [],
+  executed_orders: [],
+  open_count: 0,
+  executed_count: 0,
+};
+
+function quote(symbol: string, bid: number, ask: number, last: number) {
+  return {
+    symbol,
+    last,
+    lastIsCalculated: false,
+    bid,
+    ask,
+    bidSize: 25,
+    askSize: 25,
+    volume: 1_000,
+    high: null,
+    low: null,
+    open: null,
+    close: last,
+    week52High: null,
+    week52Low: null,
+    avgVolume: null,
+    delta: 0.4,
+    gamma: null,
+    theta: null,
+    vega: null,
+    impliedVol: 0.45,
+    undPrice: 120,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+const STRIKES = [110, 115, 120, 125, 130];
+
+const PRICE_FIXTURES: Record<string, unknown> = { [TICKER]: quote(TICKER, 119.9, 120.1, 120) };
+for (const strike of STRIKES) {
+  for (const right of ["C", "P"] as const) {
+    const key = `${TICKER}_${NEAR}_${strike}_${right}`;
+    PRICE_FIXTURES[key] = quote(key, 3.1, 3.5, 3.3);
+  }
+}
+
+function installMockWebSocket(page: import("@playwright/test").Page) {
+  return page.addInitScript((priceFixtures) => {
+    const NativeWebSocket = window.WebSocket;
+    const isRelay = (url: string) => url.includes(":8765") || url.includes("/ws");
+
+    class MockWebSocket {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+      url: string;
+      readyState = MockWebSocket.CONNECTING;
+      onopen: ((event?: unknown) => void) | null = null;
+      onmessage: ((event: { data: string }) => void) | null = null;
+      onclose: ((event?: unknown) => void) | null = null;
+      onerror: ((event?: unknown) => void) | null = null;
+      constructor(url: string) {
+        this.url = url;
+        setTimeout(() => {
+          this.readyState = MockWebSocket.OPEN;
+          this.onopen?.({});
+          this.emit({
+            type: "status",
+            ib_connected: true,
+            ib_issue: null,
+            ib_status_message: null,
+            subscriptions: [],
+          });
+        }, 0);
+      }
+      addEventListener(type: string, listener: (event: unknown) => void) {
+        if (type === "open") this.onopen = listener;
+        if (type === "message") this.onmessage = listener as (e: { data: string }) => void;
+        if (type === "close") this.onclose = listener;
+        if (type === "error") this.onerror = listener;
+      }
+      removeEventListener() {}
+      send(raw: string) {
+        const message = JSON.parse(raw) as {
+          action?: string;
+          symbols?: string[];
+          contracts?: Array<{ symbol: string; expiry: string; strike: number; right: "C" | "P" }>;
+        };
+        if (message.action !== "subscribe") return;
+        const updates: Record<string, unknown> = {};
+        for (const symbol of message.symbols ?? []) {
+          if (priceFixtures[symbol]) updates[symbol] = priceFixtures[symbol];
+        }
+        for (const contract of message.contracts ?? []) {
+          const expiry = String(contract.expiry).replace(/-/g, "");
+          const key = `${String(contract.symbol).toUpperCase()}_${expiry}_${Number(contract.strike)}_${contract.right}`;
+          if (priceFixtures[key]) updates[key] = priceFixtures[key];
+        }
+        if (Object.keys(updates).length > 0) this.emit({ type: "batch", updates });
+      }
+      close() {
+        this.readyState = MockWebSocket.CLOSED;
+        this.onclose?.({});
+      }
+      emit(payload: unknown) {
+        this.onmessage?.({ data: JSON.stringify(payload) });
+      }
+    }
+    // @ts-expect-error test-only replacement
+    window.WebSocket = function (url: string, protocols?: string | string[]) {
+      // @ts-expect-error test-only replacement
+      return isRelay(String(url)) ? new MockWebSocket(String(url)) : new NativeWebSocket(url, protocols);
+    };
+    Object.assign(window.WebSocket, { CONNECTING: 0, OPEN: 1, CLOSING: 2, CLOSED: 3 });
+  }, PRICE_FIXTURES);
+}
+
+async function stubApis(page: import("@playwright/test").Page) {
+  const json = (body: unknown) => ({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+  await page.route("**/api/portfolio", (route) => route.fulfill(json(PORTFOLIO_EMPTY)));
+  await page.route("**/api/orders", (route) => route.fulfill(json(ORDERS_EMPTY)));
+  await page.route("**/api/regime", (route) => route.fulfill(json({ score: 15, cri: { score: 15 } })));
+  await page.route("**/api/ib-status", (route) => route.fulfill(json({ connected: true })));
+  await page.route("**/api/blotter", (route) =>
+    route.fulfill(
+      json({ as_of: new Date().toISOString(), summary: { realized_pnl: 0 }, closed_trades: [], open_trades: [] }),
+    ),
+  );
+  await page.route("**/api/ticker/**", (route) =>
+    route.fulfill(json({ uw_info: { name: "Micron Technology", sector: "Technology" }, stock_state: {}, profile: {}, stats: {} })),
+  );
+  await page.route("**/api/options/expirations*", (route) =>
+    route.fulfill(json({ symbol: TICKER, expirations: [NEAR] })),
+  );
+  await page.route("**/api/options/chain*", (route) => {
+    const expiry = new URL(route.request().url()).searchParams.get("expiry") ?? NEAR;
+    return route.fulfill(
+      json({ symbol: TICKER, expiry, exchange: "SMART", strikes: STRIKES, multiplier: "100" }),
+    );
+  });
+}
+
+test.describe("Chain deck ticket scroll", () => {
+  test.use({ viewport: { width: 1440, height: 600 } });
+
+  test("keeps the ticket inside the deck and scrolls it internally", async ({ page }) => {
+    await page.unrouteAll({ behavior: "ignoreErrors" });
+    await installMockWebSocket(page);
+    await stubApis(page);
+
+    await page.goto(`/${TICKER}?deck=c`);
+
+    const deckBody = page.locator(".asset-deck.open .asset-deck-body");
+    await deckBody.waitFor({ timeout: 20_000 });
+    await deckBody.locator(".chain-grid").waitFor();
+
+    // Toolbar rides in the chain column so the ticket starts level with it.
+    await expect(deckBody.locator(".chain-rail-main > .chain-expiry-bar")).toHaveCount(1);
+
+    for (const strike of [110, 115, 120, 125, 130]) {
+      const row = deckBody.getByRole("row", { name: new RegExp(`\\$${strike}\\.00`) }).first();
+      await row.locator(".chain-mid.chain-clickable").first().click();
+    }
+
+    const rail = deckBody.locator(".order-builder--rail");
+    await expect(rail).toBeVisible();
+
+    const box = await deckBody.evaluate((body) => {
+      const ticket = body.querySelector(".order-builder--rail") as HTMLElement;
+      return {
+        bodyScrolls: body.scrollHeight > body.clientHeight + 1,
+        ticketOverflows: ticket.scrollHeight > ticket.clientHeight + 1,
+        ticketBottom: Math.round(ticket.getBoundingClientRect().bottom),
+        bodyBottom: Math.round(body.getBoundingClientRect().bottom),
+      };
+    });
+
+    // The panel around the form never scrolls…
+    expect(box.bodyScrolls).toBe(false);
+    // …the ticket does, and is fully inside the deck.
+    expect(box.ticketOverflows).toBe(true);
+    expect(box.ticketBottom).toBeLessThanOrEqual(box.bodyBottom + 1);
+
+    // Scrolling the ticket alone reaches the transmit CTA.
+    await rail.evaluate((el) => {
+      el.scrollTop = el.scrollHeight;
+    });
+    const submitVisible = await rail.evaluate((el) => {
+      const submit = el.querySelector(".order-builder-submit") as HTMLElement | null;
+      if (!submit) return false;
+      const s = submit.getBoundingClientRect();
+      const r = el.getBoundingClientRect();
+      return s.bottom <= r.bottom + 1 && s.top >= r.top - 1;
+    });
+    expect(submitVisible).toBe(true);
+
+    await page.screenshot({ path: "test-results/chain-deck-ticket-scroll.png", fullPage: false });
+
+    // Roomy window: the same layout with the ticket no longer needing to scroll.
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await expect(rail).toBeVisible();
+    await page.screenshot({ path: "test-results/chain-deck-roomy.png", fullPage: false });
+  });
+});

--- a/web/tests/chain-deck-layout.test.tsx
+++ b/web/tests/chain-deck-layout.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+
+/**
+ * Chain deck layout contract.
+ *
+ * The chain deck is a height-locked workspace: the deck body itself must NOT
+ * scroll, the chain table and the docked order ticket each scroll internally.
+ * Before this contract the ticket was sized with `calc(100dvh - 96px)` while
+ * its scrollport was the (much shorter) deck body, so the ticket overflowed
+ * the deck without ever growing its own scrollbar — the bottom of the ticket
+ * (risk block + transmit) was only reachable by scrolling the container
+ * AROUND the form.
+ *
+ * The toolbar also belongs to the chain column, not above the rail: parked
+ * above it, it left a dead band of empty panel beside it where the ticket
+ * should start.
+ */
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(""),
+  usePathname: () => "/test",
+  useRouter: () => ({
+    replace: vi.fn(),
+    push: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
+import OptionsChainTab from "../components/ticker-detail/OptionsChainTab";
+import { TickerDetailProvider } from "../lib/TickerDetailContext";
+import type { PriceData } from "../lib/pricesProtocol";
+
+const TICKER = "PLTR";
+const EXPIRY = "20991231";
+const STRIKES = [148, 150, 152.5, 155, 157.5];
+const SPOT = 153.1;
+
+function pd(over: Partial<PriceData>): PriceData {
+  return {
+    symbol: "X",
+    last: null,
+    lastIsCalculated: false,
+    bid: null,
+    ask: null,
+    bidSize: null,
+    askSize: null,
+    volume: null,
+    high: null,
+    low: null,
+    open: null,
+    close: null,
+    week52High: null,
+    week52Low: null,
+    avgVolume: null,
+    delta: null,
+    gamma: null,
+    theta: null,
+    vega: null,
+    impliedVol: null,
+    undPrice: null,
+    timestamp: new Date().toISOString(),
+    ...over,
+  };
+}
+
+function installFetchMock() {
+  const fetchMock = vi.fn<typeof fetch>();
+  fetchMock.mockImplementation((input) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : String((input as Request).url);
+    const json = (body: unknown) =>
+      Promise.resolve(
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    if (url.includes("/api/options/expirations")) return json({ symbol: TICKER, expirations: [EXPIRY] });
+    if (url.includes("/api/options/chain")) return json({ symbol: TICKER, expiry: EXPIRY, strikes: STRIKES });
+    if (url.includes("/api/risk-free-rate")) return json({ rate: 0 });
+    if (url.includes("/api/previous-close")) return json({ closes: { [TICKER]: SPOT } });
+    return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+  });
+  vi.stubGlobal("fetch", fetchMock);
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+const css = readFileSync(join(__dirname, "../app/globals.css"), "utf8");
+
+function ruleBody(selector: string): string {
+  const at = css.indexOf(`${selector} {`);
+  expect(at, `missing CSS rule ${selector}`).toBeGreaterThan(-1);
+  return css.slice(at, css.indexOf("}", at));
+}
+
+describe("chain deck — the ticket scrolls itself, not the container around it", () => {
+  it("hands the deck body's height to the chain instead of scrolling it", () => {
+    const deckBody = ruleBody(".asset-deck-body:has(.chain-tab)");
+    expect(deckBody).toMatch(/overflow:\s*hidden/);
+
+    const tab = ruleBody(".chain-tab");
+    expect(tab).toMatch(/display:\s*flex/);
+    expect(tab).toMatch(/min-height:\s*0/);
+  });
+
+  it("sizes the docked ticket by its cell, never by viewport math", () => {
+    const rail = ruleBody(".order-builder--rail");
+    expect(rail).toMatch(/overflow-y:\s*auto/);
+    expect(rail).toMatch(/max-height:\s*100%/);
+    expect(rail).toMatch(/align-self:\s*start/);
+    expect(rail).not.toMatch(/dvh|vh\b/);
+    expect(rail).not.toMatch(/position:\s*sticky/);
+  });
+
+  it("lets the chain table fill the rail rather than a fixed 520px box", () => {
+    const wrapper = ruleBody(".chain-rail .chain-grid-wrapper");
+    expect(wrapper).toMatch(/flex:\s*0 1 auto/);
+    expect(wrapper).toMatch(/min-height:\s*0/);
+    expect(wrapper).toMatch(/max-height:\s*none/);
+
+    const railBody = ruleBody(".chain-rail");
+    expect(railBody).toMatch(/flex:\s*1/);
+    expect(railBody).toMatch(/min-height:\s*0/);
+    expect(railBody).toMatch(/align-items:\s*stretch/);
+  });
+});
+
+describe("chain deck — the toolbar rides with the chain column", () => {
+  it("nests the expiry bar inside the chain column so the ticket starts at the top", async () => {
+    installFetchMock();
+    const { container } = render(
+      React.createElement(
+        TickerDetailProvider,
+        null,
+        React.createElement(OptionsChainTab, {
+          ticker: TICKER,
+          prices: { [TICKER]: pd({ last: SPOT }) },
+          tickerPriceData: pd({ last: SPOT }),
+        }),
+      ),
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector(".chain-expiry-bar")).not.toBeNull();
+    });
+
+    expect(container.querySelector(".chain-rail-main > .chain-expiry-bar")).not.toBeNull();
+    expect(container.querySelector(".chain-tab > .chain-expiry-bar")).toBeNull();
+  });
+});


### PR DESCRIPTION
The docked ticket was sized `max-height: calc(100dvh - 96px)` while its scrollport is `.asset-deck-body`, which is far shorter than the viewport. The ticket therefore overflowed the deck without ever growing its own scrollbar: the risk block and TRANSMIT were reachable only by scrolling the panel AROUND the form. The chain toolbar also sat above the rail, leaving a dead band of empty panel beside it where the ticket should start.

The deck is now height-locked: `.asset-deck-body` hands its height to `.chain-tab` and stops scrolling, and the chain table and the ticket are the only scroll containers. Both hug their content and cap at the deck. The expiry toolbar moves into `.chain-rail-main` so the ticket starts level with it. Below 1180px the rail unstacks and the deck body goes back to being the single scroll container.

Verified: e2e/chain-deck-ticket-scroll.spec.ts is red on the old CSS (bodyScrolls true, ticket bottom 679 vs deck bottom 623, no internal scroll) and green after.


Claude-Session: https://claude.ai/code/session_01ACU4Vg1SRnWeQ4DUWcjaAS

- [ ] Red/green TDD (failing test, then fix)
- [ ] Staged only the files this change owns (no `git add -A`)
- [ ] Owner doc updated, or the commit message has `docs-skip: <reason>`
- [ ] Previous `main` deploy finished before this push
