### PR TITLE
feat(assistant): stop mapping review watch list to scan

### DIFF
--- a/web/lib/agent/turnSteps.ts
+++ b/web/lib/agent/turnSteps.ts
@@ -29,6 +29,8 @@ const TOOL_LABELS: Record<string, string> = {
   get_realized_pnl: "Read realized P&L",
   query_journal: "Query trade journal",
   place_order: "Stage order proposal",
+  list_apis: "Search API catalog",
+  call_api: "Call Radon API",
 };
 
 /**

--- a/web/lib/data.ts
+++ b/web/lib/data.ts
@@ -24,9 +24,6 @@ export const PI_COMMAND_ALIASES: Record<string, string> = {
   "compare support vs against": "/scan --top 20",
   "action items": "/journal --limit 25",
   "what are action items": "/journal --limit 25",
-  "review watch list": "/scan --top 12",
-  "watch list": "/scan --top 12",
-  "watchlist": "/scan --top 12",
 };
 
 export const NAV_GROUP_LABEL: Record<import("./types").NavGroupId, string> = {

--- a/web/tests/agent-derivations.test.ts
+++ b/web/tests/agent-derivations.test.ts
@@ -75,6 +75,11 @@ describe("buildTurnSteps", () => {
     expect(describeTool("get_brand_new_thing")).toBe("Get brand new thing");
     expect(describeTool("get_flow")).toBe("Read dark-pool flow");
   });
+
+  it("labels catalog dispatcher tools for EngineTrace", () => {
+    expect(describeTool("list_apis")).toBe("Search API catalog");
+    expect(describeTool("call_api")).toBe("Call Radon API");
+  });
 });
 
 describe("describeEngines / formatElapsed", () => {

--- a/web/tests/chat.test.ts
+++ b/web/tests/chat.test.ts
@@ -44,8 +44,14 @@ test("routeToPiPrompt routes direct commands", () => {
 test("routeToPiPrompt routes aliases", () => {
   expect(routeToPiPrompt("compare support vs against")).toBe("/scan --top 20");
   expect(routeToPiPrompt("action items")).toBe("/journal --limit 25");
-  expect(routeToPiPrompt("watch list")).toBe("/scan --top 12");
-  expect(routeToPiPrompt("watchlist")).toBe("/scan --top 12");
+});
+
+test("routeToPiPrompt does not map watchlist phrases to /scan", () => {
+  expect(routeToPiPrompt("review watch list")).toBe(null);
+  expect(routeToPiPrompt("watch list")).toBe(null);
+  expect(routeToPiPrompt("watchlist")).toBe(null);
+  expect(routeToPiPrompt("/scan")).toBe("/scan");
+  expect(routeToPiPrompt("portfolio")).toBe("/portfolio");
 });
 
 test("routeToPiPrompt routes analyze to evaluate", () => {

--- a/web/tests/data.test.ts
+++ b/web/tests/data.test.ts
@@ -85,8 +85,15 @@ describe("PI_COMMAND_ALIASES", () => {
   });
 
   it("contains known aliases", () => {
-    expect(PI_COMMAND_ALIASES["watchlist"]).toBeDefined();
-    expect(PI_COMMAND_ALIASES["action items"]).toBeDefined();
+    expect(PI_COMMAND_ALIASES["compare support vs against"]).toBe("/scan --top 20");
+    expect(PI_COMMAND_ALIASES["action items"]).toBe("/journal --limit 25");
+    expect(PI_COMMAND_ALIASES["what are action items"]).toBe("/journal --limit 25");
+  });
+
+  it("does not map watchlist phrases to scan", () => {
+    expect(PI_COMMAND_ALIASES["review watch list"]).toBeUndefined();
+    expect(PI_COMMAND_ALIASES["watch list"]).toBeUndefined();
+    expect(PI_COMMAND_ALIASES["watchlist"]).toBeUndefined();
   });
 
   it("aliases map to known command roots", () => {


### PR DESCRIPTION
Alias honesty. review watch list is no longer a silent scan.

- Removed PI aliases for `review watch list`, `watch list`, and `watchlist` so they no longer run `/scan --top 12`.
- Direct `/scan` and remaining aliases (`compare support vs against`, `action items`) are unchanged.
- Conversational watchlist goes to the assistant (PR2 `call_api`).
- EngineTrace labels: `list_apis` = Search API catalog, `call_api` = Call Radon API.

Tests: `web/tests/chat.test.ts`, `web/tests/data.test.ts`, `web/tests/agent-derivations.test.ts` (89 passed).