### PR TITLE
fix(deploy): recover a stale transition before the control-plane sync (R-430)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -820,6 +820,12 @@ jobs:
             # Reconcile the root-owned control plane with this tip BEFORE
             # deploy.sh holds the deploy lock (bootstrap needs that lock).
             # Runs only here, after every gate job is green. R-430.
+            # A transition journal left by a failed deploy makes bootstrap
+            # refuse, so recover it first (deploy.sh does exactly this pass
+            # at its own start; here it runs before the sync instead).
+            if grep -q 'RADON_DEPLOY_RECOVER_ONLY' "$RUNNER/cloud/scripts/deploy.sh"; then
+              RADON_DEPLOY_RECOVER_ONLY=1 bash "$RUNNER/cloud/scripts/deploy.sh" "$SHA"
+            fi
             if [[ -f "$RUNNER/cloud/scripts/sync-control-plane.sh" ]]; then
               bash "$RUNNER/cloud/scripts/sync-control-plane.sh"
             fi

--- a/cloud/scripts/deploy.sh
+++ b/cloud/scripts/deploy.sh
@@ -1775,6 +1775,18 @@ supervise_deploy_command() {
     fi
   fi
 
+  # Recovery-only pass. The deploy job runs this BEFORE sync-control-plane:
+  # bootstrap refuses while a transition journal is pending, and a journal
+  # left by a failed deploy was only ever recovered here, after the sync had
+  # already given up (run 33266012501: six refusals, then preflight aborted
+  # on the very control-plane change the sync would have installed). R-430.
+  if [[ "${RADON_DEPLOY_RECOVER_ONLY:-0}" == "1" ]]; then
+    log_info "Recovery pass complete; no deploy requested"
+    trap - TERM INT HUP
+    exec 9>&-
+    return 0
+  fi
+
   local exit_code=0
   timeout --signal=TERM --kill-after="${DEPLOY_KILL_AFTER}s" \
     "${DEPLOY_TIMEOUT}s" "$@" 9>&- &

--- a/cloud/tests/test_sync_control_plane.py
+++ b/cloud/tests/test_sync_control_plane.py
@@ -200,17 +200,73 @@ class TestContracts:
         assert "ROOT_SYNC_ACTION_TIMEOUT" in selector
         assert "sync-control-plane" not in function_body(helper, "action_queues_radon_jobs")
 
-    def test_deploy_job_syncs_before_deploy_sh_and_prestage_does_not(self):
+    def test_deploy_job_recovers_then_syncs_then_deploys_and_prestage_does_neither(self):
         ci = CI.read_text(encoding="utf-8")
         deploy_job = ci.split("\n  deploy:\n", 1)[1]
         stage_job = ci.split("\n  stage-release:\n", 1)[1].split("\n  deploy:\n", 1)[0]
         assert "sync-control-plane.sh" not in stage_job
+        assert "RADON_DEPLOY_RECOVER_ONLY" not in stage_job
+        recover_at = deploy_job.index('RADON_DEPLOY_RECOVER_ONLY=1 bash "$RUNNER/cloud/scripts/deploy.sh" "$SHA"')
         sync_at = deploy_job.index('sync-control-plane.sh')
-        deploy_at = deploy_job.index('bash "$RUNNER/cloud/scripts/deploy.sh" "$SHA"')
-        assert sync_at < deploy_at
+        deploy_at = deploy_job.index('\n            bash "$RUNNER/cloud/scripts/deploy.sh" "$SHA"')
+        assert recover_at < sync_at < deploy_at
+        # A runner predating the flag would run a full deploy under it.
+        assert "grep -q 'RADON_DEPLOY_RECOVER_ONLY' \"$RUNNER/cloud/scripts/deploy.sh\"" in deploy_job
         # Runs from the immutable runner of the tested SHA, tolerant of a
         # release that predates the script.
         assert 'if [[ -f "$RUNNER/cloud/scripts/sync-control-plane.sh" ]]; then' in deploy_job
+
+    def _supervisor(self, tmp_path, *, journal: bool, recover_only: str, recovery_rc: int = 0):
+        journal_file = tmp_path / "transition.json"
+        if journal:
+            journal_file.write_text("{}", encoding="utf-8")
+        shell = f"""
+set -euo pipefail
+source {DEPLOY}
+# macOS test hosts have neither util-linux flock nor GNU timeout.
+flock() {{ return 0; }}
+timeout() {{ shift 3; "$@"; }}
+recover_pending_transition() {{ printf recovered > {tmp_path / 'recovered'}; return {recovery_rc}; }}
+supervise_deploy_command bash -c 'printf deployed > {tmp_path / "deployed"}'
+"""
+        return subprocess.run(
+            ["bash", "-c", shell],
+            env={
+                **os.environ,
+                "RADON_DEPLOY_LOCK_FILE": str(tmp_path / "deploy.lock"),
+                "RADON_DEPLOY_TRANSITION_JOURNAL": str(journal_file),
+                "RADON_DEPLOY_RECOVER_ONLY": recover_only,
+                "DEPLOY_TIMEOUT": "30",
+                "DEPLOY_KILL_AFTER": "5",
+            },
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+    def test_recover_only_pass_recovers_a_pending_journal_and_deploys_nothing(self, tmp_path):
+        result = self._supervisor(tmp_path, journal=True, recover_only="1")
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert (tmp_path / "recovered").exists()
+        assert not (tmp_path / "deployed").exists()
+        assert "Recovery pass complete" in result.stdout + result.stderr
+
+    def test_recover_only_pass_is_a_noop_without_a_journal(self, tmp_path):
+        result = self._supervisor(tmp_path, journal=False, recover_only="1")
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert not (tmp_path / "recovered").exists()
+        assert not (tmp_path / "deployed").exists()
+
+    def test_recover_only_pass_still_refuses_when_recovery_fails(self, tmp_path):
+        result = self._supervisor(tmp_path, journal=True, recover_only="1", recovery_rc=1)
+        assert result.returncode == 76
+        assert not (tmp_path / "deployed").exists()
+
+    def test_without_the_flag_the_supervisor_recovers_then_deploys(self, tmp_path):
+        result = self._supervisor(tmp_path, journal=True, recover_only="0")
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert (tmp_path / "recovered").exists()
+        assert (tmp_path / "deployed").exists()
 
     def test_prestage_skips_instead_of_failing_when_control_plane_is_not_ready(self, tmp_path):
         shell = f"""


### PR DESCRIPTION
Follow-up to #152/#153. `bootstrap-control-plane.sh` refuses while a transition journal is pending, and a journal left by a failed deploy (the disk-full run `33265501795`) was only ever recovered inside `deploy.sh`, *after* `sync-control-plane.sh` had given up. Run `33266012501`: six `pending transition exists` refusals, then `deploy.sh` recovered the journal and aborted at preflight on the very `radon-app-runtime.sh` change the sync would have installed.

`deploy.sh` gains `RADON_DEPLOY_RECOVER_ONLY=1`: the supervisor takes the deploy lock, recovers a pending journal exactly as it does today, and returns without deploying. The deploy job now runs that pass → `sync-control-plane.sh` → `deploy.sh`. Prestage is untouched.

Tests (`cloud/tests/test_sync_control_plane.py`, 17 passed): recover-only pass recovers a pending journal and deploys nothing, is a no-op without one, still refuses (76) when recovery fails, and without the flag the supervisor recovers then deploys; CI ordering recover → sync → deploy pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016XHuszj8x1R9z6Y99K4xDM
