### PR TITLE
feat(assistant): pin every API route with a chat capability

### DIFF
--- a/.claude/skills/new-indicator/SKILL.md
+++ b/.claude/skills/new-indicator/SKILL.md
@@ -71,6 +71,7 @@ Modify (lockstep pins — miss one and a test fails, which is the point):
 ## 3. API route (`web/app/api/<name>/route.ts`)
 
 - `export const dynamic = "force-dynamic"; export const runtime = "nodejs";` — GET only unless there is a real on-demand trigger (breadth's POST proxies FastAPI with cooldown + single-flight).
+- `export const radonCapability = "read";` (GET market data). On-demand POST scans use a method map with `read.spawn`. Unclassified routes fail `web/tests/assistant-catalog-pin.test.ts`.
 - Read through **`dbFirstRead`** (`web/lib/dbFirstRead.ts`): `fromDb` selects the latest `scan_snapshots` row (`WHERE service = '<name>' ORDER BY scan_time DESC LIMIT 1`), `fromDisk` reads `data/<name>.json`, and the helper serves whichever content timestamp is fresher.
 - `MAX_AGE_MS` derives from the real cadence with slack (daily timer → 48h; 5-min timer → 30min), commented with the reasoning: "older than X means the writer is down."
 - **Missing contract**: absent data is `HTTP 200` + a frozen `{ missing: true, scan_time: null, series: [], ... }` object — never a 4xx (feedback_http_status_for_real_errors).

--- a/scripts/api/assistant_catalog.py
+++ b/scripts/api/assistant_catalog.py
@@ -1,0 +1,128 @@
+"""Chat capability pin map for FastAPI routes.
+
+Unclassified live routes fail CI. This module is classification only:
+no OpenAPI fetch, no dispatch, no radonFetch equivalent.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+Capability = Literal[
+    "read",
+    "read.spawn",
+    "mutate.workspace",
+    "mutate.trading",
+    "admin",
+    "internal",
+]
+
+REFUSED_CAPABILITIES: frozenset[str] = frozenset(
+    {"admin", "internal", "mutate.trading"}
+)
+
+CatalogKey = tuple[str, str]
+
+CATALOG: dict[CatalogKey, Capability] = {
+    ("GET", "/admin/services"): "admin",
+    ("POST", "/admin/services/{unit}/{action}"): "admin",
+    ("POST", "/admin/stack/restart"): "admin",
+    ("GET", "/attribution"): "read",
+    ("GET", "/backtest"): "read",
+    ("GET", "/backtest/{strategy}"): "read",
+    ("POST", "/blotter"): "mutate.workspace",
+    ("POST", "/bpi/scan"): "read.spawn",
+    ("POST", "/breadth/scan"): "read.spawn",
+    ("GET", "/cash-flows"): "read",
+    ("GET", "/catalysts"): "read",
+    ("POST", "/contract/qualify"): "read.spawn",
+    ("POST", "/cta/share"): "internal",
+    ("POST", "/demo/trial-expiry"): "internal",
+    ("POST", "/discover"): "read.spawn",
+    ("GET", "/docs"): "internal",
+    ("GET", "/docs/oauth2-redirect"): "internal",
+    ("GET", "/earnings"): "read",
+    ("GET", "/earnings/{ticker}"): "read",
+    ("GET", "/event-odds/{ticker}"): "read",
+    ("POST", "/flow-analysis"): "read.spawn",
+    ("GET", "/flow-analysis/{ticker}"): "read",
+    ("POST", "/flow-analysis/{ticker}"): "read.spawn",
+    ("POST", "/flow-surprise"): "read.spawn",
+    ("POST", "/forecast/chronos"): "read.spawn",
+    ("GET", "/futures/chain"): "read",
+    ("POST", "/gamma-rotation/scan"): "read.spawn",
+    ("POST", "/garch-convergence/scan"): "read.spawn",
+    ("POST", "/gex/scan"): "read.spawn",
+    ("POST", "/gex/share"): "internal",
+    ("GET", "/health"): "internal",
+    ("GET", "/health/lite"): "internal",
+    ("POST", "/historical/bars"): "read.spawn",
+    ("POST", "/historical/head-timestamp"): "read.spawn",
+    ("POST", "/ib/reset-backoff"): "admin",
+    ("POST", "/ib/restart"): "admin",
+    ("GET", "/index-options/chain"): "read",
+    ("GET", "/informed-flow/{ticker}"): "read",
+    ("POST", "/internals/share"): "internal",
+    ("GET", "/internals/skew-history"): "read",
+    ("POST", "/journal/reconcile"): "mutate.workspace",
+    ("POST", "/journal/rehydrate"): "mutate.workspace",
+    ("GET", "/knowledge/prior-evals"): "read",
+    ("POST", "/knowledge/search"): "read",
+    ("POST", "/leap/scan"): "read.spawn",
+    ("GET", "/llm-token-index"): "read",
+    ("GET", "/market-calendar"): "read",
+    ("POST", "/market-calendar/refresh"): "read.spawn",
+    ("GET", "/openapi.json"): "internal",
+    ("GET", "/options/chain"): "read",
+    ("GET", "/options/expirations"): "read",
+    ("GET", "/options/exposure/{symbol}"): "read",
+    ("GET", "/options/rv-ratio/{symbol}"): "read",
+    ("POST", "/options/rv-ratio/{symbol}/scan"): "read.spawn",
+    ("GET", "/options/uw-chain"): "read",
+    ("POST", "/orders/cancel"): "mutate.trading",
+    ("POST", "/orders/cancel-all"): "mutate.trading",
+    ("POST", "/orders/modify"): "mutate.trading",
+    ("POST", "/orders/place"): "mutate.trading",
+    ("POST", "/orders/refresh"): "mutate.workspace",
+    ("POST", "/orders/replace"): "mutate.trading",
+    ("POST", "/orders/whatif"): "read.spawn",
+    ("POST", "/paper/place"): "mutate.trading",
+    ("POST", "/performance"): "read.spawn",
+    ("POST", "/performance/background"): "read.spawn",
+    ("POST", "/pi/exec"): "internal",
+    ("POST", "/portfolio/background-sync"): "mutate.workspace",
+    ("POST", "/portfolio/sync"): "mutate.workspace",
+    ("GET", "/preferences"): "read",
+    ("DELETE", "/preferences/{key}"): "mutate.workspace",
+    ("PUT", "/preferences/{key}"): "mutate.workspace",
+    ("GET", "/quote/{ticker}"): "read",
+    ("GET", "/redoc"): "internal",
+    ("POST", "/regime/scan"): "read.spawn",
+    ("POST", "/regime/share"): "internal",
+    ("POST", "/scan"): "read.spawn",
+    ("GET", "/share/content"): "internal",
+    ("GET", "/short-availability/{ticker}"): "read",
+    ("POST", "/strength-confirmation/scan"): "read.spawn",
+    ("POST", "/theta-harvester/scan"): "read.spawn",
+    ("GET", "/ticker/ratings"): "read",
+    ("POST", "/trading/halt"): "admin",
+    ("POST", "/trading/kill"): "admin",
+    ("POST", "/trading/resume"): "admin",
+    ("GET", "/trading/status"): "admin",
+    ("GET", "/uw/usage"): "read",
+    ("POST", "/uw/usage/record"): "internal",
+    ("POST", "/vcg/scan"): "read.spawn",
+    ("POST", "/vcg/share"): "internal",
+    ("POST", "/workflow/run"): "mutate.trading",
+    ("POST", "/ws-ticket"): "internal",
+    ("POST", "/ws-ticket/validate"): "internal",
+}
+
+
+def is_refused(cap: str) -> bool:
+    return cap in REFUSED_CAPABILITIES
+
+
+def capability_for(method: str, path: str) -> Capability | None:
+    """Look up a pinned capability. Unpinned routes, including POSTs, deny."""
+    return CATALOG.get((method.upper(), path))

--- a/scripts/api/tests/test_assistant_catalog.py
+++ b/scripts/api/tests/test_assistant_catalog.py
@@ -1,0 +1,97 @@
+"""Every live FastAPI (method, path) must be pinned with a chat capability."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from starlette.routing import Route
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def _iter_app_routes():
+    from scripts.api.server import app
+
+    for route in app.routes:
+        if not isinstance(route, Route):
+            continue
+        verbs = sorted((route.methods or set()) - {"HEAD", "OPTIONS"})
+        for verb in verbs:
+            yield verb, route.path
+
+
+class TestAssistantCatalog:
+    def test_every_live_route_is_pinned(self):
+        from scripts.api.assistant_catalog import CATALOG, capability_for
+
+        live = sorted(_iter_app_routes())
+        assert len(live) >= 40, (
+            f"Expected a non-trivial FastAPI surface; got {len(live)}"
+        )
+
+        unclassified = [
+            (method, path)
+            for method, path in live
+            if capability_for(method, path) is None
+        ]
+        assert unclassified == [], (
+            "unclassified FastAPI routes must be pinned in "
+            f"assistant_catalog.CATALOG: {unclassified}"
+        )
+
+        live_set = set(live)
+        stale = sorted(key for key in CATALOG if key not in live_set)
+        assert stale == [], f"catalog pins missing from app.routes: {stale}"
+
+    def test_named_pins(self):
+        from scripts.api.assistant_catalog import capability_for, is_refused
+
+        assert capability_for("POST", "/orders/place") == "mutate.trading"
+        assert capability_for("POST", "/pi/exec") == "internal"
+        assert capability_for("GET", "/quote/{ticker}") == "read"
+        assert is_refused("mutate.trading")
+        assert is_refused("internal")
+        assert is_refused("admin")
+        assert not is_refused("read")
+        assert not is_refused("read.spawn")
+        assert not is_refused("mutate.workspace")
+
+    def test_admin_ib_trading_prefixes_are_admin(self):
+        from scripts.api.assistant_catalog import CATALOG
+
+        for (method, path), cap in CATALOG.items():
+            if (
+                path.startswith("/admin")
+                or path.startswith("/ib/")
+                or path.startswith("/trading")
+            ):
+                assert cap == "admin", f"{method} {path} must be admin"
+
+    def test_scan_posts_are_read_spawn(self):
+        from scripts.api.assistant_catalog import capability_for
+
+        scans = (
+            "/scan",
+            "/discover",
+            "/gex/scan",
+            "/vcg/scan",
+            "/regime/scan",
+            "/breadth/scan",
+            "/leap/scan",
+            "/garch-convergence/scan",
+            "/theta-harvester/scan",
+            "/strength-confirmation/scan",
+            "/gamma-rotation/scan",
+            "/bpi/scan",
+        )
+        for path in scans:
+            assert capability_for("POST", path) == "read.spawn", path
+
+    def test_unpinned_post_is_default_deny(self):
+        from scripts.api.assistant_catalog import capability_for
+
+        assert capability_for("POST", "/not-a-real-route") is None
+        assert capability_for("GET", "/not-a-real-route") is None

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -7,6 +7,7 @@ Applies under `web/`. Mirrors `web/CLAUDE.md`; prefer the Claude file if it is n
 - Next.js 16 build uses `next build --experimental-build-mode=compile`.
 - `app/error.tsx`, `app/[ticker]/not-found.tsx`, and `app/global-error.tsx` must stay pure JSX with plain `<a>` links, no `next/link`, no `useEffect`, and no `globals.css`.
 - Every GET handler reading live disk state (`data/*.json`, `data/menthorq_cache/`) must export `dynamic = "force-dynamic"`.
+- New `app/api/**/route.ts(x)` files must `export const radonCapability` (usually GET `"read"`). Pin: `web/tests/assistant-catalog-pin.test.ts`.
 - Every client fetch hitting those routes must use `cache: "no-store"`. Contract test: `web/tests/api-routes-no-cache-contract.test.ts`.
 - Middleware runs in Edge runtime; no `node:*` imports in `web/middleware.ts`.
 - Use `RADON_AUTHLESS_TEST=1` for Playwright.

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -20,6 +20,10 @@ Every Next.js GET handler reading live disk state (`data/*.json`, `data/menthorq
 
 The covered route + hook set is pinned by the contract test: `web/tests/api-routes-no-cache-contract.test.ts`.
 
+## Assistant catalog pin
+
+Every `web/app/api/**/route.ts(x)` must `export const radonCapability` (`read` | `read.spawn` | `mutate.workspace` | `mutate.trading` | `admin` | `internal`, or a method map of those). Unclassified routes fail `web/tests/assistant-catalog-pin.test.ts`. New GET indicator routes are usually `"read"`.
+
 **Offline-fallback exception (SW only, shipped 2026-07-22).** The service worker intercepts HTML navigations plus an allowlisted `/api` GET set NETWORK-FIRST. Cache Storage (a separate store from the HTTP cache the contract targets) is written on ok responses with real payloads and read ONLY when `fetch()` rejects (network failure) — never on `res.ok === false`, never as a race/timeout. Offline-served responses carry `X-Radon-Offline: 1` + `X-Radon-Cached-At`. Online behavior is byte-identical; `force-dynamic` + `no-store` remain mandatory and untouched. Decision logic lives in `web/public/sw-decisions.js`, pinned by `web/tests/sw-decisions.test.ts` + `web/tests/sw-smoke.test.ts`. Details that bite:
 
 - Degraded 200s never enter the cache: `missing: true` bodies and per-route `API_BODY_VALIDATORS` (scanner needs `scan_time`, ticker-info needs non-empty `uw_info`) protect last-known-good from being overwritten by a 200-shaped failure.

--- a/web/app/api/admin/demo-users/route.ts
+++ b/web/app/api/admin/demo-users/route.ts
@@ -50,6 +50,8 @@ function deps(): AdminActionDeps {
   };
 }
 
+export const radonCapability = { GET: "admin", POST: "admin" };
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const admin = await requireDemoAdmin();

--- a/web/app/api/admin/edge-health/route.ts
+++ b/web/app/api/admin/edge-health/route.ts
@@ -66,6 +66,8 @@ async function readStatus(url: string): Promise<Record<string, unknown>> {
   }
 }
 
+export const radonCapability = "admin";
+
 export async function GET(): Promise<Response> {
   const access = await requireRouteAccess(undefined, { operatorOnly: true });
   if (!access.ok) return access.response;

--- a/web/app/api/admin/health/route.ts
+++ b/web/app/api/admin/health/route.ts
@@ -14,6 +14,8 @@ import {
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+export const radonCapability = "admin";
+
 export async function GET(): Promise<Response> {
   const access = await requireRouteAccess(undefined, { operatorOnly: true });
   if (!access.ok) return access.response;

--- a/web/app/api/admin/host-metrics/route.ts
+++ b/web/app/api/admin/host-metrics/route.ts
@@ -50,6 +50,8 @@ async function readHostMetricsPayload(): Promise<HostMetricsPayload> {
   return { window_ms: HOST_METRICS_WINDOW_MS, since, rows };
 }
 
+export const radonCapability = "admin";
+
 export async function GET(): Promise<Response> {
   const access = await requireRouteAccess(undefined, { operatorOnly: true });
   if (!access.ok) return access.response;

--- a/web/app/api/admin/ib/reset-backoff/route.ts
+++ b/web/app/api/admin/ib/reset-backoff/route.ts
@@ -10,6 +10,8 @@ import { requireRouteAccess } from "@/lib/routeAccess";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+export const radonCapability = "admin";
+
 export async function POST(): Promise<Response> {
   const access = await requireRouteAccess(undefined, { operatorOnly: true });
   if (!access.ok) return access.response;

--- a/web/app/api/admin/ib/restart/route.ts
+++ b/web/app/api/admin/ib/restart/route.ts
@@ -10,6 +10,8 @@ import { requireRouteAccess } from "@/lib/routeAccess";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+export const radonCapability = "admin";
+
 export async function POST(): Promise<Response> {
   const access = await requireRouteAccess(undefined, { operatorOnly: true });
   if (!access.ok) return access.response;

--- a/web/app/api/admin/reliability/route.ts
+++ b/web/app/api/admin/reliability/route.ts
@@ -71,6 +71,8 @@ async function readReliabilityPayload(): Promise<ReliabilityHistoryPayload> {
   return { window_ms: RELIABILITY_WINDOW_MS, since, events, baseline, truncated };
 }
 
+export const radonCapability = "admin";
+
 export async function GET(): Promise<Response> {
   const access = await requireRouteAccess(undefined, { operatorOnly: true });
   if (!access.ok) return access.response;

--- a/web/app/api/admin/services/[unit]/[action]/route.ts
+++ b/web/app/api/admin/services/[unit]/[action]/route.ts
@@ -13,6 +13,8 @@ export const runtime = "nodejs";
 const ALLOWED_ACTIONS = new Set(["start", "stop", "restart"]);
 const UNIT_PATTERN = /^radon-[a-z0-9-]+(?:\.service|\.timer)?$|^radon-ib-gateway\.service$/;
 
+export const radonCapability = "admin";
+
 export async function POST(
   _req: NextRequest,
   { params }: { params: Promise<{ unit: string; action: string }> },

--- a/web/app/api/admin/services/route.ts
+++ b/web/app/api/admin/services/route.ts
@@ -10,6 +10,8 @@ import { requireRouteAccess } from "@/lib/routeAccess";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+export const radonCapability = "admin";
+
 export async function GET(): Promise<Response> {
   const access = await requireRouteAccess(undefined, { operatorOnly: true });
   if (!access.ok) return access.response;

--- a/web/app/api/admin/slo/route.ts
+++ b/web/app/api/admin/slo/route.ts
@@ -56,6 +56,8 @@ async function readSloPayload(): Promise<SloPayload> {
   return { window_ms: SLO_WINDOW_MS, since, rows };
 }
 
+export const radonCapability = "admin";
+
 export async function GET(): Promise<Response> {
   const access = await requireRouteAccess(undefined, { operatorOnly: true });
   if (!access.ok) return access.response;

--- a/web/app/api/admin/stack/restart/route.ts
+++ b/web/app/api/admin/stack/restart/route.ts
@@ -15,6 +15,8 @@ export const runtime = "nodejs";
 // an in-flight success. The UI keeps polling read-only health afterward.
 const PROXY_TIMEOUT_MS = 5_000;
 
+export const radonCapability = "admin";
+
 export async function POST(_req: NextRequest): Promise<Response> {
   const access = await requireRouteAccess(undefined, { operatorOnly: true });
   if (!access.ok) return access.response;

--- a/web/app/api/admin/trading/[action]/route.ts
+++ b/web/app/api/admin/trading/[action]/route.ts
@@ -42,6 +42,8 @@ function upstreamError(error: unknown, requestId: string): Response {
   );
 }
 
+export const radonCapability = { GET: "admin", POST: "admin" };
+
 export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ action: string }> },

--- a/web/app/api/alerts/[id]/route.ts
+++ b/web/app/api/alerts/[id]/route.ts
@@ -6,6 +6,8 @@ import { requireRouteAccess } from "@/lib/routeAccess";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+export const radonCapability = "mutate.workspace";
+
 export async function DELETE(
   req: Request,
   { params }: { params: Promise<{ id: string }> },

--- a/web/app/api/alerts/route.ts
+++ b/web/app/api/alerts/route.ts
@@ -44,6 +44,8 @@ function rowToRule(row: AlertRuleRow) {
   };
 }
 
+export const radonCapability = { GET: "read", POST: "mutate.workspace" };
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const access = await requireRouteAccess(undefined, {

--- a/web/app/api/assistant/route.ts
+++ b/web/app/api/assistant/route.ts
@@ -101,6 +101,8 @@ function toTelemetryToolCalls(toolEvents: ToolEvent[]): AssistantTurnToolCall[] 
   }));
 }
 
+export const radonCapability = "internal";
+
 export async function POST(request: NextRequest): Promise<Response> {
   const access = await requireRouteAccess(request, {
     rate: { key: "assistant:route", limit: 10, windowMs: 60_000 },

--- a/web/app/api/attribution/route.ts
+++ b/web/app/api/attribution/route.ts
@@ -6,6 +6,8 @@ import { radonFetch } from "@/lib/radonApi";
 
 export const runtime = "nodejs";
 
+export const radonCapability = "read";
+
 export async function GET() {
   const access = await requireRouteAccess(undefined, { rate: { key: "attribution:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/backtest/[strategy]/route.ts
+++ b/web/app/api/backtest/[strategy]/route.ts
@@ -24,6 +24,8 @@ const STRATEGIES = new Set([
   "vcg",
 ]);
 
+export const radonCapability = "read";
+
 export async function GET(
   request: Request,
   context: { params: Promise<{ strategy: string }> },

--- a/web/app/api/blotter/route.ts
+++ b/web/app/api/blotter/route.ts
@@ -71,6 +71,8 @@ async function buildFromJournal(): Promise<BlotterPayload | null> {
   return null;
 }
 
+export const radonCapability = { GET: "read", POST: "mutate.workspace" };
+
 export async function GET(): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "blotter:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/bookmarks/[post_id]/route.ts
+++ b/web/app/api/bookmarks/[post_id]/route.ts
@@ -6,6 +6,8 @@ import { getRequestId, jsonApiError, setNoStoreResponseHeaders } from "@/lib/api
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+export const radonCapability = "mutate.workspace";
+
 export async function DELETE(
   _req: Request,
   { params }: { params: Promise<{ post_id: string }> },

--- a/web/app/api/bookmarks/route.ts
+++ b/web/app/api/bookmarks/route.ts
@@ -31,6 +31,8 @@ function rowToBookmark(row: BookmarkRow) {
   };
 }
 
+export const radonCapability = { GET: "read", POST: "mutate.workspace" };
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const { userId } = await auth();

--- a/web/app/api/bpi/route.ts
+++ b/web/app/api/bpi/route.ts
@@ -70,6 +70,8 @@ function withAllIndices(doc: BpiDoc): {
   return { generated_at: doc.generated_at ?? null, indices };
 }
 
+export const radonCapability = "read";
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const result = await dbFirstRead({

--- a/web/app/api/breadth/route.ts
+++ b/web/app/api/breadth/route.ts
@@ -61,6 +61,8 @@ async function readCachedBreadth(): Promise<Record<string, unknown> | null> {
   return result.ok ? result.data : null;
 }
 
+export const radonCapability = { GET: "read", POST: "read.spawn" };
+
 export async function GET(): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "breadth:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/cash-flows/route.ts
+++ b/web/app/api/cash-flows/route.ts
@@ -10,6 +10,8 @@ import { getRequestId, setNoStoreResponseHeaders } from "@/lib/apiContracts";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+export const radonCapability = "read";
+
 export async function GET(req: NextRequest) {
   const access = await requireRouteAccess();
   if (!access.ok) return access.response;

--- a/web/app/api/catalysts/route.ts
+++ b/web/app/api/catalysts/route.ts
@@ -53,6 +53,8 @@ async function readCatalystsFromDisk(): Promise<TimestampedRead<CatalystsPayload
   return { data, timestampMs: contentTimestampMs(data.scan_time) };
 }
 
+export const radonCapability = "read";
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const result = await cachedRead("catalysts:snapshot", READ_CACHE_TTL_MS, () =>

--- a/web/app/api/cor/route.ts
+++ b/web/app/api/cor/route.ts
@@ -49,6 +49,8 @@ async function readCorFromDisk(): Promise<TimestampedRead<Record<string, unknown
   return { data, timestampMs: contentTimestampMs(data.scan_time) };
 }
 
+export const radonCapability = "read";
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const result = await dbFirstRead({

--- a/web/app/api/credit-spread/route.ts
+++ b/web/app/api/credit-spread/route.ts
@@ -48,6 +48,8 @@ async function readCreditSpreadFromDisk(): Promise<TimestampedRead<Record<string
   return { data, timestampMs: contentTimestampMs(data.scan_time) };
 }
 
+export const radonCapability = "read";
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const result = await dbFirstRead({

--- a/web/app/api/discover/route.ts
+++ b/web/app/api/discover/route.ts
@@ -84,6 +84,8 @@ function buildCacheMetaFromMs(ms: number): CacheMeta {
   };
 }
 
+export const radonCapability = { GET: "read", POST: "read.spawn" };
+
 export async function GET(): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "discover:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/divyield/route.ts
+++ b/web/app/api/divyield/route.ts
@@ -50,6 +50,8 @@ async function readDivYieldFromDisk(): Promise<TimestampedRead<Record<string, un
   return { data, timestampMs: contentTimestampMs(data.scan_time) };
 }
 
+export const radonCapability = "read";
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const result = await dbFirstRead({

--- a/web/app/api/equibles-ats-venue-share/route.ts
+++ b/web/app/api/equibles-ats-venue-share/route.ts
@@ -53,6 +53,8 @@ async function readVenueShareFromDisk(): Promise<TimestampedRead<Record<string, 
   return { data, timestampMs: contentTimestampMs(data.scan_time) };
 }
 
+export const radonCapability = "read";
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const result = await dbFirstRead({

--- a/web/app/api/equibles-cot-positioning/route.ts
+++ b/web/app/api/equibles-cot-positioning/route.ts
@@ -50,6 +50,8 @@ async function readCotFromDisk(): Promise<TimestampedRead<Record<string, unknown
   return { data, timestampMs: contentTimestampMs(data.scan_time) };
 }
 
+export const radonCapability = "read";
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const result = await dbFirstRead({

--- a/web/app/api/equibles-filing-forensics/route.ts
+++ b/web/app/api/equibles-filing-forensics/route.ts
@@ -85,6 +85,8 @@ async function readFlaggedList(): Promise<Dossier> {
   return { dossiers, count: dossiers.length };
 }
 
+export const radonCapability = "read";
+
 export async function GET(request: Request): Promise<Response> {
   const requestId = getRequestId();
   const rawTicker = new URL(request.url).searchParams.get("ticker");

--- a/web/app/api/equibles-short-crowding/route.ts
+++ b/web/app/api/equibles-short-crowding/route.ts
@@ -58,6 +58,8 @@ function isDegraded(data: Record<string, unknown>): boolean {
   return data.missing === true || !Array.isArray(data.entries) || data.entries.length === 0;
 }
 
+export const radonCapability = "read";
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const result = await dbFirstRead({

--- a/web/app/api/equibles-smart-money-13f/route.ts
+++ b/web/app/api/equibles-smart-money-13f/route.ts
@@ -83,6 +83,8 @@ async function readFromDisk(
   return { data, timestampMs: contentTimestampMs(data.scan_time as string) };
 }
 
+export const radonCapability = "read";
+
 export async function GET(request: Request): Promise<Response> {
   const requestId = getRequestId();
   const ticker = normalizeTicker(new URL(request.url).searchParams.get("ticker"));

--- a/web/app/api/flex-token/route.ts
+++ b/web/app/api/flex-token/route.ts
@@ -18,6 +18,8 @@ interface FlexTokenConfig {
   notes: string;
 }
 
+export const radonCapability = "read";
+
 export async function GET(): Promise<Response> {
   try {
     const raw = await readFile(CONFIG_PATH, "utf-8");

--- a/web/app/api/flow-analysis/[ticker]/route.ts
+++ b/web/app/api/flow-analysis/[ticker]/route.ts
@@ -55,6 +55,8 @@ function cachePathFor(ticker: string): string {
 
 type Params = { params: Promise<{ ticker: string }> };
 
+export const radonCapability = { GET: "read", POST: "read.spawn" };
+
 export async function GET(_req: Request, ctx: Params): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "flow-analysis/[ticker]:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/flow-analysis/route.ts
+++ b/web/app/api/flow-analysis/route.ts
@@ -70,6 +70,8 @@ async function readFlowAnalysisFromDisk(): Promise<TimestampedRead<Record<string
   return { data, timestampMs: contentTimestampMs(data.analysis_time) };
 }
 
+export const radonCapability = { GET: "read", POST: "read.spawn" };
+
 export async function GET(): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "flow-analysis:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/flow-surprise/route.ts
+++ b/web/app/api/flow-surprise/route.ts
@@ -74,6 +74,8 @@ async function readFlowSurpriseFromDisk(): Promise<TimestampedRead<FlowSurpriseF
   return { data, timestampMs: contentTimestampMs(data.scan_time) };
 }
 
+export const radonCapability = "read";
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const cache_meta = buildCacheMeta(FLOW_SURPRISE_CACHE_PATH);

--- a/web/app/api/futures-quote/route.ts
+++ b/web/app/api/futures-quote/route.ts
@@ -25,6 +25,8 @@ async function fetchYahooFuturesQuote(symbol: string): Promise<PriceData | null>
   return fetchYahooChartQuote(symbol, yahooSymbol);
 }
 
+export const radonCapability = "read";
+
 export async function GET(request: Request): Promise<Response> {
   const requestId = getRequestId();
   const { searchParams } = new URL(request.url);

--- a/web/app/api/futures/chain/route.ts
+++ b/web/app/api/futures/chain/route.ts
@@ -41,6 +41,8 @@ async function readCachedFuturesChain(
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+export const radonCapability = "read";
+
 export async function GET(request: Request): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "futures/chain:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/gamma-rotation/route.ts
+++ b/web/app/api/gamma-rotation/route.ts
@@ -161,6 +161,8 @@ function triggerBackgroundScan(): void {
     .finally(() => { bgScanInFlight = false; });
 }
 
+export const radonCapability = { GET: "read", POST: "read.spawn" };
+
 export async function GET(): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "gamma-rotation:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/garch-convergence/route.ts
+++ b/web/app/api/garch-convergence/route.ts
@@ -70,6 +70,8 @@ async function readGarchFromDisk(): Promise<TimestampedRead<Record<string, unkno
   return { data, timestampMs: contentTimestampMs(data.scan_time) };
 }
 
+export const radonCapability = "read";
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const result = await cachedRead("garch:snapshot", READ_CACHE_TTL_MS, () =>

--- a/web/app/api/garch-convergence/scan/route.ts
+++ b/web/app/api/garch-convergence/scan/route.ts
@@ -16,6 +16,8 @@ import { requireRouteAccess } from "@/lib/routeAccess";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+export const radonCapability = "read.spawn";
+
 export async function POST(request: Request): Promise<Response> {
   // R-180: this SPAWNS garch_convergence.py. It was classified as "read-only
   // market data" in the filesystem-pinned matrix, whose own contract says a

--- a/web/app/api/gex/route.ts
+++ b/web/app/api/gex/route.ts
@@ -143,6 +143,8 @@ const triggerBackgroundScan = createBackgroundScanTrigger({
 // path stays uncached so a user-triggered rescan always reads the freshest.
 const GEX_CACHE_TTL_MS = 5_000;
 
+export const radonCapability = { GET: "read", POST: "read.spawn" };
+
 export async function GET(): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "gex:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/gex/share/content/route.ts
+++ b/web/app/api/gex/share/content/route.ts
@@ -5,6 +5,8 @@ import { radonFetchText, RadonApiError } from "@/lib/radonApi";
 
 export const runtime = "nodejs";
 
+export const radonCapability = "internal";
+
 export async function GET(req: NextRequest): Promise<Response> {
   const rawPath = req.nextUrl.searchParams.get("path");
   if (!rawPath) {

--- a/web/app/api/gex/share/route.ts
+++ b/web/app/api/gex/share/route.ts
@@ -7,6 +7,8 @@ import { withoutAbsoluteReportPaths } from "@/lib/publicShareRoutes";
 
 export const runtime = "nodejs";
 
+export const radonCapability = "internal";
+
 export async function POST(request: Request): Promise<Response> {
   const access = await requireRouteAccess(request, { rate: { key: "share-generator", limit: 10, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/hhlev/route.ts
+++ b/web/app/api/hhlev/route.ts
@@ -51,6 +51,8 @@ async function readHhLevFromDisk(): Promise<TimestampedRead<Record<string, unkno
   return { data, timestampMs: contentTimestampMs(data.scan_time) };
 }
 
+export const radonCapability = "read";
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const result = await dbFirstRead({

--- a/web/app/api/hyad/route.ts
+++ b/web/app/api/hyad/route.ts
@@ -50,6 +50,8 @@ async function readHyAdFromDisk(): Promise<TimestampedRead<Record<string, unknow
   return { data, timestampMs: contentTimestampMs(data.scan_time) };
 }
 
+export const radonCapability = "read";
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const result = await dbFirstRead({

--- a/web/app/api/ib/ws-ticket/route.ts
+++ b/web/app/api/ib/ws-ticket/route.ts
@@ -16,6 +16,8 @@ import { requireRouteAccess } from "@/lib/routeAccess";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+export const radonCapability = "admin";
+
 export async function POST(request?: Request) {
   const access = await requireRouteAccess(request, {
     rate: { key: "ib/ws-ticket:route", limit: 30, windowMs: 60_000 },

--- a/web/app/api/iei-hyg/route.ts
+++ b/web/app/api/iei-hyg/route.ts
@@ -40,6 +40,8 @@ async function readIeiHygFromDisk(): Promise<TimestampedRead<Record<string, unkn
   return { data, timestampMs: contentTimestampMs(data.scan_time) };
 }
 
+export const radonCapability = "read";
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const result = await dbFirstRead({

--- a/web/app/api/index-options/chain/route.ts
+++ b/web/app/api/index-options/chain/route.ts
@@ -18,6 +18,8 @@ import { OPTION_EXPIRY_PATTERN } from "@/lib/requestBounds";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+export const radonCapability = "read";
+
 export async function GET(request: Request): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "index-options/chain:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/index-quote/route.ts
+++ b/web/app/api/index-quote/route.ts
@@ -25,6 +25,8 @@ async function fetchYahooIndexQuote(symbol: string): Promise<PriceData | null> {
   return fetchYahooChartQuote(symbol, yahooSymbol);
 }
 
+export const radonCapability = "read";
+
 export async function GET(request: Request): Promise<Response> {
   const requestId = getRequestId();
   const { searchParams } = new URL(request.url);

--- a/web/app/api/informed-flow/[ticker]/route.ts
+++ b/web/app/api/informed-flow/[ticker]/route.ts
@@ -39,6 +39,8 @@ function emptySurface(ticker: string): Record<string, unknown> {
 
 type Params = { params: Promise<{ ticker: string }> };
 
+export const radonCapability = "read";
+
 export async function GET(_req: Request, ctx: Params): Promise<Response> {
   const requestId = getRequestId();
   const { ticker: raw } = await ctx.params;

--- a/web/app/api/internals/route.ts
+++ b/web/app/api/internals/route.ts
@@ -600,6 +600,8 @@ function triggerBackgroundScan(): void {
     .finally(() => { bgScanInFlight = false; });
 }
 
+export const radonCapability = { GET: "read", POST: "read.spawn" };
+
 export async function GET(): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "internals:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/internals/share/content/route.ts
+++ b/web/app/api/internals/share/content/route.ts
@@ -5,6 +5,8 @@ import { radonFetchText, RadonApiError } from "@/lib/radonApi";
 
 export const runtime = "nodejs";
 
+export const radonCapability = "internal";
+
 export async function GET(req: NextRequest): Promise<Response> {
   const rawPath = req.nextUrl.searchParams.get("path");
   if (!rawPath) {

--- a/web/app/api/internals/share/route.ts
+++ b/web/app/api/internals/share/route.ts
@@ -7,6 +7,8 @@ import { withoutAbsoluteReportPaths } from "@/lib/publicShareRoutes";
 
 export const runtime = "nodejs";
 
+export const radonCapability = "internal";
+
 export async function POST(request: Request): Promise<Response> {
   const access = await requireRouteAccess(request, { rate: { key: "share-generator", limit: 10, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/ivrank/route.ts
+++ b/web/app/api/ivrank/route.ts
@@ -54,6 +54,8 @@ async function readIvrankFromDisk(): Promise<TimestampedRead<Record<string, unkn
   return { data, timestampMs: contentTimestampMs(data.scan_time) };
 }
 
+export const radonCapability = "read";
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const result = await dbFirstRead({

--- a/web/app/api/journal/route.ts
+++ b/web/app/api/journal/route.ts
@@ -12,6 +12,8 @@ export const dynamic = "force-dynamic";
 
 export const runtime = "nodejs";
 
+export const radonCapability = { GET: "read", POST: "mutate.workspace" };
+
 export async function GET(): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "journal:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/journal/sync/route.ts
+++ b/web/app/api/journal/sync/route.ts
@@ -11,6 +11,8 @@ export const runtime = "nodejs";
  * Runs IB reconciliation, imports new IB trades into the Turso journal table.
  * Returns { imported, skipped } counts.
  */
+export const radonCapability = "mutate.workspace";
+
 export async function POST(): Promise<Response> {
   const access = await requireRouteAccess(undefined, {
     operatorOnly: true,

--- a/web/app/api/knowledge/prior-evals/route.ts
+++ b/web/app/api/knowledge/prior-evals/route.ts
@@ -18,6 +18,8 @@ function normalizeTicker(raw: string | null): string | null {
   return TICKER_RE.test(upper) ? upper : null;
 }
 
+export const radonCapability = "read";
+
 export async function GET(request: Request): Promise<Response> {
   const access = await requireRouteAccess();
   if (!access.ok) return access.response;

--- a/web/app/api/knowledge/search/route.ts
+++ b/web/app/api/knowledge/search/route.ts
@@ -22,6 +22,8 @@ function invalidQueryReason(body: SearchBody): string | null {
   return null;
 }
 
+export const radonCapability = "read";
+
 export async function POST(request: Request): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "knowledge/search:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/leap/route.ts
+++ b/web/app/api/leap/route.ts
@@ -72,6 +72,8 @@ async function readLeapFromDisk(): Promise<TimestampedRead<Record<string, unknow
   return { data, timestampMs: contentTimestampMs(data.scan_time) };
 }
 
+export const radonCapability = "read";
+
 export async function GET(): Promise<Response> {
   const access = await requireRouteAccess();
   if (!access.ok) return access.response;

--- a/web/app/api/leap/scan/route.ts
+++ b/web/app/api/leap/scan/route.ts
@@ -16,6 +16,8 @@ import { tickersBodyToRaw, validateTickerList } from "@/lib/scanTickerList";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+export const radonCapability = "read.spawn";
+
 export async function POST(request: Request): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "leap/scan:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/llm-token-index/route.ts
+++ b/web/app/api/llm-token-index/route.ts
@@ -8,6 +8,8 @@ import { getRequestId, setNoStoreResponseHeaders } from "@/lib/apiContracts";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+export const radonCapability = "read";
+
 export async function GET(req: NextRequest): Promise<Response> {
   const url = new URL(req.url);
   const days = url.searchParams.get("days") ?? "180";

--- a/web/app/api/margin-debt/route.ts
+++ b/web/app/api/margin-debt/route.ts
@@ -49,6 +49,8 @@ async function readMarginDebtFromDisk(): Promise<TimestampedRead<Record<string, 
   return { data, timestampMs: contentTimestampMs(data.scan_time) };
 }
 
+export const radonCapability = "read";
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const result = await dbFirstRead({

--- a/web/app/api/menthorq/[command]/image/route.tsx
+++ b/web/app/api/menthorq/[command]/image/route.tsx
@@ -465,6 +465,8 @@ export function resolveMenthorqRenderer(
   };
 }
 
+export const radonCapability = "read";
+
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ command: string }> }

--- a/web/app/api/menthorq/cta/image/route.tsx
+++ b/web/app/api/menthorq/cta/image/route.tsx
@@ -291,6 +291,8 @@ function DataRow({ row }: { row: CtaRow }) {
   );
 }
 
+export const radonCapability = "read";
+
 export async function GET(request: Request) {
   const access = await requireRouteAccess(undefined, { rate: { key: "menthorq/cta/image:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/menthorq/cta/route.ts
+++ b/web/app/api/menthorq/cta/route.ts
@@ -362,6 +362,8 @@ function triggerBackgroundSync(expectedDate: string): void {
   }
 }
 
+export const radonCapability = "read";
+
 export async function GET(): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "menthorq/cta:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/menthorq/cta/share/content/route.ts
+++ b/web/app/api/menthorq/cta/share/content/route.ts
@@ -3,6 +3,8 @@ import { isAllowedShareCardPath, readShareCard } from "@/lib/shareReportPath";
 
 export const runtime = "nodejs";
 
+export const radonCapability = "internal";
+
 export async function GET(req: NextRequest): Promise<Response> {
   const rawPath = req.nextUrl.searchParams.get("path");
   if (!rawPath) {

--- a/web/app/api/menthorq/cta/share/route.ts
+++ b/web/app/api/menthorq/cta/share/route.ts
@@ -7,6 +7,8 @@ import { withoutAbsoluteReportPaths } from "@/lib/publicShareRoutes";
 
 export const runtime = "nodejs";
 
+export const radonCapability = "internal";
+
 export async function POST(request: Request): Promise<Response> {
   const access = await requireRouteAccess(request, { rate: { key: "share-generator", limit: 10, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/newsfeed/posts/route.ts
+++ b/web/app/api/newsfeed/posts/route.ts
@@ -65,6 +65,8 @@ async function fetchPosts() {
   return result.rows.map((r) => rowToPost(r as unknown as PostRow));
 }
 
+export const radonCapability = "read";
+
 export async function GET() {
   const access = await requireRouteAccess();
   if (!access.ok) return access.response;

--- a/web/app/api/options/chain/route.ts
+++ b/web/app/api/options/chain/route.ts
@@ -11,6 +11,8 @@ import { boundedTicker, OPTION_EXPIRY_PATTERN } from "@/lib/requestBounds";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+export const radonCapability = "read";
+
 export async function GET(request: Request): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "options/chain:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/options/expirations/route.ts
+++ b/web/app/api/options/expirations/route.ts
@@ -11,6 +11,8 @@ import { boundedTicker } from "@/lib/requestBounds";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+export const radonCapability = "read";
+
 export async function GET(request: Request): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "options/expirations:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/options/exposure/route.ts
+++ b/web/app/api/options/exposure/route.ts
@@ -13,6 +13,8 @@ export const runtime = "nodejs";
 const SYMBOL_RE = /^[A-Z][A-Z0-9.-]{0,9}$/;
 const FREQUENCIES = new Set(["eod", "intraday"]);
 
+export const radonCapability = "read";
+
 export async function GET(request: Request): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "options/exposure:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/options/rv-ratio/route.ts
+++ b/web/app/api/options/rv-ratio/route.ts
@@ -76,6 +76,8 @@ function withSessionStaleness(payload: SnapshotPayload): SnapshotPayload {
   return { ...payload, stale: !isSnapshotCurrent(snapshotLastDate(payload)) };
 }
 
+export const radonCapability = { GET: "read", POST: "read.spawn" };
+
 export async function GET(request: Request): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "options/rv-ratio:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/orders/cancel/route.ts
+++ b/web/app/api/orders/cancel/route.ts
@@ -31,6 +31,8 @@ async function readOrdersSnapshotBestEffort() {
   }
 }
 
+export const radonCapability = "mutate.trading";
+
 export async function POST(request: Request): Promise<Response> {
   const access = await requireRouteAccess(request, {
     operatorOnly: true,

--- a/web/app/api/orders/modify/route.ts
+++ b/web/app/api/orders/modify/route.ts
@@ -143,6 +143,8 @@ function normalizeCancelTargets(
   return targets;
 }
 
+export const radonCapability = "mutate.trading";
+
 export async function POST(request: Request): Promise<Response> {
   const access = await requireRouteAccess(request, {
     operatorOnly: true,

--- a/web/app/api/orders/place/route.ts
+++ b/web/app/api/orders/place/route.ts
@@ -99,6 +99,8 @@ function indeterminatePlacementDetail(error: IndeterminatePlacementError): strin
   return `Placement was not confirmed (${reason}). The idempotency key is held so an identical resubmit cannot double-place.`;
 }
 
+export const radonCapability = "mutate.trading";
+
 export async function POST(request: Request): Promise<Response> {
   const access = await requireRouteAccess(request, {
     operatorOnly: true,

--- a/web/app/api/orders/route.ts
+++ b/web/app/api/orders/route.ts
@@ -10,6 +10,8 @@ export const dynamic = "force-dynamic";
 
 let syncInFlight: Promise<void> | null = null;
 
+export const radonCapability = { GET: "read", POST: "mutate.workspace" };
+
 export async function GET(): Promise<Response> {
   const access = await requireRouteAccess();
   if (!access.ok) return access.response;

--- a/web/app/api/orders/whatif/route.ts
+++ b/web/app/api/orders/whatif/route.ts
@@ -54,6 +54,8 @@ type WhatIfBody = {
 
 const UNAVAILABLE = { initMargin: null, maintMargin: null, source: "unavailable" as const };
 
+export const radonCapability = "read.spawn";
+
 export async function POST(request: Request): Promise<Response> {
   const access = await requireRouteAccess(request, {
     operatorOnly: true,

--- a/web/app/api/paper/place/route.ts
+++ b/web/app/api/paper/place/route.ts
@@ -15,6 +15,8 @@ import { getRequestId, jsonApiError, setNoStoreResponseHeaders } from "@/lib/api
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+export const radonCapability = "mutate.trading";
+
 export async function POST(request: Request): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "paper/place:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/performance/route.ts
+++ b/web/app/api/performance/route.ts
@@ -156,6 +156,8 @@ async function readPerformanceFromDisk(): Promise<TimestampedRead<Record<string,
   return { data, timestampMs: payloadTimestampMs(data, "") };
 }
 
+export const radonCapability = { GET: "read", POST: "read.spawn" };
+
 export async function GET(): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "performance:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/pi/route.ts
+++ b/web/app/api/pi/route.ts
@@ -592,6 +592,8 @@ const resolvePiInput = (body: PiRoutePayload): string => {
 export const __resolvePiInput = resolvePiInput;
 export const __normalizeScanArgs = normalizeScanArgs;
 
+export const radonCapability = "internal";
+
 export async function POST(request: NextRequest): Promise<Response> {
   const access = await requireRouteAccess(request, {
     operatorOnly: true,

--- a/web/app/api/portfolio/route.ts
+++ b/web/app/api/portfolio/route.ts
@@ -182,6 +182,8 @@ function unavailablePortfolioResponse(
   ));
 }
 
+export const radonCapability = { GET: "read", POST: "mutate.workspace" };
+
 export async function GET(request?: Request): Promise<Response> {
   const access = await requireRouteAccess(request, { rate: { key: "portfolio:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/preferences/route.ts
+++ b/web/app/api/preferences/route.ts
@@ -56,6 +56,8 @@ function validationFailure(
   );
 }
 
+export const radonCapability = { GET: "read", PUT: "mutate.workspace", DELETE: "mutate.workspace" };
+
 export async function GET(): Promise<Response> {
   const access = await requireRouteAccess();
   if (!access.ok) return access.response;

--- a/web/app/api/previous-close/route.ts
+++ b/web/app/api/previous-close/route.ts
@@ -265,6 +265,8 @@ async function getPreviousClose(symbol: string): Promise<number | null> {
 
 /* ── Route handler ──────────────────────────────────────── */
 
+export const radonCapability = "read";
+
 export async function POST(req: Request) {
   const access = await requireRouteAccess(undefined, { rate: { key: "previous-close:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/prices/route.ts
+++ b/web/app/api/prices/route.ts
@@ -11,6 +11,8 @@ const WS_SERVER_URL = process.env.IB_REALTIME_WS_URL || "ws://localhost:8765";
  * 
  * Legacy SSE endpoint removed.
  */
+export const radonCapability = { GET: "read", POST: "read" };
+
 export async function GET(): Promise<Response> {
   return NextResponse.json(
     {

--- a/web/app/api/probe/freshness/route.ts
+++ b/web/app/api/probe/freshness/route.ts
@@ -74,6 +74,8 @@ async function gatherInputs(): Promise<ProbeFreshnessInputs> {
   };
 }
 
+export const radonCapability = "internal";
+
 export async function GET(request: Request): Promise<Response> {
   const requestId = getRequestId();
   if (!await isAuthorizedProbeRequest(

--- a/web/app/api/profile/route.ts
+++ b/web/app/api/profile/route.ts
@@ -62,6 +62,8 @@ async function readProfile(userId: string): Promise<ProfileRow> {
   return { username: row.username ?? null, avatar_url };
 }
 
+export const radonCapability = { GET: "read", PUT: "mutate.workspace" };
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const { userId } = await auth();

--- a/web/app/api/regime/route.ts
+++ b/web/app/api/regime/route.ts
@@ -286,6 +286,8 @@ async function runCriScanAndArchive(): Promise<void> {
 
 const triggerBackgroundScan = createBackgroundScanTrigger({ label: "CRI", run: runCriScanAndArchive });
 
+export const radonCapability = { GET: "read", POST: "read.spawn" };
+
 export async function GET(): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "regime:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/regime/share/content/route.ts
+++ b/web/app/api/regime/share/content/route.ts
@@ -3,6 +3,8 @@ import { isAllowedShareCardPath, readShareCard } from "@/lib/shareReportPath";
 
 export const runtime = "nodejs";
 
+export const radonCapability = "internal";
+
 export async function GET(req: NextRequest): Promise<Response> {
   const rawPath = req.nextUrl.searchParams.get("path");
   if (!rawPath) {

--- a/web/app/api/regime/share/route.ts
+++ b/web/app/api/regime/share/route.ts
@@ -7,6 +7,8 @@ import { withoutAbsoluteReportPaths } from "@/lib/publicShareRoutes";
 
 export const runtime = "nodejs";
 
+export const radonCapability = "internal";
+
 export async function POST(request: Request): Promise<Response> {
   const access = await requireRouteAccess(request, { rate: { key: "share-generator", limit: 10, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/risk-free-rate/route.ts
+++ b/web/app/api/risk-free-rate/route.ts
@@ -48,6 +48,8 @@ function observationIsCurrent(asOf: string, now = new Date()): boolean {
   return Number.isFinite(observed) && now.getTime() - observed <= MAX_OBSERVATION_AGE_MS;
 }
 
+export const radonCapability = "read";
+
 export async function GET() {
   try {
     const result = await fetchLatestDff();

--- a/web/app/api/scanner/route.ts
+++ b/web/app/api/scanner/route.ts
@@ -70,6 +70,8 @@ async function readScannerFromDisk(): Promise<TimestampedRead<Record<string, unk
   return { data, timestampMs: contentTimestampMs(data.scan_time) };
 }
 
+export const radonCapability = { GET: "read", POST: "read.spawn" };
+
 export async function GET(): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "scanner:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/scanner/strength/route.ts
+++ b/web/app/api/scanner/strength/route.ts
@@ -69,6 +69,8 @@ export function emptyStrengthConfirmationPayload() {
   };
 }
 
+export const radonCapability = "read";
+
 export async function readStrengthConfirmationCache(): Promise<Record<string, unknown> | null> {
   const raw = await readFile(CACHE_PATH, "utf-8");
   return JSON.parse(raw) as Record<string, unknown>;

--- a/web/app/api/scanner/strength/scan/route.ts
+++ b/web/app/api/scanner/strength/scan/route.ts
@@ -15,6 +15,8 @@ function cacheMatchesRequest(cached: Record<string, unknown>, ticker: string, pr
   return universe === `preset:${preset}` || universe === `fallback:${preset}`;
 }
 
+export const radonCapability = "read.spawn";
+
 export async function POST(request: Request): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "scanner/strength/scan:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/scanner/theta/route.ts
+++ b/web/app/api/scanner/theta/route.ts
@@ -73,6 +73,8 @@ export function emptyThetaHarvesterPayload() {
   };
 }
 
+export const radonCapability = "read";
+
 export async function readThetaHarvesterCache(): Promise<Record<string, unknown> | null> {
   const raw = await readFile(CACHE_PATH, "utf-8");
   return JSON.parse(raw) as Record<string, unknown>;

--- a/web/app/api/scanner/theta/scan/route.ts
+++ b/web/app/api/scanner/theta/scan/route.ts
@@ -15,6 +15,8 @@ function cacheMatchesRequest(cached: Record<string, unknown>, ticker: string, pr
   return universe === `preset:${preset}` || universe === `fallback:${preset}`;
 }
 
+export const radonCapability = "read.spawn";
+
 export async function POST(request: Request): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "scanner/theta/scan:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/service-health/route.ts
+++ b/web/app/api/service-health/route.ts
@@ -119,6 +119,8 @@ function forProbe(row: ServiceHealthRow): ServiceHealthRow {
   return { ...row, last_error: null, error_summary: null };
 }
 
+export const radonCapability = "read";
+
 export async function GET(request?: Request): Promise<Response> {
   // Dual-auth (DUR-16): the loopback watchdog authenticates with the probe
   // bearer and has no Clerk session — a valid bearer must not fall through

--- a/web/app/api/share/pnl/route.tsx
+++ b/web/app/api/share/pnl/route.tsx
@@ -44,6 +44,8 @@ function fmtTimePST(isoTime: string): string {
   }
 }
 
+export const radonCapability = "internal";
+
 export async function GET(request: Request) {
   const limit = rateLimit(clientIp(request), { limit: SHARE_PNL_LIMIT, windowMs: SHARE_WINDOW_MS });
   if (!limit.ok) {

--- a/web/app/api/short-availability/[ticker]/route.ts
+++ b/web/app/api/short-availability/[ticker]/route.ts
@@ -19,6 +19,8 @@ type Params = { params: Promise<{ ticker: string }> };
  * Always returns 200 per the missing:true semantics contract
  * (see feedback_http_status_for_real_errors.md).
  */
+export const radonCapability = "read";
+
 export async function GET(_req: Request, ctx: Params): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "short-availability/[ticker]:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/skew/route.ts
+++ b/web/app/api/skew/route.ts
@@ -49,6 +49,8 @@ async function readSkewFromDisk(): Promise<TimestampedRead<Record<string, unknow
   return { data, timestampMs: contentTimestampMs(data.scan_time) };
 }
 
+export const radonCapability = "read";
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const result = await dbFirstRead({

--- a/web/app/api/skew2d/route.ts
+++ b/web/app/api/skew2d/route.ts
@@ -49,6 +49,8 @@ async function readSkew2dFromDisk(): Promise<TimestampedRead<Record<string, unkn
   return { data, timestampMs: contentTimestampMs(data.scan_time) };
 }
 
+export const radonCapability = "read";
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const result = await dbFirstRead({

--- a/web/app/api/straddle/route.ts
+++ b/web/app/api/straddle/route.ts
@@ -49,6 +49,8 @@ async function readStraddleFromDisk(): Promise<TimestampedRead<Record<string, un
   return { data, timestampMs: contentTimestampMs(data.scan_time) };
 }
 
+export const radonCapability = "read";
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const result = await dbFirstRead({

--- a/web/app/api/ticker/info/route.ts
+++ b/web/app/api/ticker/info/route.ts
@@ -238,6 +238,8 @@ const CACHE_TTL_SECONDS = 20;
 
 /* ─── Route handler ─── */
 
+export const radonCapability = "read";
+
 export async function GET(request: Request): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "ticker/info:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/ticker/news/route.ts
+++ b/web/app/api/ticker/news/route.ts
@@ -16,6 +16,8 @@ const NEWS_CACHE_SECONDS = 45;
 const PROVIDER_TIMEOUT_MS = 3_000;
 
 /** Try UW headlines first, fall back to Yahoo Finance on any error. */
+export const radonCapability = "read";
+
 export async function GET(request: Request): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "ticker/news:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/ticker/ratings/route.ts
+++ b/web/app/api/ticker/ratings/route.ts
@@ -22,6 +22,8 @@ function coalescedRatings(ticker: string): Promise<Record<string, unknown>> {
   return pending;
 }
 
+export const radonCapability = "read";
+
 export async function GET(request: Request): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "ticker/ratings:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/ticker/seasonality/route.ts
+++ b/web/app/api/ticker/seasonality/route.ts
@@ -150,6 +150,8 @@ async function extractViaVision(ticker: string, requestId: string): Promise<Mont
 const SEASONALITY_CACHE_SECONDS = 900;
 const STALE_REVALIDATE_SECONDS = 3600;
 
+export const radonCapability = "read";
+
 export async function GET(request: Request): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "ticker/seasonality:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/trin/route.ts
+++ b/web/app/api/trin/route.ts
@@ -40,6 +40,8 @@ async function readTrinFromDisk(): Promise<TimestampedRead<Record<string, unknow
   return { data, timestampMs: contentTimestampMs(data.scan_time) };
 }
 
+export const radonCapability = "read";
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const result = await dbFirstRead({

--- a/web/app/api/vcg/route.ts
+++ b/web/app/api/vcg/route.ts
@@ -121,6 +121,8 @@ const triggerBackgroundScan = createBackgroundScanTrigger({
   run: () => radonFetch<Record<string, unknown>>("/vcg/scan", { method: "POST", timeout: 130_000 }),
 });
 
+export const radonCapability = "read";
+
 export async function GET(): Promise<Response> {
   const access = await requireRouteAccess(undefined, { rate: { key: "vcg:route", limit: 20, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/vcg/share/content/route.ts
+++ b/web/app/api/vcg/share/content/route.ts
@@ -3,6 +3,8 @@ import { isAllowedShareCardPath, readShareCard } from "@/lib/shareReportPath";
 
 export const runtime = "nodejs";
 
+export const radonCapability = "internal";
+
 export async function GET(req: NextRequest): Promise<Response> {
   const rawPath = req.nextUrl.searchParams.get("path");
   if (!rawPath) {

--- a/web/app/api/vcg/share/route.ts
+++ b/web/app/api/vcg/share/route.ts
@@ -7,6 +7,8 @@ import { withoutAbsoluteReportPaths } from "@/lib/publicShareRoutes";
 
 export const runtime = "nodejs";
 
+export const radonCapability = "internal";
+
 export async function POST(request: Request): Promise<Response> {
   const access = await requireRouteAccess(request, { rate: { key: "share-generator", limit: 10, windowMs: 60_000 } });
   if (!access.ok) return access.response;

--- a/web/app/api/vixcor/route.ts
+++ b/web/app/api/vixcor/route.ts
@@ -56,6 +56,8 @@ async function readVixcorFromDisk(): Promise<TimestampedRead<Record<string, unkn
   return { data, timestampMs: contentTimestampMs(data.scan_time) };
 }
 
+export const radonCapability = "read";
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const result = await dbFirstRead({

--- a/web/app/api/vixts/route.ts
+++ b/web/app/api/vixts/route.ts
@@ -41,6 +41,8 @@ async function readVixTsFromDisk(): Promise<TimestampedRead<Record<string, unkno
   return { data, timestampMs: contentTimestampMs(data.scan_time) };
 }
 
+export const radonCapability = "read";
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const result = await dbFirstRead({

--- a/web/app/api/vol-cone/route.ts
+++ b/web/app/api/vol-cone/route.ts
@@ -52,6 +52,8 @@ async function readVolConeFromDisk(): Promise<TimestampedRead<Record<string, unk
   return { data, timestampMs: contentTimestampMs(data.scan_time) };
 }
 
+export const radonCapability = "read";
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const result = await dbFirstRead({

--- a/web/app/api/watchlist/[symbol]/route.ts
+++ b/web/app/api/watchlist/[symbol]/route.ts
@@ -6,6 +6,8 @@ import { getRequestId, jsonApiError, setNoStoreResponseHeaders } from "@/lib/api
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+export const radonCapability = "mutate.workspace";
+
 export async function DELETE(
   _req: Request,
   { params }: { params: Promise<{ symbol: string }> },

--- a/web/app/api/watchlist/route.ts
+++ b/web/app/api/watchlist/route.ts
@@ -22,6 +22,8 @@ function rowToWatch(row: WatchlistRow) {
   };
 }
 
+export const radonCapability = { GET: "read", POST: "mutate.workspace" };
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const { userId } = await auth();

--- a/web/app/api/webhooks/clerk/route.ts
+++ b/web/app/api/webhooks/clerk/route.ts
@@ -34,6 +34,8 @@ async function setClerkMetadata(
   await client.users.updateUserMetadata(userId, { publicMetadata });
 }
 
+export const radonCapability = "internal";
+
 export async function POST(request: Request): Promise<Response> {
   const requestId = getRequestId();
   const ok = (body: Record<string, unknown>, status = 200) =>

--- a/web/app/api/workflow/route.ts
+++ b/web/app/api/workflow/route.ts
@@ -42,6 +42,8 @@ function parseGraph(raw: string): unknown {
   }
 }
 
+export const radonCapability = { GET: "read", POST: "mutate.workspace" };
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const { userId } = await auth();

--- a/web/app/api/workflow/run/route.ts
+++ b/web/app/api/workflow/run/route.ts
@@ -12,6 +12,8 @@ export const runtime = "nodejs";
 // FastAPI (`POST /workflow/run`) where the Python executor lives. Order-emitting
 // nodes block unless `confirm_order` is passed — the OrderRiskGate confirmation.
 
+export const radonCapability = "mutate.trading";
+
 export async function POST(req: Request): Promise<Response> {
   const access = await requireRouteAccess(req, {
     operatorOnly: true,

--- a/web/app/api/yield-curve/live/route.ts
+++ b/web/app/api/yield-curve/live/route.ts
@@ -97,6 +97,8 @@ async function refreshLivePayload(): Promise<Record<string, unknown>> {
   return refreshInFlight;
 }
 
+export const radonCapability = "read";
+
 export async function GET() {
   const requestId = getRequestId();
   if (!cached || Date.now() - cached.at >= CACHE_TTL_MS) {

--- a/web/app/api/yield-curve/route.ts
+++ b/web/app/api/yield-curve/route.ts
@@ -48,6 +48,8 @@ async function readYieldCurveFromDisk(): Promise<TimestampedRead<Record<string, 
   return { data, timestampMs: contentTimestampMs(data.scan_time) };
 }
 
+export const radonCapability = "read";
+
 export async function GET(): Promise<Response> {
   const requestId = getRequestId();
   const result = await dbFirstRead({

--- a/web/lib/assistant/capabilities.ts
+++ b/web/lib/assistant/capabilities.ts
@@ -1,0 +1,24 @@
+export const CAPABILITIES = [
+  "read",
+  "read.spawn",
+  "mutate.workspace",
+  "mutate.trading",
+  "admin",
+  "internal",
+] as const;
+
+export type Capability = (typeof CAPABILITIES)[number];
+
+export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD";
+
+export type RouteCapability = Capability | Partial<Record<HttpMethod, Capability>>;
+
+const REFUSED: ReadonlySet<Capability> = new Set([
+  "admin",
+  "internal",
+  "mutate.trading",
+]);
+
+export function isRefused(cap: Capability): boolean {
+  return REFUSED.has(cap);
+}

--- a/web/tests/assistant-catalog-pin.test.ts
+++ b/web/tests/assistant-catalog-pin.test.ts
@@ -1,0 +1,284 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  CAPABILITIES,
+  isRefused,
+  type Capability,
+  type RouteCapability,
+} from "@/lib/assistant/capabilities";
+
+const CAPABILITY_SET = new Set<string>(CAPABILITIES);
+
+type PinnedCapability = Capability | Record<string, Capability>;
+
+/**
+ * Exhaustive chat-capability pin for every Next.js API route file.
+ * A disk route missing from this map is unclassified. A listed path
+ * missing on disk is stale. Values must match `export const radonCapability`.
+ */
+const PINNED: Record<string, PinnedCapability> = {
+  "admin/demo-users": { GET: "admin", POST: "admin" },
+  "admin/edge-health": "admin",
+  "admin/health": "admin",
+  "admin/host-metrics": "admin",
+  "admin/ib/reset-backoff": "admin",
+  "admin/ib/restart": "admin",
+  "admin/reliability": "admin",
+  "admin/services": "admin",
+  "admin/services/[unit]/[action]": "admin",
+  "admin/slo": "admin",
+  "admin/stack/restart": "admin",
+  "admin/trading/[action]": { GET: "admin", POST: "admin" },
+  "alerts": { GET: "read", POST: "mutate.workspace" },
+  "alerts/[id]": "mutate.workspace",
+  "assistant": "internal",
+  "attribution": "read",
+  "backtest/[strategy]": "read",
+  "blotter": { GET: "read", POST: "mutate.workspace" },
+  "bookmarks": { GET: "read", POST: "mutate.workspace" },
+  "bookmarks/[post_id]": "mutate.workspace",
+  "bpi": "read",
+  "breadth": { GET: "read", POST: "read.spawn" },
+  "cash-flows": "read",
+  "catalysts": "read",
+  "cor": "read",
+  "credit-spread": "read",
+  "discover": { GET: "read", POST: "read.spawn" },
+  "divyield": "read",
+  "equibles-ats-venue-share": "read",
+  "equibles-cot-positioning": "read",
+  "equibles-filing-forensics": "read",
+  "equibles-short-crowding": "read",
+  "equibles-smart-money-13f": "read",
+  "flex-token": "read",
+  "flow-analysis": { GET: "read", POST: "read.spawn" },
+  "flow-analysis/[ticker]": { GET: "read", POST: "read.spawn" },
+  "flow-surprise": "read",
+  "futures-quote": "read",
+  "futures/chain": "read",
+  "gamma-rotation": { GET: "read", POST: "read.spawn" },
+  "garch-convergence": "read",
+  "garch-convergence/scan": "read.spawn",
+  "gex": { GET: "read", POST: "read.spawn" },
+  "gex/share": "internal",
+  "gex/share/content": "internal",
+  "hhlev": "read",
+  "hyad": "read",
+  "ib/ws-ticket": "admin",
+  "iei-hyg": "read",
+  "index-options/chain": "read",
+  "index-quote": "read",
+  "informed-flow/[ticker]": "read",
+  "internals": { GET: "read", POST: "read.spawn" },
+  "internals/share": "internal",
+  "internals/share/content": "internal",
+  "ivrank": "read",
+  "journal": { GET: "read", POST: "mutate.workspace" },
+  "journal/sync": "mutate.workspace",
+  "knowledge/prior-evals": "read",
+  "knowledge/search": "read",
+  "leap": "read",
+  "leap/scan": "read.spawn",
+  "llm-token-index": "read",
+  "margin-debt": "read",
+  "menthorq/[command]/image": "read",
+  "menthorq/cta": "read",
+  "menthorq/cta/image": "read",
+  "menthorq/cta/share": "internal",
+  "menthorq/cta/share/content": "internal",
+  "newsfeed/posts": "read",
+  "options/chain": "read",
+  "options/expirations": "read",
+  "options/exposure": "read",
+  "options/rv-ratio": { GET: "read", POST: "read.spawn" },
+  "orders": { GET: "read", POST: "mutate.workspace" },
+  "orders/cancel": "mutate.trading",
+  "orders/modify": "mutate.trading",
+  "orders/place": "mutate.trading",
+  "orders/whatif": "read.spawn",
+  "paper/place": "mutate.trading",
+  "performance": { GET: "read", POST: "read.spawn" },
+  "pi": "internal",
+  "portfolio": { GET: "read", POST: "mutate.workspace" },
+  "preferences": { GET: "read", PUT: "mutate.workspace", DELETE: "mutate.workspace" },
+  "previous-close": "read",
+  "prices": { GET: "read", POST: "read" },
+  "probe/freshness": "internal",
+  "profile": { GET: "read", PUT: "mutate.workspace" },
+  "regime": { GET: "read", POST: "read.spawn" },
+  "regime/share": "internal",
+  "regime/share/content": "internal",
+  "risk-free-rate": "read",
+  "scanner": { GET: "read", POST: "read.spawn" },
+  "scanner/strength": "read",
+  "scanner/strength/scan": "read.spawn",
+  "scanner/theta": "read",
+  "scanner/theta/scan": "read.spawn",
+  "service-health": "read",
+  "share/pnl": "internal",
+  "short-availability/[ticker]": "read",
+  "skew": "read",
+  "skew2d": "read",
+  "straddle": "read",
+  "ticker/info": "read",
+  "ticker/news": "read",
+  "ticker/ratings": "read",
+  "ticker/seasonality": "read",
+  "trin": "read",
+  "vcg": "read",
+  "vcg/share": "internal",
+  "vcg/share/content": "internal",
+  "vixcor": "read",
+  "vixts": "read",
+  "vol-cone": "read",
+  "watchlist": { GET: "read", POST: "mutate.workspace" },
+  "watchlist/[symbol]": "mutate.workspace",
+  "webhooks/clerk": "internal",
+  "workflow": { GET: "read", POST: "mutate.workspace" },
+  "workflow/run": "mutate.trading",
+  "yield-curve": "read",
+  "yield-curve/live": "read",
+};
+
+const WEB_ROOT = fileURLToPath(new URL("..", import.meta.url));
+
+function collectApiRoutesFromFilesystem(): string[] {
+  const apiRoot = resolve(WEB_ROOT, "app", "api");
+  const found: string[] = [];
+
+  function walk(dir: string, routePath: string): void {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        walk(join(dir, entry.name), routePath ? `${routePath}/${entry.name}` : entry.name);
+      } else if (/^route\.(ts|tsx)$/.test(entry.name)) {
+        found.push(routePath);
+      }
+    }
+  }
+
+  walk(apiRoot, "");
+  return found.sort();
+}
+
+function routeFile(route: string): string {
+  const ts = resolve(WEB_ROOT, "app", "api", route, "route.ts");
+  const tsx = resolve(WEB_ROOT, "app", "api", route, "route.tsx");
+  try {
+    return readFileSync(ts, "utf8");
+  } catch {
+    return readFileSync(tsx, "utf8");
+  }
+}
+
+function parseRadonCapability(source: string, route: string): RouteCapability {
+  const match = source.match(
+    /export\s+const\s+radonCapability(?:\s*:\s*[^=;]+)?\s*=\s*([^;]+);/,
+  );
+  expect(match, `${route} must export const radonCapability`).not.toBeNull();
+  const expr = match![1].trim().replace(/\s+as const$/, "").trim();
+  const asString = expr.match(
+    /^["'](read|read\.spawn|mutate\.workspace|mutate\.trading|admin|internal)["']$/,
+  );
+  if (asString) return asString[1] as Capability;
+
+  expect(expr.startsWith("{") && expr.endsWith("}"), `${route} capability expr`).toBe(true);
+  const map: Record<string, Capability> = {};
+  const pair =
+    /\b(GET|POST|PUT|PATCH|DELETE|HEAD)\s*:\s*["'](read|read\.spawn|mutate\.workspace|mutate\.trading|admin|internal)["']/g;
+  let hit: RegExpExecArray | null;
+  while ((hit = pair.exec(expr))) {
+    map[hit[1]] = hit[2] as Capability;
+  }
+  expect(Object.keys(map).length, `${route} method map`).toBeGreaterThan(0);
+  return map;
+}
+
+function samePin(actual: RouteCapability, expected: PinnedCapability): boolean {
+  if (typeof expected === "string") return actual === expected;
+  if (typeof actual === "string") return false;
+  const actualKeys = Object.keys(actual).sort();
+  const expectedKeys = Object.keys(expected).sort();
+  if (actualKeys.join() !== expectedKeys.join()) return false;
+  return expectedKeys.every((key) => actual[key as keyof typeof actual] === expected[key]);
+}
+
+describe("assistant catalog pin", () => {
+  it("keeps the capability helper tiny and refused-set exact", () => {
+    const src = readFileSync(resolve(WEB_ROOT, "lib/assistant/capabilities.ts"), "utf8");
+    expect(src).not.toMatch(/radonFetch|openapi/i);
+    expect(isRefused("admin")).toBe(true);
+    expect(isRefused("internal")).toBe(true);
+    expect(isRefused("mutate.trading")).toBe(true);
+    expect(isRefused("read")).toBe(false);
+    expect(isRefused("read.spawn")).toBe(false);
+    expect(isRefused("mutate.workspace")).toBe(false);
+  });
+
+  it("classifies every route file on disk (filesystem pin)", () => {
+    const disk = collectApiRoutesFromFilesystem();
+    const classified = new Set(Object.keys(PINNED));
+
+    const unclassified = disk.filter((route) => !classified.has(route));
+    expect(
+      unclassified,
+      "new API route files must export radonCapability and land in PINNED",
+    ).toEqual([]);
+
+    const stale = [...classified].filter((route) => !disk.includes(route)).sort();
+    expect(stale, "classified routes that no longer exist on disk").toEqual([]);
+  });
+
+  it("every disk route exports a parseable radonCapability matching PINNED", () => {
+    for (const route of collectApiRoutesFromFilesystem()) {
+      const source = routeFile(route);
+      expect(source, route).toMatch(/export\s+const\s+radonCapability/);
+      const parsed = parseRadonCapability(source, route);
+      const expected = PINNED[route];
+      expect(expected, `PINNED missing ${route}`).toBeDefined();
+      expect(samePin(parsed, expected), `${route} capability`).toBe(true);
+
+      if (typeof parsed === "string") {
+        expect(CAPABILITY_SET.has(parsed), route).toBe(true);
+      } else {
+        for (const cap of Object.values(parsed)) {
+          expect(CAPABILITY_SET.has(cap), `${route} ${cap}`).toBe(true);
+        }
+      }
+    }
+  });
+
+  it("pins assistant, pi, webhooks, and share HTML as internal", () => {
+    expect(PINNED.assistant).toBe("internal");
+    expect(PINNED.pi).toBe("internal");
+    expect(PINNED["webhooks/clerk"]).toBe("internal");
+    expect(PINNED["gex/share/content"]).toBe("internal");
+    expect(PINNED["internals/share/content"]).toBe("internal");
+    expect(PINNED["menthorq/cta/share/content"]).toBe("internal");
+    expect(PINNED["regime/share/content"]).toBe("internal");
+    expect(PINNED["vcg/share/content"]).toBe("internal");
+    expect(PINNED["share/pnl"]).toBe("internal");
+  });
+
+  it("pins admin and ib operator routes as admin", () => {
+    expect(PINNED["admin/demo-users"]).toEqual({ GET: "admin", POST: "admin" });
+    expect(PINNED["admin/ib/restart"]).toBe("admin");
+    expect(PINNED["admin/ib/reset-backoff"]).toBe("admin");
+    expect(PINNED["admin/services"]).toBe("admin");
+    expect(PINNED["admin/trading/[action]"]).toEqual({ GET: "admin", POST: "admin" });
+    expect(PINNED["ib/ws-ticket"]).toBe("admin");
+  });
+
+  it("pins live order placement as mutate.trading", () => {
+    expect(PINNED["orders/place"]).toBe("mutate.trading");
+    expect(PINNED["orders/cancel"]).toBe("mutate.trading");
+    expect(PINNED["orders/modify"]).toBe("mutate.trading");
+    expect(PINNED["paper/place"]).toBe("mutate.trading");
+  });
+
+  it("pins watchlist GET read and POST/DELETE mutate.workspace", () => {
+    expect(PINNED.watchlist).toEqual({ GET: "read", POST: "mutate.workspace" });
+    expect(PINNED["watchlist/[symbol]"]).toBe("mutate.workspace");
+  });
+});


### PR DESCRIPTION
Catalog pin so unclassified routes fail CI. No chat behavior change. Stack-independent.

- Next.js: every `web/app/api/**/route.ts(x)` exports `radonCapability`. Filesystem pin in `web/tests/assistant-catalog-pin.test.ts`.
- FastAPI: central `(method, path) -> capability` map in `scripts/api/assistant_catalog.py`. Live `app.routes` coverage in `scripts/api/tests/test_assistant_catalog.py`.
- Classes: `read`, `read.spawn`, `mutate.workspace`, `mutate.trading`, `admin`, `internal`. Unpinned POST is default-deny.