### PR TITLE
fix(flow): land the per-ticker scan and date a served cache

### DIFF
--- a/scripts/api/server.py
+++ b/scripts/api/server.py
@@ -435,15 +435,28 @@ ORDERS_SYNC_SHED_RETRY_DELAY_SECS = 8.0
 # Operator POST /flow-analysis/{ticker} shares that general lane. Fail-fast
 # 502 leaves the UI on ANALYZING with a raw capacity error. Retry the claim
 # with the same budget as orders-sync; persistent shed still 502s.
-FLOW_REPORT_SHED_RETRIES = 2
+# A shed is fail-fast — `_claim_subprocess_slot` returns False with no awaits —
+# so 2 retries cost ~21s of a 120s budget and 502'd while the journal showed
+# general-lane slots freeing every few seconds. /flow-analysis/AMZN served a
+# Jun 16 report through 2026-08-28 on exactly that. The deadline below is the
+# real bound; this is the ceiling that keeps the loop finite.
+FLOW_REPORT_SHED_RETRIES = 12
 # NOT 8.0 like orders-sync: a shared constant put both retry chains on the
 # same 8s grid, contending in lockstep against a lane already saturated. R-355.
 FLOW_REPORT_SHED_RETRY_DELAY_SECS = 5.0
-# The Next.js proxy gives up at 130s and takes its stale-cache branch, so a
-# chain that outlives this deadline holds a general-lane slot for a response
-# nobody will read — extending the saturation for the next caller. Worst case
-# was 3 x 300 + 16 = 916s. R-354.
-FLOW_REPORT_TOTAL_DEADLINE_SECS = 120.0
+# Uncapped, the exponential doubling spends the whole budget on two sleeps.
+_SHED_BACKOFF_CAP_SECS = 20.0
+# A 20-session AMZN pull measured 81s end to end. Claiming a slot with less
+# budget than that left burns the lane and the UW spend on a run that must
+# time out, so the chain stops probing below it.
+FLOW_REPORT_MIN_RUN_SECS = 90.0
+# Total wall clock one scan may occupy a general-lane slot for, probing
+# included. Worst case was 3 x 300 + 16 = 916s of saturation for the next
+# caller. R-354. Sized to seat one real scan plus a retry window. No longer
+# tied to the HTTP round trip: the edge cuts the browser at 30s either way, so
+# `_scan_once_per_ticker` detaches the scan and this budget bounds the CACHE
+# WRITE, not a response anyone is still waiting on.
+FLOW_REPORT_TOTAL_DEADLINE_SECS = 225.0
 _CAPACITY_SHED_MARKER = "subprocess capacity exhausted"
 
 # One in-flight scan per ticker. Nothing deduped concurrent requests, so N
@@ -456,6 +469,47 @@ def _is_capacity_shed(error: Optional[str]) -> bool:
     return bool(error) and _CAPACITY_SHED_MARKER in error.lower()
 
 
