### PR TITLE
fix(ci): build python and node app images in parallel

### DIFF
--- a/.github/workflows/app-images.yml
+++ b/.github/workflows/app-images.yml
@@ -1,8 +1,10 @@
 name: App-plane images
 
-# Builds radon-python / radon-node. This workflow is NOT a deploy need and
-# must never live in ci.yml `deploy.needs`. Host binaries remain the
-# production runtime until per-unit drop-ins are installed after hours.
+# Builds radon-python / radon-node as sibling jobs so wall clock is the
+# slower image, not python+node+four sequential pushes. This workflow is
+# NOT a deploy need and must never live in ci.yml `deploy.needs`. Host
+# binaries remain the production runtime until per-unit drop-ins are
+# installed after hours.
 
 on:
   pull_request:
@@ -13,20 +15,38 @@ permissions:
   contents: read
   packages: write
 
+concurrency:
+  group: app-images-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  app-images:
-    name: Build app-plane images
+  python-image:
+    name: Build python image
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    concurrency:
-      group: app-images-${{ github.ref }}
-      cancel-in-progress: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build python image
         run: |
           cp docker/app/.dockerignore .dockerignore
           docker build -f docker/app/Dockerfile.python -t radon-python:ci .
+      - name: Push python SHA tags to GHCR
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: |
+          set -euo pipefail
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          sha="${GITHUB_SHA}"
+          docker tag radon-python:ci "ghcr.io/joemccann/radon-python:${sha}"
+          docker tag radon-python:ci "ghcr.io/joemccann/radon-python:latest"
+          docker push "ghcr.io/joemccann/radon-python:${sha}"
+          docker push "ghcr.io/joemccann/radon-python:latest"
+
+  node-image:
+    name: Build node image
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build node image
         env:
           # NEXT_PUBLIC_* are COMPILE-TIME inlined by the Next build, so an
@@ -51,17 +71,13 @@ jobs:
             --build-arg NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY="$NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY" \
             --build-arg NEXT_PUBLIC_RADON_API_URL="$NEXT_PUBLIC_RADON_API_URL" \
             --build-arg NEXT_PUBLIC_IB_REALTIME_WS_URL="$NEXT_PUBLIC_IB_REALTIME_WS_URL"
-      - name: Push SHA tags to GHCR
+      - name: Push node SHA tags to GHCR
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: |
           set -euo pipefail
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
           sha="${GITHUB_SHA}"
-          docker tag radon-python:ci "ghcr.io/joemccann/radon-python:${sha}"
           docker tag radon-node:ci "ghcr.io/joemccann/radon-node:${sha}"
-          docker tag radon-python:ci "ghcr.io/joemccann/radon-python:latest"
           docker tag radon-node:ci "ghcr.io/joemccann/radon-node:latest"
-          docker push "ghcr.io/joemccann/radon-python:${sha}"
           docker push "ghcr.io/joemccann/radon-node:${sha}"
-          docker push "ghcr.io/joemccann/radon-python:latest"
           docker push "ghcr.io/joemccann/radon-node:latest"

--- a/cloud/scripts/radon-app-runtime.sh
+++ b/cloud/scripts/radon-app-runtime.sh
@@ -44,9 +44,9 @@ usage() {
 
 # Tag used when the pinned SHA was never pushed. app-images.yml sets
 # cancel-in-progress, so a second push to main inside the 60-minute build
-# budget cancels the first build and SHA1's `Push SHA tags to GHCR` step never
-# runs — while ci.yml's deploy deliberately does not wait on app-images, so
-# SHA1 still deploys. Without a fallback all five app units docker-run a
+# budget cancels the first build and SHA1's GHCR push steps never run while
+# ci.yml's deploy deliberately does not wait on app-images, so SHA1 still
+# deploys. Without a fallback all five app units docker-run a
 # `manifest unknown` at once. R-234.
 RADON_APP_IMAGE_FALLBACK_TAG="${RADON_APP_IMAGE_FALLBACK_TAG:-latest}"
 

--- a/cloud/tests/test_app_plane_cutover_safety.py
+++ b/cloud/tests/test_app_plane_cutover_safety.py
@@ -40,6 +40,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
@@ -215,10 +216,33 @@ class TestImageBuildCarriesPublicEnv:
         assert "next-clerk-guard" in text
 
     def test_the_workflow_pushes_latest_only_after_the_node_image_bakes(self):
-        workflow = WORKFLOW.read_text(encoding="utf-8")
-        assert "radon-node:latest" in workflow
-        push = workflow.split("Push SHA tags to GHCR", 1)[-1]
-        assert "radon-node:latest" in push
+        jobs = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]
+        node = jobs["node-image"]
+        python = jobs["python-image"]
+        node_blob = yaml.dump(node)
+        python_blob = yaml.dump(python)
+        assert "Dockerfile.node" in node_blob
+        assert "radon-node:latest" in node_blob
+        assert "Dockerfile.python" not in node_blob
+        assert "radon-python:latest" not in node_blob
+        assert "Dockerfile.python" in python_blob
+        assert "radon-python:latest" in python_blob
+        assert "Dockerfile.node" not in python_blob
+        assert "radon-node:latest" not in python_blob
+
+    def test_python_and_node_image_jobs_run_in_parallel(self):
+        """One runner doing python then node serializes ~2m of node behind 34s
+        of python, then four sequential GHCR pushes. Sibling jobs with no
+        needs: cut wall clock to the slower image."""
+        parsed = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+        jobs = parsed["jobs"]
+        assert "python-image" in jobs
+        assert "node-image" in jobs
+        assert "needs" not in jobs["python-image"]
+        assert "needs" not in jobs["node-image"]
+        concurrency = parsed.get("concurrency") or jobs["python-image"].get("concurrency")
+        assert concurrency
+        assert concurrency.get("cancel-in-progress") is True
 
 
 class TestImageTagIsPreflighted:


### PR DESCRIPTION
## Why

`App-plane images` ran as one job: python (34s) then node (2m) then four sequential GHCR pushes (1m51s). Wall clock was the sum.

## What

- Sibling jobs `python-image` and `node-image` with no `needs`.
- Each job builds and, on main, pushes only its own SHA + `latest`.
- Workflow-level `cancel-in-progress` kept (R-234).
- Node job still fails closed on empty `NEXT_PUBLIC_*` (R-233).

Expected wall clock: about the node build plus its two pushes, not python + node + four pushes.

## Tests

`cloud/tests/test_app_plane_cutover_safety.py` 27 passed, 2 skipped.
