### PR TITLE
fix: green main — five CI breaks across the control plane, a uptime sentinel, and three stale tests

### DIFF
--- a/cloud/scripts/bootstrap-control-plane.sh
+++ b/cloud/scripts/bootstrap-control-plane.sh
@@ -333,8 +333,12 @@ for index in "${!SOURCES[@]}"; do
       # Kept byte-for-byte in step with dropin_body_is_valid() in
       # deploy-root-helper.sh; test_rel133_control_plane_recovery.py pins the
       # two gates against each other. R-394.
-      grep -q '^Type=simple$' "$staged_path" || \
-        die "drop-in must set Type=simple: $relative_source"
+      # NOT Type=simple only: R-391 moved the monitor and relay drop-ins to
+      # Type=notify + WatchdogSec because forcing simple made systemd stop
+      # requiring keepalives, and a relay with a dead socket sat
+      # `active (running)` forever. Both gates refused what the repo ships.
+      grep -qE '^Type=(simple|notify)$' "$staged_path" || \
+        die "drop-in must set Type=simple or Type=notify: $relative_source"
       grep -q '^ExecStart=/usr/local/sbin/radon-app-runtime run %n$' "$staged_path" || \
         die "drop-in must ExecStart radon-app-runtime: $relative_source"
       grep -q '^ExecStartPre=$' "$staged_path" || \

