### PR TITLE
feat(newsfeed): drop Market Ear attribution and source-link pill from feed posts

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -4733,10 +4733,6 @@ body[data-mobile="true"] .dashboard-news .news-feed-refresh--rail {
   color: var(--text-muted);
 }
 
-.news-feed-meta__source {
-  color: var(--text-secondary);
-}
-
 .news-feed-item .news-feed-tags {
   margin-top: 16px;
 }
@@ -4782,10 +4778,6 @@ body[data-mobile="true"] .dashboard-news .news-feed-refresh--rail {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.news-feed-figcaption span:last-child {
-  flex: none;
 }
 
 .news-feed-image-wrapper {
@@ -5233,29 +5225,6 @@ body[data-mobile="true"] .dashboard-news .news-feed-refresh--rail {
   gap: 16px;
   margin-top: 0;
   padding: 14px 0 6px;
-}
-
-.news-feed-link-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 4px 12px;
-  border: 1px solid var(--line-grid);
-  border-radius: 999px;
-  background: transparent;
-  color: var(--text-secondary);
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  text-decoration: none;
-  transition: color 150ms ease, border-color 150ms ease, background 150ms ease;
-}
-
-.news-feed-link-pill:hover {
-  color: var(--signal-core-text);
-  border-color: var(--line-grid);
-  background: var(--bg-panel-raised);
 }
 
 .news-feed-timestamp {

--- a/web/components/DashboardNewsFeed.module.css
+++ b/web/components/DashboardNewsFeed.module.css
@@ -228,16 +228,6 @@
   z-index: 1;
 }
 
-:global(body[data-mobile="true"]) .linkPill.linkPill {
-  display: inline-flex;
-  align-items: center;
-  position: relative;
-  flex: 0 0 auto;
-  min-height: 24px;
-  padding: 0 var(--nf-s2);
-  gap: var(--nf-s1);
-}
-
 :global(body[data-mobile="true"]) .timestamp.timestamp {
   display: inline-flex;
   align-items: center;
@@ -273,7 +263,6 @@
    card's 12px padding, both of which sit well inside those scroll ports. Any
    future pad that could reach a scroll-port edge has to be re-measured. */
 :global(body[data-mobile="true"]) .refresh.refresh::after,
-:global(body[data-mobile="true"]) .linkPill.linkPill::after,
 :global(body[data-mobile="true"]) .footer.footer :global(.star-toggle)::after {
   content: "";
   position: absolute;

--- a/web/components/DashboardNewsFeed.tsx
+++ b/web/components/DashboardNewsFeed.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Image from "next/image";
-import { ArrowUpRight, ChevronLeft, ChevronRight, RefreshCw } from "lucide-react";
+import { ChevronLeft, ChevronRight, RefreshCw } from "lucide-react";
 
 import { estimateReadMinutes } from "../lib/newsfeedReadTime";
 import { formatAbsolute, formatCompact, formatRelative, formatTime } from "../lib/newsfeedTime";
@@ -33,7 +33,6 @@ function buildPostSnapshot(post: NormalisedPost) {
 }
 
 const PAGE_SIZE = 18;
-const SOURCE_NAME = "Market Ear";
 
 export type { MarketEarPost };
 
@@ -318,7 +317,6 @@ export default function DashboardNewsFeed() {
                   <h3 className={`news-feed-headline ${styles.headline}`}>{post.title}</h3>
                   <div data-testid="news-feed-meta" className={`news-feed-meta ${styles.meta}`}>
                     <span title={absolute}>{absolute}</span>
-                    <span className="news-feed-meta__source">{SOURCE_NAME}</span>
                     <span>{readMinutes} min read</span>
                   </div>
                   {postTags.length > 0 ? (
@@ -388,21 +386,10 @@ export default function DashboardNewsFeed() {
                       </button>
                       <figcaption className={`news-feed-figcaption ${styles.figcaption}`}>
                         <span>Chart · {post.title}</span>
-                        <span>Source · {SOURCE_NAME}</span>
                       </figcaption>
                     </figure>
                   ) : null}
                   <div data-testid="news-feed-footer" className={`news-feed-footer ${styles.footer}`}>
-                    <a
-                      data-testid="news-feed-link-pill"
-                      className={`news-feed-link-pill ${styles.linkPill}`}
-                      href={post.href}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      <ArrowUpRight size={11} aria-hidden />
-                      <span>Source link</span>
-                    </a>
                     <span
                       data-testid="news-feed-timestamp"
                       className={`news-feed-timestamp ${styles.timestamp}`}

--- a/web/tests/dashboard-newsfeed-article-layout.test.tsx
+++ b/web/tests/dashboard-newsfeed-article-layout.test.tsx
@@ -66,11 +66,11 @@ describe("DashboardNewsFeed article layout", () => {
     expect(document.querySelector(".news-feed-live-badge")!.textContent).toBe("LIVE");
   });
 
-  it("renders a mono meta row: stamp · Market Ear · read time", async () => {
+  it("renders a mono meta row: stamp · read time, with no source attribution", async () => {
     await renderFeed([POST]);
     const meta = document.querySelector("[data-testid='news-feed-meta']")!;
     const cells = Array.from(meta.querySelectorAll("span")).map((s) => s.textContent);
-    expect(cells).toEqual([formatAbsolute(POST.timestamp), "Market Ear", "2 min read"]);
+    expect(cells).toEqual([formatAbsolute(POST.timestamp), "2 min read"]);
   });
 
   it("places the tag strip between the meta row and the body", async () => {
@@ -83,20 +83,20 @@ describe("DashboardNewsFeed article layout", () => {
     expect(order.indexOf("news-feed-tags")).toBeLessThan(order.indexOf("news-feed-summary"));
   });
 
-  it("wraps the chart in a figure with a caption crediting the source", async () => {
+  it("wraps the chart in a figure with a caption naming the chart only", async () => {
     await renderFeed([POST]);
     const figure = document.querySelector("figure.news-feed-figure")!;
     expect(figure.querySelector("img.news-feed-image")).not.toBeNull();
     const caption = figure.querySelector("figcaption")!;
-    expect(caption.textContent).toContain(POST.title);
-    expect(caption.textContent).toContain("Source · Market Ear");
+    expect(caption.textContent).toBe(`Chart · ${POST.title}`);
+    expect(caption.textContent).not.toContain("Market Ear");
   });
 
-  it("labels the footer pill as the source link", async () => {
+  it("renders no source-link pill in the footer", async () => {
     await renderFeed([POST]);
-    const pill = screen.getByTestId("news-feed-link-pill");
-    expect(pill.textContent).toBe("Source link");
-    expect(pill.getAttribute("href")).toBe("https://themarketear.com/posts/p1");
+    expect(screen.queryByTestId("news-feed-link-pill")).toBeNull();
+    const footer = screen.getByTestId("news-feed-footer");
+    expect(footer.textContent).not.toContain("Source link");
   });
 });
 

--- a/web/tests/dashboard-newsfeed-headline-no-link.test.tsx
+++ b/web/tests/dashboard-newsfeed-headline-no-link.test.tsx
@@ -2,7 +2,8 @@
  * @vitest-environment jsdom
  *
  * Feed headlines must NOT be outbound links to the source (Market Ear).
- * The footer Link pill remains the only outbound anchor per post.
+ * The footer source-link pill is gone too, so a post carries no outbound
+ * anchor at all.
  */
 import React from "react";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
@@ -63,11 +64,9 @@ describe("DashboardNewsFeed headline", () => {
     expect(headline.closest("a")).toBeNull();
   });
 
-  it("keeps the footer Link pill as the only outbound anchor", async () => {
+  it("leaves no outbound anchor anywhere on the post", async () => {
     await renderFeed();
     const item = screen.getAllByTestId("news-feed-item")[0];
-    const anchors = item.querySelectorAll("a[href]");
-    expect(anchors).toHaveLength(1);
-    expect(anchors[0].getAttribute("data-testid")).toBe("news-feed-link-pill");
+    expect(item.querySelectorAll("a[href]")).toHaveLength(0);
   });
 });

--- a/web/tests/dashboard-newsfeed-mobile-item.test.tsx
+++ b/web/tests/dashboard-newsfeed-mobile-item.test.tsx
@@ -202,7 +202,6 @@ describe("DashboardNewsFeed mobile item", () => {
       ["button.news-feed-image-wrapper--button", styles.imageWrapper],
       ["img.news-feed-image", styles.image],
       ["div.news-feed-footer", styles.footer],
-      ["a.news-feed-link-pill", styles.linkPill],
     ];
 
     for (const [selector, moduleClass] of expectations) {
@@ -286,9 +285,6 @@ describe("DashboardNewsFeed.module.css mobile rules", () => {
     expect(timestamp).toMatch(/white-space:\s*nowrap/);
     expect(timestamp).toMatch(/min-height:\s*24px/);
     expect(timestamp).toMatch(/flex:\s*1\s+1\s+auto/);
-
-    const pill = ruleBlock(moduleCss, `:global(${mobile}) .linkPill.linkPill`);
-    expect(pill).toMatch(/min-height:\s*24px/);
 
     const star = ruleBlock(
       moduleCss,


### PR DESCRIPTION
Feed cards carried the source name twice (meta row + chart caption) and a
"Source link" pill in the footer. All three are gone: the meta row is now
stamp + read time, the caption is just "Chart - <title>", and the footer
holds the timestamp and star only. Posts no longer carry an outbound anchor
(the lightbox "Open original" link is untouched). Orphaned CSS removed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017K67rUKF5VX9kGGbjv7X9n