### PR TITLE
fix(runtime): keep the notify proxy alive past the run handoff (R-429)

### DIFF
--- a/cloud/scripts/radon-app-runtime.sh
+++ b/cloud/scripts/radon-app-runtime.sh
@@ -191,9 +191,12 @@ while True:
 PY
 }
 
-# Starts the forwarder for one unit and prints the socket path the container
-# must use as NOTIFY_SOCKET. Refuses to launch the container if the socket
-# never appears: without it a Type=notify unit can only time out.
+# Starts the forwarder for one unit and sets NOTIFY_PROXY_SOCKET to the path
+# the container must use as NOTIFY_SOCKET. Refuses to launch the container if
+# the socket never appears: without it a Type=notify unit can only time out.
+# Must run in THIS shell, never in a $(...) substitution: the forwarder exits
+# when its parent changes, and a subshell parent is gone the moment it
+# returns, which left a dead socket behind on the first live probe.
 start_notify_proxy() {
   local unit="$1" upstream="$2" listen attempt
   listen="${NOTIFY_PROXY_DIR}/${unit}.sock"
@@ -204,7 +207,7 @@ start_notify_proxy() {
   rm -f "$listen"
   "$0" notify-proxy "$listen" "$upstream" &
   for attempt in $(seq 1 50); do
-    [[ -S "$listen" ]] && { printf '%s\n' "$listen"; return 0; }
+    [[ -S "$listen" ]] && { NOTIFY_PROXY_SOCKET="$listen"; return 0; }
     sleep 0.1
   done
   echo "radon-app-runtime: notify proxy for ${unit} did not bind ${listen}" >&2
@@ -213,7 +216,7 @@ start_notify_proxy() {
 
 cmd_run() {
   local unit="${1:-}"
-  local ids image workdir notify_socket
+  local ids image workdir
   [[ -n "$unit" ]] || usage
   refuse_host_plane "$unit"
   is_app_unit "$unit" || {
@@ -278,9 +281,9 @@ cmd_run() {
     -v "${LEASE_DIR}:/var/lib/radon/ib-lease"
 
   if [[ -n "${NOTIFY_SOCKET:-}" && "${NOTIFY_SOCKET}" == /* ]]; then
-    notify_socket="$(start_notify_proxy "$unit" "$NOTIFY_SOCKET")" || exit $?
-    set -- "$@" --env "NOTIFY_SOCKET=${notify_socket}" --env WATCHDOG_USEC \
-      --mount "type=bind,src=${notify_socket},dst=${notify_socket}"
+    start_notify_proxy "$unit" "$NOTIFY_SOCKET" || exit $?
+    set -- "$@" --env "NOTIFY_SOCKET=${NOTIFY_PROXY_SOCKET}" --env WATCHDOG_USEC \
+      --mount "type=bind,src=${NOTIFY_PROXY_SOCKET},dst=${NOTIFY_PROXY_SOCKET}"
   fi
   if [[ "$unit" == "radon-newsfeed.service" ]]; then
     # Page 3e952746: the image ENV is PLAYWRIGHT_BROWSERS_PATH=/ms-playwright,

--- a/cloud/tests/test_app_runtime.py
+++ b/cloud/tests/test_app_runtime.py
@@ -310,6 +310,44 @@ def test_run_forwards_notify_through_a_proxy_in_the_unit_cgroup(tmp_path: Path) 
     assert str(tmp_path / "notify.sock") not in log
 
 
+def test_notify_proxy_outlives_the_run_handoff_and_relays_while_docker_runs(tmp_path: Path) -> None:
+    """The forwarder is spawned before `exec docker`; it must still be alive
+    once the container is up. The first implementation started it inside a
+    $(...) substitution, so its parent was a subshell that had already exited
+    and the proxy quit within 250ms: the socket file stayed behind and the
+    container got `Connection refused` on every READY=1 (live probe
+    2026-08-29 17:26Z). Asserted at the wire: a datagram sent to the proxy
+    socket while the fake docker is still running must reach NOTIFY_SOCKET."""
+    d = Path(tempfile.mkdtemp(prefix="rdn", dir="/tmp"))
+    upstream_path = d / "u"
+    upstream = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    upstream.bind(str(upstream_path))
+    fake_docker = tmp_path / "docker"
+    _write_executable(fake_docker, "#!/bin/bash\nif [[ \"$1\" == run ]]; then sleep 3; fi\nexit 0\n")
+    env = {**_runtime_env(tmp_path, fake_docker), "NOTIFY_SOCKET": str(upstream_path)}
+    proxy_socket = Path(env["RADON_TEST_NOTIFY_PROXY_DIR"]) / "radon-relay.service.sock"
+    proc = subprocess.Popen(
+        ["bash", str(RUNTIME), "run", "radon-relay.service"],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        deadline = time.monotonic() + 5
+        while not proxy_socket.exists() and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert proxy_socket.exists()
+        time.sleep(0.8)  # past the proxy's parent poll interval
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+        client.sendto(b"READY=1\n", str(proxy_socket))
+        upstream.settimeout(5)
+        assert b"READY=1" in upstream.recv(256)
+    finally:
+        proc.kill()
+        proc.wait(timeout=5)
+        upstream.close()
+
+
 def _proxy_dir_from(result: subprocess.CompletedProcess[str]) -> str:
     return result.proxy_dir  # type: ignore[attr-defined]
 


### PR DESCRIPTION
Follow-up to #152. `start_notify_proxy` ran inside a `$(...)` substitution, so the forwarder's parent was a subshell that exited immediately; the proxy's parent-death check fired within 250 ms and the container got `Connection refused` on every `READY=1` (live probe 2026-08-29 17:26Z under a transient `Type=notify` drop-in on the relay: start timed out at 90 s; the relay was restored to `Type=simple` right after).

The function now sets `NOTIFY_PROXY_SOCKET` in the calling shell, so the proxy's parent is the ExecStart process that `exec`s docker.

Wire-level test: `run` against a fake docker that sleeps, a datagram sent to the proxy socket while the container is "up" must arrive at `NOTIFY_SOCKET`. Red on the previous implementation (`1 failed`), green now (`35 passed`).

This SHA edits `radon-app-runtime.sh` (control-plane manifested). It is the first release expected to install its bundle through `radon-deploy-root sync-control-plane` with no root SSH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016XHuszj8x1R9z6Y99K4xDM