+def _flow_report_inflight_lock() -> "asyncio.Lock":
+    """Created on first use: the loop does not exist at import time."""
+    global _FLOW_REPORT_INFLIGHT_LOCK
+    if _FLOW_REPORT_INFLIGHT_LOCK is None:
+        _FLOW_REPORT_INFLIGHT_LOCK = asyncio.Lock()
+    return _FLOW_REPORT_INFLIGHT_LOCK
+
+
+async def _scan_once_per_ticker(ticker: str, scan) -> Any:
+    """Collapse concurrent scans of one ticker onto a single detached run.
+
+    Two properties, both load-bearing:
+
+    Dedupe — N tabs on one symbol each claimed a general-lane slot, so the
+    operator's own duplicates were part of the saturation that then shed the
+    scan they were all waiting for.
+
+    Detachment — Caddy bounds the app upstream at a 30s
+    `response_header_timeout` and a 20-session AMZN pull measures 81s, so the
+    browser request is always cut first. Shielding the scan from its caller's
+    cancellation lets the cache write land anyway, so the next page load is
+    fresh instead of replaying the same doomed scan.
+    """
+    lock = _flow_report_inflight_lock()
+    async with lock:
+        task = _FLOW_REPORT_INFLIGHT.get(ticker)
+        if task is None or task.done():
+            task = asyncio.create_task(scan())
+            # Nobody may be awaiting when this settles; consume the outcome so
+            # a detached failure is not an "exception was never retrieved" log.
+            task.add_done_callback(
+                lambda t: None if t.cancelled() else t.exception()
+            )
+            _FLOW_REPORT_INFLIGHT[ticker] = task
+    try:
+        return await asyncio.shield(task)
+    finally:
+        if task.done() and _FLOW_REPORT_INFLIGHT.get(ticker) is task:
+            _FLOW_REPORT_INFLIGHT.pop(ticker, None)
+
+
 async def _run_script_retrying_capacity(
     script: str,
     args: list[str],
@@ -465,12 +519,17 @@ async def _run_script_retrying_capacity(
     delay_s: float,
     label: str,
     deadline_s: Optional[float] = None,
+    min_run_s: Optional[float] = None,
 ) -> ScriptResult:
     """Re-claim a general-lane slot after a capacity shed.
 
     The claim is fail-fast. Peer scans often free a slot in seconds, so a
     bounded sleep-and-retry is the operator-facing equivalent of the
     orders-sync / flow-refresh wrappers. Real script failures do not retry.
+
+    `min_run_s` is the shortest window the script can finish in. Once less
+    than that remains, probing stops: a slot claimed too late burns the lane
+    and the upstream spend on a run that is guaranteed to time out.
     """
     started = time.monotonic()
 
@@ -483,6 +542,13 @@ async def _run_script_retrying_capacity(
         left = _budget_left()
         return timeout if left is None else max(1.0, min(timeout, left))
 
+    def _can_seat_a_run(after_backoff: float) -> bool:
+        left = _budget_left()
+        if left is None:
+            return True
+        remaining = left - after_backoff
+        return remaining > 0 and (min_run_s is None or remaining >= min_run_s)
+
     result = await run_script(script, args, timeout=_attempt_timeout())
     attempts = 0
     while (
@@ -493,12 +559,14 @@ async def _run_script_retrying_capacity(
         # Exponential with jitter. A fixed delay meant every client shed in the
         # same instant retried in the same instant — synchronised waves against
         # a lane that is by definition already saturated. R-355.
-        backoff = delay_s * (2 ** attempts) * (0.5 + random.random())
-        left = _budget_left()
-        if left is not None and left <= backoff:
+        backoff = min(
+            _SHED_BACKOFF_CAP_SECS,
+            delay_s * (2 ** attempts) * (0.5 + random.random()),
+        )
+        if not _can_seat_a_run(backoff):
             logger.info(
-                "%s: capacity shed and the %.0fs deadline is spent — giving up "
-                "after %d attempt(s) rather than holding a lane slot",
+                "%s: capacity shed and the %.0fs deadline no longer seats a run "
+                "— giving up after %d attempt(s) rather than holding a lane slot",
                 label, deadline_s, attempts + 1,
             )
             return ScriptResult(
@@ -2434,6 +2502,11 @@ async def run_flow_report(ticker: str):
                 pass
         return demo_disabled_payload(f"Live flow analysis for {upper}")
 
+    return await _scan_once_per_ticker(upper, lambda: _scan_and_cache(upper))
+
+
+async def _scan_and_cache(upper: str) -> dict:
+    """One flow scan for one ticker: run it, gate it, persist it, return it."""
     # 20 trading-day dark-pool history (flow_report DEFAULT_LOOKBACK_DAYS).
     # Cold liquid names paginate UW heavily; allow longer than the old 120s.
     # Capacity shed is retryable: the general lane is often full for seconds
@@ -2446,6 +2519,7 @@ async def run_flow_report(ticker: str):
         delay_s=FLOW_REPORT_SHED_RETRY_DELAY_SECS,
         label=f"flow-report {upper}",
         deadline_s=FLOW_REPORT_TOTAL_DEADLINE_SECS,
+        min_run_s=FLOW_REPORT_MIN_RUN_SECS,
     )
     if not result.ok:
         raise HTTPException(status_code=502, detail=result.error)

--- a/scripts/api/tests/test_flow_report_deadline_and_jitter.py
+++ b/scripts/api/tests/test_flow_report_deadline_and_jitter.py
@@ -19,6 +19,7 @@ client copy told the operator to refresh for a proven-persistent condition.
 from __future__ import annotations
 
 import asyncio
+import re
 import sys
 from pathlib import Path
 
@@ -180,3 +181,135 @@ class TestExhaustedShedIsDistinct:
             )
         )
         assert result.ok is True
+
+
+class TestTheShedBudgetIsActuallySpent:
+    """2026-08-28: /flow-analysis/AMZN served a Jun 16 report.
+
+    A capacity shed is fail-fast — `_claim_subprocess_slot` returns False with
+    no awaits — so the whole retry chain cost ~21s of a 120s budget and 502'd
+    at 18:24:21 while the journal shows general-lane slots freeing every few
+    seconds (regime/gex/vcg scans completing at 18:24:30-35). The Next.js
+    route then served the June cache. `retries` was the real bound, never the
+    deadline it was paired with.
+    """
+
+    @staticmethod
+    def _budget_clock(monkeypatch, calls, timeouts):
+        clock = {"t": 0.0}
+
+        async def _run(_script, _args, *, timeout):
+            calls.append(clock["t"])
+            timeouts.append(timeout)
+            return _shed_result()
+
+        async def _sleep(secs):
+            clock["t"] += secs
+
+        monkeypatch.setattr(server, "run_script", _run)
+        monkeypatch.setattr(server.asyncio, "sleep", _sleep)
+        monkeypatch.setattr(server.time, "monotonic", lambda: clock["t"])
+
+    def test_a_shed_chain_probes_the_lane_for_most_of_its_budget(self, monkeypatch):
+        calls: list[float] = []
+        timeouts: list[float] = []
+        self._budget_clock(monkeypatch, calls, timeouts)
+
+        result = asyncio.run(
+            server._run_script_retrying_capacity(
+                "flow_report.py", ["AMZN"],
+                timeout=300,
+                retries=server.FLOW_REPORT_SHED_RETRIES,
+                delay_s=server.FLOW_REPORT_SHED_RETRY_DELAY_SECS,
+                label="t",
+                deadline_s=server.FLOW_REPORT_TOTAL_DEADLINE_SECS,
+                min_run_s=server.FLOW_REPORT_MIN_RUN_SECS,
+            )
+        )
+
+        assert result.ok is False
+        assert len(calls) >= 5, (
+            "three fail-fast probes spend ~21s of the budget and hand the "
+            f"operator a months-old cache; probed at {calls}"
+        )
+
+    def test_the_backoff_is_capped_so_late_probes_still_happen(self, monkeypatch):
+        calls: list[float] = []
+        timeouts: list[float] = []
+        self._budget_clock(monkeypatch, calls, timeouts)
+
+        asyncio.run(
+            server._run_script_retrying_capacity(
+                "flow_report.py", ["AMZN"],
+                timeout=300,
+                retries=server.FLOW_REPORT_SHED_RETRIES,
+                delay_s=server.FLOW_REPORT_SHED_RETRY_DELAY_SECS,
+                label="t",
+                deadline_s=server.FLOW_REPORT_TOTAL_DEADLINE_SECS,
+                min_run_s=server.FLOW_REPORT_MIN_RUN_SECS,
+            )
+        )
+
+        gaps = [b - a for a, b in zip(calls, calls[1:])]
+        assert gaps, "the chain must retry at least once"
+        # Gaps are differences of an accumulated float clock, so a capped 20.0
+        # reads back as 20.000000000000007. Compare with a tolerance, not ==.
+        assert max(gaps) <= server._SHED_BACKOFF_CAP_SECS + 1e-6, (
+            f"uncapped exponential backoff swallows the budget; gaps={gaps}"
+        )
+
+    def test_it_never_claims_a_slot_it_cannot_finish_the_scan_in(self, monkeypatch):
+        calls: list[float] = []
+        timeouts: list[float] = []
+        self._budget_clock(monkeypatch, calls, timeouts)
+
+        asyncio.run(
+            server._run_script_retrying_capacity(
+                "flow_report.py", ["AMZN"],
+                timeout=300,
+                retries=server.FLOW_REPORT_SHED_RETRIES,
+                delay_s=server.FLOW_REPORT_SHED_RETRY_DELAY_SECS,
+                label="t",
+                deadline_s=server.FLOW_REPORT_TOTAL_DEADLINE_SECS,
+                min_run_s=server.FLOW_REPORT_MIN_RUN_SECS,
+            )
+        )
+
+        assert timeouts, "at least one attempt must run"
+        assert all(t >= server.FLOW_REPORT_MIN_RUN_SECS for t in timeouts), (
+            "a slot claimed with less budget than a scan needs burns the lane "
+            f"and the UW spend on a run that must time out; timeouts={timeouts}"
+        )
+
+
+class TestTheBudgetFitsARealScan:
+    """A 20-session AMZN pull measured 81s. A budget that cannot seat one real
+    scan plus a retry window can only ever serve cache."""
+
+    def test_the_deadline_seats_a_real_scan_and_a_retry_window(self):
+        assert server.FLOW_REPORT_TOTAL_DEADLINE_SECS >= (
+            server.FLOW_REPORT_MIN_RUN_SECS + 60.0
+        ), "no room to probe for a slot before the scan itself has to start"
+
+    def test_the_route_answers_before_the_edge_cuts_it(self):
+        """Caddy 502s the app upstream that has not written a response header
+        within `response_header_timeout`. A route that waits longer than that
+        can only ever hand the operator a raw edge 502 in place of Radon's own
+        answer — and the scan it was waiting for now lands on its own."""
+        repo = Path(__file__).resolve().parents[3]
+        route = (
+            repo / "web" / "app" / "api" / "flow-analysis" / "[ticker]" / "route.ts"
+        )
+        match = re.search(r"timeout:\s*([\d_]+)", route.read_text())
+        assert match, "the route must declare an explicit radonFetch timeout"
+        route_secs = int(match.group(1).replace("_", "")) / 1000
+
+        caddyfile = (repo / "cloud" / "caddy" / "Caddyfile").read_text()
+        app_block = caddyfile.split("reverse_proxy localhost:3000")[1]
+        edge = re.search(r"response_header_timeout\s+(\d+)s", app_block)
+        assert edge, "the app upstream must state its response_header_timeout"
+
+        assert route_secs < int(edge.group(1)), (
+            f"a {route_secs}s route wait outlives the {edge.group(1)}s edge bound, "
+            "so the operator gets a raw 502 instead of the dated cache"
+        )

--- a/scripts/api/tests/test_flow_report_single_flight.py
+++ b/scripts/api/tests/test_flow_report_single_flight.py
@@ -1,0 +1,114 @@
+"""R-354's per-ticker dedupe was declared and never wired.
+
+`_FLOW_REPORT_INFLIGHT` and `_FLOW_REPORT_INFLIGHT_LOCK` were added with the
+comment "One in-flight scan per ticker. Nothing deduped concurrent requests,
+so N browser tabs on the same symbol each claimed a slot" — and then no code
+read or wrote either. Every tab still claimed its own general-lane slot, so
+the operator's own duplicates were part of the saturation the shed retry then
+had to wait out. /flow-analysis/AMZN served a Jun 16 report on 2026-08-28.
+
+The shield matters as much as the dedupe: Caddy bounds the app upstream at a
+30s `response_header_timeout`, well under an 81s AMZN scan, so the browser
+request is cut long before the scan lands. Detaching the scan from any one
+caller is what lets the cache write finish anyway, so the next page load is
+fresh instead of replaying the same doomed scan.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+API_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(API_DIR))
+sys.path.insert(0, str(API_DIR.parent))
+
+import server  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _clean_inflight():
+    server._FLOW_REPORT_INFLIGHT.clear()
+    server._FLOW_REPORT_INFLIGHT_LOCK = None
+    yield
+    server._FLOW_REPORT_INFLIGHT.clear()
+    server._FLOW_REPORT_INFLIGHT_LOCK = None
+
+
+def _stub_scan(runs: list[str], *, delay: float = 0.05):
+    async def _scan(ticker: str):
+        runs.append(ticker)
+        await asyncio.sleep(delay)
+        return {"ticker": ticker, "fetched_at": "now"}
+
+    return _scan
+
+
+class TestOneScanPerTicker:
+    def test_concurrent_requests_for_one_ticker_share_a_single_scan(self):
+        runs: list[str] = []
+        scan = _stub_scan(runs)
+
+        async def _exercise():
+            return await asyncio.gather(*[
+                server._scan_once_per_ticker("AMZN", lambda: scan("AMZN"))
+                for _ in range(4)
+            ])
+
+        results = asyncio.run(_exercise())
+        assert runs == ["AMZN"], f"each tab claimed its own lane slot: {runs}"
+        assert all(r["ticker"] == "AMZN" for r in results)
+
+    def test_different_tickers_are_not_collapsed(self):
+        runs: list[str] = []
+        scan = _stub_scan(runs)
+
+        async def _exercise():
+            return await asyncio.gather(
+                server._scan_once_per_ticker("AMZN", lambda: scan("AMZN")),
+                server._scan_once_per_ticker("NVDA", lambda: scan("NVDA")),
+            )
+
+        asyncio.run(_exercise())
+        assert sorted(runs) == ["AMZN", "NVDA"]
+
+    def test_a_later_request_rescans_once_the_first_has_finished(self):
+        runs: list[str] = []
+        scan = _stub_scan(runs, delay=0.0)
+
+        async def _exercise():
+            await server._scan_once_per_ticker("AMZN", lambda: scan("AMZN"))
+            await server._scan_once_per_ticker("AMZN", lambda: scan("AMZN"))
+
+        asyncio.run(_exercise())
+        assert runs == ["AMZN", "AMZN"], "a finished scan must not pin the cache forever"
+
+
+class TestTheScanOutlivesTheCaller:
+    def test_a_cancelled_caller_does_not_kill_the_scan(self):
+        """Caddy cuts the app upstream at 30s; an 81s scan has to survive it."""
+        finished: list[str] = []
+
+        async def _scan():
+            await asyncio.sleep(0.05)
+            finished.append("AMZN")
+            return {"ticker": "AMZN"}
+
+        async def _exercise():
+            waiter = asyncio.create_task(
+                server._scan_once_per_ticker("AMZN", _scan)
+            )
+            await asyncio.sleep(0)
+            waiter.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await waiter
+            await asyncio.sleep(0.2)
+
+        asyncio.run(_exercise())
+        assert finished == ["AMZN"], (
+            "the scan died with the request that started it, so the cache write "
+            "never landed and the next visit replayed the same doomed scan"
+        )

--- a/web/app/api/flow-analysis/[ticker]/route.ts
+++ b/web/app/api/flow-analysis/[ticker]/route.ts
@@ -103,9 +103,17 @@ export async function POST(_req: Request, ctx: Params): Promise<Response> {
   }
 
   try {
+    // Caddy bounds this upstream at a 30s `response_header_timeout`
+    // (cloud/caddy/Caddyfile), and a 20-session AMZN pull measures 81s before
+    // FastAPI has even probed the saturated general lane for a slot. A 130s
+    // wait here could therefore only ever end as a raw edge 502, so answer
+    // first with the cache branch below and let the scan land on its own:
+    // FastAPI detaches it from this request and writes the cache when it
+    // finishes, so the next load is fresh. Pinned under the edge bound by
+    // `test_the_route_answers_before_the_edge_cuts_it`.
     const data = await radonFetch(`/flow-analysis/${ticker}`, {
       method: "POST",
-      timeout: 130_000,
+      timeout: 25_000,
     });
     const cache_meta = buildCacheMeta(cachePathFor(ticker));
     return setNoStoreResponseHeaders(

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -18195,6 +18195,23 @@ body[data-mobile="true"] td.right {
   color: var(--fault);
 }
 
+/* A cached verdict's age must not read as part of the direction. R-358 added
+   this span with no styling, so "BULLISH" and "LAST GOOD SCAN 2026-06-16" ran
+   together at 22px as one headline. */
+.ticker-flow-badge-stale {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 2px 6px;
+  border: 1px solid color-mix(in srgb, var(--warn-text) 34%, transparent);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--warn-text) 12%, transparent);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: var(--warn-text);
+  vertical-align: middle;
+}
+
 .ticker-flow-badge-rationale {
   font-family: var(--font-sans);
   font-size: 12px;

--- a/web/components/flow-analysis/TickerFlowReport.tsx
+++ b/web/components/flow-analysis/TickerFlowReport.tsx
@@ -10,6 +10,7 @@ import SpectralLoader from "@/components/SpectralLoader";
 import { useViewport } from "@/lib/useViewport";
 import DailyDarkPoolHistory from "@/components/flow-analysis/DailyDarkPoolHistory";
 import { flowReportErrorCopy } from "@/lib/flowReportError";
+import { flowReportAgeLabel } from "@/lib/flowReportStaleness";
 
 /** The scan the server actually runs is `--days 20` (server.py). Every piece
  * of window copy derives from this or from the payload's own
@@ -26,6 +27,7 @@ export default function TickerFlowReport({ ticker }: Props) {
   const verdict = useMemo(() => deriveVerdict(data), [data]);
   const isAnalyzing = status === "loading" || status === "scanning";
   const { isMobile, hasMounted } = useViewport();
+  const cachedAge = data && isServingCachedReport(status) ? flowReportAgeLabel(data) : null;
 
   if (hasMounted && isMobile) {
     return (
@@ -36,6 +38,7 @@ export default function TickerFlowReport({ ticker }: Props) {
         status={status}
         error={error}
         isAnalyzing={isAnalyzing}
+        cachedAge={cachedAge}
         onRefresh={refresh}
       />
     );
@@ -43,9 +46,9 @@ export default function TickerFlowReport({ ticker }: Props) {
 
   return (
     <div className="ticker-flow-report" data-testid="ticker-flow-report">
-      <SignalBadge ticker={ticker} verdict={verdict} status={status} error={error} onRefresh={refresh} />
+      <SignalBadge ticker={ticker} verdict={verdict} status={status} error={error} cachedAge={cachedAge} onRefresh={refresh} />
 
-      {error && (
+      {error && !cachedAge && (
         <div className="section">
           <div className="section-body">
             <div className="alert-item bearish" role="alert">{flowReportErrorCopy(error)}</div>
@@ -61,12 +64,20 @@ export default function TickerFlowReport({ ticker }: Props) {
         />
       )}
 
-      {data && <ReportSections data={data} isAnalyzing={isAnalyzing} />}
+      {data && <ReportSections data={data} isAnalyzing={isAnalyzing} cachedAge={cachedAge} />}
     </div>
   );
 }
 
 type Verdict = ReturnType<typeof classifyFlowSignal>;
+
+type FlowReportStatus = ReturnType<typeof useTickerFlowReport>["status"];
+
+/** The hook preserves the previous report on any failed scan, so these two
+ * statuses render real figures that did not come from a completed scan. */
+function isServingCachedReport(status: FlowReportStatus): boolean {
+  return status === "error" || status === "stale";
+}
 
 /* ── Mobile ticker flow report ── */
 
@@ -92,14 +103,16 @@ function MobileTickerFlowReport({
   status,
   error,
   isAnalyzing,
+  cachedAge,
   onRefresh,
 }: {
   ticker: string;
   data: FlowReportData | null;
   verdict: Verdict | null;
-  status: ReturnType<typeof useTickerFlowReport>["status"];
+  status: FlowReportStatus;
   error: string | null;
   isAnalyzing: boolean;
+  cachedAge: string | null;
   onRefresh: () => void;
 }) {
   const [section, setSection] = useState<MobileFlowSection>("overview");
@@ -201,9 +214,17 @@ function MobileTickerFlowReport({
         </button>
       </div>
 
-      {error && (
+      {error && !cachedAge && (
         <div style={{ padding: "8px 16px" }}>
           <div className="alert-item bearish" role="alert">{flowReportErrorCopy(error)}</div>
+        </div>
+      )}
+
+      {cachedAge && (
+        <div style={{ padding: "8px 16px" }}>
+          <div className="alert-item bearish" role="alert" data-testid="flow-stale-age">
+            Last good scan {cachedAge}. Every figure below is from that scan, not from live flow.
+          </div>
         </div>
       )}
 
@@ -405,12 +426,14 @@ function SignalBadge({
   verdict,
   status,
   error,
+  cachedAge,
   onRefresh,
 }: {
   ticker: string;
   verdict: Verdict | null;
-  status: ReturnType<typeof useTickerFlowReport>["status"];
+  status: FlowReportStatus;
   error: string | null;
+  cachedAge: string | null;
   onRefresh: () => void;
 }) {
   const direction = verdict?.direction ?? null;
@@ -427,7 +450,7 @@ function SignalBadge({
   // "Too Many Requests" strip above a hero still showing BULLISH with
   // yesterday's rationale, and the `Retry-After` the route sets was read by
   // nobody.
-  const servingStale = showVerdict && (status === "error" || status === "stale");
+  const servingStale = showVerdict && isServingCachedReport(status);
 
   return (
     <section className="section ticker-flow-hero">
@@ -464,7 +487,7 @@ function SignalBadge({
             {failed ? "Scan failed" : showVerdict && verdict ? meta.label : `Analyzing ${ticker}`}
             {servingStale && verdict && (
               <span className="ticker-flow-badge-stale" data-testid="flow-hero-stale">
-                {" "}LAST GOOD SCAN
+                {" "}LAST GOOD SCAN{cachedAge ? ` · ${cachedAge}` : ""}
               </span>
             )}
           </div>
@@ -532,12 +555,30 @@ function AnalyzingPanel({
   );
 }
 
+/** The figures below this strip are real, and they are old: /flow-analysis/AMZN
+ * served a Jun 16 aggregate through late August because every live scan lost
+ * the general subprocess lane. The age and only the age — the hero carries WHY
+ * the scan did not complete, and this exists to outlive scrolling past it. */
+function CachedReportAge({ ageLabel }: { ageLabel: string }) {
+  return (
+    <section className="section">
+      <div className="section-body">
+        <div className="alert-item bearish" role="alert" data-testid="flow-stale-age">
+          Last good scan {ageLabel}. Every figure below is from that scan, not from live flow.
+        </div>
+      </div>
+    </section>
+  );
+}
+
 function ReportSections({
   data,
   isAnalyzing,
+  cachedAge,
 }: {
   data: FlowReportData;
   isAnalyzing: boolean;
+  cachedAge: string | null;
 }) {
   const dpAgg = data.dark_pool?.aggregate ?? {};
   const buyRatio = dpAgg.dp_buy_ratio;
@@ -550,6 +591,8 @@ function ReportSections({
 
   return (
     <>
+      {cachedAge && <CachedReportAge ageLabel={cachedAge} />}
+
       <section className="section">
         <div className="section-header">
           <div className="section-title">Dark Pool Aggregate</div>

--- a/web/e2e/flow-analysis-ticker.spec.ts
+++ b/web/e2e/flow-analysis-ticker.spec.ts
@@ -293,4 +293,55 @@ test.describe("Flow Analysis per-ticker route", () => {
     await expect(report.getByRole("status")).toContainText(/Scan failed/i);
     await expect(report).not.toContainText(/Analyzing JOBY/i);
   });
+
+  /* 2026-08-28: /flow-analysis/AMZN rendered a Jun 16 aggregate. The scan had
+   * lost the general subprocess lane on every attempt since, so the route kept
+   * serving a cache with no upper age, and DARK POOL AGGREGATE / OPTIONS FLOW
+   * BIAS looked byte-identical to a fresh scan. The operator found the gap by
+   * reading ISO dates in the history table. */
+  test("a served cache names its age above the figures it produced", async ({ page }) => {
+    await setupBaseMocks(page);
+    const DAYS_OLD = 73;
+    const stamped = new Date(Date.now() - DAYS_OLD * 86_400_000);
+    const isoDay = new Intl.DateTimeFormat("en-CA", {
+      timeZone: "America/New_York",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(stamped);
+    const cached = bullishReport("AMZN", stamped.toISOString());
+
+    await page.route("**/api/flow-analysis/AMZN**", async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(cached),
+        });
+        return;
+      }
+      // What the route returns when its own wait elapses: the cache, marked.
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        headers: { "X-Sync-Warning": "Radon API unavailable - serving cached data" },
+        body: JSON.stringify({ ...cached, is_stale: true }),
+      });
+    });
+
+    await page.goto("/flow-analysis/AMZN");
+
+    const strip = page.getByTestId("flow-stale-age");
+    await expect(strip).toBeVisible();
+    await expect(strip).toContainText(isoDay);
+    await expect(strip).toContainText(`${DAYS_OLD} days old`);
+
+    // The dating must be readable without scrolling past the aggregate.
+    const aggregate = page.locator(".section", { hasText: "Dark Pool Aggregate" }).first();
+    const stripBox = await strip.boundingBox();
+    const aggBox = await aggregate.boundingBox();
+    expect(stripBox!.y).toBeLessThan(aggBox!.y);
+
+    await expect(page.getByTestId("flow-hero-stale")).toContainText(isoDay);
+  });
 });

--- a/web/lib/flowReportStaleness.ts
+++ b/web/lib/flowReportStaleness.ts
@@ -69,3 +69,45 @@ export const FLOW_REPORT_STALENESS = {
   MARKET_HOURS_TTL_MS,
   AFTER_HOURS_TTL_MS,
 };
+
+/** Report date in market time, `YYYY-MM-DD` — the format the daily history
+ * table already uses. UTC would move an after-hours scan to the next day. */
+function marketDate(when: Date): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: "America/New_York",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(when);
+}
+
+function calendarDaysApart(from: string, to: string): number {
+  return Math.round(
+    (Date.parse(`${to}T00:00:00Z`) - Date.parse(`${from}T00:00:00Z`)) / 86_400_000,
+  );
+}
+
+/**
+ * "2026-06-16 · 73 days old" — the age of a report, for rendering next to the
+ * figures it produced. Returns null when no timestamp is usable.
+ *
+ * A cached flow report is served whenever a live scan fails, and the cache has
+ * no upper age: /flow-analysis/AMZN served a June report through August. The
+ * verdict, the aggregate and the options bias all render identically to a
+ * fresh scan, so the age has to travel with them.
+ */
+export function flowReportAgeLabel(
+  report: FlowReportLike | null | undefined,
+  now: Date = new Date(),
+): string | null {
+  const ts = flowReportTimestamp(report);
+  if (!ts) return null;
+  const parsed = parseScanTime(ts);
+  if (!parsed) return null;
+
+  const reportDate = marketDate(parsed);
+  const days = Math.max(0, calendarDaysApart(reportDate, marketDate(now)));
+  if (days === 0) return `${reportDate} · today`;
+  if (days === 1) return `${reportDate} · 1 day old`;
+  return `${reportDate} · ${days} days old`;
+}

--- a/web/tests/flow-report-capacity-error.test.tsx
+++ b/web/tests/flow-report-capacity-error.test.tsx
@@ -111,3 +111,68 @@ describe("TickerFlowReport hero — a preserved verdict is marked stale", () => 
     expect(screen.queryByTestId("flow-hero-stale")).toBeNull();
   });
 });
+
+/* ── 2026-08-28: a cached report must name its own age in the body ──────────
+ *
+ * /flow-analysis/AMZN served the Jun 16 cache after a capacity 502. The hero
+ * chip said "LAST GOOD SCAN" without a date, and DARK POOL AGGREGATE /
+ * OPTIONS FLOW BIAS rendered byte-identically to a fresh scan. The operator
+ * found the ten-week gap by reading ISO dates in the history table.
+ */
+describe("TickerFlowReport — a stale report names its own age", () => {
+  const JUNE = {
+    ticker: "AMZN",
+    fetched_at: "2026-06-16T23:43:00Z",
+    verdict: { direction: "BULLISH" as const, confidence: 27, rationale: "Sustained DP buying" },
+    dark_pool: {
+      aggregate: { flow_direction: "NEUTRAL", flow_strength: 4, dp_buy_ratio: 0.52, num_prints: 2500 },
+      daily: [{ date: "2026-06-16", flow_direction: "DISTRIBUTION", flow_strength: 70, dp_buy_ratio: 0.15, num_prints: 500 }],
+    },
+    options_flow: { bias: "STRONGLY_BULLISH", put_call_ratio: 0.16 },
+  };
+
+  function renderWith(state: Record<string, unknown>) {
+    Object.assign(hookState, state);
+    return render(<TickerFlowReport ticker="AMZN" />);
+  }
+
+  afterEach(() => {
+    Object.assign(hookState, {
+      data: null,
+      status: "error",
+      error: "Radon API 502: Subprocess capacity exhausted",
+      refresh: () => {},
+    });
+    vi.useRealTimers();
+  });
+
+  function freezeToday() {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-28T18:24:00Z"));
+  }
+
+  it("dates the cached figures above the numbers themselves", () => {
+    freezeToday();
+    renderWith({ data: JUNE, status: "stale", error: "Scan did not complete" });
+    expect(screen.getByTestId("flow-stale-age").textContent).toContain("2026-06-16");
+    expect(screen.getByTestId("flow-stale-age").textContent).toContain("73 days old");
+  });
+
+  it("dates the hero chip too", () => {
+    freezeToday();
+    renderWith({ data: JUNE, status: "stale", error: "Scan did not complete" });
+    expect(screen.getByTestId("flow-hero-stale").textContent).toContain("2026-06-16");
+  });
+
+  it("marks a capacity 502 that left a cached report standing", () => {
+    freezeToday();
+    renderWith({ data: JUNE, status: "error", error: "Radon API 502: Subprocess capacity exhausted" });
+    expect(screen.getByTestId("flow-stale-age").textContent).toContain("73 days old");
+  });
+
+  it("adds no age strip to a fresh report", () => {
+    freezeToday();
+    renderWith({ data: { ...JUNE, fetched_at: "2026-08-28T18:20:00Z" }, status: "fresh", error: null });
+    expect(screen.queryByTestId("flow-stale-age")).toBeNull();
+  });
+});

--- a/web/tests/flow-report-staleness.test.ts
+++ b/web/tests/flow-report-staleness.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   isFlowReportStale,
+  flowReportAgeLabel,
   flowReportTimestamp,
   FLOW_REPORT_STALENESS,
 } from "@/lib/flowReportStaleness";
@@ -95,5 +96,51 @@ describe("isFlowReportStale", () => {
       true, // pretend market open to use the strict 10m TTL
     );
     expect(result).toBe(false);
+  });
+});
+
+/* ── 2026-08-28: /flow-analysis/AMZN rendered a Jun 16 report ───────────────
+ *
+ * The POST 502'd on a capacity shed, the route served the cache, and the hero
+ * said "LAST GOOD SCAN" with no date. Nothing between the operator and a
+ * STRONGLY BULLISH options bias told them the figures were ten weeks old —
+ * only the ISO dates in the history table, which needs scrolling to reach.
+ * A cached report has to name its own age wherever its numbers are shown.
+ */
+describe("flowReportAgeLabel", () => {
+  it("names the report date and how old it is", () => {
+    const now = new Date("2026-08-28T18:24:00Z"); // 14:24 ET
+    expect(
+      flowReportAgeLabel({ fetched_at: "2026-06-16T23:43:00Z" }, now),
+    ).toBe("2026-06-16 · 73 days old");
+  });
+
+  it("says today for a report from the current session", () => {
+    const now = new Date("2026-08-28T18:24:00Z");
+    expect(
+      flowReportAgeLabel({ fetched_at: "2026-08-28T13:05:00Z" }, now),
+    ).toBe("2026-08-28 · today");
+  });
+
+  it("singularises a one day old report", () => {
+    const now = new Date("2026-08-28T18:24:00Z");
+    expect(
+      flowReportAgeLabel({ fetched_at: "2026-08-27T20:00:00Z" }, now),
+    ).toBe("2026-08-27 · 1 day old");
+  });
+
+  it("dates the report in market time, not UTC", () => {
+    // 2026-08-27 21:30 ET is 2026-08-28 01:30 UTC. A UTC label would move an
+    // after-hours scan to the next trading day.
+    const now = new Date("2026-08-28T18:24:00Z");
+    expect(
+      flowReportAgeLabel({ fetched_at: "2026-08-28T01:30:00Z" }, now),
+    ).toBe("2026-08-27 · 1 day old");
+  });
+
+  it("returns null when there is no usable timestamp", () => {
+    expect(flowReportAgeLabel(null)).toBeNull();
+    expect(flowReportAgeLabel({})).toBeNull();
+    expect(flowReportAgeLabel({ fetched_at: "not-a-date" })).toBeNull();
   });
 });


### PR DESCRIPTION
/flow-analysis/AMZN rendered a Jun 16 report on 2026-08-28. Three independent causes, all fixed here.

1. The scan never landed. A capacity shed is fail-fast, so `retries=2` spent ~21s of a 120s budget and 502'd at 18:24:21 while the journal shows general-lane slots freeing seconds later. AMZN's cache had not been written since Jun 16. The deadline is now the real bound (retries raised to a finite ceiling, backoff capped at 20s), and a new `min_run_s` stops the chain from claiming a slot with less budget left than a scan needs — a measured 81s for a 20-session AMZN pull.

2. R-354's per-ticker dedupe was declared and never wired. `_FLOW_REPORT_INFLIGHT` had no reader or writer, so every tab on one symbol still claimed its own slot. `_scan_once_per_ticker` collapses them onto one detached task, and the shield matters as much as the dedupe: Caddy bounds the app upstream at a 30s `response_header_timeout`, so the browser request is always cut before an 81s scan finishes. Detaching lets the cache write land anyway. The route's own wait now sits under that edge bound, so the operator gets Radon's dated cache instead of a raw edge 502.

3. Nothing said the figures were old. The hero chip said "LAST GOOD SCAN" with no date and the aggregate rendered identically to a fresh scan; the ten-week gap was legible only in the history table's ISO dates. `flowReportAgeLabel` now dates the hero chip and a strip directly above DARK POOL AGGREGATE.

Verified: 16 new/updated pytest cases green over 8 repeat runs; 7/7 flow-analysis Playwright specs green with a browser screenshot of the dated strip; full vitest 7952/7960 and full pytest 8226/8253 with every failure pre-existing on this branch (lib/tools wrappers, scan_gate, cash-flow/flex WIP).


Claude-Session: https://claude.ai/code/session_01ACU4Vg1SRnWeQ4DUWcjaAS

- [ ] Red/green TDD (failing test, then fix)
- [ ] Staged only the files this change owns (no `git add -A`)
- [ ] Owner doc updated, or the commit message has `docs-skip: <reason>`
- [ ] Previous `main` deploy finished before this push
