### PR TITLE
Give the nightly runners web/.env and a working worktree fan-out

### DIFF
--- a/.claude/skills/reliability-weekend/SKILL.md
+++ b/.claude/skills/reliability-weekend/SKILL.md
@@ -164,12 +164,19 @@ how this loop improves as the codebase grows.
   the runner clone does not inherit that. Run the full gate FIRST, and if
   it is red, diff the failure set against `ci.yml`'s install line before
   attributing anything to your own changes.
-- 2026-08-16 (remediate): 10 `cloud/tests` cases fail on darwin only —
-  they assert on a `sha256sum` binary macOS does not ship
-  (`shutil.which("sha256sum")` is `None`). They pass in Linux CI. Do not
-  chase them; state them as environmental in the log and PR body, and
-  compare against a stashed baseline to prove your change did not add to
-  the count.
+- 2026-08-16 (remediate): `cloud/tests` cases fail on darwin only. They
+  pass in Linux CI. Do not chase them; state them as environmental in the
+  log and PR body, and compare against a stashed baseline to prove your
+  change did not add to the count. **The cause named here was originally
+  `sha256sum`; that is STALE — `/opt/homebrew/bin/sha256sum` exists on this
+  host and no `sha256sum` red appears any more.** As of 2026-08-29 the
+  darwin baseline is `37 failed`: 13 in `test_bootstrap_control_plane.py`
+  (`exec {fd}<>` is bash 4+; `/bin/bash` here is 3.2, so it exits 127), 21
+  in `test_ib_gateway_control.py` (`operator-radon.sh` uses `mapfile`,
+  bash 4+), and 3 in `test_caddy_edge_timeouts.py` (no `caddy` on PATH).
+  `setup_reliability_weekend.sh` now checks both and names the
+  consequence. Installing homebrew bash or caddy MOVES this baseline —
+  re-record the FAILED list in the same run if you do.
 - 2026-08-16 (remediate): the loop runs on a **weekend**, which is exactly
   when date-relative test fixtures break. `previous-close-yahoo-daily-array`
   spaced its bars by calendar days, so "yesterday" was a Saturday and the
@@ -548,6 +555,7 @@ how this loop improves as the codebase grows.
 - 2026-08-29 (remediate): three findings this run were closed only PARTIALLY and each says so in its
   own row — R-424's `service_health` row (no error-only catalog category exists, and a scheduled key
   for a no-cadence signal ages to stale and pages forever), R-408's browser screenshot (this runner
-  clone has no `web/.env`, so the app cannot boot), and R-402's `signals-refresh` registration
+  clone had no `web/.env`, so the app could not boot; `setup_reliability_weekend.sh` now provisions
+  it into the clone, so this residual is closed for later runs), and R-402's `signals-refresh` registration
   (deliberately refused, above). Writing the reason into the row is the difference between a known
   residual and a silent gap.

--- a/.claude/skills/testing-weekend/SKILL.md
+++ b/.claude/skills/testing-weekend/SKILL.md
@@ -107,8 +107,12 @@ then any older non-P2 stragglers), exactly by the PART B contract:
    correct); for a net-negative test, show what real defect it passes
    over; (b) implement surgically; (c) show green; (d) run the full gates
    from the repo root (`python3.13 -m pytest`, `npx vitest run`, and
-   `pytest cloud/tests` when units/cloud files changed); (e) append the
-   TEST_LOG.md row with red/green counts; (f) commit with the T-### id.
+   `pytest cloud/tests` when units/cloud files changed); when the task
+   changed UI, also run the relevant `web/e2e` spec in the worktree and
+   attach the screenshot: the clone-copied `node_modules` is what makes
+   that possible, and CLAUDE.md does not accept unit-only evidence for
+   UI; (e) append the TEST_LOG.md row with red/green counts; (f) commit
+   with the T-### id.
    Source-code fixes are in scope ONLY when a test correctly fails
    against a real defect the audit identified — fix the defect, keep the
    test; never the reverse.
@@ -195,12 +199,20 @@ how this loop improves as the codebase grows.
   reproduced and had to be logged as an observation rather than a finding.
   Write the full reporter output to a file per gate run and read the tail
   from that file, so a flake round is nameable the first time it happens.