--- a/cloud/scripts/deploy-root-helper.sh
+++ b/cloud/scripts/deploy-root-helper.sh
@@ -1103,8 +1103,8 @@ sync_scheduled_units() {
 # pins the two against each other so they cannot drift. R-394.
 dropin_body_is_valid() {
   local path="$1" label="${2:-$1}"
-  grep -q '^Type=simple$' "$path" || {
-    echo "drop-in must set Type=simple: ${label}" >&2
+  grep -qE '^Type=(simple|notify)$' "$path" || {
+    echo "drop-in must set Type=simple or Type=notify: ${label}" >&2
     return 1
   }
   grep -q '^ExecStart=/usr/local/sbin/radon-app-runtime run %n$' "$path" || {

--- a/cloud/tests/test_bootstrap_control_plane.py
+++ b/cloud/tests/test_bootstrap_control_plane.py
@@ -157,6 +157,28 @@ ARTIFACTS = (
 )
 
 
+def _dropin_base_units() -> tuple[str, ...]:
+    """`services/<unit>` for every manifested `services/<unit>.d/*.conf`.
+
+    A drop-in is only parsed by `systemd-analyze verify` beside its base unit,
+    so bootstrap stages the pair and refuses when the base unit is missing
+    (R-394). Two of the five base units — radon-nextjs.service and
+    radon-newsfeed.service — are NOT control-plane artifacts: the app tier owns
+    them, only their runtime-container drop-ins are manifested. The sandbox
+    therefore has to stage them even though they are not in ARTIFACTS.
+    """
+    bases = []
+    for artifact in ARTIFACTS:
+        source = Path(artifact.source)
+        # `config/sudoers.d/*` is a .d directory too, and has no base unit.
+        if source.parent.parent.name != "services" or source.parent.suffix != ".d":
+            continue
+        base = f"services/{source.parent.name.removesuffix('.d')}"
+        if base not in bases:
+            bases.append(base)
+    return tuple(bases)
+
+
 def _write_executable(path: Path, body: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(body, encoding="utf-8")
@@ -205,6 +227,11 @@ def _sandbox(tmp_path: Path) -> Sandbox:
         destination = source / artifact.source
         destination.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(CLOUD_ROOT / artifact.source, destination)
+
+    for base in _dropin_base_units():
+        destination = source / base
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(CLOUD_ROOT / base, destination)
 
     _write_executable(
         fake_bin / "flock",

--- a/cloud/tests/test_rel133_control_plane_recovery.py
+++ b/cloud/tests/test_rel133_control_plane_recovery.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import pathlib
 import re
 import shutil
+import subprocess
 import sys
 
 import pytest
@@ -108,7 +109,9 @@ def _dropin_gate_arm(helper_text: str) -> str:
 
 def test_refresh_install_file_gates_dropin_content() -> None:
     arm = _dropin_gate_arm(ROOT_HELPER.read_text(encoding="utf-8"))
-    assert "Type=simple" in arm
+    # The pattern, not the bare word: the refusal message names both types, so
+    # asserting "Type=simple" passed on the echo line alone.
+    assert "Type=(simple|notify)" in arm
     assert "radon-app-runtime" in arm
     assert "ExecStartPre=" in arm
     assert "radon-ib-gateway" in arm
@@ -168,9 +171,51 @@ def test_the_two_privileged_gates_enforce_the_same_dropin_rules() -> None:
     match = re.search(r"\n\s*dropin\)\s*\n(.*?);;", bootstrap, re.DOTALL)
     assert match, "bootstrap has no dropin validator"
     boot_arm = match.group(1)
-    for rule in ("Type=simple", "radon-app-runtime", "ExecStartPre=", "radon-ib-gateway", "/home/radon"):
+    for rule in (
+        "Type=(simple|notify)", "radon-app-runtime", "ExecStartPre=",
+        "radon-ib-gateway", "/home/radon",
+    ):
         assert rule in arm, rule
         assert rule in boot_arm, rule
+
+
+def _run_shipped_dropin_gate(target: pathlib.Path) -> subprocess.CompletedProcess:
+    """Run the SHIPPED `dropin_body_is_valid` body against one file."""
+    body = function_body(ROOT_HELPER.read_text(encoding="utf-8"), "dropin_body_is_valid")
+    script = f"set -uo pipefail\ndropin_body_is_valid() {{\n{body}\n}}\ndropin_body_is_valid \"$1\"\n"
+    return subprocess.run(
+        ["bash", "-c", script, "bash", str(target)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _manifested_dropins() -> list[str]:
+    """`services/*.service.d/*.conf` entries in the bootstrap manifest.
+
+    Not a glob over the tree: `services/radon-.service.d/common.conf` is the
+    systemd prefix-glob fleet drop-in that `setup-vps.sh` copies directly, and
+    it never reaches this gate.
+    """
+    bootstrap = (CLOUD_ROOT / "scripts" / "bootstrap-control-plane.sh").read_text(
+        encoding="utf-8"
+    )
+    return sorted(set(re.findall(r"^\s*(services/\S+\.service\.d/\S+\.conf)\s*$", bootstrap, re.M)))
+
+
+@pytest.mark.parametrize("relative", _manifested_dropins(), ids=lambda r: r.split("/")[1])
+def test_every_shipped_dropin_passes_the_privileged_gate(relative) -> None:
+    """What ships must install.
+
+    R-391 moved the monitor and relay drop-ins to `Type=notify` + `WatchdogSec`
+    — forcing `Type=simple` there made systemd stop requiring keepalives, so a
+    relay with a dead socket sat `active (running)` forever. Both privileged
+    gates still hard-required `Type=simple`, so root bootstrap and the
+    every-deploy `refresh_install_file` arm would refuse two of the five
+    drop-ins the repo actually ships. Nothing ran the gate against them.
+    """
+    result = _run_shipped_dropin_gate(CLOUD_ROOT / relative)
+    assert result.returncode == 0, result.stderr
 
 
 def test_bootstrap_stages_dropins_for_systemd_analyze() -> None:

--- a/scripts/api/server.py
+++ b/scripts/api/server.py
@@ -3183,7 +3183,10 @@ from data_refresh import CRI_SCAN_TIMEOUT_SECS  # noqa: E402,PLC0415
 # artifact was a 429 whose detail read "backing off after a failure". One record
 # per burst, not one per request. R-424.
 SCAN_GATE_SATURATION_REPORT_INTERVAL_S = 300.0
-_SCAN_GATE_SATURATION_REPORTED_AT = 0.0
+# None, NOT 0.0: `time.monotonic()` counts host uptime, so `0.0` reads as
+# "reported at boot" and swallowed the whole first burst on any host less than
+# SCAN_GATE_SATURATION_REPORT_INTERVAL_S old. The sentinel has to mean never.
+_SCAN_GATE_SATURATION_REPORTED_AT: Optional[float] = None
 
 
 def _scan_gate_overflow_detail() -> str:
@@ -3214,7 +3217,11 @@ def _record_scan_gate_saturation() -> None:
 
     detail = _scan_gate_overflow_detail()
     now = time.monotonic()
-    if now - _SCAN_GATE_SATURATION_REPORTED_AT < SCAN_GATE_SATURATION_REPORT_INTERVAL_S:
+    reported_at = _SCAN_GATE_SATURATION_REPORTED_AT
+    if (
+        reported_at is not None
+        and now - reported_at < SCAN_GATE_SATURATION_REPORT_INTERVAL_S
+    ):
         return
     _SCAN_GATE_SATURATION_REPORTED_AT = now
     _write_scan_gate_saturation_row(detail)

--- a/scripts/tests/test_db_readers.py
+++ b/scripts/tests/test_db_readers.py
@@ -17,7 +17,16 @@ _SCRIPTS_DIR = Path(__file__).resolve().parent.parent
 if str(_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_DIR))
 
-if "libsql_experimental" not in sys.modules:
+# Import-time, process-wide and never undone, so this stub is visible to every
+# test module collected alongside this one. `not in sys.modules` is true
+# whenever the real driver merely has not been imported YET, which is the
+# normal case, so the stub displaced a driver that was installed all along:
+# test_flex_delivery_claim_writer.py exists to exercise the claim against a
+# REAL libsql connection and got MagicMocks instead, taking `rowcount` and
+# `fetchall()` with it. Stub only when the driver is genuinely absent.
+try:  # noqa: SIM105 - the ImportError is the condition, not an accident
+    import libsql_experimental  # noqa: F401
+except ImportError:
     _libsql_stub = types.ModuleType("libsql_experimental")
     _libsql_stub.connect = MagicMock(return_value=MagicMock())  # type: ignore[attr-defined]
     sys.modules["libsql_experimental"] = _libsql_stub

--- a/scripts/tests/test_flex_delivery_claim_writer.py
+++ b/scripts/tests/test_flex_delivery_claim_writer.py
@@ -28,6 +28,8 @@ from pathlib import Path
 import libsql_experimental as libsql
 import pytest
 
+from unittest.mock import MagicMock
+
 SCRIPTS = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(SCRIPTS))
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -37,6 +39,21 @@ FIXTURES = Path(__file__).resolve().parent / "fixtures"
 ACTIVITY_XML = FIXTURES / "cash_transactions_flex_ytd_detail_sample.xml"
 
 SHA = "a" * 64
+
+
+def test_the_driver_under_test_is_the_real_one():
+    """This whole file is worthless against a stub.
+
+    A peer module installed a process-wide `sys.modules["libsql_experimental"]`
+    MagicMock at import time, so collection order decided whether these tests
+    exercised the driver or a mock — and a mock passes `rowcount` and
+    `fetchall()` back as MagicMocks, which is exactly the seam T-250 exists to
+    close. Fail with a sentence rather than a MagicMock comparison.
+    """
+    assert not isinstance(getattr(libsql, "connect", None), MagicMock), (
+        "libsql_experimental is a stub installed by another test module; these "
+        "tests prove nothing about the real driver"
+    )
 
 
 @pytest.fixture

--- a/scripts/tests/test_rel146_flex_sftp_honesty.py
+++ b/scripts/tests/test_rel146_flex_sftp_honesty.py
@@ -209,7 +209,14 @@ class TestTheClaimNamesTheDeliveredFile:
 
         monkeypatch.setattr(journal_rehydrate, "rehydrate", lambda **_k: {"ok": True})
 
-        pull._default_ingest("<FlexQueryResponse/>", source_path="/var/lib/radon/flex-inbox/activity.xml")
+        # An inbox-SHAPED path under tmp_path, not the literal production one:
+        # `_default_ingest` writes the plaintext to `source_path` itself (R-419),
+        # so naming /var/lib/radon/flex-inbox made the test fail with
+        # FileNotFoundError on every machine that is not the VPS. What is under
+        # test is the RECORDED name, and that is a basename either way.
+        inbox = tmp_path / "flex-inbox"
+        inbox.mkdir()
+        pull._default_ingest("<FlexQueryResponse/>", source_path=str(inbox / "activity.xml"))
 
         assert recorded and recorded[0] is not None
         assert "activity" in recorded[0], recorded

--- a/scripts/tests/test_rel148_operability_fixes.py
+++ b/scripts/tests/test_rel148_operability_fixes.py
@@ -118,7 +118,23 @@ class TestGateSaturationIsVisible:
         server = importlib.import_module("api.server")
         emitted: list = []
         monkeypatch.setattr(server, "_write_scan_gate_saturation_row", lambda detail: emitted.append(detail))
-        monkeypatch.setattr(server, "_SCAN_GATE_SATURATION_REPORTED_AT", 0.0, raising=False)
+        monkeypatch.setattr(server, "_SCAN_GATE_SATURATION_REPORTED_AT", None, raising=False)
+        for _ in range(20):
+            server._record_scan_gate_saturation()
+        assert len(emitted) == 1, emitted
+
+    def test_the_first_burst_after_a_reboot_is_still_reported(self, monkeypatch):
+        """`time.monotonic()` counts host UPTIME, so a `0.0` sentinel does not
+        mean "never reported" — it means "reported at boot". On a host less
+        than 300s old the whole first burst was swallowed. Green on any
+        long-lived machine, red on a fresh CI runner."""
+        import importlib
+
+        server = importlib.import_module("api.server")
+        emitted: list = []
+        monkeypatch.setattr(server, "_write_scan_gate_saturation_row", lambda detail: emitted.append(detail))
+        monkeypatch.setattr(server, "_SCAN_GATE_SATURATION_REPORTED_AT", None, raising=False)
+        monkeypatch.setattr(server.time, "monotonic", lambda: 90.0)
         for _ in range(20):
             server._record_scan_gate_saturation()
         assert len(emitted) == 1, emitted

--- a/web/tests/regime-day-change.test.tsx
+++ b/web/tests/regime-day-change.test.tsx
@@ -115,16 +115,22 @@ describe("Regime strip day change — baseline selection", () => {
     expect(dayChangeText()).toBeNull();
   });
 
-  it("falls back to the relay close only when the payload carries no history", () => {
+  it("withholds the baseline when the payload carries no history at all", () => {
+    // NOT a relay-close fallback. `prices.VIX.close` is IB's tick-9 close
+    // cached in the relay's memory for the life of the process, and the guard
+    // that read it fired exactly when history was empty — which is the
+    // DEGRADED case, since the regime route sets `history: []` on any upstream
+    // failure. R-404 removed that fallback; this case was written against the
+    // behaviour it replaced and asserted the relay close (14.52) instead.
     const state = resolveRegimeStripLiveState({
       sessionDate: SESSION,
       prices: { VIX: quote(14.76, 14.52) },
       data: { vix: 16.65 },
     });
 
-    expect(state.vixClose).toBe(14.52);
+    expect(state.vixClose).toBeNull();
     render(<DayChange last={state.liveVix} close={state.vixClose} />);
-    expect(dayChangeText()).toBe("+0.24 (+1.65%)");
+    expect(dayChangeText()).toBeNull();
   });
 
   it("renders nothing while the market is closed and there is no live last", () => {


### PR DESCRIPTION
`main` is red on three gating jobs — `pytest (cloud al)`, `pytest (scripts-rs)`, `pytest (scripts-df)` — plus `Vitest (shard 4/8)`. Five distinct defects. None is a flake in the ordinary sense; each is something the suite was structurally unable to see.

## 1. `pytest (cloud al)` — the privileged drop-in gate refuses what the repo ships

`REFUSING control-plane bootstrap: drop-in has no base unit to verify against: services/radon-nextjs.service.d/runtime-container.conf`

Two stacked defects, the first hiding the second.

**Fixture gap.** `b8fe32ef` (REL-133 / R-394) added base-unit staging so `systemd-analyze verify` actually parses a drop-in, reading `$CLOUD_ROOT/services/<base>.service` and refusing when it is absent. Two of the five manifested drop-ins belong to units the app tier owns — `radon-nextjs.service` and `radon-newsfeed.service` are not control-plane artifacts, only their runtime-container drop-ins are — and `_sandbox()` stages only `ARTIFACTS`. `_dropin_base_units()` now derives and stages the pair.

**A live production refusal that hid behind it.** R-391 moved the monitor and relay drop-ins to `Type=notify` + `WatchdogSec`, because forcing `Type=simple` made systemd stop requiring keepalives and a relay with a dead socket sat `active (running)` forever. Both privileged gates still hard-required `^Type=simple$`:

- `cloud/scripts/bootstrap-control-plane.sh` — root bootstrap
- `cloud/scripts/deploy-root-helper.sh:dropin_body_is_valid` — the **every-deploy** `refresh_install_file` arm

So both would have refused two of the five drop-ins the repo actually ships. Both now accept `^Type=(simple|notify)$`, kept byte-for-byte in step as R-394 requires.

Nothing ever ran either gate against the shipped files. `test_every_shipped_dropin_passes_the_privileged_gate` does, parametrized off the bootstrap manifest so a new drop-in is covered on arrival. It excludes `services/radon-.service.d/common.conf` — the systemd prefix-glob fleet drop-in `setup-vps.sh` copies directly, which this gate never sees. The two paired-gate assertions now match `Type=(simple|notify)` instead of the bare word, which was passing on the refusal message's own text.

## 2. `pytest (scripts-rs)` — a `0.0` sentinel means "reported at boot", not "never"

`_record_scan_gate_saturation` throttles with `time.monotonic()` — **host uptime** — against a module sentinel of `0.0`. On a host younger than `SCAN_GATE_SATURATION_REPORT_INTERVAL_S` (300s) the guard reads `90 - 0.0 < 300` and swallows the entire first burst, the one thing R-424 added the record for. Proven against the unmodified tree:

```
uptime 90s  -> emitted: 0     # a fresh GitHub runner
uptime 4d   -> emitted: 1     # a developer laptop (monotonic 354,697)
```

The sentinel is now `None` and the guard tests for it. `test_the_first_burst_after_a_reboot_is_still_reported` pins it with a patched clock rather than the runner's uptime.

## 3. `pytest (scripts-rs)` — the sftp honesty test wrote to the production inbox

`FileNotFoundError: '/var/lib/radon/flex-inbox/activity.xml'` at `scripts/flex_sftp_pull.py:270`.

`_default_ingest` does not merely record `source_path` — it **writes** the decrypted plaintext there, deliberately, so `flex_deliveries.source_path` is a real delivered file rather than a dead `/tmp` name inside the unit's PrivateTmp namespace (R-419). Handing it the literal production path fails on every machine that is not the VPS. What the test asserts is the recorded *basename*, so an inbox-shaped directory under `tmp_path` proves the same thing.

## 4. `pytest (scripts-df)` — a process-wide libsql stub decided whether the claim test ran

Seven failures, none reproducible with the file alone:

```
AssertionError: the first sight of a delivery did not win the claim
assert <MagicMock name='mock.execute().fetchall()'> == [('aaaa...activity.xml')]
```

`test_db_readers.py` installs `sys.modules["libsql_experimental"]` as a MagicMock at **import** time, process-wide and never undone, guarded only by `not in sys.modules` — true whenever the real driver merely has not been imported *yet*. Python imports every collected module before running any test, so a file later in the shard poisons one earlier; bisected to the pair `test_db_readers.py test_flex_delivery_claim_writer.py`, 7 failures in 0.22s.

`test_flex_delivery_claim_writer.py` exists precisely to exercise the claim against a **real** libsql connection — T-250 is `rowcount` (Python driver) versus `rows_affected` (JS driver), and whether the INSERT commits. A MagicMock answers both, so collection order silently decided whether the file proved anything at all.

The stub now installs only on a real `ImportError`, and `test_the_driver_under_test_is_the_real_one` fails with a sentence rather than a MagicMock comparison if a stub ever shadows it again.

## 5. `Vitest (shard 4/8)` — a test asserting a fallback R-404 removed

`falls back to the relay close only when the payload carries no history` — expected null to be 14.52.

R-404 (`1cd6e16b`) removed the relay-close fallback on purpose: `prices.*.close` is IB's tick-9 close cached in the relay's memory for the life of the process, and the guard that read it was `data?.history?.length`, so it fired exactly when history was **empty** — the degraded case, since the regime route sets `history: []` on any upstream failure. The least trustworthy state was the one drawing a signed, coloured day change with no stale marker.

`d921debf` rewrote this file onto the real implementation (T-280) but wrote this case against the behaviour R-404 had already replaced. The sibling case two above it already pins "an absent baseline renders absent"; this one now pins the same contract for the no-history payload.

## ⚠️ Merging this requires a root bootstrap before the next deploy

`cloud/scripts/deploy-root-helper.sh` is control-plane-manifested, so deploy preflight will abort with `[preflight] installed control plane is incompatible with ...` until root bootstrap installs the new control plane. Runbook (`cloud/CLAUDE.md`, "Safe control-plane refresh"), to run while the CI gate is still going:

```bash
sudo -u radon -H git -C /home/radon/radon fetch && git -C /home/radon/radon merge --ff-only <sha>
# then as root:
cd /home/radon/radon && bash cloud/scripts/bootstrap-control-plane.sh
```

I could not do this myself — SSH to the VPS is blackholed on port 22 from this machine (NordVPN).

## Follow-up, not fixed here

Same defect class as #2: `_leap_last_scan`, `_theta_last_scan`, `_strength_last_scan`, `_garch_last_scan`, `_gamma_rotation_last_scan` and `_flow_tab_last` all compare `time.monotonic()` against `0.0` sentinels (`scripts/api/server.py:2120, 3488, 3631, 3723, 4091, 4205`), so each refuses its first scan as "cooling down" for up to one full cooldown after a host reboot.

## Verification

- Red first for every fix. #1: 7 bootstrap failures → 2 shipped-drop-in failures → green. #4: bisected to a 2-file, 0.22s repro.
- **Full pytest: 8482 passed, 0 failed** (was 27 failed at the start of this work).
- `cloud/tests`: 1359 passed, 3 failed — all `caddy is not on PATH`, which CI installs in this shard.
- Full vitest: 8000 tests, the only non-passes being two source-file-path tests that resolve against cwd and fail in a linked worktree; both green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)