### PR TITLE
fix(runtime): a containerised unit cannot satisfy Type=notify

### DIFF
--- a/cloud/config/installed-units.sha256
+++ b/cloud/config/installed-units.sha256
@@ -150,9 +150,9 @@ e8a7dca2f2f2c7d1176010a2c4df4e4a60842a6bb1cb34682d2ce9c815c11938  radon-disk-cle
 # daily drift audit compares it live as `fleet-dropin`.
 16b56fc5c731cefb4d8184e01c9da042aa1a623b3bd23b6face060e9d0b4df08  radon-.service.d/common.conf
 c9e4ef36521cb7a923853f5478d6c52d7076fdb24876e38f2bab8feb86c05947  radon-api.service.d/runtime-container.conf
-947ea4b35741cb58f23ab0ced9954c1be4fc202b44dc0da189a7269be6d7c267  radon-monitor.service.d/runtime-container.conf
+7e82d875af1bf02c400f3cdf3a71d70e99ec2c30424c63396b544ef5f0a261cc  radon-monitor.service.d/runtime-container.conf
 c9e4ef36521cb7a923853f5478d6c52d7076fdb24876e38f2bab8feb86c05947  radon-newsfeed.service.d/runtime-container.conf
 c9e4ef36521cb7a923853f5478d6c52d7076fdb24876e38f2bab8feb86c05947  radon-nextjs.service.d/runtime-container.conf
-90989b1a8d8907ef95c48d054871f818320f61f15d00dcf36eb8b907ca1a31f4  radon-relay.service.d/runtime-container.conf
+7e82d875af1bf02c400f3cdf3a71d70e99ec2c30424c63396b544ef5f0a261cc  radon-relay.service.d/runtime-container.conf
 c0fbaff90cb1e57758374ac63e7793c7a80108470589d3a0fae071f3976ccfc3  radon-flex-pull.service
 b5532b732c2a1b7347b3ddddcafe5d5b8123ad8671cdfcad9ba3a8176ee88d50  radon-flex-pull.timer

--- a/cloud/services/radon-monitor.service.d/runtime-container.conf
+++ b/cloud/services/radon-monitor.service.d/runtime-container.conf
@@ -6,15 +6,18 @@ Environment=RADON_RUNTIME=container
 # PATH every other root unit pins -- a root process must not resolve a
 # bare binary name through an inherited PATH. R-393.
 Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-# The base unit is Type=notify with WatchdogSec=900 (DUR-17 for the relay,
-# REL-008 for the monitor, installed to catch the alive-but-dead loop wedge).
-# Forcing Type=simple + WatchdogSec=infinity here made systemd stop waiting
-# for READY=1 and stop requiring keepalives, so a relay that stopped
-# delivering ticks sat active (running) forever with a dead socket. The
-# notify socket is already bind-mounted into the container and
-# radon-app-runtime.sh already forwards NOTIFY_SOCKET/WATCHDOG_USEC. R-391.
-Type=notify
-WatchdogSec=900
+# systemd attributes a notify datagram to a unit by the SENDER'S CGROUP.
+# radon-app-runtime.sh runs the payload under `--cgroup-parent=system.slice`,
+# so the container lands in /system.slice/docker-<id>.scope, never in
+# /system.slice/<unit>. The datagram is unattributable and Type=notify
+# hangs at `activating` until TimeoutStartSec, then restart-loops --
+# observed in production 2026-08-29. Docker's systemd cgroup driver
+# refuses `--cgroup-parent=system.slice/<unit>.service` ("should be a
+# valid slice named as xxx.slice"), so the container CANNOT be placed
+# inside the unit cgroup and READY=1 can never be attributed. The
+# watchdog R-391 restored has to come back by another mechanism.
+Type=simple
+WatchdogSec=infinity
 ExecStartPre=
 ExecStart=
 ExecStart=/usr/local/sbin/radon-app-runtime run %n

--- a/cloud/services/radon-relay.service.d/runtime-container.conf
+++ b/cloud/services/radon-relay.service.d/runtime-container.conf
@@ -6,15 +6,18 @@ Environment=RADON_RUNTIME=container
 # PATH every other root unit pins -- a root process must not resolve a
 # bare binary name through an inherited PATH. R-393.
 Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-# The base unit is Type=notify with WatchdogSec=45 (DUR-17 for the relay,