-- **2026-08-17 (remediate): `pytest cloud/tests` is 10-red on macOS on
-  `origin/main` too.** Ten `sha256sum`-dependent control-plane tests cannot
-  pass on a darwin runner. Diff the failure LIST against a clean
-  `origin/main` worktree before treating any cloud red as yours; the count
-  alone is not a signal. Baseline as of this run: `10 failed, 848 passed,
-  4 skipped`.
+- **2026-08-17 (remediate): `pytest cloud/tests` is red on macOS on
+  `origin/main` too.** Diff the failure LIST against a clean `origin/main`
+  worktree before treating any cloud red as yours; the count alone is not a
+  signal. Baseline as of this run: `10 failed, 848 passed, 4 skipped`, then
+  attributed to `sha256sum`. **That attribution is STALE as of 2026-08-29**
+  — `/opt/homebrew/bin/sha256sum` exists on this host and no `sha256sum`
+  red remains. The current darwin baseline is `37 failed`: 13 in
+  `test_bootstrap_control_plane.py` (`exec {fd}<>` is bash 4+ and
+  `/bin/bash` here is 3.2, so it exits 127), 21 in
+  `test_ib_gateway_control.py` (`operator-radon.sh` uses `mapfile`, bash
+  4+), 3 in `test_caddy_edge_timeouts.py` (no `caddy` on PATH).
+  `setup_testing_weekend.sh` now checks both and names the consequence;
+  installing either MOVES this baseline, so re-record the FAILED list in
+  the same run.
 - **2026-08-17 (remediate): pre-flight a spec under `next start` before
   curating it into CI.** The e2e job builds and serves a production
   server, and this repo has a documented dev-vs-prod divergence. Every
@@ -217,7 +229,9 @@ how this loop improves as the codebase grows.
 - **2026-08-22 (audit): the darwin cloud baseline is a LIST, not a count, and
   it moves.** Round 1 read `12 failed` against a recorded baseline of 10; the
   diff of `FAILED` lines against the 2026-08-17 list is what separated two
-  new `sha256sum`-shim reds (T-088) from the known ten. Always `sort` the
+  new environment-shim reds (T-088) from the known ten. (The environment
+  cause has since changed from `sha256sum` to bash 3.2 + missing `caddy`;
+  the list is 37 today.) Always `sort` the
   `FAILED` lines to a file and `diff` them; update the recorded baseline in
   the audit whenever it changes.
 - **2026-08-22 (audit, second pass): CHECK `origin` FOR AN EXISTING WEEKEND
@@ -276,13 +290,20 @@ how this loop improves as the codebase grows.
   `TEST_LOG.md`.
 - **2026-08-23 (remediate): fan the backlog out to one worktree per task
   group; cherry-pick back serially.** `git worktree add --detach /tmp/...`
-  plus symlinked `node_modules` (root AND `web/`) gives each subagent a clean
-  tree; the shared venv needs nothing. Group findings that touch the SAME
-  test file into one agent (T-082+T-097, T-084+T-099, T-086+T-098 here) or
-  the cherry-picks conflict. The main clone stays untouched, so a baseline
-  gate can run there while the agents work, and each `cherry-pick -n` +
-  docs row + push is one durable commit. Sixteen P1s landed in ~15 minutes
-  of wall clock this way versus one-at-a-time.
+  plus an APFS clone copy of `node_modules` (`cp -Rc <clone>/node_modules
+  <wt>/node_modules` and the same for `web/`; fall back to `cp -R` off APFS)
+  gives each subagent a clean tree; the shared venv needs nothing. NEVER
+  symlink `node_modules`: a symlink out of the worktree root breaks BOTH
+  gates. vitest cannot resolve `@rollup/rollup-darwin-arm64` through the
+  link's real path, and Turbopack hard-fails the Playwright webServer with
+  `Symlink [project]/web/node_modules is invalid, it points out of the
+  filesystem root`, so the worktree cannot run e2e at all. `cp -Rc` is
+  copy-on-write, so it costs seconds and near-zero disk. Group findings that
+  touch the SAME test file into one agent (T-082+T-097, T-084+T-099,
+  T-086+T-098 here) or the cherry-picks conflict. The main clone stays
+  untouched, so a baseline gate can run there while the agents work, and
+  each `cherry-pick -n` + docs row + push is one durable commit. Sixteen
+  P1s landed in ~15 minutes of wall clock this way versus one-at-a-time.
 - **2026-08-23 (remediate): a subagent's "green" is scoped; re-read the
   source diff before landing.** Two things the per-task reports could not
   show: (a) the relay is ESM with socket side effects on import, so T-087's
