### PR TITLE
feat(chat): paste an image into the composer and send it to the model

### DIFF
--- a/web/app/api/assistant/route.ts
+++ b/web/app/api/assistant/route.ts
@@ -9,9 +9,20 @@ import { etCalendarDateString } from "@/lib/journal/rangePnl";
 
 type ChatRole = "user" | "assistant";
 
+export type ChatImageMediaType = "image/png" | "image/jpeg" | "image/gif" | "image/webp";
+
+export type ChatTextBlock = { type: "text"; text: string };
+
+export type ChatImageBlock = {
+  type: "image";
+  source: { type: "base64"; media_type: ChatImageMediaType; data: string };
+};
+
+export type ChatContentBlock = ChatTextBlock | ChatImageBlock;
+
 export type ChatMessage = {
   role: ChatRole;
-  content: string;
+  content: string | ChatContentBlock[];
 };
 
 export type AssistantPayload = {
@@ -40,7 +51,8 @@ export const SYSTEM_PROMPT =
   "JOURNAL CONVENTIONS: The trade journal contains two row families for the same executions: Flex-rehydrate aggregate rows (family flex_agg, composite exec ids, carrying realized_pnl / cost_basis / proceeds / open_basis) and realtime per-fill rows (family fill). " +
   "The same fill can appear in BOTH families; never sum across families without deduping, and rows marked dup:true duplicate an aggregate. " +
   "Closes lot-match against opens by VWAP (per-unit basis = open_basis / quantity), and the matching open may lie OUTSIDE the date window you queried: a close early in a week can realize P&L against an open from a prior week. " +
-  "For realized P&L questions prefer get_realized_pnl: it dedupes and lot-matches for you, attributes P&L to the close date, and handles cross-window opens. Use query_journal only to inspect raw rows.";
+  "For realized P&L questions prefer get_realized_pnl: it dedupes and lot-matches for you, attributes P&L to the close date, and handles cross-window opens. Use query_journal only to inspect raw rows. " +
+  "The operator may attach chart or screenshot images to a message: read every attached image as part of that request.";
 
 const isMockMode = () =>
   process.env.ASSISTANT_MOCK === "1" ||
@@ -50,6 +62,56 @@ function cleanString(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
+// Trust boundary for pasted images. Anything failing a limit is dropped
+// silently — never thrown, never forwarded unvalidated.
+const IMAGE_MEDIA_TYPES: readonly string[] = ["image/png", "image/jpeg", "image/gif", "image/webp"];
+const MAX_IMAGES_PER_MESSAGE = 4;
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+const BASE64_PATTERN = /^[A-Za-z0-9+/]+={0,2}$/;
+
+function decodedBase64Bytes(data: string): number {
+  return Math.floor((data.length * 3) / 4);
+}
+
+function safeImageBlock(block: { source?: unknown }): ChatImageBlock | null {
+  const source = block.source as { type?: unknown; media_type?: unknown; data?: unknown } | undefined;
+  if (!source || source.type !== "base64") return null;
+
+  const mediaType = source.media_type;
+  if (typeof mediaType !== "string" || !IMAGE_MEDIA_TYPES.includes(mediaType)) return null;
+
+  const data = source.data;
+  if (typeof data !== "string" || !BASE64_PATTERN.test(data)) return null;
+  if (decodedBase64Bytes(data) > MAX_IMAGE_BYTES) return null;
+
+  return {
+    type: "image",
+    source: { type: "base64", media_type: mediaType as ChatImageMediaType, data },
+  };
+}
+
+function safeContentBlocks(rawContent: unknown[]): ChatContentBlock[] {
+  const blocks: ChatContentBlock[] = [];
+  let images = 0;
+  for (const raw of rawContent) {
+    const block = raw as { type?: unknown; text?: unknown; source?: unknown };
+    if (block?.type === "text") {
+      const text = cleanString(block.text);
+      if (text) blocks.push({ type: "text", text });
+      continue;
+    }
+    if (block?.type === "image") {
+      if (images >= MAX_IMAGES_PER_MESSAGE) continue;
+      const image = safeImageBlock(block);
+      if (image) {
+        blocks.push(image);
+        images += 1;
+      }
+    }
+  }
+  return blocks;
+}
+
 function safeMessages(rawMessages: unknown): ChatMessage[] {
   if (!Array.isArray(rawMessages)) return [];
 
@@ -57,8 +119,15 @@ function safeMessages(rawMessages: unknown): ChatMessage[] {
   for (const item of rawMessages) {
     const role = (item as { role?: unknown }).role;
     const content = (item as { content?: unknown }).content;
-    if ((role === "user" || role === "assistant") && typeof content === "string" && content.trim()) {
-      parsed.push({ role, content: content.trim() });
+    if (role !== "user" && role !== "assistant") continue;
+
+    if (typeof content === "string") {
+      if (content.trim()) parsed.push({ role, content: content.trim() });
+      continue;
+    }
+    if (Array.isArray(content)) {
+      const blocks = safeContentBlocks(content);
+      if (blocks.length) parsed.push({ role, content: blocks });
     }
   }
   return parsed;
@@ -91,8 +160,19 @@ function toTurns(messages: ChatMessage[]): AssistantTurn[] {
   return messages.map((message) => ({ role: message.role, content: message.content }));
 }
 
+// Text only: the fallback reply and telemetry both want a readable string, and
+// an image block carries nothing readable.
+function contentText(content: ChatMessage["content"]): string {
+  if (typeof content === "string") return content;
+  return content
+    .filter((block): block is ChatTextBlock => block.type === "text")
+    .map((block) => block.text)
+    .join(" ");
+}
+
 function lastUserContent(messages: ChatMessage[]): string {
-  return [...messages].reverse().find((message) => message.role === "user")?.content ?? "";
+  const message = [...messages].reverse().find((entry) => entry.role === "user");
+  return message ? contentText(message.content) : "";
 }
 
 function toTelemetryToolCalls(toolEvents: ToolEvent[]): AssistantTurnToolCall[] {

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -5471,7 +5471,9 @@ body[data-mobile="true"] .dashboard-news .news-feed-refresh--rail {
 .chat-empty-card {
   display: flex;
   align-items: center;
-  gap: 8px;
+  /* The slash and the command are one token ("/portfolio"), so the flex gap
+     must be 0 — an 8px gap rendered it as "/ portfolio". */
+  gap: 0;
   text-align: left;
   padding: 10px 12px;
   border: 1px solid var(--border-dim);
@@ -20871,6 +20873,20 @@ body[data-mobile="true"] .alerts-rule__channel {
   font-family: var(--font-mono); font-size: var(--text-meta);
   color: var(--signal-core-text); background: rgba(5, 173, 152, 0.08);
   border: 1px solid var(--signal-core); border-radius: 3px; padding: 0 5px;
+  cursor: pointer;
+}
+.ask-composer__attachments { display: flex; gap: 6px; flex-wrap: wrap; padding: 8px 12px 0; }
+.ask-composer__thumb {
+  position: relative; width: 44px; height: 44px; overflow: hidden;
+  border: 1px solid var(--line-grid); border-radius: 4px; background: var(--bg-panel-raised);
+}
+.ask-composer__thumb img { display: block; width: 100%; height: 100%; object-fit: cover; }
+.ask-composer__thumb-remove {
+  position: absolute; top: 0; right: 0; width: 14px; height: 14px; padding: 0;
+  display: flex; align-items: center; justify-content: center;
+  font-family: var(--font-mono); font-size: 10px; line-height: 1;
+  color: var(--text-primary); background: var(--bg-panel);
+  border: 1px solid var(--line-grid); border-radius: 0 4px 0 4px;
   cursor: pointer;
 }
 .ask-composer__input {

--- a/web/components/ChatPanel.tsx
+++ b/web/components/ChatPanel.tsx
@@ -9,6 +9,7 @@ import type {
   AssistantOrderInput,
   AssistantOrderProposal,
   AssistantToolEvent,
+  ChatImageAttachment,
   Message,
   PortfolioData,
   WorkspaceSection,
@@ -250,12 +251,14 @@ export default function ChatPanel({
     scrollToBottom();
   }, [scrollToBottom]);
 
-  const sendMessage = async (prompt: string) => {
+  const sendMessage = async (prompt: string, attachments: ChatImageAttachment[] = []) => {
     // One controller per turn: a new send supersedes the previous stream.
     streamAbortRef.current?.abort();
     streamAbortRef.current = new AbortController();
     const cleaned = prompt.trim();
-    if (!cleaned || isBusy) {
+    // An attachment alone is a complete turn: the composer enables Send with no
+    // text once an image is pasted, so an empty prompt must not drop it here.
+    if ((!cleaned && !attachments.length) || isBusy) {
       return;
     }
     // A new turn invalidates any prior model-controlled destructive intent.
@@ -267,6 +270,7 @@ export default function ChatPanel({
       role: "user",
       timestamp: createTimestamp(),
       content: cleaned,
+      ...(attachments.length ? { attachments } : {}),
     };
 
     const conversation: ApiMessage[] = messages.map((message) => ({
@@ -293,8 +297,11 @@ export default function ChatPanel({
     setTurnTools([]);
     setTurnModel(null);
 
+    // A PI command runs a script and never sees an image, so a turn carrying a
+    // pasted image always goes to the assistant rather than silently dropping it.
+    const piCommand = attachments.length ? null : routeToPiPrompt(cleaned);
+
     try {
-      const piCommand = routeToPiPrompt(cleaned);
       if (piCommand) {
         const assistantContent = await requestPiReply(piCommand);
         setStatus("streaming");
@@ -302,7 +309,7 @@ export default function ChatPanel({
           signal: streamAbortRef.current?.signal,
         });
       } else {
-        const turn = await requestAssistantTurn(conversation, cleaned);
+        const turn = await requestAssistantTurn(conversation, cleaned, attachments);
         setTurnTools(turn.toolEvents);
         setTurnModel(turn.model);
         setStatus("streaming");
@@ -317,7 +324,7 @@ export default function ChatPanel({
       }
       setStatus("done");
     } catch (error) {
-      const isPiCommand = Boolean(routeToPiPrompt(cleaned));
+      const isPiCommand = Boolean(piCommand);
       const fallback = isPiCommand ? "PI command failed to run in this session." : fallbackReply(cleaned);
       const errorMessage =
         error instanceof Error
@@ -442,6 +449,21 @@ export default function ChatPanel({
                           />
                         ) : (
                           <>
+                            {message.attachments?.length ? (
+                              // Same thumbnail treatment the composer used, so
+                              // the operator sees exactly what they sent.
+                              <div className="ask-composer__attachments" aria-label="Attached images">
+                                {message.attachments.map((attachment) => (
+                                  <span key={attachment.id} className="ask-composer__thumb">
+                                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                                    <img
+                                      src={`data:${attachment.mediaType};base64,${attachment.data}`}
+                                      alt={attachment.name || "Pasted image"}
+                                    />
+                                  </span>
+                                ))}
+                              </div>
+                            ) : null}
                             <MarkdownRenderer content={message.content} />
                             {isStreamingThis ? (
                               <span className="chat-cursor" aria-hidden="true" />
@@ -520,7 +542,7 @@ export default function ChatPanel({
                     onClick={() => sendMessage(prompt)}
                     className="pill-chip"
                   >
-                    / {prompt}
+                    /{prompt}
                   </button>
                 ))}
               </div>
@@ -528,7 +550,7 @@ export default function ChatPanel({
             <AskComposer
               busy={isBusy}
               focusKey={isOpen}
-              onSubmit={(text) => void sendMessage(text)}
+              onSubmit={(text, _engine, attachments) => void sendMessage(text, attachments)}
             />
           </div>
         </div>

--- a/web/components/agent/AskComposer.tsx
+++ b/web/components/agent/AskComposer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  type ClipboardEvent,
   type FormEvent,
   type KeyboardEvent,
   useEffect,
@@ -8,6 +9,8 @@ import {
   useState,
 } from "react";
 import { Send } from "lucide-react";
+
+import type { ChatImageAttachment, ChatImageMediaType } from "@/lib/types";
 
 /**
  * AskComposer — conversational composer adopted from beautifului.dev
@@ -19,6 +22,45 @@ import { Send } from "lucide-react";
 
 export const ENGINES = ["AUTO", "SPECTRAL", "EIGEN", "MARKOV", "LAPLACE"] as const;
 export type Engine = (typeof ENGINES)[number];
+
+/** Mirrors the server allowlist in app/api/assistant/route.ts. */
+const ALLOWED_MEDIA_TYPES: ChatImageMediaType[] = [
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+];
+const MAX_ATTACHMENTS = 4;
+const MAX_DECODED_BYTES = 5 * 1024 * 1024;
+
+function isAllowedMediaType(type: string): type is ChatImageMediaType {
+  return (ALLOWED_MEDIA_TYPES as string[]).includes(type);
+}
+
+/** Clipboard/drop payloads expose files through `items` first, `files` second. */
+function imageFilesFrom(data: DataTransfer | null): File[] {
+  if (!data) return [];
+  const fromItems = Array.from(data.items ?? [])
+    .filter((item) => item.kind === "file")
+    .map((item) => item.getAsFile())
+    .filter((file): file is File => file != null);
+  const files = fromItems.length ? fromItems : Array.from(data.files ?? []);
+  return files.filter((file) => isAllowedMediaType(file.type));
+}
+
+/** Resolves the RAW base64 payload — the "data:<mt>;base64," prefix is stripped. */
+function readBase64(file: File): Promise<string | null> {
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.onerror = () => resolve(null);
+    reader.onload = () => {
+      const result = typeof reader.result === "string" ? reader.result : "";
+      const comma = result.indexOf(",");
+      resolve(comma === -1 ? null : result.slice(comma + 1));
+    };
+    reader.readAsDataURL(file);
+  });
+}
 
 type AskComposerProps = {
   placeholder?: string;
@@ -32,7 +74,7 @@ type AskComposerProps = {
    * (replaces ChatPanel's composerRef focus effect).
    */
   focusKey?: string | number | boolean;
-  onSubmit: (text: string, engine: Engine) => void;
+  onSubmit: (text: string, engine: Engine, attachments: ChatImageAttachment[]) => void;
 };
 
 export default function AskComposer({
@@ -45,19 +87,48 @@ export default function AskComposer({
 }: AskComposerProps) {
   const [text, setText] = useState("");
   const [engine, setEngine] = useState<Engine>("AUTO");
+  const [attachments, setAttachments] = useState<ChatImageAttachment[]>([]);
   const composingRef = useRef(false);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
+  // Monotonic so a removal can never let a later paste reuse a live id.
+  const nextIdRef = useRef(0);
 
   useEffect(() => {
     if (focusKey === false) return;
     inputRef.current?.focus();
   }, [focusKey]);
 
+  const attach = async (files: File[]) => {
+    for (const file of files) {
+      const mediaType = file.type;
+      if (!isAllowedMediaType(mediaType)) continue;
+      const data = await readBase64(file);
+      if (!data) continue;
+      // Contract: decoded bytes, not base64 length.
+      if ((data.length * 3) / 4 > MAX_DECODED_BYTES) continue;
+      const id = `${nextIdRef.current++}-${file.name || mediaType}`;
+      setAttachments((prev) =>
+        prev.length >= MAX_ATTACHMENTS
+          ? prev
+          : [...prev, { id, mediaType, data, name: file.name || undefined }],
+      );
+    }
+  };
+
+  const onPaste = (event: ClipboardEvent<HTMLTextAreaElement>) => {
+    const files = imageFilesFrom(event.clipboardData);
+    if (!files.length) return;
+    // Only swallow the paste once we know it is an image; text keeps its default.
+    event.preventDefault();
+    void attach(files);
+  };
+
   const submit = () => {
     const cleaned = text.trim();
-    if (!cleaned || busy) return;
-    onSubmit(cleaned, engine);
+    if ((!cleaned && !attachments.length) || busy) return;
+    onSubmit(cleaned, engine, attachments);
     setText("");
+    setAttachments([]);
     inputRef.current?.focus();
   };
 
@@ -95,6 +166,27 @@ export default function AskComposer({
           ))}
         </div>
       ) : null}
+      {attachments.length ? (
+        <div className="ask-composer__attachments" aria-label="Attached images">
+          {attachments.map((a) => (
+            <span key={a.id} className="ask-composer__thumb">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={`data:${a.mediaType};base64,${a.data}`} alt={a.name || "Pasted image"} />
+              <button
+                type="button"
+                className="ask-composer__thumb-remove"
+                aria-label="Remove image"
+                title={a.name ? `Remove ${a.name}` : "Remove image"}
+                onClick={() =>
+                  setAttachments((prev) => prev.filter((candidate) => candidate.id !== a.id))
+                }
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+      ) : null}
       <textarea
         ref={inputRef}
         className="ask-composer__input"
@@ -105,6 +197,7 @@ export default function AskComposer({
         aria-label="Ask Radon"
         onChange={(e) => setText(e.target.value)}
         onKeyDown={onKeyDown}
+        onPaste={onPaste}
         onCompositionStart={() => {
           composingRef.current = true;
         }}
@@ -133,7 +226,7 @@ export default function AskComposer({
         <button
           type="submit"
           className="ask-composer__send"
-          disabled={!text.trim() || busy}
+          disabled={(!text.trim() && !attachments.length) || busy}
           title="Send (Enter)"
           aria-label="Send"
         >

--- a/web/lib/assistant/loop.ts
+++ b/web/lib/assistant/loop.ts
@@ -16,7 +16,7 @@
  * them in `toOpenAiMessages`. String turns from the UI stay strings.
  */
 
-import { chat, type LlmMessage, type LlmToolCall, type LlmUsage } from "@/lib/llm/provider";
+import { chat, type LlmContentBlock, type LlmMessage, type LlmToolCall, type LlmUsage } from "@/lib/llm/provider";
 import {
   createAssistantTurnBudget,
   executeTool,
@@ -46,9 +46,12 @@ const KNOWLEDGE_EXTRACTION_SYSTEM =
 const KNOWLEDGE_BLOCKED_MESSAGE =
   "Retrieved context was isolated, but no safe structured facts could be extracted.";
 
+type TextBlock = { type: "text"; text: string };
+type ImageBlock = Extract<LlmContentBlock, { type: "image" }>;
+
 export type AssistantTurn = {
   role: "user" | "assistant";
-  content: string;
+  content: string | Array<TextBlock | ImageBlock>;
 };
 
 export type ToolEvent = {
@@ -95,11 +98,11 @@ type ToolResultBlock = {
 // `chat()` consumes `LlmMessage[]`; we widen content to the structured block
 // arrays Anthropic accepts. The provider passes content through verbatim.
 type LoopMessage = Omit<LlmMessage, "content"> & {
-  content: string | Array<ToolUseBlock | ToolResultBlock | { type: "text"; text: string }>;
+  content: string | Array<ToolUseBlock | ToolResultBlock | TextBlock | ImageBlock>;
 };
 
 function toAssistantToolUseBlocks(text: string, toolCalls: LlmToolCall[]): LoopMessage {
-  const blocks: Array<ToolUseBlock | { type: "text"; text: string }> = [];
+  const blocks: Array<ToolUseBlock | TextBlock> = [];
   if (text.trim()) blocks.push({ type: "text", text });
   for (const call of toolCalls) {
     blocks.push({ type: "tool_use", id: call.id, name: call.name, input: call.input });
@@ -200,8 +203,18 @@ function logRound(round: number, model: string, toolCalls: LlmToolCall[]): void 
   console.log(`[assistant] round=${round} model=${model} tools=${tools}`);
 }
 
+/** Text of a turn, ignoring any image blocks. */
+function turnText(content: AssistantTurn["content"]): string {
+  if (typeof content === "string") return content;
+  return content
+    .filter((block): block is TextBlock => block.type === "text")
+    .map((block) => block.text)
+    .join(" ");
+}
+
 function hasExplicitOrderIntent(turns: AssistantTurn[]): boolean {
-  const current = [...turns].reverse().find((turn) => turn.role === "user")?.content ?? "";
+  const last = [...turns].reverse().find((turn) => turn.role === "user");
+  const current = last ? turnText(last.content) : "";
   return /\b(?:place|submit|execute|send)\b.{0,40}\b(?:order|buy|sell)\b/i.test(current)
     || /\b(?:buy|sell)\s+\d+(?:\.\d+)?\s+[A-Z]{1,10}\b/i.test(current);
 }

--- a/web/lib/chat.ts
+++ b/web/lib/chat.ts
@@ -4,6 +4,7 @@ import type {
   AssistantOrderProposal,
   AssistantResponse,
   AssistantToolEvent,
+  ChatImageAttachment,
   Message,
   PiResponse,
   WorkspaceSection,
@@ -185,6 +186,32 @@ export async function requestAssistantReply(history: ApiMessage[], latestMessage
   return fallbackReply(latestMessage);
 }
 
+/**
+ * The turn's user message. Text-only turns keep the plain-string content shape
+ * the endpoint has always accepted; pasted images promote it to the Anthropic
+ * block array, images first so the model reads them before the question.
+ */
+function buildUserMessage(text: string, attachments: ChatImageAttachment[]): ApiMessage {
+  if (!attachments.length) {
+    return { role: "user", content: text };
+  }
+  return {
+    role: "user",
+    content: [
+      ...attachments.map((attachment) => ({
+        type: "image" as const,
+        source: {
+          type: "base64" as const,
+          media_type: attachment.mediaType,
+          data: attachment.data,
+        },
+      })),
+      // An image-only turn carries no text block: an empty one is not content.
+      ...(text ? [{ type: "text" as const, text }] : []),
+    ],
+  };
+}
+
 export type AssistantTurn = {
   content: string;
   proposal: AssistantOrderProposal | null;
@@ -203,12 +230,13 @@ export type AssistantTurn = {
 export async function requestAssistantTurn(
   history: ApiMessage[],
   latestMessage: string,
+  attachments: ChatImageAttachment[] = [],
 ): Promise<AssistantTurn> {
   const response = await fetch("/api/assistant", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
-      messages: [...history, { role: "user", content: latestMessage }],
+      messages: [...history, buildUserMessage(latestMessage, attachments)],
     }),
   });
 

--- a/web/lib/data.ts
+++ b/web/lib/data.ts
@@ -61,9 +61,9 @@ export const navItems: WorkspaceNavItem[] = [
 
 export const quickPromptsBySection: Record<WorkspaceSection, string[]> = {
   dashboard: ["portfolio", "scan --top 12", "compare support vs against", "review watch list", "help"],
-  "flow-analysis": ["analyze brze", "compare support vs against", "what are action items", "review watch list", "scan --top 12", "evaluate brze", "portfolio"],
+  "flow-analysis": ["analyze nvda", "compare support vs against", "what are action items", "review watch list", "scan --top 12", "evaluate nvda", "portfolio"],
   options: ["evaluate mu", "scan --top 12", "portfolio", "help"],
-  portfolio: ["portfolio", "analyze brze", "journal --limit 10", "evaluate msft", "help"],
+  portfolio: ["portfolio", "analyze nvda", "journal --limit 10", "evaluate msft", "help"],
   performance: ["portfolio", "stress-test", "journal --limit 10", "help"],
   orders: ["portfolio", "journal --limit 10", "scan --top 12", "help"],
   scanner: ["scan --top 25", "scan --min-score 12", "evaluate igv", "discover", "help"],

--- a/web/lib/llm/provider.ts
+++ b/web/lib/llm/provider.ts
@@ -20,6 +20,7 @@ export type LlmRole = "user" | "assistant";
 /** Structured content blocks used by the multi-round tool loop. */
 export type LlmContentBlock =
   | { type: "text"; text: string }
+  | { type: "image"; source: { type: "base64"; media_type: string; data: string } }
   | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> }
   | { type: "tool_result"; tool_use_id: string; content: string };
 
@@ -269,8 +270,12 @@ type OpenAiResponse = {
   usage?: { prompt_tokens?: number; completion_tokens?: number };
 };
 
+type OpenAiContentPart =
+  | { type: "text"; text: string }
+  | { type: "image_url"; image_url: { url: string } };
+
 type OpenAiOutboundMessage =
-  | { role: string; content: string | null; tool_calls?: OpenAiToolCall[] }
+  | { role: string; content: string | OpenAiContentPart[] | null; tool_calls?: OpenAiToolCall[] }
   | { role: "tool"; tool_call_id: string; content: string };
 
 function openAiConfig(provider: Exclude<LlmProviderName, "grok" | "anthropic" | "gemini">) {
@@ -326,6 +331,7 @@ export function toOpenAiMessages(request: LlmChatRequest): OpenAiOutboundMessage
     const toolUses = blocks.filter(
       (block): block is Extract<LlmContentBlock, { type: "tool_use" }> => block.type === "tool_use",
     );
+    const hasImage = blocks.some((block) => block.type === "image");
 
     if (toolUses.length > 0) {
       messages.push({
@@ -339,6 +345,25 @@ export function toOpenAiMessages(request: LlmChatRequest): OpenAiOutboundMessage
             arguments: JSON.stringify(call.input ?? {}),
           },
         })),
+      });
+      continue;
+    }
+
+    if (hasImage) {
+      // Images force the array content shape; text-only turns stay plain
+      // strings so the provider-side prompt cache keeps hitting.
+      messages.push({
+        role: message.role,
+        content: blocks.flatMap((block): OpenAiContentPart[] => {
+          if (block.type === "text") return [{ type: "text", text: block.text }];
+          if (block.type === "image") {
+            return [{
+              type: "image_url",
+              image_url: { url: `data:${block.source.media_type};base64,${block.source.data}` },
+            }];
+          }
+          return [];
+        }),
       });
       continue;
     }

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -12,11 +12,31 @@ export type NavIcon = ComponentType<{
   strokeWidth?: number;
 }>;
 
+/** Media types the assistant endpoint accepts for a pasted image. */
+export type ChatImageMediaType = "image/png" | "image/jpeg" | "image/gif" | "image/webp";
+
+/**
+ * An image pasted into the chat composer. The preview src is built as
+ * `data:${mediaType};base64,${data}` at render time — there is deliberately no
+ * second dataUrl field to drift out of sync.
+ */
+export type ChatImageAttachment = {
+  /** Stable id for React keys and removal. Derived from index + name. */
+  id: string;
+  mediaType: ChatImageMediaType;
+  /** Raw base64 payload, NO "data:" prefix. */
+  data: string;
+  /** Original file name when the clipboard supplied one. */
+  name?: string;
+};
+
 export type Message = {
   id: string;
   role: MessageRole;
   content: string;
   timestamp: string;
+  /** Images the operator pasted with this turn; rendered in their own bubble. */
+  attachments?: ChatImageAttachment[];
 };
 
 export type FlowRow = {
@@ -28,9 +48,18 @@ export type FlowRow = {
   note: string;
 };
 
+/** Anthropic Messages API content blocks, verbatim. */
+export type ApiTextBlock = { type: "text"; text: string };
+export type ApiImageBlock = {
+  type: "image";
+  source: { type: "base64"; media_type: ChatImageMediaType; data: string };
+};
+export type ApiContentBlock = ApiTextBlock | ApiImageBlock;
+
 export type ApiMessage = {
   role: MessageRole;
-  content: string;
+  /** A plain string for a text-only turn; blocks once an image rides along. */
+  content: string | ApiContentBlock[];
 };
 
 export type AssistantToolEvent = {

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -1,4 +1,5 @@
 import type { JsonValue } from "./types";
+import { formatRelativeTime } from "./adminFormat";
 
 export function createTimestamp() {
   return new Date().toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
@@ -182,17 +183,37 @@ export function formatJsonObject(value: Record<string, JsonValue>, indent = 0): 
   return lines.join("\n");
 }
 
+const ET_CLOCK = new Intl.DateTimeFormat("en-US", {
+  timeZone: "America/New_York",
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+  hourCycle: "h23",
+});
+
+/** "Synced 4m ago (16:06 ET)" — how a person reads a clock, not an ISO-8601
+ *  string with microseconds. The age is derived from the snapshot's own
+ *  timestamp, never a hardcoded cadence. An unusable timestamp says so. */
+function formatSyncLine(lastSync: unknown): string {
+  const raw = typeof lastSync === "string" ? lastSync.trim() : "";
+  const parsed = Date.parse(raw);
+  if (!raw || !Number.isFinite(parsed)) {
+    return "Sync time unavailable";
+  }
+  return `Synced ${formatRelativeTime(raw)} (${ET_CLOCK.format(parsed)} ET)`;
+}
+
 export function formatPortfolioPayload(raw: unknown): string {
   const payload = raw as { bankroll?: unknown; position_count?: unknown; defined_risk_count?: unknown; undefined_risk_count?: unknown; last_sync?: unknown; positions?: unknown[] };
   const positions = Array.isArray(payload?.positions) ? payload.positions : [];
+  const definedRisk = Number(payload?.defined_risk_count ?? 0);
+  const undefinedRisk = Number(payload?.undefined_risk_count ?? 0);
 
   const lines = [
     "Portfolio Snapshot",
     `Bankroll: ${formatCurrency(payload?.bankroll)}`,
-    `Positions: ${Number(payload?.position_count ?? positions.length)}`,
-    `Defined Risk: ${Number(payload?.defined_risk_count ?? 0)}`,
-    `Undefined Risk: ${Number(payload?.undefined_risk_count ?? 0)}`,
-    `Last Sync: ${String(payload?.last_sync ?? "N/A")}`,
+    `Positions: ${Number(payload?.position_count ?? positions.length)} (${definedRisk} defined risk, ${undefinedRisk} undefined risk)`,
+    formatSyncLine(payload?.last_sync),
     "",
     "Positions:",
   ];

--- a/web/tests/agent-ask-composer-image-paste.test.tsx
+++ b/web/tests/agent-ask-composer-image-paste.test.tsx
@@ -1,0 +1,241 @@
+// @vitest-environment jsdom
+//
+// AskComposer — clipboard image attachments.
+//
+// An operator screenshots a chain, a vol surface, or a broker error and pastes
+// it straight into the composer. The bytes have to reach onSubmit as RAW base64
+// (no "data:" prefix) because the wire format is the Anthropic image block
+// verbatim — a prefixed payload is rejected by the API, silently costing the
+// operator the image their prompt was written about.
+//
+// Everything here asserts on the ARGUMENT PASSED TO onSubmit, never on internal
+// state: the third positional argument IS the contract with ChatPanel.
+
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import AskComposer from "../components/agent/AskComposer";
+
+/** 0x89 0x50 0x4E 0x47 — the PNG magic number. base64: "iVBORw==". */
+const PNG_BYTES = new Uint8Array([137, 80, 78, 71]);
+const PNG_BASE64 = "iVBORw==";
+
+function imageFile(name: string, type: string, bytes: Uint8Array = PNG_BYTES) {
+  return new File([bytes], name, { type });
+}
+
+/** A clipboard carrying `items`, the shape Chrome/Safari hand a paste handler. */
+function clipboardWithFiles(files: File[]) {
+  return {
+    items: files.map((file) => ({
+      kind: "file" as const,
+      type: file.type,
+      getAsFile: () => file,
+    })),
+    files,
+  };
+}
+
+function renderComposer(overrides: Partial<React.ComponentProps<typeof AskComposer>> = {}) {
+  const onSubmit = vi.fn();
+  const utils = render(<AskComposer onSubmit={onSubmit} {...overrides} />);
+  const textarea = screen.getByLabelText("Ask Radon") as HTMLTextAreaElement;
+  const send = screen.getByLabelText("Send") as HTMLButtonElement;
+  return { ...utils, onSubmit, textarea, send };
+}
+
+async function pasteFiles(textarea: HTMLTextAreaElement, files: File[]) {
+  fireEvent.paste(textarea, { clipboardData: clipboardWithFiles(files) });
+  // FileReader is async even for a 4-byte blob.
+  await waitFor(() => expect(true).toBe(true));
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AskComposer — pasting an image", () => {
+  it("adds a thumbnail and enables send with an empty textarea", async () => {
+    const { send, textarea } = renderComposer();
+    expect(send.disabled).toBe(true);
+
+    await pasteFiles(textarea, [imageFile("chart.png", "image/png")]);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("img")).toHaveLength(1);
+    });
+    expect(textarea.value).toBe("");
+    expect(send.disabled).toBe(false);
+  });
+
+  it("renders the thumbnail from a data URL built at render time", async () => {
+    const { textarea } = renderComposer();
+    await pasteFiles(textarea, [imageFile("chart.png", "image/png")]);
+
+    const img = await screen.findByRole("img");
+    expect(img.getAttribute("src")).toBe(`data:image/png;base64,${PNG_BASE64}`);
+  });
+
+  it("ignores a text/plain clipboard entry", async () => {
+    const { send, textarea } = renderComposer();
+    fireEvent.paste(textarea, {
+      clipboardData: {
+        items: [{ kind: "string", type: "text/plain", getAsFile: () => null }],
+        files: [],
+      },
+    });
+    await waitFor(() => expect(true).toBe(true));
+
+    expect(screen.queryAllByRole("img")).toHaveLength(0);
+    expect(send.disabled).toBe(true);
+  });
+
+  it("rejects a disallowed image type (image/svg+xml)", async () => {
+    const { send, textarea } = renderComposer();
+    await pasteFiles(textarea, [imageFile("payload.svg", "image/svg+xml")]);
+
+    expect(screen.queryAllByRole("img")).toHaveLength(0);
+    expect(send.disabled).toBe(true);
+  });
+
+  it("caps the attachment list at 4", async () => {
+    const { textarea } = renderComposer();
+    await pasteFiles(
+      textarea,
+      ["a", "b", "c", "d", "e"].map((n) => imageFile(`${n}.png`, "image/png")),
+    );
+
+    await waitFor(() => expect(screen.getAllByRole("img")).toHaveLength(4));
+  });
+
+  it("drops an image whose decoded size exceeds 5 MB", async () => {
+    const { send, textarea } = renderComposer();
+    const oversized = imageFile("huge.png", "image/png", new Uint8Array(5 * 1024 * 1024 + 1));
+    await pasteFiles(textarea, [oversized]);
+
+    await waitFor(() => {
+      expect(screen.queryAllByRole("img")).toHaveLength(0);
+    });
+    expect(send.disabled).toBe(true);
+  });
+});
+
+describe("AskComposer — submitting attachments", () => {
+  it("passes the attachment array as the THIRD onSubmit argument, raw base64", async () => {
+    const { onSubmit, textarea } = renderComposer();
+    await pasteFiles(textarea, [imageFile("chart.png", "image/png")]);
+    await screen.findByRole("img");
+
+    fireEvent.change(textarea, { target: { value: "what is this chain telling me" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const [text, engine, attachments] = onSubmit.mock.calls[0];
+    expect(text).toBe("what is this chain telling me");
+    expect(engine).toBe("AUTO");
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0]).toMatchObject({
+      mediaType: "image/png",
+      data: PNG_BASE64,
+      name: "chart.png",
+    });
+    expect(attachments[0].data.startsWith("data:")).toBe(false);
+    expect(typeof attachments[0].id).toBe("string");
+    expect(attachments[0].id.length).toBeGreaterThan(0);
+    expect(attachments[0]).not.toHaveProperty("dataUrl");
+  });
+
+  it("sends an image-only turn with empty text", async () => {
+    const { onSubmit, textarea } = renderComposer();
+    await pasteFiles(textarea, [imageFile("chart.png", "image/png")]);
+    await screen.findByRole("img");
+
+    fireEvent.click(screen.getByLabelText("Send"));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0][0]).toBe("");
+    expect(onSubmit.mock.calls[0][2]).toHaveLength(1);
+  });
+
+  it("clears the attachments after a successful submit", async () => {
+    const { onSubmit, textarea } = renderComposer();
+    await pasteFiles(textarea, [imageFile("chart.png", "image/png")]);
+    await screen.findByRole("img");
+
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => expect(screen.queryAllByRole("img")).toHaveLength(0));
+
+    fireEvent.change(textarea, { target: { value: "follow up" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSubmit.mock.calls[1][2]).toEqual([]);
+  });
+
+  it("does not submit an empty turn with no attachments", () => {
+    const { onSubmit, textarea } = renderComposer();
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});
+
+describe("AskComposer — removing an attachment", () => {
+  it("drops only the attachment whose remove control was clicked", async () => {
+    const { onSubmit, textarea } = renderComposer();
+    await pasteFiles(textarea, [
+      imageFile("first.png", "image/png"),
+      imageFile("second.png", "image/png"),
+    ]);
+    await waitFor(() => expect(screen.getAllByRole("img")).toHaveLength(2));
+
+    const removes = screen.getAllByLabelText("Remove image");
+    expect(removes).toHaveLength(2);
+    fireEvent.click(removes[0]);
+
+    await waitFor(() => expect(screen.getAllByRole("img")).toHaveLength(1));
+
+    fireEvent.click(screen.getByLabelText("Send"));
+    const attachments = onSubmit.mock.calls[0][2];
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0].name).toBe("second.png");
+  });
+
+  it("disables send again once the last attachment is removed", async () => {
+    const { send, textarea } = renderComposer();
+    await pasteFiles(textarea, [imageFile("chart.png", "image/png")]);
+    await screen.findByRole("img");
+    expect(send.disabled).toBe(false);
+
+    fireEvent.click(screen.getByLabelText("Remove image"));
+
+    await waitFor(() => expect(send.disabled).toBe(true));
+  });
+});
+
+describe("AskComposer — paste does not disturb existing composer behavior", () => {
+  it("leaves a text paste to the browser (no preventDefault)", () => {
+    const { textarea } = renderComposer();
+    const event = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", {
+      value: { items: [{ kind: "string", type: "text/plain", getAsFile: () => null }], files: [] },
+    });
+    fireEvent(textarea, event);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("still suppresses Enter during an IME composition when an image is attached", async () => {
+    const { onSubmit, textarea } = renderComposer();
+    await pasteFiles(textarea, [imageFile("chart.png", "image/png")]);
+    await screen.findByRole("img");
+
+    fireEvent.compositionStart(textarea);
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    fireEvent.compositionEnd(textarea);
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/tests/agent-ask-composer.test.tsx
+++ b/web/tests/agent-ask-composer.test.tsx
@@ -78,7 +78,7 @@ describe("AskComposer — Enter to send", () => {
     type(textarea, "scan MU flow");
     fireEvent.click(screen.getByLabelText("Send"));
 
-    expect(onSubmit).toHaveBeenCalledWith("scan MU flow", "AUTO");
+    expect(onSubmit).toHaveBeenCalledWith("scan MU flow", "AUTO", []);
   });
 
   it("disables the send button on empty input and enables it once typed", () => {
@@ -136,7 +136,7 @@ describe("AskComposer — IME composition guard", () => {
 
     fireEvent.compositionEnd(textarea);
     fireEvent.keyDown(textarea, { key: "Enter" });
-    expect(onSubmit).toHaveBeenCalledWith("ミュー", "AUTO");
+    expect(onSubmit).toHaveBeenCalledWith("ミュー", "AUTO", []);
   });
 });
 

--- a/web/tests/assistant-image-content-blocks.test.ts
+++ b/web/tests/assistant-image-content-blocks.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Pasted-image attachments on the assistant turn.
+ *
+ * `safeMessages()` used to hard-drop any message whose content was not a
+ * non-empty string, so an image turn reached the model as nothing at all.
+ * Content may now also be an array of Anthropic-shaped blocks:
+ *
+ *   { type: "text", text }
+ *   { type: "image", source: { type: "base64", media_type, data } }
+ *
+ * The route is the trust boundary: media_type allowlist, max 4 images per
+ * message, 5 MB decoded per image, base64 charset. Anything failing a limit is
+ * dropped SILENTLY (never thrown), and a message left with no usable block
+ * never reaches the loop.
+ */
+
+const ENV_KEYS = ["ASSISTANT_MOCK", "NODE_ENV", "ANTHROPIC_API_KEY"];
+
+const PNG_B64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+function postRequest(body: unknown): Request {
+  return new Request("http://localhost/api/assistant", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function imageBlock(mediaType: string, data: string = PNG_B64) {
+  return { type: "image", source: { type: "base64", media_type: mediaType, data } };
+}
+
+describe("assistant route image content blocks", () => {
+  const saved: Record<string, string | undefined> = {};
+  let runAssistantLoop: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    for (const key of ENV_KEYS) saved[key] = process.env[key];
+    process.env.ASSISTANT_MOCK = "1";
+
+    runAssistantLoop = vi.fn(async () => ({
+      content: "Read the chart.",
+      model: "mock",
+      toolEvents: [],
+      rounds: 1,
+      usage: { inputTokens: 1, outputTokens: 1 },
+      outcome: "answered" as const,
+    }));
+    vi.doMock("@/lib/assistant/loop", async () => {
+      const actual = await vi.importActual<typeof import("@/lib/assistant/loop")>("@/lib/assistant/loop");
+      return { ...actual, runAssistantLoop };
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.doUnmock("@/lib/assistant/loop");
+    for (const key of ENV_KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  async function post(messages: unknown[]): Promise<Response> {
+    const { POST } = await import("@/app/api/assistant/route");
+    return POST(postRequest({ messages }) as never);
+  }
+
+  function turns(): Array<{ role: string; content: unknown }> {
+    expect(runAssistantLoop).toHaveBeenCalledTimes(1);
+    return runAssistantLoop.mock.calls[0][0] as Array<{ role: string; content: unknown }>;
+  }
+
+  it("forwards a valid image block to the loop intact", async () => {
+    const res = await post([
+      {
+        role: "user",
+        content: [{ type: "text", text: "What is this chart saying?" }, imageBlock("image/png")],
+      },
+    ]);
+
+    expect(res.status).toBe(200);
+    expect(turns()).toEqual([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "What is this chart saying?" },
+          { type: "image", source: { type: "base64", media_type: "image/png", data: PNG_B64 } },
+        ],
+      },
+    ]);
+  });
+
+  it("accepts an image-only message with no text block", async () => {
+    // The composer sends an image with no prompt as a complete turn, so the
+    // route must forward it rather than treat a text-less message as empty.
+    const res = await post([{ role: "user", content: [imageBlock("image/png")] }]);
+
+    expect(res.status).toBe(200);
+    expect(turns()).toEqual([
+      {
+        role: "user",
+        content: [{ type: "image", source: { type: "base64", media_type: "image/png", data: PNG_B64 } }],
+      },
+    ]);
+  });
+
+  it("drops a non-allowlisted media type and keeps the text block", async () => {
+    const res = await post([
+      {
+        role: "user",
+        content: [{ type: "text", text: "Read this" }, imageBlock("image/svg+xml")],
+      },
+    ]);
+
+    expect(res.status).toBe(200);
+    expect(turns()[0].content).toEqual([{ type: "text", text: "Read this" }]);
+  });
+
+  it("drops the fifth image in one message and keeps the first four", async () => {
+    const datas = ["AAAA", "BBBB", "CCCC", "DDDD", "EEEE"];
+    const res = await post([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Five charts" },
+          ...datas.map((data) => imageBlock("image/png", data)),
+        ],
+      },
+    ]);
+
+    expect(res.status).toBe(200);
+    const content = turns()[0].content as Array<{ type: string; source?: { data: string } }>;
+    expect(content.filter((block) => block.type === "image").map((block) => block.source?.data)).toEqual([
+      "AAAA",
+      "BBBB",
+      "CCCC",
+      "DDDD",
+    ]);
+  });
+
+  it("drops an image whose decoded payload exceeds 5 MB", async () => {
+    // 8,000,000 base64 chars decode to ~6 MB.
+    const oversized = "A".repeat(8_000_000);
+    const res = await post([
+      {
+        role: "user",
+        content: [{ type: "text", text: "Big one" }, imageBlock("image/jpeg", oversized)],
+      },
+    ]);
+
+    expect(res.status).toBe(200);
+    expect(turns()[0].content).toEqual([{ type: "text", text: "Big one" }]);
+  });
+
+  it("drops an image whose data is not base64", async () => {
+    const res = await post([
+      {
+        role: "user",
+        content: [{ type: "text", text: "Garbage" }, imageBlock("image/webp", "not base64!!! ***")],
+      },
+    ]);
+
+    expect(res.status).toBe(200);
+    expect(turns()[0].content).toEqual([{ type: "text", text: "Garbage" }]);
+  });
+
+  it("drops a message whose only block was rejected", async () => {
+    const res = await post([
+      { role: "user", content: [imageBlock("image/svg+xml")] },
+      { role: "user", content: "Still here" },
+    ]);
+
+    expect(res.status).toBe(200);
+    expect(turns()).toEqual([{ role: "user", content: "Still here" }]);
+  });
+
+  it("returns 400 when every message is dropped, without throwing", async () => {
+    const res = await post([{ role: "user", content: [imageBlock("image/svg+xml")] }]);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "No messages supplied." });
+    expect(runAssistantLoop).not.toHaveBeenCalled();
+  });
+
+  it("still forwards a plain string message unchanged", async () => {
+    const res = await post([{ role: "user", content: "  How is SPY flow?  " }]);
+
+    expect(res.status).toBe(200);
+    expect(turns()).toEqual([{ role: "user", content: "How is SPY flow?" }]);
+  });
+
+  it("tells the model that attached images are part of the request", async () => {
+    const { SYSTEM_PROMPT } = await import("@/app/api/assistant/route");
+    expect(SYSTEM_PROMPT).toMatch(/image|screenshot|chart/i);
+    expect(SYSTEM_PROMPT).toMatch(/attach/i);
+  });
+});

--- a/web/tests/chat-image-attachment-request.test.tsx
+++ b/web/tests/chat-image-attachment-request.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Client transport for pasted chat images. The gate here is the WIRE: a pasted
+ * image must leave the browser as an Anthropic image block on the latest user
+ * message of POST /api/assistant, and a turn with no attachment must keep the
+ * plain-string content shape it has always had.
+ *
+ * ChatPanel owns the fetch, so ChatPanel is what renders. AskComposer is
+ * replaced with a submit harness: the clipboard-to-attachment capture is a
+ * separate contract, and this file pins the transport, not the paste.
+ */
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ChatImageAttachment } from "@/lib/types";
+
+const PASTED: ChatImageAttachment = {
+  id: "0-screenshot.png",
+  mediaType: "image/png",
+  data: "iVBORw0KGgoAAAANSUhEUg==",
+  name: "screenshot.png",
+};
+
+vi.mock("@/components/agent", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/agent")>();
+  return {
+    ...actual,
+    AskComposer: ({
+      onSubmit,
+    }: {
+      onSubmit: (text: string, engine: string, attachments: ChatImageAttachment[]) => void;
+    }) =>
+      React.createElement(
+        "div",
+        null,
+        React.createElement(
+          "button",
+          {
+            type: "button",
+            "data-testid": "submit-with-image",
+            onClick: () => onSubmit("read this chart", "AUTO", [PASTED]),
+          },
+          "with image",
+        ),
+        React.createElement(
+          "button",
+          {
+            type: "button",
+            "data-testid": "submit-plain",
+            onClick: () => onSubmit("read this chart", "AUTO", []),
+          },
+          "plain",
+        ),
+        React.createElement(
+          "button",
+          {
+            type: "button",
+            "data-testid": "submit-image-only",
+            onClick: () => onSubmit("", "AUTO", [PASTED]),
+          },
+          "image only",
+        ),
+      ),
+  };
+});
+
+import ChatPanel from "../components/ChatPanel";
+
+type SentRequest = { url: string; method: string; body: string };
+const sent: SentRequest[] = [];
+const fetchMock = vi.fn<typeof fetch>();
+
+beforeEach(() => {
+  sent.length = 0;
+  fetchMock.mockReset();
+  fetchMock.mockImplementation((input, init) => {
+    sent.push({
+      url: String(input),
+      method: (init as RequestInit | undefined)?.method ?? "GET",
+      body: String((init as RequestInit | undefined)?.body ?? ""),
+    });
+    return Promise.resolve(
+      new Response(JSON.stringify({ content: "Read." }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  });
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function lastMessageOf(request: SentRequest) {
+  const parsed = JSON.parse(request.body) as {
+    messages: Array<{ role: string; content: unknown }>;
+  };
+  return parsed.messages[parsed.messages.length - 1];
+}
+
+describe("pasted chat image reaches the assistant endpoint", () => {
+  it("sends the image as an Anthropic image block ahead of the text block", async () => {
+    render(<ChatPanel activeSection="orders" />);
+
+    expect(sent).toHaveLength(0);
+    fireEvent.click(screen.getByTestId("submit-with-image"));
+
+    await waitFor(() => expect(sent).toHaveLength(1));
+    expect(sent[0].url).toBe("/api/assistant");
+    expect(sent[0].method).toBe("POST");
+
+    const latest = lastMessageOf(sent[0]);
+    expect(latest.role).toBe("user");
+    expect(latest.content).toEqual([
+      {
+        type: "image",
+        source: { type: "base64", media_type: "image/png", data: "iVBORw0KGgoAAAANSUhEUg==" },
+      },
+      { type: "text", text: "read this chart" },
+    ]);
+  });
+
+  it("sends an image-only turn with no text", async () => {
+    render(<ChatPanel activeSection="orders" />);
+
+    fireEvent.click(screen.getByTestId("submit-image-only"));
+
+    await waitFor(() => expect(sent).toHaveLength(1));
+    expect(sent[0].url).toBe("/api/assistant");
+    expect(sent[0].method).toBe("POST");
+
+    const latest = lastMessageOf(sent[0]);
+    expect(latest.role).toBe("user");
+    // No empty text block rides along: the image is the whole message.
+    expect(latest.content).toEqual([
+      {
+        type: "image",
+        source: { type: "base64", media_type: "image/png", data: "iVBORw0KGgoAAAANSUhEUg==" },
+      },
+    ]);
+  });
+
+  it("renders the image-only turn in the operator's own bubble", async () => {
+    const { container } = render(<ChatPanel activeSection="orders" />);
+
+    fireEvent.click(screen.getByTestId("submit-image-only"));
+
+    const thumb = await waitFor(() => {
+      const found = container.querySelector<HTMLImageElement>(".chat-message.user img");
+      expect(found).not.toBeNull();
+      return found as HTMLImageElement;
+    });
+    expect(thumb.getAttribute("src")).toBe("data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==");
+  });
+
+  it("keeps plain-string content when nothing is attached", async () => {
+    render(<ChatPanel activeSection="orders" />);
+    fireEvent.click(screen.getByTestId("submit-plain"));
+
+    await waitFor(() => expect(sent).toHaveLength(1));
+    expect(sent[0].url).toBe("/api/assistant");
+    expect(lastMessageOf(sent[0]).content).toBe("read this chart");
+  });
+
+  it("renders the pasted image in the operator's own bubble", async () => {
+    const { container } = render(<ChatPanel activeSection="orders" />);
+    fireEvent.click(screen.getByTestId("submit-with-image"));
+
+    await waitFor(() => expect(sent).toHaveLength(1));
+    const thumb = await waitFor(() => {
+      const found = container.querySelector<HTMLImageElement>(".chat-message.user img");
+      expect(found).not.toBeNull();
+      return found as HTMLImageElement;
+    });
+    expect(thumb.getAttribute("src")).toBe("data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==");
+  });
+});

--- a/web/tests/llm-provider-image-blocks.test.ts
+++ b/web/tests/llm-provider-image-blocks.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Image content blocks across the provider layer and the agent loop.
+ *
+ * Anthropic takes the block verbatim (its native Messages API shape). The
+ * OpenAI-compatible path (xAI Grok / OpenAI) has to translate it to
+ * `image_url` parts, without regressing the cache-friendly plain-string
+ * content that text-only turns still serialize to.
+ */
+
+type FetchCall = { url: string; init: RequestInit };
+
+function captureFetch(responder: (call: FetchCall) => Response | Promise<Response>) {
+  const calls: FetchCall[] = [];
+  const impl = vi.fn(async (url: unknown, init?: RequestInit) => {
+    const call: FetchCall = { url: String(url), init: init ?? {} };
+    calls.push(call);
+    return responder(call);
+  });
+  vi.stubGlobal("fetch", impl as unknown as typeof fetch);
+  return { calls };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function bodyOf(call: FetchCall): Record<string, unknown> {
+  return JSON.parse(String(call.init.body)) as Record<string, unknown>;
+}
+
+const IMAGE_BLOCK = {
+  type: "image" as const,
+  source: { type: "base64" as const, media_type: "image/png", data: "AAA" },
+};
+
+const ENV_KEYS = [
+  "ASSISTANT_MOCK",
+  "LLM_PROVIDER",
+  "LLM_FALLBACK_PROVIDER",
+  "ANTHROPIC_API_KEY",
+  "CLAUDE_CODE_API_KEY",
+  "CLAUDE_API_KEY",
+  "ANTHROPIC_MODEL",
+  "OPENAI_API_KEY",
+  "OPENAI_BASE_URL",
+  "OPENAI_MODEL",
+  "XAI_API_KEY",
+  "GROK_API_KEY",
+  "XAI_BASE_URL",
+  "XAI_MODEL",
+];
+
+describe("llm provider image blocks", () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) saved[key] = process.env[key];
+    for (const key of ENV_KEYS) delete process.env[key];
+    process.env.ASSISTANT_MOCK = "0";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    for (const key of ENV_KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  it("forwards the image block to Anthropic unchanged", async () => {
+    const { chat } = await import("@/lib/llm/provider");
+    process.env.LLM_PROVIDER = "anthropic";
+    process.env.ANTHROPIC_API_KEY = "sk-test";
+    const { calls } = captureFetch(() =>
+      jsonResponse({ model: "claude-sonnet-4-5-20250929", content: [{ type: "text", text: "ok" }] }),
+    );
+
+    await chat({
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "What is this chart?" }, IMAGE_BLOCK],
+        },
+      ],
+    });
+
+    const body = bodyOf(calls[0]);
+    expect(body.messages).toEqual([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "What is this chart?" },
+          { type: "image", source: { type: "base64", media_type: "image/png", data: "AAA" } },
+        ],
+      },
+    ]);
+  });
+
+  it("maps the image block to an image_url part on the xAI path", async () => {
+    const { chat } = await import("@/lib/llm/provider");
+    process.env.LLM_PROVIDER = "xai";
+    process.env.XAI_API_KEY = "xai-test";
+    const { calls } = captureFetch(() =>
+      jsonResponse({ model: "grok-4", choices: [{ message: { content: "ok" } }] }),
+    );
+
+    await chat({
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "What is this chart?" }, IMAGE_BLOCK],
+        },
+      ],
+    });
+
+    const body = bodyOf(calls[0]);
+    expect(body.messages).toEqual([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "What is this chart?" },
+          { type: "image_url", image_url: { url: "data:image/png;base64,AAA" } },
+        ],
+      },
+    ]);
+  });
+
+  it("keeps text-only turns on the plain-string content shape", async () => {
+    const { toOpenAiMessages } = await import("@/lib/llm/provider");
+
+    expect(
+      toOpenAiMessages({
+        system: "You are Radon.",
+        messages: [
+          { role: "user", content: "plain string turn" },
+          { role: "assistant", content: [{ type: "text", text: "block turn" }] },
+        ],
+      }),
+    ).toEqual([
+      { role: "system", content: "You are Radon." },
+      { role: "user", content: "plain string turn" },
+      { role: "assistant", content: "block turn" },
+    ]);
+  });
+
+  it("does not leak [object Object] into the mock prompt extraction", async () => {
+    process.env.ASSISTANT_MOCK = "1";
+    const { chat } = await import("@/lib/llm/provider");
+
+    const response = await chat({
+      messages: [{ role: "user", content: [{ type: "text", text: "read it" }, IMAGE_BLOCK] }],
+    });
+
+    expect(response.text).toContain("read it");
+    expect(response.text).not.toContain("[object Object]");
+  });
+});
+
+describe("assistant loop image passthrough", () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    vi.resetModules();
+    for (const key of ["ASSISTANT_MOCK"]) saved[key] = process.env[key];
+    process.env.ASSISTANT_MOCK = "1";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.doUnmock("@/lib/llm/provider");
+    for (const key of ["ASSISTANT_MOCK"]) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  it("hands the first-turn image message to chat() intact", async () => {
+    const chat = vi.fn().mockResolvedValue({
+      provider: "anthropic",
+      model: "mock",
+      text: "That is a vol surface.",
+      stopReason: "end_turn",
+    });
+    vi.doMock("@/lib/llm/provider", () => ({ chat }));
+
+    const { runAssistantLoop } = await import("@/lib/assistant/loop");
+    const result = await runAssistantLoop(
+      [{ role: "user", content: [{ type: "text", text: "What is this?" }, IMAGE_BLOCK] }],
+      "system",
+      { userId: "user_1" },
+    );
+
+    expect(result.content).toBe("That is a vol surface.");
+    expect(chat).toHaveBeenCalledTimes(1);
+    expect(chat.mock.calls[0][0].messages).toEqual([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "What is this?" },
+          { type: "image", source: { type: "base64", media_type: "image/png", data: "AAA" } },
+        ],
+      },
+    ]);
+  });
+});

--- a/web/tests/utils-extended.test.ts
+++ b/web/tests/utils-extended.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   createTimestamp,
   sleep,
@@ -400,6 +400,58 @@ describe("formatPortfolioPayload extended", () => {
     const result = formatPortfolioPayload({});
     expect(result).toContain("Portfolio Snapshot");
     expect(result).toContain("No positions found.");
+  });
+});
+
+// =============================================================================
+// formatPortfolioPayload — human-readable snapshot header
+// =============================================================================
+
+describe("formatPortfolioPayload snapshot header", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-29T20:10:30Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const snapshot = {
+    bankroll: 1315883,
+    position_count: 10,
+    defined_risk_count: 9,
+    undefined_risk_count: 1,
+    last_sync: "2026-08-29T20:06:24.768526+00:00",
+    positions: [],
+  };
+
+  it("renders sync age plus an ET wall clock, never the raw ISO timestamp", () => {
+    const result = formatPortfolioPayload(snapshot);
+    expect(result).toContain("Synced 4m ago (16:06 ET)");
+    expect(result).not.toContain("2026-08-29T20:06:24.768526+00:00");
+    expect(result).not.toContain("Last Sync:");
+  });
+
+  it("collapses the risk split onto the positions line", () => {
+    const result = formatPortfolioPayload(snapshot);
+    expect(result).toContain("Positions: 10 (9 defined risk, 1 undefined risk)");
+    expect(result).not.toContain("Defined Risk: 9");
+    expect(result).not.toContain("Undefined Risk: 1");
+  });
+
+  it("says the sync time is unavailable when the payload has none", () => {
+    const result = formatPortfolioPayload({ bankroll: 1000, positions: [] });
+    expect(result).toContain("Sync time unavailable");
+    expect(result).not.toContain("N/A");
+    expect(result).not.toContain("Invalid Date");
+  });
+
+  it("says the sync time is unavailable when it cannot be parsed", () => {
+    const result = formatPortfolioPayload({ ...snapshot, last_sync: "not-a-timestamp" });
+    expect(result).toContain("Sync time unavailable");
+    expect(result).not.toContain("unknown");
+    expect(result).not.toContain("Invalid Date");
   });
 });
 


### PR DESCRIPTION
An operator can paste a chart or screenshot into Radon chat and have it analyzed alongside the prompt. Images travel as Anthropic-shaped content blocks the whole way down, so no layer has to guess at a data URL.

## What changed

**Composer** — `onPaste` reads clipboard image files, stores raw base64 (no `data:` prefix), renders removable 42px thumbnails, and enables submit on an attachment alone. Enter-to-send, Shift+Enter and the IME composition guards are unchanged. Client caps mirror the server's: 4 images, 5 MB decoded each, png/jpeg/gif/webp only.

**Transport** — ChatPanel threads attachments through `sendMessage` into `requestAssistantTurn`, which builds the latest user message as a block array only when there are attachments. A text-only turn still serializes to a plain string, keeping the cache-friendly prefix intact.

**Server** — `safeMessages()` previously hard-dropped any non-string content, so an image turn would have reached the model as nothing at all. It now accepts text/image block arrays and enforces the allowlist, the per-message image cap, the 5 MB decoded cap and a base64 charset check by dropping bad blocks rather than throwing.

**Provider** — `LlmContentBlock` gains the image variant. The Anthropic path already forwarded content verbatim (now pinned by a test); `toOpenAiMessages` maps images to `image_url` data URLs for the xAI/Grok path and leaves text-only messages as plain strings.

## Bug the review caught

An image-only turn was silently dropped between the composer and the network: the composer allowed it, ChatPanel's `if (!cleaned)` guard swallowed it, and the attachment was cleared with no bubble, no request and no error. The guard now matches the composer's gate, and `buildUserMessage` stops emitting an empty text block the server would strip anyway.

## Deliberately not done

An image is bound to the turn that owns it and is not replayed on follow-ups. Replaying would resend up to 4x5 MB every turn of a thread. A follow-up question about a pasted chart is answered blind. That is a product decision to reverse with a budget, not something to patch in silently.

## Also in this branch

Shares ChatPanel and globals.css, so it rides along:
- slash suggestions read `/portfolio`, not `/ portfolio` (the gap was a flex gap on `.chat-empty-card`, not JSX whitespace)
- quick prompts point at NVDA instead of BRZE
- the portfolio snapshot reply drops the raw ISO timestamp for `Synced 4m ago (16:06 ET)` and folds the risk split into the positions line

## Verification

- Full web suite: 7666 passed / 10 skipped
- One failure in `api-routes-extended.test.ts` is pre-existing, proven on HEAD by stashing the feature files
- Live in Chromium: a synthetic `ClipboardEvent` carrying a 6x6 PNG renders a decoded thumbnail (`naturalWidth 6`, `complete=true`)

Note: `main` is currently red for an unrelated reason - `test_orders_place_safety_contract.py::test_orders_place_subprocess_timeout_fits_inside_next_budget` returns 429. That gate blocks deploy on this PR too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nVvKvpEXYszv9coXt8a5i