-# REL-008 for the monitor, installed to catch the alive-but-dead loop wedge).
-# Forcing Type=simple + WatchdogSec=infinity here made systemd stop waiting
-# for READY=1 and stop requiring keepalives, so a relay that stopped
-# delivering ticks sat active (running) forever with a dead socket. The
-# notify socket is already bind-mounted into the container and
-# radon-app-runtime.sh already forwards NOTIFY_SOCKET/WATCHDOG_USEC. R-391.
-Type=notify
-WatchdogSec=45
+# systemd attributes a notify datagram to a unit by the SENDER'S CGROUP.
+# radon-app-runtime.sh runs the payload under `--cgroup-parent=system.slice`,
+# so the container lands in /system.slice/docker-<id>.scope, never in
+# /system.slice/<unit>. The datagram is unattributable and Type=notify
+# hangs at `activating` until TimeoutStartSec, then restart-loops --
+# observed in production 2026-08-29. Docker's systemd cgroup driver
+# refuses `--cgroup-parent=system.slice/<unit>.service` ("should be a
+# valid slice named as xxx.slice"), so the container CANNOT be placed
+# inside the unit cgroup and READY=1 can never be attributed. The
+# watchdog R-391 restored has to come back by another mechanism.
+Type=simple
+WatchdogSec=infinity
 ExecStartPre=
 ExecStart=
 ExecStart=/usr/local/sbin/radon-app-runtime run %n