@@ -293,10 +314,11 @@ how this loop improves as the codebase grows.
   scoped run. Grep every caller of a changed signature in the LANDED tree,
   not the worktree.
 - **2026-08-23 (remediate): the darwin cloud baseline grew by three
-  `sha256sum`-class reds without any test being wrong.** At `4985a7f8`
+  environment-class reds without any test being wrong.** At `4985a7f8`
   this host reads 12; at `2e904678` it reads 15 because
-  `test_refresh_control_plane.py` (new in the delta) also asserts
-  `shutil.which("sha256sum")`. Same rule as the audit lesson: sort the
+  `test_refresh_control_plane.py` was new in the delta. (The `sha256sum`
+  cause named at the time is stale; as of 2026-08-29 the baseline is 37 and
+  the cause is bash 3.2 + missing `caddy`.) Same rule as the audit lesson: sort the
   `FAILED` lines, run the base SHA in a worktree, `diff` — and record the
   new list in the log so the next run does not misattribute it.
 - **2026-08-23 (remediate): two hosts remediated the same branch at once —
@@ -453,16 +475,18 @@ how this loop improves as the codebase grows.
   the main clone after each cherry-pick. Doing that caught nothing wrong this
   run, but it is what makes the closing gate a confirmation rather than a
   discovery. Never run the closing 3x gate until the fan-out is fully drained.
-- **2026-08-26 (remediate): a worktree with symlinked `node_modules` cannot
-  start vitest on this host** — `@rollup/rollup-darwin-arm64` resolves relative
-  to the symlink's real path and is absent, so vitest dies at startup. Three
-  agents hit it independently and each worked around it by installing that one
-  binding to a scratch dir and setting `NODE_PATH`, which is the right move:
-  the main clone is UNAFFECTED (verified with a scoped `npx vitest run` before
-  trusting the closing gate) and nothing in the repo was modified. Put the
-  workaround in the agent prompt next time instead of making each one discover
-  it, and always smoke-test vitest in the MAIN clone before concluding the
-  suite is broken.
+- **2026-08-26 (remediate): SUPERSEDED by the `cp -Rc` rule at the fan-out
+  bullet above. Kept for the symptom.** A worktree with symlinked
+  `node_modules` cannot start vitest on this host: `@rollup/rollup-darwin-arm64`
+  resolves relative to the symlink's real path and is absent, so vitest dies at
+  startup. Three agents hit it independently and each worked around it by
+  installing that one binding to a scratch dir and setting `NODE_PATH`; do NOT
+  do that any more, clone-copy `node_modules` instead, because the `NODE_PATH`
+  patch rescues vitest but leaves e2e dead, which is worse because it looks
+  green. The main clone is UNAFFECTED (verified with a scoped `npx vitest run`
+  before trusting the closing gate) and nothing in the repo was modified.
+  Always smoke-test vitest in the MAIN clone before concluding the suite is
+  broken.
 - **2026-08-26 (remediate): two agents branched from the same base can land
   CONTRADICTORY pins — diff the landed tree, not the two reports.** T-162
   wrapped `run()` in the credit-spread and IEI/HYG producers; T-163, working

--- a/scripts/setup_reliability_weekend.sh
+++ b/scripts/setup_reliability_weekend.sh
@@ -17,6 +17,9 @@ WEEKEND_VENV="$WEEKEND_ROOT/venv"
 # every round hard-resets and cleans that clone.
 WEEKEND_ENV="$WEEKEND_ROOT/.env"
 LAUNCH_AGENTS="$HOME/Library/LaunchAgents"
+# The checkout this script lives in is the source of the gitignored env files
+# the runner clone cannot get from `git clone`. Override for an unusual layout.
+SRC_REPO="${RADON_WEEKEND_SRC_REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 ORIGIN_URL="$(git config --get remote.origin.url 2>/dev/null || echo git@github.com:joemccann/radon.git)"
 
 fail=0
