### PR TITLE
fix(newsfeed): write images into the media volume the container mounts

### DIFF
--- a/cloud/scripts/radon-app-runtime.sh
+++ b/cloud/scripts/radon-app-runtime.sh
@@ -7,6 +7,10 @@ set -euo pipefail
 
 readonly APP_UNITS="radon-api.service radon-nextjs.service radon-relay.service radon-monitor.service radon-newsfeed.service"
 
+# Where the media volume lands INSIDE the container. Fixed regardless of the
+# host path, because Caddy's root and the newsfeed's download dir must agree.
+readonly MEDIA_DIR_IN_CONTAINER=/var/lib/radon/media
+
 if [[ "${RADON_APP_RUNTIME_TEST_MODE:-0}" == "1" ]]; then
   DOCKER="${RADON_TEST_DOCKER:?test docker is required}"
   ID_BIN="${RADON_TEST_ID:?test id is required}"
@@ -202,7 +206,7 @@ cmd_run() {
     --env PYTHONPATH=/home/radon/radon/scripts \
     -w "$workdir" \
     -v "${DATA_DIR}:/home/radon/radon/data" \
-    -v "${MEDIA_DIR}:/var/lib/radon/media" \
+    -v "${MEDIA_DIR}:${MEDIA_DIR_IN_CONTAINER}" \
     -v "${LEASE_DIR}:/var/lib/radon/ib-lease"
 
   if [[ -n "${NOTIFY_SOCKET:-}" && "${NOTIFY_SOCKET}" == /* ]]; then
@@ -225,11 +229,20 @@ cmd_run() {
       newsfeed_browsers="${RADON_NEWSFEED_BROWSERS_PATH:-/home/radon/.cache/ms-playwright}"
       newsfeed_scripts="${RADON_NEWSFEED_SCRIPTS_PATH:-/home/radon/radon/scripts/newsfeed}"
     fi
+    # The scraper's default media dir is <repo>/web/public/media, which lives
+    # in the image layer and is discarded on every restart, while Caddy serves
+    # the bind mount above. Point the downloader straight at the mount and
+    # override the HOST-shaped RADON_MEDIA_REMOTE that --env-file carries in
+    # (/home/radon/radon-cloud/media/ does not exist in the container), so the
+    # rsync hop collapses to a no-op instead of failing on an image with no
+    # rsync. Without this every scraped image 404s on media.radon.run.
     set -- "$@" --ipc host \
       --env PLAYWRIGHT_CHROMIUM_SANDBOX=0 \
       --env PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
       -v "${newsfeed_browsers}:/ms-playwright" \
-      -v "${newsfeed_scripts}:/home/radon/radon/scripts/newsfeed"
+      -v "${newsfeed_scripts}:/home/radon/radon/scripts/newsfeed" \
+      --env "RADON_NEWSFEED_MEDIA_DIR=${MEDIA_DIR_IN_CONTAINER}" \
+      --env "RADON_MEDIA_REMOTE=${MEDIA_DIR_IN_CONTAINER}/"
   fi
 
   set -- "$@" "$image"

--- a/cloud/tests/test_app_runtime.py
+++ b/cloud/tests/test_app_runtime.py
@@ -420,3 +420,25 @@ def test_image_workflow_exists_and_is_not_a_deploy_need() -> None:
     assert "--build-arg NEXT_PUBLIC_RADON_API_URL" in wf
     assert "--build-arg NEXT_PUBLIC_IB_REALTIME_WS_URL" in wf
     assert "vars.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY" in wf
+
+
+def test_run_newsfeed_writes_images_into_the_served_media_volume(tmp_path: Path) -> None:
+    """The scraper's default media dir is <repo>/web/public/media, which lives in
+    the image layer and is discarded on every container restart, while Caddy
+    serves the bind-mounted /var/lib/radon/media. Without this override every
+    image scraped after the container cutover 404s on media.radon.run
+    (2026-08-29 regression: 8 posts, no thumbnails)."""
+    result = _run(tmp_path, ["run", "radon-newsfeed.service"])
+    assert result.returncode == 0, result.stderr
+    log = result.docker_log.read_text(encoding="utf-8")  # type: ignore[attr-defined]
+    assert "RADON_NEWSFEED_MEDIA_DIR=/var/lib/radon/media" in log, log
+
+
+def test_run_newsfeed_points_media_delivery_at_the_mounted_volume(tmp_path: Path) -> None:
+    """/etc/radon/env carries the HOST-shaped RADON_MEDIA_REMOTE
+    (/home/radon/radon-cloud/media/), a path that does not exist inside the
+    container. --env-file would hand it straight to the scraper's rsync push."""
+    result = _run(tmp_path, ["run", "radon-newsfeed.service"])
+    assert result.returncode == 0, result.stderr
+    log = result.docker_log.read_text(encoding="utf-8")  # type: ignore[attr-defined]
+    assert "RADON_MEDIA_REMOTE=/var/lib/radon/media/" in log, log

--- a/scripts/newsfeed/backfill_tags.js
+++ b/scripts/newsfeed/backfill_tags.js
@@ -86,7 +86,7 @@ async function main() {
   let visionTagger = null;
   try {
     visionTagger = createVisionTagger({
-      publicRoot: paths.publicRoot,
+      mediaDir: paths.mediaDir,
       getTaxonomySnapshot: taxonomyFn,
     });
   } catch (err) {

--- a/scripts/newsfeed/index.js
+++ b/scripts/newsfeed/index.js
@@ -49,10 +49,10 @@ function buildTextTaggerOrNull({ projectRoot }) {
   }
 }
 
-function buildVisionTaggerOrNull({ projectRoot, publicRoot }) {
+function buildVisionTaggerOrNull({ projectRoot, mediaDir }) {
   try {
     return createVisionTagger({
-      publicRoot,
+      mediaDir,
       getTaxonomySnapshot: async () => (await loadTaxonomy(projectRoot)).tags,
     });
   } catch (err) {
@@ -208,7 +208,7 @@ export function createScraper(overrides = {}) {
       recordServiceHealth,
       buildTextTagger: () => buildTextTaggerOrNull({ projectRoot: paths.projectRoot }),
       buildVisionTagger: () =>
-        buildVisionTaggerOrNull({ projectRoot: paths.projectRoot, publicRoot: paths.publicRoot }),
+        buildVisionTaggerOrNull({ projectRoot: paths.projectRoot, mediaDir: paths.mediaDir }),
       onNewTags: async (tags) => {
         const additions = await appendTagsToTaxonomy(paths.projectRoot, tags);
         if (additions.length > 0) {

--- a/scripts/newsfeed/mediaPermissions.js
+++ b/scripts/newsfeed/mediaPermissions.js
@@ -20,6 +20,22 @@ export function localMediaDest(remote) {
   return remote.endsWith("/") ? remote.slice(0, -1) : remote;
 }
 
+// Under the P3 container runtime the served media volume is bind-mounted into
+// the scraper, so the download tree and the Caddy tree are the same directory
+// and there is no hop left to make. Compare resolved paths, not strings: the
+// host reaches the same inode through /home/radon/radon-cloud/media (a
+// symlink) and /var/lib/radon/media.
+export function isSameMediaTree(local, remote) {
+  const source = localMediaDest(local);
+  const dest = localMediaDest(remote);
+  if (!source || !dest) return false;
+  try {
+    return fs.realpathSync(source) === fs.realpathSync(dest);
+  } catch {
+    return false;
+  }
+}
+
 // R-137: the sweep chmods files in an OPERATOR-SUPPLIED directory. Without
 // an allowlist a stray storageState / cookie jar under a Caddy web root
 // becomes world-readable. Only the shapes the newsfeed actually publishes.

--- a/scripts/newsfeed/push_media.js
+++ b/scripts/newsfeed/push_media.js
@@ -8,6 +8,7 @@
 import { spawn } from "node:child_process";
 import {
   ensurePublicMediaPermissions,
+  isSameMediaTree,
   localMediaDest,
   pruneMediaTree,
 } from "./mediaPermissions.js";
@@ -29,6 +30,16 @@ export async function pushMedia({
   remote = REMOTE,
   timeoutMs = RSYNC_TIMEOUT_MS,
 } = {}) {
+  // The container runtime bind-mounts the Caddy-served volume onto the
+  // scraper's own media dir, so the images are already at their destination.
+  // rsync is not in the node image; spawning it here failed every cycle and
+  // left mediaDirty latched while media.radon.run 404'd (2026-08-29).
+  if (isSameMediaTree(local, remote)) {
+    const inPlace = { ok: true, transferred: 0, repairMode: "in-place" };
+    await repairLocalTree(inPlace, localMediaDest(remote));
+    return inPlace;
+  }
+
   const result = await new Promise((resolve) => {
     // R-137: `--ignore-existing` skipped every pre-fix 0600 image forever, so
     // they stayed 403 on media.radon.run permanently, and the post-transfer
@@ -89,28 +100,35 @@ export async function pushMedia({
     const dest = localMediaDest(remote);
     if (dest) {
       result.repairMode = "local-chmod";
-      // R-171: readdir + stat over the WHOLE tree on every 2-minute cycle, at
-      // a cost growing linearly in a directory that only grows. rsync's own
-      // --chmod already sets the mode on transferred files; this sweep is the
-      // backstop for files written before that landed, so it does not need to
-      // run 720 times a day.
-      if (Date.now() - lastSweepAt >= SWEEP_MIN_INTERVAL_MS) {
-        lastSweepAt = Date.now();
-        try {
-          result.repaired = await ensurePublicMediaPermissions(dest);
-          result.pruned = await pruneMediaTree(dest);
-        } catch (err) {
-          result.repaired = 0;
-          result.repairError = err instanceof Error ? err.message : String(err);
-        }
-      } else {
-        result.repairMode = "local-chmod-skipped";
-      }
+      await repairLocalTree(result, dest);
     } else {
       result.repairMode = "rsync-chmod";
     }
   }
   return result;
+}
+
+// Files written under UMask=0077 land 0600 and Caddy 403s them. rsync's own
+// --chmod already sets the mode on transferred files, so this sweep is only
+// the backstop for files written before that landed — and for the in-place
+// tree, where there is no rsync to do it.
+//
+// R-171: readdir + stat over the WHOLE tree on every 2-minute cycle costs
+// linearly in a directory that only grows, so it does not run 720 times a day.
+async function repairLocalTree(result, dest) {
+  if (!dest) return;
+  if (Date.now() - lastSweepAt < SWEEP_MIN_INTERVAL_MS) {
+    result.repairMode = `${result.repairMode}-skipped`;
+    return;
+  }
+  lastSweepAt = Date.now();
+  try {
+    result.repaired = await ensurePublicMediaPermissions(dest);
+    result.pruned = await pruneMediaTree(dest);
+  } catch (err) {
+    result.repaired = 0;
+    result.repairError = err instanceof Error ? err.message : String(err);
+  }
 }
 
 // Run directly: `bun run scripts/newsfeed/push_media.js [local] [remote]`

--- a/scripts/newsfeed/vision_tagger.js
+++ b/scripts/newsfeed/vision_tagger.js
@@ -43,14 +43,16 @@ function detectMediaType(filename) {
   return null;
 }
 
-// Resolves a post's first image URL to the on-disk file under publicRoot.
+// Resolves a post's first image URL to the on-disk file inside mediaDir —
+// the same directory the downloader wrote it to (resolveScraperPaths owns
+// that location; rebuilding it from publicRoot here made a second copy that
+// went stale the moment the container runtime moved the tree).
 // Accepts either form:
 //   - absolute  `https://media.radon.run/<file>`   (current — written by media.js)
 //   - relative  `/media/<file>` or `media/<file>`  (legacy — kept for
 //                                                   posts written before
 //                                                   the absolute migration)
-// Always lands at `<publicRoot>/media/<file>` on disk regardless of input.
-function resolveImageAbsolutePath(post, publicRoot) {
+function resolveImageAbsolutePath(post, mediaDir) {
   if (!Array.isArray(post.images) || post.images.length === 0) return null;
   const src = post.images[0];
   if (typeof src !== "string" || src.length === 0) return null;
@@ -66,10 +68,10 @@ function resolveImageAbsolutePath(post, publicRoot) {
     }
   }
   const trimmed = rel.replace(/^\//, "");
-  // Bare filenames (no `media/` prefix) still land under `media/` because
-  // that's where the on-disk file actually sits.
-  const prefixed = trimmed.startsWith("media/") ? trimmed : `media/${trimmed}`;
-  return path.join(publicRoot, prefixed);
+  // Legacy `/media/<file>` URLs carry a prefix that is already implied by
+  // mediaDir; strip it so both URL shapes land on the same file.
+  const filename = trimmed.startsWith("media/") ? trimmed.slice("media/".length) : trimmed;
+  return path.join(mediaDir, filename);
 }
 
 function buildUserPrompt(post) {
@@ -188,22 +190,22 @@ function parseTagsFromText(text) {
 export function createVisionTagger({
   apiKey = process.env.ANTHROPIC_API_KEY,
   model = DEFAULT_MODEL,
-  publicRoot,
+  mediaDir,
   getTaxonomySnapshot,
   readImage = (p) => fs.promises.readFile(p),
 } = {}) {
   if (!apiKey) {
     throw new Error("createVisionTagger: ANTHROPIC_API_KEY is not set");
   }
-  if (!publicRoot) {
-    throw new Error("createVisionTagger: publicRoot is required");
+  if (!mediaDir) {
+    throw new Error("createVisionTagger: mediaDir is required");
   }
   if (typeof getTaxonomySnapshot !== "function") {
     throw new Error("createVisionTagger: getTaxonomySnapshot callback is required");
   }
 
   async function tagPost(post) {
-    const imgPath = resolveImageAbsolutePath(post, publicRoot);
+    const imgPath = resolveImageAbsolutePath(post, mediaDir);
     if (!imgPath) return null;
     const mediaType = detectMediaType(imgPath);
     if (!mediaType) return null;

--- a/web/tests/newsfeed-image-url.test.ts
+++ b/web/tests/newsfeed-image-url.test.ts
@@ -250,7 +250,7 @@ describe("vision_tagger.js — resolveImageAbsolutePath handles both URL forms",
     expect(
       __resolveImageAbsolutePath(
         { images: ["https://media.radon.run/abc.png"] },
-        "/root",
+        "/root/media",
       ),
     ).toBe("/root/media/abc.png");
   });
@@ -260,7 +260,7 @@ describe("vision_tagger.js — resolveImageAbsolutePath handles both URL forms",
       "../../scripts/newsfeed/vision_tagger.js"
     );
     expect(
-      __resolveImageAbsolutePath({ images: ["/media/abc.png"] }, "/root"),
+      __resolveImageAbsolutePath({ images: ["/media/abc.png"] }, "/root/media"),
     ).toBe("/root/media/abc.png");
   });
 
@@ -269,7 +269,7 @@ describe("vision_tagger.js — resolveImageAbsolutePath handles both URL forms",
       "../../scripts/newsfeed/vision_tagger.js"
     );
     expect(
-      __resolveImageAbsolutePath({ images: ["media/abc.png"] }, "/root"),
+      __resolveImageAbsolutePath({ images: ["media/abc.png"] }, "/root/media"),
     ).toBe("/root/media/abc.png");
   });
 
@@ -278,7 +278,7 @@ describe("vision_tagger.js — resolveImageAbsolutePath handles both URL forms",
       "../../scripts/newsfeed/vision_tagger.js"
     );
     expect(
-      __resolveImageAbsolutePath({ images: ["http://"] }, "/root"),
+      __resolveImageAbsolutePath({ images: ["http://"] }, "/root/media"),
     ).toBeNull();
   });
 });

--- a/web/tests/newsfeed-push-media-in-place.test.ts
+++ b/web/tests/newsfeed-push-media-in-place.test.ts
@@ -1,0 +1,78 @@
+// The newsfeed's image delivery hop assumes two distinct trees: the scraper
+// downloads into <repo>/web/public/media on the laptop and rsyncs to the
+// Hetzner media volume that Caddy serves.
+//
+// Under the P3 container runtime there is only ONE tree. The served volume is
+// bind-mounted into the container at /var/lib/radon/media, so the scraper
+// writes its images directly where Caddy reads them and there is no hop left
+// to make. rsync is not even installed in the node image, so spawning it
+// fails, pushMedia returns ok:false, and mediaDirty never clears — the
+// 2026-08-29 regression where every scraped image 404'd on media.radon.run.
+//
+// Contract: when local and remote resolve to the same directory, pushMedia
+// must not spawn rsync at all and must still report success.
+
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let workdir: string;
+
+beforeEach(async () => {
+  workdir = await fs.mkdtemp(path.join(os.tmpdir(), "radon-media-"));
+});
+
+afterEach(async () => {
+  await fs.remove(workdir);
+});
+
+describe("pushMedia — the container's single media tree", () => {
+  it("skips rsync when local and remote are the same directory", async () => {
+    const { pushMedia } = await import("../../scripts/newsfeed/push_media.js");
+    const media = path.join(workdir, "media");
+    await fs.ensureDir(media);
+    await fs.writeFile(path.join(media, "a-01.png"), "png", { mode: 0o600 });
+
+    const result = await pushMedia({ local: `${media}/`, remote: media });
+
+    expect(result.ok).toBe(true);
+    expect(result.transferred).toBe(0);
+    expect(result.repairMode).toBe("in-place");
+    expect(result.reason).toBeUndefined();
+    // The file the scraper just wrote is still there, now Caddy-readable.
+    expect(await fs.pathExists(path.join(media, "a-01.png"))).toBe(true);
+    expect((await fs.stat(path.join(media, "a-01.png"))).mode & 0o777).toBe(0o644);
+  });
+
+  it("treats a trailing-slash and symlinked remote as the same tree", async () => {
+    const { pushMedia } = await import("../../scripts/newsfeed/push_media.js");
+    const media = path.join(workdir, "media");
+    await fs.ensureDir(media);
+    const link = path.join(workdir, "media-link");
+    await fs.symlink(media, link);
+
+    const result = await pushMedia({ local: `${media}/`, remote: `${link}/` });
+
+    expect(result.ok).toBe(true);
+    // The hourly permission sweep is throttled across calls, so only the
+    // prefix is stable here; the sweep itself is pinned by the test above.
+    expect(result.repairMode).toMatch(/^in-place/);
+  });
+
+  it("still rsyncs when the remote is a genuinely different tree", async () => {
+    const { pushMedia } = await import("../../scripts/newsfeed/push_media.js");
+    const local = path.join(workdir, "local");
+    const remote = path.join(workdir, "remote");
+    await fs.ensureDir(local);
+    await fs.ensureDir(remote);
+    await fs.writeFile(path.join(local, "b-01.png"), "png");
+
+    const result = await pushMedia({ local: `${local}/`, remote: `${remote}/` });
+
+    // Whether rsync itself succeeds depends on the host binary (macOS ships
+    // 2.6.9, which rejects --chmod), so pin only the branch: two distinct
+    // trees must never take the in-place shortcut.
+    expect(String(result.repairMode)).not.toMatch(/^in-place/);
+  });
+});

--- a/web/tests/newsfeed-vision-tagger.test.ts
+++ b/web/tests/newsfeed-vision-tagger.test.ts
@@ -32,7 +32,7 @@ function anthropicCompletion(content: string): unknown {
 }
 
 const TAXONOMY = ["BTC", "VOL", "POSITIONING", "EQUITIES"];
-const PUBLIC_ROOT = "/fake/public";
+const MEDIA_DIR = "/fake/public/media";
 
 describe("createVisionTagger.tagPost", () => {
   it("sends image + caption to Anthropic and returns the model's 3 tags normalised", async () => {
@@ -45,7 +45,7 @@ describe("createVisionTagger.tagPost", () => {
 
     const { createVisionTagger } = await import("../../scripts/newsfeed/vision_tagger.js");
     const tagger = createVisionTagger({
-      publicRoot: PUBLIC_ROOT,
+      mediaDir: MEDIA_DIR,
       getTaxonomySnapshot: async () => TAXONOMY,
       readImage: async () => fakeImage,
     });
@@ -93,7 +93,7 @@ describe("createVisionTagger.tagPost", () => {
 
     const { createVisionTagger } = await import("../../scripts/newsfeed/vision_tagger.js");
     const tagger = createVisionTagger({
-      publicRoot: PUBLIC_ROOT,
+      mediaDir: MEDIA_DIR,
       getTaxonomySnapshot: async () => TAXONOMY,
       readImage: async () => Buffer.from([]),
     });
@@ -109,7 +109,7 @@ describe("createVisionTagger.tagPost", () => {
 
     const { createVisionTagger } = await import("../../scripts/newsfeed/vision_tagger.js");
     const tagger = createVisionTagger({
-      publicRoot: PUBLIC_ROOT,
+      mediaDir: MEDIA_DIR,
       getTaxonomySnapshot: async () => TAXONOMY,
       readImage: async () => {
         throw new Error("ENOENT");
@@ -134,7 +134,7 @@ describe("createVisionTagger.tagPost", () => {
 
     const { createVisionTagger } = await import("../../scripts/newsfeed/vision_tagger.js");
     const tagger = createVisionTagger({
-      publicRoot: PUBLIC_ROOT,
+      mediaDir: MEDIA_DIR,
       getTaxonomySnapshot: async () => TAXONOMY,
       readImage: async () => Buffer.from([1, 2, 3]),
     });
@@ -160,7 +160,7 @@ describe("createVisionTagger.tagPost", () => {
 
     const { createVisionTagger } = await import("../../scripts/newsfeed/vision_tagger.js");
     const tagger = createVisionTagger({
-      publicRoot: PUBLIC_ROOT,
+      mediaDir: MEDIA_DIR,
       getTaxonomySnapshot: async () => TAXONOMY,
       readImage: async () => Buffer.from([0x89, 0x50, 0x4e, 0x47]),
     });
@@ -187,7 +187,7 @@ describe("createVisionTagger.tagPost", () => {
 
     const { createVisionTagger } = await import("../../scripts/newsfeed/vision_tagger.js");
     const tagger = createVisionTagger({
-      publicRoot: PUBLIC_ROOT,
+      mediaDir: MEDIA_DIR,
       getTaxonomySnapshot: async () => TAXONOMY,
       readImage: async () => Buffer.from([0x89, 0x50, 0x4e, 0x47]),
     });
@@ -210,7 +210,7 @@ describe("createVisionTagger.tagPost", () => {
 
     const { createVisionTagger } = await import("../../scripts/newsfeed/vision_tagger.js");
     const tagger = createVisionTagger({
-      publicRoot: PUBLIC_ROOT,
+      mediaDir: MEDIA_DIR,
       getTaxonomySnapshot: async () => TAXONOMY,
       readImage: async () => Buffer.from([0x89, 0x50, 0x4e, 0x47]),
     });
@@ -226,7 +226,7 @@ describe("createVisionTagger.tagPost", () => {
 
     const { createVisionTagger } = await import("../../scripts/newsfeed/vision_tagger.js");
     const tagger = createVisionTagger({
-      publicRoot: PUBLIC_ROOT,
+      mediaDir: MEDIA_DIR,
       getTaxonomySnapshot: async () => TAXONOMY,
       readImage: async () => Buffer.from([0x89, 0x50, 0x4e, 0x47]),
     });
@@ -240,19 +240,50 @@ describe("createVisionTagger.tagPost", () => {
     const { createVisionTagger } = await import("../../scripts/newsfeed/vision_tagger.js");
     expect(() =>
       createVisionTagger({
-        publicRoot: PUBLIC_ROOT,
+        mediaDir: MEDIA_DIR,
         getTaxonomySnapshot: async () => TAXONOMY,
       }),
     ).toThrow(/ANTHROPIC_API_KEY/);
   });
 
-  it("throws when publicRoot is missing", async () => {
+  it("throws when mediaDir is missing", async () => {
     const { createVisionTagger } = await import("../../scripts/newsfeed/vision_tagger.js");
     expect(() =>
       createVisionTagger({
         getTaxonomySnapshot: async () => TAXONOMY,
       }),
-    ).toThrow(/publicRoot/);
+    ).toThrow(/mediaDir/);
+  });
+
+  // The tagger used to rebuild the on-disk path as `<publicRoot>/media/<file>`,
+  // duplicating the download location that resolveScraperPaths already owns.
+  // Under the container runtime the media tree moves to the bind-mounted
+  // /var/lib/radon/media and that second copy of the knowledge went stale —
+  // every vision tag logged "missing image" against a path nothing writes.
+  it("reads the image from the configured media dir, not <publicRoot>/media", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      jsonResponse(anthropicCompletion(JSON.stringify({ tags: ["vol", "spx", "equities"] }))),
+    ) as unknown as typeof fetch;
+
+    const seen: string[] = [];
+    const { createVisionTagger } = await import("../../scripts/newsfeed/vision_tagger.js");
+    const tagger = createVisionTagger({
+      mediaDir: "/var/lib/radon/media",
+      getTaxonomySnapshot: async () => TAXONOMY,
+      readImage: async (p: string) => {
+        seen.push(p);
+        return Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+      },
+    });
+
+    await tagger.tagPost({
+      id: "p9",
+      title: "Vol",
+      content: "vol",
+      images: ["https://media.radon.run/p9-01.png"],
+    });
+
+    expect(seen).toEqual(["/var/lib/radon/media/p9-01.png"]);
   });
 });
 
@@ -300,17 +331,21 @@ describe("__extractFirstJsonObject (balanced-brace extractor)", () => {
 });
 
 describe("__resolveImageAbsolutePath / __detectMediaType", () => {
-  it("resolves leading-slash and bare relative paths against publicRoot", async () => {
+  it("resolves absolute, leading-slash and bare relative paths into mediaDir", async () => {
     const { __resolveImageAbsolutePath } = await import("../../scripts/newsfeed/vision_tagger.js");
-    expect(__resolveImageAbsolutePath({ images: ["/media/x.png"] }, "/root")).toBe("/root/media/x.png");
-    expect(__resolveImageAbsolutePath({ images: ["media/x.png"] }, "/root")).toBe("/root/media/x.png");
+    expect(__resolveImageAbsolutePath({ images: ["/media/x.png"] }, "/root/media")).toBe("/root/media/x.png");
+    expect(__resolveImageAbsolutePath({ images: ["media/x.png"] }, "/root/media")).toBe("/root/media/x.png");
+    expect(__resolveImageAbsolutePath({ images: ["x.png"] }, "/root/media")).toBe("/root/media/x.png");
+    expect(
+      __resolveImageAbsolutePath({ images: ["https://media.radon.run/x.png"] }, "/root/media"),
+    ).toBe("/root/media/x.png");
   });
 
   it("returns null for empty/missing images", async () => {
     const { __resolveImageAbsolutePath } = await import("../../scripts/newsfeed/vision_tagger.js");
-    expect(__resolveImageAbsolutePath({}, "/root")).toBeNull();
-    expect(__resolveImageAbsolutePath({ images: [] }, "/root")).toBeNull();
-    expect(__resolveImageAbsolutePath({ images: [""] }, "/root")).toBeNull();
+    expect(__resolveImageAbsolutePath({}, "/root/media")).toBeNull();
+    expect(__resolveImageAbsolutePath({ images: [] }, "/root/media")).toBeNull();
+    expect(__resolveImageAbsolutePath({ images: [""] }, "/root/media")).toBeNull();
   });
 
   it("detects media type from extension", async () => {


### PR DESCRIPTION
## What broke

`radon-newsfeed` was cut over to the container runtime at **2026-08-28 22:50 UTC**. `radon-app-runtime.sh` bind-mounts only `data/`, the media volume, and the IB lease dir. The scraper's media dir still defaulted to `<repo>/web/public/media`, which inside the container is an image layer nothing serves — Caddy serves the bind mount.

Every image scraped after the cutover 404'd on `media.radon.run`. Clean cutoff: last good `2026-08-28T22:05Z`, first bad `2026-08-29T00:00Z`, 8 dashboard posts with broken thumbnails.

The rsync hop could not bridge the two trees either: the node image has no `rsync` binary, and `/etc/radon/env` carries the host-shaped `RADON_MEDIA_REMOTE=/home/radon/radon-cloud/media/`, a path absent inside the container.

## Fix

- `radon-app-runtime` points the newsfeed's download dir and delivery target at the mount, so the scraper writes straight where Caddy reads.
- `pushMedia` short-circuits when local and remote resolve to the same directory — no rsync spawn, just the throttled permission + prune sweep. Resolved paths, not strings: the host reaches the same inode through the `/home/radon/radon-cloud/media` symlink.
- The vision tagger rebuilt the on-disk path as `<publicRoot>/media/<file>`, a second copy of a location `resolveScraperPaths` already owns. It now takes `mediaDir`, so relocating the tree cannot strand it again.

## Verification

Production was mitigated ahead of this PR via `/etc/radon/env` (`RADON_NEWSFEED_MEDIA_DIR`, `RADON_MEDIA_REMOTE`) plus a copy of the 22 stranded images into `/var/lib/radon/media`. All previously-404 URLs now return `200 image/png`; new images land directly in the served tree (`pushedToHetzner=0`). This PR makes that the code contract.

`cloud/tests/test_app_runtime.py` 32 passed (2 new, red before the fix). Newsfeed vitest files all pass.

## ⚠️ Deploy note

`cloud/scripts/radon-app-runtime.sh` is control-plane-manifested, so deploy preflight fails until root bootstrap runs on the VPS:

```
cd /home/radon/radon && bash cloud/scripts/bootstrap-control-plane.sh
```

`main` is also currently red from unrelated failures in `test_rel146_flex_sftp_honesty.py` and `test_rel148_operability_fixes.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016XHuszj8x1R9z6Y99K4xDM