### PR TITLE
fix(p3): persist container drop-ins on the control plane

### DIFF
--- a/cloud/scripts/bootstrap-control-plane.sh
+++ b/cloud/scripts/bootstrap-control-plane.sh
@@ -139,6 +139,11 @@ readonly -a SOURCES=(
   services/radon-drift-audit.timer
   services/radon-nextjs-db-watchdog.service
   services/radon-nextjs-db-watchdog.timer
+  services/radon-api.service.d/runtime-container.conf
+  services/radon-nextjs.service.d/runtime-container.conf
+  services/radon-relay.service.d/runtime-container.conf
+  services/radon-monitor.service.d/runtime-container.conf
+  services/radon-newsfeed.service.d/runtime-container.conf
 )
 readonly -a LOGICAL_TARGETS=(
   /usr/local/sbin/radon-deploy-root
@@ -172,12 +177,18 @@ readonly -a LOGICAL_TARGETS=(
   /etc/systemd/system/radon-drift-audit.timer
   /etc/systemd/system/radon-nextjs-db-watchdog.service
   /etc/systemd/system/radon-nextjs-db-watchdog.timer
+  /etc/systemd/system/radon-api.service.d/runtime-container.conf
+  /etc/systemd/system/radon-nextjs.service.d/runtime-container.conf
+  /etc/systemd/system/radon-relay.service.d/runtime-container.conf
+  /etc/systemd/system/radon-monitor.service.d/runtime-container.conf
+  /etc/systemd/system/radon-newsfeed.service.d/runtime-container.conf
 )
 readonly -a MODES=(
   0755 0755 0755 0644 0644 0755
   0440 0440 0440 0440
   0644
   0644 0644 0644 0644 0644 0644 0644 0644 0644 0644 0644 0644 0644 0644 0644
+  0644 0644 0644 0644 0644
   0644 0644 0644 0644 0644
 )
 readonly -a KINDS=(
@@ -186,6 +197,7 @@ readonly -a KINDS=(
   polkit
   systemd systemd systemd systemd systemd systemd systemd systemd systemd systemd
   systemd systemd systemd systemd systemd systemd systemd systemd systemd systemd
+  dropin dropin dropin dropin dropin
 )
 
 [[ "${#SOURCES[@]}" -eq "${#LOGICAL_TARGETS[@]}" && \
@@ -316,6 +328,16 @@ for index in "${!SOURCES[@]}"; do
       ;;
     systemd)
       SYSTEMD_CANDIDATES+=("$staged_path")
+      ;;
+    dropin)
+      grep -q '^Type=simple$' "$staged_path" || \
+        die "drop-in must set Type=simple: $relative_source"
+      grep -q 'ExecStart=/usr/local/sbin/radon-app-runtime run %n' "$staged_path" || \
+        die "drop-in must ExecStart radon-app-runtime: $relative_source"
+      grep -q 'ExecStartPre=' "$staged_path" || \
+        die "drop-in must reset ExecStartPre: $relative_source"
+      grep -q 'radon-ib-gateway' "$staged_path" && \
+        die "drop-in must not mention Gateway: $relative_source"
       ;;
     *)
       die "unknown validator for: $relative_source"

--- a/cloud/scripts/deploy-root-helper.sh
+++ b/cloud/scripts/deploy-root-helper.sh
@@ -43,6 +43,11 @@ readonly -a CONTROL_PLANE_SOURCES=(
   services/radon-drift-audit.timer
   services/radon-nextjs-db-watchdog.service
   services/radon-nextjs-db-watchdog.timer
+  services/radon-api.service.d/runtime-container.conf
+  services/radon-nextjs.service.d/runtime-container.conf
+  services/radon-relay.service.d/runtime-container.conf
+  services/radon-monitor.service.d/runtime-container.conf
+  services/radon-newsfeed.service.d/runtime-container.conf
 )
 readonly -a CONTROL_PLANE_TARGETS=(
   /usr/local/sbin/radon-deploy-root
@@ -76,12 +81,18 @@ readonly -a CONTROL_PLANE_TARGETS=(
   /etc/systemd/system/radon-drift-audit.timer
   /etc/systemd/system/radon-nextjs-db-watchdog.service
   /etc/systemd/system/radon-nextjs-db-watchdog.timer
+  /etc/systemd/system/radon-api.service.d/runtime-container.conf
+  /etc/systemd/system/radon-nextjs.service.d/runtime-container.conf
+  /etc/systemd/system/radon-relay.service.d/runtime-container.conf
+  /etc/systemd/system/radon-monitor.service.d/runtime-container.conf
+  /etc/systemd/system/radon-newsfeed.service.d/runtime-container.conf
 )
 readonly -a CONTROL_PLANE_MODES=(
   755 755 755 644 644 755
   440 440 440 440
   644
   644 644 644 644 644 644 644 644 644 644 644 644 644 644 644 644 644 644 644 644
+  644 644 644 644 644
 )
 
 if [[ "${RADON_DEPLOY_HELPER_TEST_MODE:-0}" == "1" ]]; then

--- a/cloud/services/radon-api.service.d/runtime-container.conf
+++ b/cloud/services/radon-api.service.d/runtime-container.conf
@@ -1,0 +1,10 @@
+[Service]
+User=root
+NotifyAccess=all
+Environment=RADON_RUNTIME=container
+Type=simple
+WatchdogSec=infinity
+ExecStartPre=
+ExecStart=
+ExecStart=/usr/local/sbin/radon-app-runtime run %n
+ExecStopPost=/usr/local/sbin/radon-app-runtime stop %n

--- a/cloud/services/radon-monitor.service.d/runtime-container.conf
+++ b/cloud/services/radon-monitor.service.d/runtime-container.conf
@@ -1,0 +1,10 @@
+[Service]
+User=root
+NotifyAccess=all
+Environment=RADON_RUNTIME=container
+Type=simple
+WatchdogSec=infinity
+ExecStartPre=
+ExecStart=
+ExecStart=/usr/local/sbin/radon-app-runtime run %n
+ExecStopPost=/usr/local/sbin/radon-app-runtime stop %n

--- a/cloud/services/radon-newsfeed.service.d/runtime-container.conf
+++ b/cloud/services/radon-newsfeed.service.d/runtime-container.conf
@@ -1,0 +1,10 @@
+[Service]
+User=root
+NotifyAccess=all
+Environment=RADON_RUNTIME=container
+Type=simple
+WatchdogSec=infinity
+ExecStartPre=
+ExecStart=
+ExecStart=/usr/local/sbin/radon-app-runtime run %n
+ExecStopPost=/usr/local/sbin/radon-app-runtime stop %n

--- a/cloud/services/radon-nextjs.service.d/runtime-container.conf
+++ b/cloud/services/radon-nextjs.service.d/runtime-container.conf
@@ -1,0 +1,10 @@
+[Service]
+User=root
+NotifyAccess=all
+Environment=RADON_RUNTIME=container
+Type=simple
+WatchdogSec=infinity
+ExecStartPre=
+ExecStart=
+ExecStart=/usr/local/sbin/radon-app-runtime run %n
+ExecStopPost=/usr/local/sbin/radon-app-runtime stop %n

--- a/cloud/services/radon-relay.service.d/runtime-container.conf
+++ b/cloud/services/radon-relay.service.d/runtime-container.conf
@@ -1,0 +1,10 @@
+[Service]
+User=root
+NotifyAccess=all
+Environment=RADON_RUNTIME=container
+Type=simple
+WatchdogSec=infinity
+ExecStartPre=
+ExecStart=
+ExecStart=/usr/local/sbin/radon-app-runtime run %n
+ExecStopPost=/usr/local/sbin/radon-app-runtime stop %n

--- a/cloud/tests/test_app_images.py
+++ b/cloud/tests/test_app_images.py
@@ -203,3 +203,21 @@ class TestRuntimeContainerDropin:
         assert "scripts/radon-app-runtime.sh" in sources
         assert "/usr/local/sbin/radon-app-runtime" in targets
         assert "runtime-container.conf.example" not in sources
+
+    def test_live_dropins_are_control_plane_and_type_simple(self) -> None:
+        sources = _readonly_array(BOOTSTRAP.read_text(encoding="utf-8"), "SOURCES")
+        helper = _readonly_array(HELPER.read_text(encoding="utf-8"), "CONTROL_PLANE_SOURCES")
+        assert "radon-ib-gateway.service.d" not in sources
+        assert "radon-health.service.d" not in sources
+        for unit in APP_UNITS:
+            rel = f"services/{unit}.d/runtime-container.conf"
+            live = CLOUD_ROOT / "services" / f"{unit}.d" / "runtime-container.conf"
+            assert live.is_file(), unit
+            text = live.read_text(encoding="utf-8")
+            assert "Type=simple" in text, unit
+            assert "WatchdogSec=infinity" in text, unit
+            assert "ExecStart=/usr/local/sbin/radon-app-runtime run %n" in text, unit
+            assert "ExecStartPre=" in text, unit
+            assert "ib-gateway" not in text, unit
+            assert rel in sources, unit
+            assert rel in helper, unit

--- a/cloud/tests/test_bootstrap_control_plane.py
+++ b/cloud/tests/test_bootstrap_control_plane.py
@@ -129,6 +129,31 @@ ARTIFACTS = (
         "/etc/systemd/system/radon-nextjs-db-watchdog.timer",
         0o644,
     ),
+    Artifact(
+        "services/radon-api.service.d/runtime-container.conf",
+        "/etc/systemd/system/radon-api.service.d/runtime-container.conf",
+        0o644,
+    ),
+    Artifact(
+        "services/radon-nextjs.service.d/runtime-container.conf",
+        "/etc/systemd/system/radon-nextjs.service.d/runtime-container.conf",
+        0o644,
+    ),
+    Artifact(
+        "services/radon-relay.service.d/runtime-container.conf",
+        "/etc/systemd/system/radon-relay.service.d/runtime-container.conf",
+        0o644,
+    ),
+    Artifact(
+        "services/radon-monitor.service.d/runtime-container.conf",
+        "/etc/systemd/system/radon-monitor.service.d/runtime-container.conf",
+        0o644,
+    ),
+    Artifact(
+        "services/radon-newsfeed.service.d/runtime-container.conf",
+        "/etc/systemd/system/radon-newsfeed.service.d/runtime-container.conf",
+        0o644,
+    ),
 )
 
 


### PR DESCRIPTION
**Do not merge until after 16:00 ET.** Auto-deploy would bounce app units during RTH.

Ships uncommented `runtime-container.conf` for api/nextjs/relay/monitor/newsfeed as bootstrap/refresh artifacts so the next main deploy cannot wipe ExecStart back to host uvicorn.

Type=simple (docker client never sends READY=1). No Gateway/health drop-in.

After hours: merge, bootstrap, pull, restart-managed.