@@ -27,6 +30,18 @@ check() {
   else
     echo "  MISSING  $name  ($*)"
     fail=1
+  fi
+}
+
+# Same report shape as `check`, but advisory only: an absent env file must not
+# block installing the job on a fresh machine — the provisioning step below
+# says what it did instead.
+advise() {
+  local name="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    echo "  ok  $name"
+  else
+    echo "  MISSING  $name  ($*)"
   fi
 }
 
@@ -41,9 +56,18 @@ check "git ssh to origin" git ls-remote --exit-code "$ORIGIN_URL" HEAD
 check "pushover creds"    grep -qE '^PUSHOVER_(USER|TOKEN)=.+' "$WEEKEND_ENV"
 check "root ssh to VPS (optional, for operator use only)" \
   ssh -o BatchMode=yes -o ConnectTimeout=5 root@ib-gateway true
+check "bash 4+ (cloud/tests)" bash -c '((BASH_VERSINFO[0] >= 4))'
+check "caddy (cloud/tests edge)" command -v caddy
+advise "$SRC_REPO/web/.env (else no dev server, so no browser verification)" \
+  test -s "$SRC_REPO/web/.env"
 if [[ $fail -ne 0 ]]; then
   echo "Fix the MISSING items above, then re-run. (VPS ssh is optional —"
   echo "the unattended loop never uses it; it is for your follow-ups.)"
+  echo "  bash 3.2 leaves 34 cloud/tests permanently red on this runner (13 in"
+  echo "  test_bootstrap_control_plane.py via 'exec {fd}<>', 21 in"
+  echo "  test_ib_gateway_control.py via 'mapfile'); no caddy leaves 3 more."
+  echo "  Installing either MOVES the recorded darwin baseline — the next audit"
+  echo "  must re-record the FAILED list in the same run."
   # VPS ssh alone should not block install:
   # continue only if everything except that check passed.
 fi
@@ -79,6 +103,41 @@ git -C "$WEEKEND_REPO" checkout -f --quiet main
 git -C "$WEEKEND_REPO" reset --hard --quiet origin/main
 touch "$WEEKEND_REPO/.radon-weekend-runner"
 mkdir -p "$WEEKEND_REPO/logs/reliability-weekend"
+
+# web/.env is gitignored, so a fresh `git clone` can never carry it and the
+# nightly hard-reset would drop it anyway; both wrappers already exclude it
+# from their per-round `git clean`. Without it the Next dev server cannot
+# boot, so the loop cannot do the browser verification CLAUDE.md requires
+# (filed as R-408's residual on 2026-08-29).
+#
+# ONLY web/.env. The root .env is deliberately NOT provisioned: python-dotenv
+# already walks up from the clone to $WEEKEND_ROOT/.env, which carries the
+# same TURSO/IB keys, so a copy is redundant, and it would put IB_FLEX_TOKEN
+# in a second place. web/.env is read by Next, never by pytest.
+# Re-copied every setup run so a rotated key propagates. Never inline a value.
+provision_env_file() {
+  local rel="$1"
+  local src="$SRC_REPO/$rel"
+  local dst="$WEEKEND_REPO/$rel"
+  if [[ ! -s "$src" ]]; then
+    echo "  skipped $rel (none at $src; the loops run without it)"
+    return 0
+  fi
+  if [[ -s "$dst" && "$dst" -nt "$src" ]]; then
+    echo "  kept $rel (clone copy is newer than $src)"
+    return 0
+  fi
+  mkdir -p "$(dirname "$dst")"
+  install -m 600 "$src" "$dst"
+  echo "  provisioned $rel from $SRC_REPO (0600)"
+}
+if [[ "$SRC_REPO" == "$WEEKEND_REPO" ]]; then
+  echo "  MISSING  env provisioning: run setup from your own checkout, not the runner clone"
+else
+  for env_rel in web/.env; do
+    provision_env_file "$env_rel"
+  done
+fi
 
 if [[ ! -f "$WEEKEND_ENV" ]]; then
   cat > "$WEEKEND_ENV" <<'EOF'