--- a/cloud/tests/test_rel138_dropin_supervision_and_drift.py
+++ b/cloud/tests/test_rel138_dropin_supervision_and_drift.py
@@ -1,12 +1,33 @@
 """R-391 / R-392 / REL-138: the drop-ins keep the supervision and the drift signal.
 
-R-391: base `radon-relay.service` is `Type=notify` + `WatchdogSec=45`; base
-`radon-monitor.service` is `Type=notify` + `WatchdogSec=900`, the latter
-installed BY REL-008 to catch the alive-but-dead loop wedge. Both drop-ins
-overrode to `Type=simple` + `WatchdogSec=infinity`, so systemd stopped waiting
-for `READY=1` and stopped requiring keepalives -- reverting REL-008 and DUR-17
-and making the `NOTIFY_SOCKET` / `WATCHDOG_USEC` plumbing in
-`radon-app-runtime.sh` dead code.
+R-391 (SUPERSEDED 2026-08-29, see below): base `radon-relay.service` is
+`Type=notify` + `WatchdogSec=45`; base `radon-monitor.service` is
+`Type=notify` + `WatchdogSec=900`, the latter installed BY REL-008 to catch the
+alive-but-dead loop wedge. R-391 made both drop-ins inherit that contract
+instead of overriding it to `Type=simple` + `WatchdogSec=infinity`.
+
+Those drop-ins could not be installed until the privileged gate was fixed, so
+R-391 first reached production on 2026-08-29 -- and both units immediately
+restart-looped. systemd attributes a notify datagram to a unit by the SENDER'S
+CGROUP. `radon-app-runtime.sh` runs the payload under
+`--cgroup-parent=system.slice`, so the container lands in
+`/system.slice/docker-<id>.scope`, never in `/system.slice/<unit>`; the
+datagram is unattributable, `Type=notify` hangs at `activating` until
+TimeoutStartSec, and the unit restart-loops.
+
+Measured, not inferred:
+
+  * the app side is correct -- running `radon-node` with `NOTIFY_SOCKET` set
+    delivers `READY=1` (`ib_realtime_server.js:383`), and `socat` in the image
+    reaches a host socket
+  * the placement cannot be fixed: docker's systemd cgroup driver rejects
+    `--cgroup-parent=system.slice/<unit>.service` with "cgroup-parent for
+    systemd cgroup should be a valid slice named as xxx.slice"
+
+So a CONTAINERISED unit cannot satisfy `Type=notify`, and these tests now pin
+that constraint rather than the contract it makes impossible. The supervision
+R-391 restored is genuinely lost and needs a different mechanism; it is not
+re-established by the drop-in.
 
 R-392: `_check_units` merges the LIVE unit with its drop-ins but compares
 against the repo BASE unit alone, so every setting a drop-in adds reads as
@@ -56,50 +77,52 @@ def _dropin(unit: str) -> str:
     return (SERVICES / f"{unit}.d" / "runtime-container.conf").read_text(encoding="utf-8")
 
 
-class TestSupervisionSurvivesContainerisation:
+class TestContainerisedUnitsCannotUseNotify:
+    """The 2026-08-29 production regression, pinned as a constraint.
+
+    A drop-in that asks systemd to wait for `READY=1` from a process systemd
+    cannot attribute to the unit is not stricter supervision -- it is a
+    guaranteed restart loop. Every one of these units runs its payload in a
+    container placed outside the unit cgroup.
+    """
+
     @pytest.mark.parametrize("unit", APP_UNITS)
-    def test_the_dropin_does_not_downgrade_the_service_type(self, unit):
-        base_type = _directive(_base(unit), "Type") or "simple"
-        drop_type = _directive(_dropin(unit), "Type")
-        assert drop_type == base_type, (
-            f"{unit}: base is Type={base_type} but the drop-in forces "
-            f"Type={drop_type}; systemd stops waiting for READY=1"
+    def test_no_containerised_dropin_asks_for_notify(self, unit):
+        drop_type = _directive(_dropin(unit), "Type") or "simple"
+        assert drop_type != "notify", (
+            f"{unit}: the payload runs under --cgroup-parent=system.slice, so its "
+            "READY=1 is unattributable and systemd hangs at `activating` until "
+            "TimeoutStartSec, then restart-loops (observed in production "
+            "2026-08-29). Docker refuses --cgroup-parent=system.slice/<unit>."
         )
 
     @pytest.mark.parametrize("unit", APP_UNITS)
-    def test_the_dropin_does_not_disable_the_watchdog(self, unit):
-        base_wd = _directive(_base(unit), "WatchdogSec")
-        drop_wd = _directive(_dropin(unit), "WatchdogSec")
-        if base_wd is None:
-            return  # the base never had one; nothing to preserve
-        assert drop_wd in (None, base_wd), (
-            f"{unit}: base WatchdogSec={base_wd}, drop-in={drop_wd}. A relay "
-            "that stops delivering ticks, or a monitor wedged on an IB socket, "
-            "used to get SIGABRT and a restart; with infinity it sits "
-            "active (running) forever with a dead socket."
+    def test_a_notify_dropin_would_have_to_neutralise_the_watchdog_too(self, unit):
+        """`WatchdogSec` without a reachable notify socket is a timed SIGABRT."""
+        if (_directive(_base(unit), "WatchdogSec")) is None:
+            return
+        assert _directive(_dropin(unit), "WatchdogSec") == "infinity", (
+            f"{unit}: the base declares a watchdog the container can never feed, "
+            "so the drop-in must disable it explicitly rather than inherit it."
         )
 
-    def test_the_two_notify_units_keep_their_watchdogs(self):
-        """The specific regression: REL-008 (monitor 900s) and DUR-17 (relay 45s)."""
+    def test_the_base_units_keep_their_watchdogs_for_a_host_run(self):
+        """Unchanged by this: the base units are still correct off-container."""
         assert _directive(_base("radon-monitor.service"), "WatchdogSec") == "900"
         assert _directive(_base("radon-relay.service"), "WatchdogSec") == "45"
-        for unit in ("radon-monitor.service", "radon-relay.service"):
-            # Strip comments first: the explanatory comment QUOTES the value it
-            # is explaining, and would satisfy or break this assertion by itself.
-            body = "\n".join(
-                ln for ln in _dropin(unit).splitlines() if not ln.lstrip().startswith("#")
-            )
-            assert "infinity" not in body, unit
 
-    def test_the_notify_socket_plumbing_is_reachable(self):
-        """`WATCHDOG_USEC` is only set for a Type=notify unit with a watchdog."""
+    def test_the_dropin_states_why_supervision_is_downgraded(self):
+        """A bare `Type=simple` reads as an oversight; this one is a finding."""
+        for unit in ("radon-monitor.service", "radon-relay.service"):
+            body = _dropin(unit)
+            assert "cgroup" in body.lower(), unit
+            assert "2026-08-29" in body, unit
+
+    def test_the_notify_plumbing_is_still_forwarded_for_a_future_fix(self):
+        """Harmless while unused, and the only thing a real fix would reuse."""
         source = RUNTIME.read_text(encoding="utf-8")
         assert "WATCHDOG_USEC" in source
         assert "NOTIFY_SOCKET" in source
-        notify_units = [
-            u for u in APP_UNITS if (_directive(_dropin(u), "Type") or "simple") == "notify"
-        ]
-        assert set(notify_units) == {"radon-monitor.service", "radon-relay.service"}, notify_units
 
 
 class TestDriftAuditSeesTheRepoDropins:


### PR DESCRIPTION
## What happened

R-391 made the relay and monitor drop-ins inherit their base units' `Type=notify` + `WatchdogSec` instead of overriding to `Type=simple` + `WatchdogSec=infinity`. The privileged drop-in gate refused those files (fixed in #143), so **R-391 first reached production on 2026-08-29** — and both units restart-looped immediately.

```
radon-relay   activating  NRestarts 1 → 2
radon-monitor activating  NRestarts 1
radon-health  inactive (dead)   # left down by the aborted deploy
```

## Root cause

systemd attributes a notify datagram to a unit by the **sender's cgroup**. `radon-app-runtime.sh` runs the payload under `--cgroup-parent=system.slice`, so the container lands in `/system.slice/docker-<id>.scope`, never in `/system.slice/<unit>`:

```
$ cat /proc/$(docker inspect radon-relay.service --format '{{.State.Pid}}')/cgroup
0::/system.slice/docker-9203aee91848….scope
```

The datagram is unattributable, so `Type=notify` waits at `activating` until `TimeoutStartSec` and then loops. `NotifyAccess=all` does not help — it widens *which processes of the unit* may send; the sender must still belong to the unit.

## Measured, not inferred

**The app side is correct.** Running the shipped image with `NOTIFY_SOCKET` set:

```
$ docker run --rm --network host --user 1000:1000 \
    --mount type=bind,src=/tmp/notifytest.sock,dst=/tmp/notifytest.sock \
    --env NOTIFY_SOCKET=/tmp/notifytest.sock --env WATCHDOG_USEC=45000000 \
    ghcr.io/joemccann/radon-node:79e38b9a node scripts/ib_realtime_server.js --port 18765 …
listening
GOT: READY=1
```

`socat` in `radon-node` also reaches a host unix socket, and the monitor sends natively via `AF_UNIX SOCK_DGRAM`.

**The placement cannot be fixed.** A scratch unit with `Delegate=yes` and `--cgroup-parent=system.slice/radon-notifytest.service`:

```
docker: Error response from daemon: cgroup-parent for systemd cgroup
should be a valid slice named as "xxx.slice"
```

Docker's systemd cgroup driver will not place a container inside a `.service` cgroup, so `READY=1` can never be attributed while the payload runs in a container.

## The change

- relay + monitor drop-ins → `Type=simple` + `WatchdogSec=infinity`, each carrying the cgroup finding inline so a bare `Type=simple` never reads as an oversight again
- `installed-units.sha256` bumped for both (the R-058 install contract)
- REL-138 tests re-pointed at the **constraint** rather than the contract it makes impossible: no containerised drop-in may ask for notify; one that inherits a base watchdog must disable it explicitly; the drop-in must state why. Base units are untouched and still correct off-container.

## What this costs

The supervision R-391 restored — REL-008 (monitor wedged on an IB socket, 900s) and DUR-17 (relay stops delivering ticks, 45s) — is **genuinely lost**, not re-established by another route in this PR. Restoring it needs a mechanism that does not depend on cgroup attribution: a host-side liveness prober that feeds the watchdog on the container's behalf, or moving these two units off the container runtime. Worth an issue.

## Also unblocks deploys

The host was hot-fixed to `Type=simple` during the incident, which made every subsequent deploy abort:

```
[ERROR] [preflight] installed control-plane target drifted:
        /etc/systemd/system/radon-relay.service.d/runtime-container.conf
```

After this merges, a root bootstrap makes installed == release and that clears.

## Verification

- `cloud/tests`: 1367 passed. The 4 failures are pre-existing locally — 3× `caddy is not on PATH` (CI installs it in this shard) and a secrets scan that fails identically with these changes stashed.
- Production is currently stable on the hot-fixed state: 5/5 active, `NRestarts` 0, `api:200 relay:426 health:200`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)