### PR TITLE
fix(caddy): IPv4 loopback + healthd dial-refused is not a 502

### DIFF
--- a/cloud/caddy/Caddyfile
+++ b/cloud/caddy/Caddyfile
@@ -31,7 +31,7 @@
     }
 
     handle /ws* {
-        reverse_proxy localhost:8765
+        reverse_proxy 127.0.0.1:8765
     }
 
     # Ride out an upstream restart instead of forwarding it to the browser.
@@ -43,7 +43,7 @@
     # Do NOT add fail_duration: marking the single upstream down would take
     # the retry loop out of the picture and 502 immediately again.
     handle_path /api/ib/* {
-        reverse_proxy localhost:8321 {
+        reverse_proxy 127.0.0.1:8321 {
             lb_try_duration 15s
             lb_try_interval 250ms
 
@@ -90,10 +90,18 @@
                 respond `{"reachable":false,"observer":"caddy"}` 200
             }
         }
+        # handle_response only sees an upstream HTTP response. A dial refused
+        # to :8330 (healthd stopped during deploy) is a Caddy-synthesized 502
+        # that never matches @down, which is how Tier-3 recorded status_http_502
+        # at 318ms while ping still returned 200.
+        handle_errors {
+            header Content-Type application/json
+            respond `{"reachable":false,"observer":"caddy"}` 200
+        }
     }
 
     handle {
-        reverse_proxy localhost:3000 {
+        reverse_proxy 127.0.0.1:3000 {
             lb_try_duration 15s
             lb_try_interval 250ms
 

--- a/cloud/tests/test_caddy_edge_timeouts.py
+++ b/cloud/tests/test_caddy_edge_timeouts.py
@@ -58,8 +58,8 @@ from test_caddyfile import (  # noqa: E402
 REPO = Path(__file__).resolve().parents[2]
 WS_TICKET = REPO / "web" / "lib" / "wsTicket.ts"
 
-APP_UPSTREAM = "localhost:3000"
-IB_UPSTREAM = "localhost:8321"
+APP_UPSTREAM = "127.0.0.1:3000"
+IB_UPSTREAM = "127.0.0.1:8321"
 
 
 def _directive_seconds(block: str, name: str) -> float | None:

--- a/cloud/tests/test_caddyfile.py
+++ b/cloud/tests/test_caddyfile.py
@@ -71,17 +71,17 @@ class TestRouting:
     def test_websocket_route_to_8765(self, caddy_dir):
         content = read_caddyfile(caddy_dir)
         assert re.search(r"handle\s+/ws\*", content)
-        assert "localhost:8765" in content
+        assert "127.0.0.1:8765" in content
 
     def test_api_ib_route_to_8321(self, caddy_dir):
         content = read_caddyfile(caddy_dir)
         assert re.search(r"handle_path\s+/api/ib/\*", content)
-        assert "localhost:8321" in content
+        assert "127.0.0.1:8321" in content
 
     def test_default_route_to_3000(self, caddy_dir):
         content = read_caddyfile(caddy_dir)
         assert re.search(r"handle\s*\{", content, re.MULTILINE)
-        assert "localhost:3000" in content
+        assert "127.0.0.1:3000" in content
 
     def test_handle_path_used_for_api_ib(self, caddy_dir):
         content = read_caddyfile(caddy_dir)
@@ -90,6 +90,24 @@ class TestRouting:
         assert match.group(1) == "handle_path", (
             "/api/ib/* must use handle_path (not handle) for prefix stripping"
         )
+
+    def test_reverse_proxy_does_not_dial_localhost_hostname(self, caddy_dir):
+        # `localhost` prefers ::1. Relay binds 127.0.0.1:8765 only, so
+        # reverse_proxy localhost:8765 502s with connection refused. Same
+        # trap hit [::1]:3000 during nextjs restarts (2026-08-25).
+        content = read_caddyfile(caddy_dir)
+        stripped = re.sub(r"(?m)^\s*#.*$", "", content)
+        assert not re.search(r"reverse_proxy\s+localhost:", stripped), (
+            "reverse_proxy must dial 127.0.0.1, not localhost"
+        )
+
+    def test_edge_health_status_maps_dial_errors_to_200(self, caddy_dir):
+        content = read_caddyfile(caddy_dir)
+        block = reverse_proxy_block(content, "127.0.0.1:8330")
+        assert "handle_response" in block
+        status_section = content.split("@edge_health_status", 1)[1].split("\n    handle {", 1)[0]
+        assert "handle_errors" in status_section
+        assert '{"reachable":false,"observer":"caddy"}' in status_section
 
 
 class TestRetiredBetaStack:
@@ -262,20 +280,20 @@ class TestUpstreamRestartWindow:
     """
 
     def test_app_proxy_retries_across_the_restart_gap(self, caddy_dir):
-        block = reverse_proxy_block(read_caddyfile(caddy_dir), "localhost:3000")
+        block = reverse_proxy_block(read_caddyfile(caddy_dir), "127.0.0.1:3000")
         assert retry_window_seconds(block) >= MIN_RETRY_WINDOW_SECONDS, (
             "the app upstream has no retry window that outlasts a radon-nextjs "
             "restart; every request during the deploy gap 502s"
         )
 
     def test_api_proxy_retries_across_the_restart_gap(self, caddy_dir):
-        block = reverse_proxy_block(read_caddyfile(caddy_dir), "localhost:8321")
+        block = reverse_proxy_block(read_caddyfile(caddy_dir), "127.0.0.1:8321")
         assert retry_window_seconds(block) >= MIN_RETRY_WINDOW_SECONDS, (
             "the /api/ib/* upstream has no retry window that outlasts a "
             "radon-api restart; ws-ticket calls 502 through every deploy"
         )
 
-    @pytest.mark.parametrize("upstream", ["localhost:3000", "localhost:8321"])
+    @pytest.mark.parametrize("upstream", ["127.0.0.1:3000", "127.0.0.1:8321"])
     def test_retry_interval_re_dials_across_the_gap(self, caddy_dir, upstream):
         block = reverse_proxy_block(read_caddyfile(caddy_dir), upstream)
         interval = retry_interval_seconds(block)
@@ -308,7 +326,7 @@ class TestSingleUpstreamStaysInThePool:
     proxy block so the warning comment itself neither satisfies nor trips it.
     """
 
-    @pytest.mark.parametrize("upstream", ["localhost:3000", "localhost:8321"])
+    @pytest.mark.parametrize("upstream", ["127.0.0.1:3000", "127.0.0.1:8321"])
     def test_no_fail_duration_on_the_single_upstream_blocks(self, caddy_dir, upstream):
         block = reverse_proxy_block(read_caddyfile(caddy_dir), upstream)
         assert "fail_duration" not in block, (
@@ -430,7 +448,7 @@ class TestRestartWindowMechanism:
     def test_request_during_an_upstream_gap_is_served_not_502ed(
         self, caddy_dir, tmp_path
     ):
-        proxied = reverse_proxy_block(read_caddyfile(caddy_dir), "localhost:3000")
+        proxied = reverse_proxy_block(read_caddyfile(caddy_dir), "127.0.0.1:3000")
         order = []
         request_issued = threading.Event()
 

--- a/cloud/tests/test_integration.py
+++ b/cloud/tests/test_integration.py
@@ -50,7 +50,7 @@ class TestPortConsistency:
 
     def test_caddyfile_routes_to_relay_port_8765(self, caddy_dir):
         caddyfile = read_text(caddy_dir / "Caddyfile")
-        assert "localhost:8765" in caddyfile
+        assert "127.0.0.1:8765" in caddyfile
 
     def test_deploy_health_checks_fastapi_port_8321(self, scripts_dir):
         deploy = read_text(scripts_dir / "deploy.sh")
@@ -63,18 +63,18 @@ class TestPortConsistency:
     def test_caddyfile_api_route_matches_api_service_port(self, caddy_dir, services_dir):
         caddyfile = read_text(caddy_dir / "Caddyfile")
         api = read_text(services_dir / "radon-api.service")
-        assert "localhost:8321" in caddyfile
+        assert "127.0.0.1:8321" in caddyfile
         assert "--port 8321" in api
 
     def test_relay_service_corresponds_to_port_8765(self, caddy_dir):
         caddyfile = read_text(caddy_dir / "Caddyfile")
         assert re.search(r"handle\s+/ws", caddyfile)
-        assert "localhost:8765" in caddyfile
+        assert "127.0.0.1:8765" in caddyfile
 
     def test_nextjs_service_corresponds_to_port_3000(self, caddy_dir, services_dir):
         caddyfile = read_text(caddy_dir / "Caddyfile")
         nextjs = read_text(services_dir / "radon-nextjs.service")
-        assert "localhost:3000" in caddyfile
+        assert "127.0.0.1:3000" in caddyfile
         assert "radon-nextjs" in nextjs.lower() or "Next.js" in nextjs
 
     def test_docker_compose_exposes_live_and_paper_gateway_ports(self, root):

--- a/scripts/api/tests/test_flow_report_deadline_and_jitter.py
+++ b/scripts/api/tests/test_flow_report_deadline_and_jitter.py
@@ -305,7 +305,7 @@ class TestTheBudgetFitsARealScan:
         route_secs = int(match.group(1).replace("_", "")) / 1000
 
         caddyfile = (repo / "cloud" / "caddy" / "Caddyfile").read_text()
-        app_block = caddyfile.split("reverse_proxy localhost:3000")[1]
+        app_block = caddyfile.split("reverse_proxy 127.0.0.1:3000")[1]
         edge = re.search(r"response_header_timeout\s+(\d+)s", app_block)
         assert edge, "the app upstream must state its response_header_timeout"
 


### PR DESCRIPTION
Caddy `reverse_proxy localhost:8765` dials `[::1]` while the relay binds `127.0.0.1:8765`, so `/ws` 502s. Same trap on `:3000` during nextjs restarts.

`/edge-health/status` still returned raw 502 when healthd was stopped (deploy). `handle_response` only matches an upstream HTTP 5xx; a refused dial is a Caddy-synthesized 502. `handle_errors` on that handle now returns `{"reachable":false,"observer":"caddy"}` 200.