### PR TITLE
fix(test): the LEAP prefill fixture aged out of its own freshness window

### DIFF
--- a/web/e2e/leap-order-prefill.spec.ts
+++ b/web/e2e/leap-order-prefill.spec.ts
@@ -1,7 +1,14 @@
 import { expect, test, type Page } from "@playwright/test";
 
+// Window-relative, NOT a literal: `LeapScanner.isScanStale` suppresses
+// `bestRow` — and with it the TRADE BEST link this spec clicks — once the scan
+// is older than SERVICE_FRESHNESS_WINDOWS["leap-scan"].open (26h). A hardcoded
+// stamp passes until it crosses that line and then fails forever; this one
+// aged out on 2026-08-28 and took the P0-financial smoke red with it.
+const FRESH_SCAN_TIME = new Date(Date.now() - 5 * 60_000).toISOString();
+
 const LEAP_PAYLOAD = {
-  scan_time: "2026-08-27T18:02:30Z",
+  scan_time: FRESH_SCAN_TIME,
   min_gap: 10,
   universe: "preset:largecaps",
   requested_tickers: [],
@@ -121,7 +128,7 @@ async function stubApis(page: Page) {
 
     if (path === "/api/leap") return json(LEAP_PAYLOAD);
     if (path === "/api/scanner") {
-      return json({ scan_time: "2026-08-27T18:02:30Z", tickers_scanned: 0, signals_found: 0, top_signals: [] });
+      return json({ scan_time: FRESH_SCAN_TIME, tickers_scanned: 0, signals_found: 0, top_signals: [] });
     }
     if (path === "/api/portfolio") {
       return json({


### PR DESCRIPTION
`Playwright P0-financial smoke` has been red since 2026-08-28:

```
locator.click: Test timeout of 30000ms exceeded.
  waiting for getByTestId('leap-best-order-link')
e2e/leap-order-prefill.spec.ts:166
```

## Not a UI regression

`LeapScanner` suppresses `bestRow` — and with it the TRADE BEST link this spec clicks — once the scan is stale:

```ts
const scanIsStale = isScanStale(scanStamp);        // LeapScanner.tsx:151
const bestRow = scanIsStale ? null : widestMispriced(rows);
const bestHref = bestRow ? leapOrderHref(bestRow) : null;
{bestRow && bestHref && ( … data-testid="leap-best-order-link" … )}
```

`LEAP_STALE_MS` is `SERVICE_FRESHNESS_WINDOWS["leap-scan"].open` = **26h**. The fixture pinned `scan_time: "2026-08-27T18:02:30Z"`, so it crossed that line at **2026-08-28 20:02Z** and could never pass again — which is exactly when the smoke job went red.

The suppression is correct behaviour: R-388 made the headline slot rank on the contract's own gap, and pointing it at a stale contract is the thing that guard exists to prevent. The fixture was simply describing a scan that had aged out.

## The change

`scan_time` is derived from `Date.now()`, so it describes a fresh scan on every run rather than one particular afternoon. Same for the `/api/scanner` stub beside it.

## Verification

- Red first: reproduced the 30s timeout locally on `origin/main`
- Green after: the spec passes in 3.0s
- Full P0-financial set: **55 passed**. The one other failure was `act-ticket-scroll` under parallel load; it passes on its own both with and without this commit, and passes in CI today

## Siblings worth a sweep later

Same shape, not touched here — hardcoded stamps that will rot when their window closes:

`bpi-tab`, `catalyst-card-weekend`, `cta-page`, `cta-stale-banner`, `ib-mfa-reconnect-alert`, `internals-market-closed`, `mobile-scanner-mode-tabs-overflow`, `mobile-vol-cone-table`, `performance-chart-axes`.

Several are deliberately testing the *stale* branch, so this needs reading case by case rather than a blanket replace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)