--- a/scripts/setup_testing_weekend.sh
+++ b/scripts/setup_testing_weekend.sh
@@ -22,6 +22,9 @@ WEEKEND_VENV="$WEEKEND_ROOT/venv"
 # every round hard-resets and cleans that clone.
 WEEKEND_ENV="$WEEKEND_ROOT/.env"
 LAUNCH_AGENTS="$HOME/Library/LaunchAgents"
+# The checkout this script lives in is the source of the gitignored env files
+# the runner clone cannot get from `git clone`. Override for an unusual layout.
+SRC_REPO="${RADON_WEEKEND_SRC_REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 ORIGIN_URL="$(git config --get remote.origin.url 2>/dev/null || echo git@github.com:joemccann/radon.git)"
 
 fail=0
@@ -35,6 +38,18 @@ check() {
   fi
 }
 
+# Same report shape as `check`, but advisory only: an absent env file must not
+# block installing the job on a fresh machine — the provisioning step below
+# says what it did instead.
+advise() {
+  local name="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    echo "  ok  $name"
+  else
+    echo "  MISSING  $name  ($*)"
+  fi
+}
+
 echo "[1/4] toolchain"
 check "claude CLI"        command -v claude
 check "gh CLI (authed)"   gh auth status
@@ -44,8 +59,17 @@ check "bun"               command -v bun
 check "node"              command -v node
 check "git ssh to origin" git ls-remote --exit-code "$ORIGIN_URL" HEAD
 check "pushover creds"    grep -qE '^PUSHOVER_(USER|TOKEN)=.+' "$WEEKEND_ENV"
+check "bash 4+ (cloud/tests)" bash -c '((BASH_VERSINFO[0] >= 4))'
+check "caddy (cloud/tests edge)" command -v caddy
+advise "$SRC_REPO/web/.env (else no dev server, so no browser verification)" \
+  test -s "$SRC_REPO/web/.env"
 if [[ $fail -ne 0 ]]; then
   echo "Fix the MISSING items above, then re-run."
+  echo "  bash 3.2 leaves 34 cloud/tests permanently red on this runner (13 in"
+  echo "  test_bootstrap_control_plane.py via 'exec {fd}<>', 21 in"
+  echo "  test_ib_gateway_control.py via 'mapfile'); no caddy leaves 3 more."
+  echo "  Installing either MOVES the recorded darwin baseline — the next audit"
+  echo "  must re-record the FAILED list in the same run."
 fi
 
 echo "[2/4] dedicated runner clone at $WEEKEND_REPO"
@@ -79,6 +103,41 @@ git -C "$WEEKEND_REPO" checkout -f --quiet main
 git -C "$WEEKEND_REPO" reset --hard --quiet origin/main
 touch "$WEEKEND_REPO/.radon-weekend-runner"
 mkdir -p "$WEEKEND_REPO/logs/testing-weekend"
+
+# web/.env is gitignored, so a fresh `git clone` can never carry it and the
+# nightly hard-reset would drop it anyway; both wrappers already exclude it
+# from their per-round `git clean`. Without it the Next dev server cannot
+# boot, so the loop cannot do the browser verification CLAUDE.md requires
+# (T-248 filed the resulting permanent local false-red on 2026-08-29).
+#
+# ONLY web/.env. The root .env is deliberately NOT provisioned: python-dotenv
+# already walks up from the clone to $WEEKEND_ROOT/.env, which carries the
+# same TURSO/IB keys, so a copy is redundant, and it would put IB_FLEX_TOKEN
+# in a second place. web/.env is read by Next, never by pytest.
+# Re-copied every setup run so a rotated key propagates. Never inline a value.
+provision_env_file() {
+  local rel="$1"
+  local src="$SRC_REPO/$rel"
+  local dst="$WEEKEND_REPO/$rel"
+  if [[ ! -s "$src" ]]; then
+    echo "  skipped $rel (none at $src; the loops run without it)"
+    return 0
+  fi
+  if [[ -s "$dst" && "$dst" -nt "$src" ]]; then
+    echo "  kept $rel (clone copy is newer than $src)"
+    return 0
+  fi
+  mkdir -p "$(dirname "$dst")"
+  install -m 600 "$src" "$dst"
+  echo "  provisioned $rel from $SRC_REPO (0600)"
+}
+if [[ "$SRC_REPO" == "$WEEKEND_REPO" ]]; then
+  echo "  MISSING  env provisioning: run setup from your own checkout, not the runner clone"
+else
+  for env_rel in web/.env; do
+    provision_env_file "$env_rel"
+  done
+fi
 
 if [[ ! -f "$WEEKEND_ENV" ]]; then
   cat > "$WEEKEND_ENV" <<'EOF'

