### PR TITLE
fix(knowledge): stop hourly re-distillation of unchanged incidents docs

### DIFF
--- a/scripts/knowledge/sources/incidents.py
+++ b/scripts/knowledge/sources/incidents.py
@@ -1,7 +1,14 @@
 """Incidents connector — service_health is current-state-per-service (PK is
 service, upserted each writer cycle; no history retained), so this emits one
 live state digest per service. Historical incident knowledge lives in
-tasks/lessons.md via the docs connector."""
+tasks/lessons.md via the docs connector.
+
+Content carries only what changes when something HAPPENS: the state, and the
+error text for a non-ok state. Attempt/updated timestamps and the per-run
+detail payload of a healthy service are rewritten every writer cycle; putting
+them in content made every service re-distill every hour. Timestamps ride
+last_activity_at, which the store only bumps when content changes — so it
+reads as "when this service's state last changed", not "last run"."""
 from __future__ import annotations
 
 import json
@@ -24,7 +31,7 @@ def fetch(db) -> Iterator[KnowledgeDoc]:
             source=SOURCE,
             scope=SCOPE,
             doc_key=service,
-            content=_digest(service, state, started, finished, last_error, updated),
+            content=_digest(service, state, last_error),
             title=f"{service} service health: {state}",
             metadata={"service": service, "state": state},
             created_at=updated,
@@ -32,18 +39,11 @@ def fetch(db) -> Iterator[KnowledgeDoc]:
         )
 
 
-def _digest(service, state, started, finished, last_error, updated) -> str:
+def _digest(service, state, last_error) -> str:
     lines = [f"Service {service} is {state or 'unknown'}."]
-    if started or finished:
-        lines.append(
-            f"Last attempt started {started or 'unknown'}, finished {finished or 'unknown'}."
-        )
-    detail = _detail(last_error)
+    detail = _detail(last_error) if state != "ok" else None
     if detail:
-        label = "Last run detail" if state == "ok" else "Last error"
-        lines.append(f"{label}: {detail}")
-    if updated:
-        lines.append(f"Updated {updated}.")
+        lines.append(f"Last error: {detail}")
     return "\n".join(lines)
 
 

--- a/scripts/tests/test_knowledge_sources.py
+++ b/scripts/tests/test_knowledge_sources.py
@@ -545,12 +545,51 @@ def test_incidents_one_doc_per_service_with_state_digest(db):
     ok_doc = docs["journal-gap-sli"]
     assert ok_doc.scope == "ops"
     assert "ok" in ok_doc.content
-    assert "missing_exec_id_count=0" in ok_doc.content
+    # Per-run counters of a healthy service are run exhaust, not incident
+    # knowledge — keeping them out of content is what stops hourly churn.
+    assert "missing_exec_id_count" not in ok_doc.content
     assert ok_doc.metadata == {"service": "journal-gap-sli", "state": "ok"}
     err_doc = docs["ib-realtime-relay"]
     assert "no ticks for 60s" in err_doc.content
     assert "error" in err_doc.content
     assert err_doc.last_activity_at == _days_ago(0)
+
+
+def test_incidents_content_stable_across_writer_cycles(db):
+    """Every writer cycle rewrites the service_health timestamps (and, for ok
+    rows, the run-detail payload). None of that may reach content: an
+    unchanged state must hash identical so ingest skips it instead of
+    re-distilling every service every hour (2026-08-29: 12-20 Cerebras calls
+    per hourly run for 81 unchanged services)."""
+    _seed_service_health(db)
+    before = {d.doc_key: d for d in incidents_source.fetch(db)}
+    db.execute(
+        "UPDATE service_health SET last_attempt_started_at = ?, "
+        "last_attempt_finished_at = ?, updated_at = ?, last_error = ? "
+        "WHERE service = 'journal-gap-sli'",
+        (
+            _days_ago(0), _days_ago(0), _days_ago(0),
+            json.dumps({"missing_exec_id_count": 0, "window_days": 7, "scanned": 999}),
+        ),
+    )
+    db.execute(
+        "UPDATE service_health SET last_attempt_started_at = ?, "
+        "last_attempt_finished_at = ?, updated_at = ? WHERE service = 'ib-realtime-relay'",
+        (_days_ago(0), _days_ago(0), _days_ago(0)),
+    )
+    db.commit()
+    after = {d.doc_key: d for d in incidents_source.fetch(db)}
+    for key in before:
+        assert after[key].content_hash() == before[key].content_hash(), key
+    # A real state/error transition still re-syncs the row.
+    db.execute(
+        "UPDATE service_health SET state = 'error', last_error = 'gap detected' "
+        "WHERE service = 'journal-gap-sli'"
+    )
+    db.commit()
+    flipped = {d.doc_key: d for d in incidents_source.fetch(db)}
+    assert flipped["journal-gap-sli"].content_hash() != before["journal-gap-sli"].content_hash()
+    assert "gap detected" in flipped["journal-gap-sli"].content
 
 
 def test_incidents_deterministic_order(db):


### PR DESCRIPTION
## Summary
- `incidents` connector put `service_health` attempt/updated timestamps and the ok-row run-detail payload into `content`, so every writer cycle changed every service's `content_hash` and each hourly ingest re-distilled 12-20 unchanged docs via Cerebras (73/81 rows "active" in the last 24h; recency decay meaningless).
- Content is now `Service X is <state>.` plus `Last error: ...` for non-ok rows only. Timestamps ride `last_activity_at`, which the store bumps only on content change, so it now means "state last changed".
- First ingest after deploy re-distills all 81 incident docs once, then steady state should be ~0/hour.

## Test plan
- [x] Red: `test_incidents_content_stable_across_writer_cycles` + updated digest test fail on the old connector (2 failed)
- [x] Green: `.venv/bin/python -m pytest scripts/tests/test_knowledge_*.py scripts/api/tests/test_knowledge_routes.py` → 195 passed
- [ ] After deploy: `journalctl -u radon-knowledge.service` shows `incidents: distilled=81` once, then `distilled=0` on later hours

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tL6SCTsyQuEFAoVwfzj8r
