### PR TITLE
fix(api-tests): give every case a clean per-minute order budget

### DIFF
--- a/scripts/api/tests/conftest.py
+++ b/scripts/api/tests/conftest.py
@@ -33,6 +33,26 @@ def _isolate_ib_2fa_lock_orphan_state(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _isolate_order_rate_budget():
+    """Hand every test a fresh per-minute order budget.
+
+    `server._order_rate_timestamps` is process-wide and holds every accepted
+    placement for a rolling 60 s, capped at RADON_MAX_ORDERS_PER_MIN (10). A
+    placement posted without an `orderRef` appends `None`, which the dedupe
+    branch never matches, so cases spent a SHARED budget and the eleventh
+    placement in a worker got a 429 it never asked for. Under
+    `pytest -n auto --dist loadfile` the victim depends on file-to-worker
+    assignment; on 2026-08-29 it was the /orders/place timeout contract, the
+    last red job on main. Contract: test_order_rate_limit_isolation.py.
+    """
+    from scripts.api import server
+
+    server._order_rate_timestamps.clear()
+    yield
+    server._order_rate_timestamps.clear()
+
+
+@pytest.fixture(autouse=True)
 def _isolate_flow_reports_dir(tmp_path, monkeypatch):
     """Point the flow-report cache at tmp_path for every test in this subtree.
 

--- a/scripts/api/tests/test_order_rate_limit_isolation.py
+++ b/scripts/api/tests/test_order_rate_limit_isolation.py
@@ -1,0 +1,89 @@
+"""The per-minute order brake must not leak across tests.
+
+`server._order_rate_timestamps` is a process-wide deque holding every accepted
+placement for a rolling 60 s, capped by RADON_MAX_ORDERS_PER_MIN (default 10).
+Nothing reset it between cases, and a placement posted without an `orderRef`
+appends `None` — which the dedupe branch never matches — so every placement
+test in a worker consumed one slot of a shared budget. Under
+`pytest -n auto --dist loadfile` the file-to-worker assignment decides who runs
+past the cap, and on 2026-08-29 that was
+test_orders_place_safety_contract.py::test_orders_place_subprocess_timeout_fits_inside_next_budget,
+which asserted 200 and got 429 — the only red job left on main.
+
+These two cases pin the isolation: the first deliberately saturates the budget,
+the second must still be handed a clean one.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+@pytest.fixture
+def trusted_client(monkeypatch):
+    from scripts.api import auth, server
+
+    monkeypatch.setattr(auth, "is_trusted_local_request", lambda request: True)
+    monkeypatch.setattr(server, "is_trusted_local_request", lambda request: True)
+    monkeypatch.setattr(server, "test_mode", False)
+    return TestClient(server.app), server
+
+
+def _successful_place_result() -> SimpleNamespace:
+    return SimpleNamespace(
+        ok=True,
+        error=None,
+        data={
+            "status": "ok",
+            "orderId": 42,
+            "permId": 420042,
+            "initialStatus": "Submitted",
+            "message": "BUY 1 AAPL @ $200.00 — Submitted",
+        },
+    )
+
+
+_STOCK_ORDER = {
+    "type": "stock",
+    "symbol": "AAPL",
+    "action": "BUY",
+    "quantity": 1,
+    "limitPrice": 200.0,
+    "tif": "DAY",
+}
+
+
+def _place(client, server, monkeypatch):
+    async def fake_recovery(script, args, timeout):
+        return _successful_place_result()
+
+    monkeypatch.setattr(server, "_run_ib_script_with_recovery", fake_recovery)
+    return client.post("/orders/place", json=_STOCK_ORDER)
+
+
+def test_a_case_may_spend_the_whole_minute_budget(trusted_client, monkeypatch):
+    from order_limits import max_orders_per_min
+
+    client, server = trusted_client
+    cap = max_orders_per_min()
+
+    accepted = [_place(client, server, monkeypatch).status_code for _ in range(cap)]
+    assert accepted == [200] * cap
+
+    refused = _place(client, server, monkeypatch)
+    assert refused.status_code == 429
+    assert refused.json()["detail"]["code"] == "ORDER_RATE_LIMIT"
+
+
+def test_the_next_case_starts_from_a_clean_budget(trusted_client, monkeypatch):
+    client, server = trusted_client
+    assert _place(client, server, monkeypatch).status_code == 200


### PR DESCRIPTION
`pytest (rest-api)` is the last red job on `main` (run 33274832703). It fails on `test_orders_place_safety_contract.py::test_orders_place_subprocess_timeout_fits_inside_next_budget` with `assert 429 == 200` — a real-money placement contract refused by the order brake, in a suite where nothing places real orders.

## Cause

`server._order_rate_timestamps` is a process-wide deque holding every accepted placement for a rolling 60s, capped at `RADON_MAX_ORDERS_PER_MIN` (default 10). Nothing reset it between cases. A placement posted without an `orderRef` appends `None`, and the dedupe branch skips only a **truthy** repeat ref — so every case burned a slot of a budget shared by the whole worker. The api suite runs in ~9s, far inside the 60s window, so the eleventh placement in a worker was refused.

Under `-n auto --dist loadfile` the file-to-worker assignment decides which file is unlucky. That is why the suite passes serially and passes locally, and why this read as flake rather than pollution.

## Fix

An autouse fixture in `scripts/api/tests/conftest.py` clearing the deque around every test, alongside the two process-wide isolations already declared there (`ib_2fa_lock` orphan state, flow-reports dir).

**No production code changes** — the brake itself is correct and stays as is.

## Tests

`test_order_rate_limit_isolation.py` pins the contract as a red/green pair: one case deliberately spends the whole budget and asserts the 429 with `code: ORDER_RATE_LIMIT`, the next asserts it still gets a clean one. Without the fixture the second case fails with exactly the CI error.

- `scripts/api/tests` — **761 passed** under CI's own `-n auto --dist loadfile`
- full pytest — **8797 passed**

The other three gates that were red earlier today (Flex 1025 lockout, `cloud/tests` unit-install ack, `flow-report-one-scan-per-refresh`) are already green on main via #160–#163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177apGqsWaVFmiCkBvzNCSs