--- a/scripts/tests/test_weekend_loop_deadman.py
+++ b/scripts/tests/test_weekend_loop_deadman.py
@@ -318,6 +318,27 @@ class TestSetupGuardsTheSharedVenv:
             "the other loop's cycle is executing against it"
         )
 
+    @pytest.mark.parametrize("name", ["reliability", "testing"])
+    def test_each_setup_checks_the_bash_version(self, name):
+        """GAP C: `/bin/bash` on this runner is 3.2, and `cloud/tests` needs 4+.
+
+        `cloud/scripts/operator-radon.sh` uses `mapfile` and
+        `cloud/scripts/bootstrap-control-plane.sh` uses `exec {fd}<>`; both
+        are bash-4 only, and both suites resolve bash from `PATH` themselves.
+        Neither setup ever reads `BASH_VERSINFO`, so the runner installs
+        clean and 34 `cloud/tests` are permanently red with no signal.
+        """
+        text = self.SETUPS[name].read_text(encoding="utf-8")
+        assert "BASH_VERSINFO" in text, (
+            f"{name} setup verifies the toolchain without checking the bash "
+            "version; on bash 3.2 the cloud suite is permanently red and the "
+            "install prints ok"
+        )
+        assert "cloud/tests" in text, (
+            f"{name} setup never names the consequence: an operator reading "
+            "MISSING has no way to know which suite goes red"
+        )
+
 
 def _claude_invocation_line(path: Path) -> str:
     """The `timeout ... claude -p` command lifted verbatim, so a test can RUN it.

--- a/scripts/tests/test_weekend_runner_env_provisioning.py
+++ b/scripts/tests/test_weekend_runner_env_provisioning.py
@@ -1,0 +1,213 @@
+"""GAP A: the nightly runner clones are never given `web/.env`.
+
+`web/.env` is gitignored, so the dedicated clones at
+`~/radon-weekend/radon{,-testing}` (created by `git clone` and hard-reset to
+`origin/main` every night) structurally cannot contain it. Both wrappers
+already exclude it from their per-round `git clean`
+(`reliability_weekend.sh` `reground_for_continuation`/`ground_truth`,
+`testing_weekend.sh` `ground_truth`), i.e. surviving the reset has always been
+the intent; only the provisioning step was never written.
+
+ONLY `web/.env` is provisioned. The root `.env` is deliberately left out:
+python-dotenv already walks up from the clone to `$WEEKEND_ROOT/.env` for the
+same TURSO/IB keys, so a copy is redundant and would duplicate IB_FLEX_TOKEN.
+`test_setup_does_not_provision_the_root_env` guards that.
+
+Consequences the loops actually hit: no `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`
+means a dev server the browser-verification step starts renders no
+Clerk-wrapped page, and no `TURSO_DB_URL` in `os.environ` means the runner's
+pytest pins the OPPOSITE of production wherever a collected module's
+import-time `load_dotenv` would have set it.
+
+These tests drive the real setup scripts against a staged fake source checkout
+and a staged fake clone, with the whole toolchain stubbed on PATH. No real
+credential is ever read or written.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+BASH = shutil.which("bash") or "/bin/bash"
+
+SETUPS = {
+    "reliability": (REPO / "scripts" / "setup_reliability_weekend.sh", "radon"),
+    "testing": (REPO / "scripts" / "setup_testing_weekend.sh", "radon-testing"),
+}
+PLISTS = {
+    "reliability": "com.radon.reliability-daily.plist",
+    "testing": "com.radon.testing-daily.plist",
+}
+
+# Dummy values only. Never stage a real credential into a fixture.
+DUMMY = {
+    ".env": "TURSO_DB_URL=libsql://dummy.invalid\nTURSO_AUTH_TOKEN=dummy\n",
+    ".env.ib-mode": "IB_GATEWAY_MODE=local\n",
+    "web/.env": "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_dummy\n",
+}
+
+
+def _stub_bin(tmp_path: Path) -> Path:
+    """Every external the setup scripts shell out to, neutered."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    scripts = {
+        # `git config --get remote.origin.url` must answer; everything else
+        # (ls-remote / fetch / checkout / reset) just succeeds.
+        "git": (
+            "#!/bin/sh\n"
+            'case "$*" in *"config --get remote.origin.url"*)'
+            ' echo git@example.invalid:stub/radon.git;; esac\n'
+            "exit 0\n"
+        ),
+        "gh": "#!/bin/sh\nexit 0\n",
+        "claude": "#!/bin/sh\nexit 0\n",
+        "node": "#!/bin/sh\nexit 0\n",
+        "bun": "#!/bin/sh\nexit 0\n",
+        "caddy": "#!/bin/sh\nexit 0\n",
+        # Only the `bash 4+` toolchain check shells out to `bash`; this
+        # keeps [1/4] green on a macOS runner so the run reaches [2/4].
+        "bash": "#!/bin/sh\nexit 0\n",
+        "ssh": "#!/bin/sh\nexit 0\n",
+        "python3.13": "#!/bin/sh\nexit 0\n",
+        "launchctl": "#!/bin/sh\nexit 0\n",
+        # -lint succeeds; -extract feeds the closing printf a number.
+        "plutil": (
+            "#!/bin/sh\n"
+            'if [ "$1" = "-lint" ]; then exit 0; fi\n'
+            "echo 0\n"
+        ),
+    }
+    for name, body in scripts.items():
+        path = bin_dir / name
+        path.write_text(body, encoding="utf-8")
+        path.chmod(0o755)
+    return bin_dir
+
+
+def _stage(tmp_path: Path, name: str) -> tuple[Path, Path, dict]:
+    """A fake source checkout, a fake already-provisioned clone, and env."""
+    _, clone_name = SETUPS[name]
+
+    src = tmp_path / "src"
+    (src / "web").mkdir(parents=True)
+    for rel, body in DUMMY.items():
+        (src / rel).write_text(body, encoding="utf-8")
+
+    root = tmp_path / "weekend"
+    clone = root / clone_name
+    (clone / ".git").mkdir(parents=True)
+    (clone / "web").mkdir()
+    (clone / "config").mkdir()
+    (clone / "requirements.txt").write_text("", encoding="utf-8")
+    shutil.copy(REPO / "config" / PLISTS[name], clone / "config" / PLISTS[name])
+
+    # The venv the toolchain check and the pip lines address.
+    venv_bin = root / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    for tool in ("python", "pip"):
+        exe = venv_bin / tool
+        exe.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        exe.chmod(0o755)
+
+    (root / ".env").write_text("PUSHOVER_USER=dummy\nPUSHOVER_TOKEN=dummy\n", encoding="utf-8")
+
+    home = tmp_path / "home"
+    home.mkdir()
+    env = {
+        "PATH": f"{_stub_bin(tmp_path)}:/usr/bin:/bin:/usr/sbin:/sbin",
+        "HOME": str(home),
+        "RADON_WEEKEND_ROOT": str(root),
+        "RADON_WEEKEND_SRC_REPO": str(src),
+    }
+    return src, clone, env
+
+
+def _run(name: str, env: dict, cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [BASH, str(SETUPS[name][0])],
+        env=env,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+@pytest.mark.parametrize("name", sorted(SETUPS))
+class TestRunnerEnvProvisioning:
+    def test_setup_copies_the_env_files_into_the_clone(self, name, tmp_path):
+        src, clone, env = _stage(tmp_path, name)
+
+        proc = _run(name, env, tmp_path)
+
+        rel = "web/.env"
+        dst = clone / rel
+        assert dst.is_file(), (
+            f"{name}: {rel} was never provisioned into the runner clone, so the "
+            "Next dev server cannot boot and the nightly agent cannot do the "
+            "browser verification CLAUDE.md requires.\n"
+            f"{proc.stdout}\n{proc.stderr}"
+        )
+        assert dst.read_text(encoding="utf-8") == DUMMY[rel]
+        assert oct(dst.stat().st_mode & 0o777) == "0o600", (
+            f"{name}: {rel} holds secrets and must land 0600"
+        )
+
+    def test_setup_does_not_provision_the_root_env(self, name, tmp_path):
+        """The root .env must stay OUT of the runner clone.
+
+        python-dotenv already walks up from the clone to $WEEKEND_ROOT/.env for
+        the same TURSO/IB keys, so a second copy is redundant, and it would put
+        IB_FLEX_TOKEN in one more place. web/.env is read by Next, never pytest.
+        """
+        src, clone, env = _stage(tmp_path, name)
+
+        proc = _run(name, env, tmp_path)
+
+        for rel in (".env", ".env.ib-mode"):
+            assert not (clone / rel).exists(), (
+                f"{name}: {rel} was copied into the runner clone. Only web/.env "
+                "is provisioned; see the comment above provision_env_file.\n"
+                f"{proc.stdout}\n{proc.stderr}"
+            )
+
+    def test_setup_reports_a_missing_source_env_file(self, name, tmp_path):
+        src, clone, env = _stage(tmp_path, name)
+        (src / "web" / ".env").unlink()
+
+        proc = _run(name, env, tmp_path)
+        out = proc.stdout + proc.stderr
+
+        assert "MISSING" in out and "web/.env" in out, (
+            f"{name}: the toolchain block said nothing about the absent "
+            f"web/.env:\n{out}"
+        )
+        # Usable on a fresh machine: warn, do not hard-fail.
+        assert proc.returncode == 0, out
+        assert not (clone / "web" / ".env").exists()
+        # It must say what it did rather than skip in silence.
+        assert "web/.env" in out.split("[2/4]", 1)[-1]
+
+    def test_setup_does_not_silently_clobber_a_newer_clone_copy(self, name, tmp_path):
+        src, clone, env = _stage(tmp_path, name)
+        newer = "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_rotated\n"
+        (clone / "web" / ".env").write_text(newer, encoding="utf-8")
+        # `-nt` compares whole seconds, so make the gap unambiguous.
+        stamp = time.time() + 120
+        os.utime(clone / "web" / ".env", (stamp, stamp))
+
+        proc = _run(name, env, tmp_path)
+        out = proc.stdout + proc.stderr
+
+        assert (clone / "web" / ".env").read_text(encoding="utf-8") == newer, (
+            f"{name}: an older source copy overwrote a newer clone copy:\n{out}"
+        )
+        assert "web/.env" in out.split("[2/4]", 1)[-1], out


### PR DESCRIPTION
Three environment gaps the 2026-08-29 nightly runs filed against their own runners, none fixable from inside a run.

- **`web/.env` was never provisioned into either dedicated clone.** Both wrappers already exclude it from their per-round `git clean`, so surviving the nightly hard-reset was always the intent; only the copy step was missing. Without it the Next dev server cannot boot, so the loop cannot do the browser verification CLAUDE.md requires: reliability closed R-408 partially for exactly this reason, and testing filed T-248 as a permanent local false-red.
- **Only `web/.env`.** Provisioning the root `.env` was measured, not assumed: the full suite in the reliability clone was unchanged with it present vs absent, because python-dotenv already walks up from the clone to `$WEEKEND_ROOT/.env` for the same TURSO/IB keys. Redundant, and it would put `IB_FLEX_TOKEN` in a second place. A test pins it out.
- **The testing skill told its fan-out to symlink `node_modules`** while recording, twelve lines later, that a symlinked `node_modules` cannot run the gates. Turbopack rejects it outright ("points out of the filesystem root"), so every fanned-out worktree was structurally unable to run e2e while looking green on units. Now clone-copies with `cp -Rc`.
- **Setup reports bash 4+ and caddy**, naming the consequence (bash 3.2 leaves 34 cloud/tests permanently red here). Advisory only, since installing either moves the darwin baseline the audits diff against.

## Verification

- 114 passed across the four runner suites.
- New root-`.env` guard mutation checked: red when `.env` is added back to the provisioning loop.
- `bash -n` clean on both setup scripts under bash 3.2 and PATH bash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)