### PR TITLE
feat(dashboard): Commentary/Headlines tabs with proxied MKTNews hub

### DIFF
--- a/cloud/caddy/Caddyfile
+++ b/cloud/caddy/Caddyfile
@@ -30,6 +30,10 @@
         format json
     }
 
+    handle /ws-headlines {
+        reverse_proxy localhost:8766
+    }
+
     handle /ws* {
         reverse_proxy 127.0.0.1:8765
     }

--- a/cloud/config/drift-allowlist.conf
+++ b/cloud/config/drift-allowlist.conf
@@ -22,5 +22,4 @@
 # memory project_llm_token_index_2026_05_19) -- units committed, not installed.
 not-installed:radon-llm-index.service expires=2026-12-31 gated on Artificial Analysis signup; deliberately not installed
 not-installed:radon-llm-index.timer expires=2026-12-31 gated on Artificial Analysis signup; deliberately not installed
-
-
+not-installed:radon-mktnews.service expires=2026-12-31 headlines hub; enable after first green local run

--- a/cloud/services/radon-mktnews.service
+++ b/cloud/services/radon-mktnews.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Radon MKTNews headlines hub (upstream flash WS, loopback fan-out)
+After=network-online.target radon-api.service
+Wants=network-online.target
+
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
+[Service]
+Type=simple
+User=radon
+UMask=0077
+WorkingDirectory=/home/radon/radon
+EnvironmentFile=/etc/radon/env
+Environment=RADON_DB_NO_REPLICA=1
+Environment=WS_BIND_HOST=127.0.0.1
+ExecStart=/usr/bin/node /home/radon/radon/scripts/mktnews/index.js --serve
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/cloud/tests/test_caddyfile.py
+++ b/cloud/tests/test_caddyfile.py
@@ -73,6 +73,19 @@ class TestRouting:
         assert re.search(r"handle\s+/ws\*", content)
         assert "127.0.0.1:8765" in content
 
+    def test_headlines_websocket_before_generic_ws(self, caddy_dir):
+        content = read_caddyfile(caddy_dir)
+        active = "\n".join(
+            line for line in content.splitlines() if not line.lstrip().startswith("#")
+        )
+        headlines = active.find("handle /ws-headlines")
+        generic = active.find("handle /ws*")
+        assert headlines != -1, "Caddy must proxy /ws-headlines"
+        assert generic != -1
+        assert headlines < generic, "/ws-headlines must win over /ws*"
+        assert "handle /ws-headlines*" not in active
+        assert "localhost:8766" in active
+
     def test_api_ib_route_to_8321(self, caddy_dir):
         content = read_caddyfile(caddy_dir)
         assert re.search(r"handle_path\s+/api/ib/\*", content)

--- a/scripts/dev
+++ b/scripts/dev
@@ -21,13 +21,13 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-ALL_NAMES=(next ib api scraper)
+ALL_NAMES=(next ib api scraper headlines)
 ONLY=""
 PROFILE="${RADON_DEV_PROFILE:-full}"
 
 usage() {
   cat <<EOF
-Usage: npm run dev [-- --only <next|ib|api|scraper>]
+Usage: npm run dev [-- --only <next|ib|api|scraper|headlines>]
 
   npm run dev                       Run all four services with full logs.
   npm run dev -- --only <name>      Show only that service's logs.
@@ -94,9 +94,10 @@ if [[ "$PROFILE" == "cloud-thin" ]]; then
 fi
 
 exec npx concurrently "${HIDE_ARGS[@]}" \
-  -n next,ib,api,scraper \
-  -c cyan,yellow,green,magenta \
+  -n next,ib,api,scraper,headlines \
+  -c cyan,yellow,green,magenta,white \
   "next dev" \
   "node ../scripts/ib_realtime_server.js" \
   "python3.13 -m uvicorn scripts.api.server:app --host 127.0.0.1 --port 8321 --reload --app-dir .. --reload-dir ../scripts" \
-  "node ../scripts/newsfeed/index.js"
+  "node ../scripts/newsfeed/index.js" \
+  "node ../scripts/mktnews/index.js --serve"

--- a/scripts/mktnews/cli.js
+++ b/scripts/mktnews/cli.js
@@ -1,0 +1,64 @@
+import { DEFAULT_HOST, DEFAULT_LANG, DEFAULT_URL } from "./protocol.js";
+
+export function buildUrl({ url, lang = DEFAULT_LANG } = {}) {
+  if (url) return url;
+  return `${DEFAULT_HOST}?lang=${lang}`;
+}
+
+function takeValue(argv, i) {
+  const next = argv[i + 1];
+  if (next == null || next.startsWith("--")) {
+    throw new Error(`missing value for ${argv[i]}`);
+  }
+  return next;
+}
+
+export function parseArgs(argv) {
+  const opts = {
+    url: null,
+    lang: DEFAULT_LANG,
+    all: false,
+    pretty: false,
+    seconds: null,
+    max: null,
+    serve: false,
+    port: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--all") opts.all = true;
+    else if (arg === "--pretty") opts.pretty = true;
+    else if (arg === "--serve") opts.serve = true;
+    else if (arg === "--url") {
+      opts.url = takeValue(argv, i);
+      i += 1;
+    } else if (arg === "--lang") {
+      opts.lang = takeValue(argv, i);
+      i += 1;
+    } else if (arg === "--seconds") {
+      opts.seconds = Number(takeValue(argv, i));
+      i += 1;
+    } else if (arg === "--max") {
+      opts.max = Number(takeValue(argv, i));
+      i += 1;
+    } else if (arg === "--port") {
+      opts.port = Number(takeValue(argv, i));
+      i += 1;
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  if (opts.seconds != null && (!Number.isFinite(opts.seconds) || opts.seconds <= 0)) {
+    throw new Error("--seconds must be a positive number");
+  }
+  if (opts.max != null && (!Number.isInteger(opts.max) || opts.max <= 0)) {
+    throw new Error("--max must be a positive integer");
+  }
+  if (opts.port != null && (!Number.isInteger(opts.port) || opts.port <= 0)) {
+    throw new Error("--port must be a positive integer");
+  }
+  opts.url = buildUrl(opts);
+  return opts;
+}
+
+export { DEFAULT_URL };

--- a/scripts/mktnews/cli.test.js
+++ b/scripts/mktnews/cli.test.js
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { buildUrl, parseArgs } from "./cli.js";
+import { DEFAULT_URL } from "./protocol.js";
+
+describe("parseArgs", () => {
+  it("defaults to the English public feed, JSONL, heartbeats off", () => {
+    expect(parseArgs([])).toEqual({
+      url: DEFAULT_URL,
+      lang: "en",
+      all: false,
+      pretty: false,
+      seconds: null,
+      max: null,
+      serve: false,
+      port: null,
+    });
+  });
+
+  it("accepts --pretty --all --seconds --max --lang", () => {
+    const opts = parseArgs([
+      "--pretty",
+      "--all",
+      "--seconds",
+      "15",
+      "--max",
+      "3",
+      "--lang",
+      "zh",
+    ]);
+    expect(opts.pretty).toBe(true);
+    expect(opts.all).toBe(true);
+    expect(opts.seconds).toBe(15);
+    expect(opts.max).toBe(3);
+    expect(opts.lang).toBe("zh");
+    expect(opts.url).toBe("wss://api.mktnews.net/?lang=zh");
+  });
+
+  it("lets --url override lang", () => {
+    const opts = parseArgs(["--url", "wss://example.test/ws", "--lang", "zh"]);
+    expect(opts.url).toBe("wss://example.test/ws");
+  });
+});
+
+describe("buildUrl", () => {
+  it("appends lang to the default host", () => {
+    expect(buildUrl({ lang: "en" })).toBe(DEFAULT_URL);
+    expect(buildUrl({ lang: "zh" })).toBe("wss://api.mktnews.net/?lang=zh");
+  });
+});

--- a/scripts/mktnews/client.js
+++ b/scripts/mktnews/client.js
@@ -1,0 +1,98 @@
+import WebSocket from "ws";
+
+import { reconnectDelayMs } from "../lib/reconnectGate.js";
+import { MAX_FRAME_BYTES } from "./normalize.js";
+import {
+  DEFAULT_ORIGIN,
+  DEFAULT_URL,
+  DEFAULT_USER_AGENT,
+  parseFrame,
+} from "./protocol.js";
+
+export function connectMktnews({
+  url = DEFAULT_URL,
+  origin = DEFAULT_ORIGIN,
+  userAgent = DEFAULT_USER_AGENT,
+  WebSocketImpl = WebSocket,
+  onMessage,
+  onStatus,
+  signal,
+  reconnect = true,
+  delayFn = reconnectDelayMs,
+  maxPayload = MAX_FRAME_BYTES,
+} = {}) {
+  let attempt = 0;
+  let socket = null;
+  let timer = null;
+  let stopped = false;
+
+  function status(event, extra = {}) {
+    onStatus?.({ event, ...extra });
+  }
+
+  function clearTimer() {
+    if (timer != null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  }
+
+  function open() {
+    if (stopped || signal?.aborted) return;
+    clearTimer();
+    socket = new WebSocketImpl(url, {
+      maxPayload,
+      headers: {
+        Origin: origin,
+        "User-Agent": userAgent,
+      },
+    });
+    socket.on("open", () => {
+      attempt = 0;
+      status("open", { url });
+    });
+    socket.on("message", (data) => {
+      onMessage?.(parseFrame(data));
+    });
+    socket.on("error", (error) => {
+      status("error", { error: error?.message ?? String(error) });
+    });
+    socket.on("close", (code, reason) => {
+      status("close", { code, reason: reason?.toString?.() ?? String(reason ?? "") });
+      socket = null;
+      scheduleReconnect();
+    });
+  }
+
+  function scheduleReconnect() {
+    if (stopped || !reconnect || signal?.aborted) return;
+    const delay = delayFn(attempt);
+    attempt += 1;
+    status("reconnect", { attempt, delayMs: delay });
+    timer = setTimeout(open, delay);
+  }
+
+  function stop() {
+    stopped = true;
+    clearTimer();
+    if (socket) {
+      try {
+        socket.close();
+      } catch {
+        // already closing
+      }
+      socket = null;
+    }
+  }
+
+  if (signal) {
+    if (signal.aborted) {
+      stopped = true;
+      return { stop };
+    }
+    signal.addEventListener("abort", stop, { once: true });
+  }
+
+  open();
+  return { stop };
+}

--- a/scripts/mktnews/client.test.js
+++ b/scripts/mktnews/client.test.js
@@ -1,0 +1,130 @@
+import { createServer } from "node:http";
+
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocketServer } from "ws";
+
+import { connectMktnews } from "./client.js";
+
+function listenServer() {
+  const httpServer = createServer();
+  const wss = new WebSocketServer({ server: httpServer });
+  return new Promise((resolve) => {
+    httpServer.listen(0, "127.0.0.1", () => {
+      const { port } = httpServer.address();
+      resolve({
+        wss,
+        httpServer,
+        url: `ws://127.0.0.1:${port}`,
+        close() {
+          return new Promise((done) => {
+            wss.close(() => httpServer.close(done));
+          });
+        },
+      });
+    });
+  });
+}
+
+describe("connectMktnews", () => {
+  const servers = [];
+
+  afterEach(async () => {
+    while (servers.length) {
+      await servers.pop().close();
+    }
+  });
+
+  it("emits parsed frames from a local websocket", async () => {
+    const server = await listenServer();
+    servers.push(server);
+    server.wss.on("connection", (socket) => {
+      socket.send(JSON.stringify({ type: "time", data: 99 }));
+      socket.send(
+        JSON.stringify({
+          type: "flash",
+          data: { id: "f1", data: { content: "hello flash" } },
+        }),
+      );
+    });
+
+    const received = [];
+    const client = connectMktnews({
+      url: server.url,
+      reconnect: false,
+      onMessage: (msg) => received.push(msg),
+    });
+
+    await viWait(() => received.some((m) => m.kind === "flash"));
+    client.stop();
+
+    const kinds = received.map((m) => m.kind);
+    expect(kinds).toContain("time");
+    expect(kinds).toContain("flash");
+    expect(received.find((m) => m.kind === "flash").data.data.content).toBe(
+      "hello flash",
+    );
+  });
+
+  it("reconnects after the server drops the socket", async () => {
+    const server = await listenServer();
+    servers.push(server);
+    let connections = 0;
+    server.wss.on("connection", (socket) => {
+      connections += 1;
+      socket.send(JSON.stringify({ type: "flash", data: { id: String(connections) } }));
+      if (connections === 1) socket.close();
+    });
+
+    const received = [];
+    const client = connectMktnews({
+      url: server.url,
+      onMessage: (msg) => received.push(msg),
+      delayFn: () => 20,
+    });
+
+    await viWait(() => received.filter((m) => m.kind === "flash").length >= 2);
+    client.stop();
+    expect(connections).toBeGreaterThanOrEqual(2);
+  });
+
+  it("sends Origin and stops on abort", async () => {
+    const server = await listenServer();
+    servers.push(server);
+    const origins = [];
+    server.wss.on("connection", (socket, req) => {
+      origins.push(req.headers.origin);
+    });
+    const controller = new AbortController();
+    const client = connectMktnews({
+      url: server.url,
+      reconnect: false,
+      signal: controller.signal,
+    });
+    await viWait(() => origins.length >= 1);
+    controller.abort();
+    client.stop();
+    expect(origins[0]).toBe("https://mktnews.net");
+  });
+});
+
+function viWait(predicate, timeoutMs = 2000) {
+  const start = Date.now();
+  return new Promise((resolve, reject) => {
+    const tick = () => {
+      try {
+        if (predicate()) {
+          resolve();
+          return;
+        }
+      } catch {
+        // keep waiting until timeout
+      }
+      if (Date.now() - start > timeoutMs) {
+        reject(new Error("timed out waiting for websocket condition"));
+        return;
+      }
+      setTimeout(tick, 15);
+    };
+    tick();
+  });
+}

--- a/scripts/mktnews/format.js
+++ b/scripts/mktnews/format.js
@@ -1,0 +1,46 @@
+export function shouldEmit(msg, { all = false } = {}) {
+  if (!msg) return false;
+  if (msg.kind === "time" && !all) return false;
+  return true;
+}
+
+function flashText(data) {
+  if (!data || typeof data !== "object") return "";
+  const inner = data.data && typeof data.data === "object" ? data.data : data;
+  return String(inner.content || inner.title || "").replace(/\s+/g, " ").trim();
+}
+
+function impactSuffix(data) {
+  const impacts = Array.isArray(data?.impact) ? data.impact : [];
+  if (!impacts.length) return "";
+  return (
+    "  " +
+    impacts
+      .map((row) => {
+        const symbol = row?.symbol || "";
+        const impact = row?.impact || "";
+        return [symbol, impact].filter(Boolean).join(":");
+      })
+      .filter(Boolean)
+      .join(" ")
+  );
+}
+
+export function formatMessage(msg, { pretty = false, all = false } = {}) {
+  if (!shouldEmit(msg, { all })) return null;
+  if (!pretty) return JSON.stringify({ kind: msg.kind, type: msg.type, data: msg.data });
+  if (msg.kind === "time") {
+    return `TIME  ${new Date(msg.data).toISOString()}`;
+  }
+  if (msg.kind === "flash") {
+    const when = msg.data?.time || "";
+    const important = msg.data?.important ? " IMPORTANT" : "";
+    return `FLASH${important}  ${when}  ${flashText(msg.data)}${impactSuffix(msg.data)}`.trim();
+  }
+  if (msg.kind === "news") {
+    const title = msg.data?.title || flashText(msg.data);
+    return `NEWS  ${title}`.trim();
+  }
+  if (msg.kind === "raw") return `RAW  ${msg.raw}`;
+  return `${String(msg.kind).toUpperCase()}  ${JSON.stringify(msg.data)}`;
+}

--- a/scripts/mktnews/format.test.js
+++ b/scripts/mktnews/format.test.js
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { formatMessage, shouldEmit } from "./format.js";
+import { parseFrame } from "./protocol.js";
+
+const FLASH = parseFrame(
+  JSON.stringify({
+    type: "flash",
+    data: {
+      id: "flash-1",
+      time: "2026-08-29T20:29:50.000Z",
+      important: 1,
+      data: { content: "Hormuz oil-route report denied." },
+      impact: [{ impact: "bearish", symbol: "WTI" }],
+    },
+  }),
+);
+
+const TIME = parseFrame('{"type":"time","data":1788035440035}');
+
+describe("shouldEmit", () => {
+  it("drops time heartbeats unless --all", () => {
+    expect(shouldEmit(TIME, { all: false })).toBe(false);
+    expect(shouldEmit(TIME, { all: true })).toBe(true);
+    expect(shouldEmit(FLASH, { all: false })).toBe(true);
+  });
+});
+
+describe("formatMessage", () => {
+  it("emits JSONL by default", () => {
+    const line = formatMessage(FLASH, { pretty: false });
+    const parsed = JSON.parse(line);
+    expect(parsed.kind).toBe("flash");
+    expect(parsed.data.data.content).toContain("Hormuz");
+  });
+
+  it("pretty-prints flash content on one line", () => {
+    const line = formatMessage(FLASH, { pretty: true });
+    expect(line).toContain("FLASH");
+    expect(line).toContain("Hormuz oil-route report denied.");
+    expect(line).toContain("WTI");
+    expect(line.includes("\n")).toBe(false);
+  });
+
+  it("returns null when the filter drops the frame", () => {
+    expect(formatMessage(TIME, { pretty: true, all: false })).toBeNull();
+  });
+});

--- a/scripts/mktnews/hub.js
+++ b/scripts/mktnews/hub.js
@@ -1,0 +1,242 @@
+import http from "node:http";
+import { WebSocketServer } from "ws";
+
+import { reconnectDelayMs } from "../lib/reconnectGate.js";
+import {
+  resolveRelaySecurityConfig,
+  resolveUpgradeTarget,
+  shouldSkipTicketValidation,
+} from "../lib/wsTrust.js";
+import { connectMktnews } from "./client.js";
+import {
+  MAX_FRAME_BYTES,
+  RING_SIZE,
+  containsUpstreamHost,
+  toHeadline,
+} from "./normalize.js";
+import { parseFrame } from "./protocol.js";
+
+export const HEADLINES_PATH = "/ws-headlines";
+export const DEFAULT_LISTEN_PORT = 8766;
+export const MAX_CLIENTS = 32;
+const TICKET_VALIDATION_TIMEOUT_MS = 3000;
+const LOOPBACK_LISTEN_HOSTS = new Set(["127.0.0.1", "::1"]);
+
+function isOriginFormPath(requestUrl, path) {
+  const raw = String(requestUrl ?? "");
+  return raw === path || raw.startsWith(`${path}?`);
+}
+
+function resolveHubListenHost(listenHost, bindHost) {
+  const candidate = listenHost || bindHost || "127.0.0.1";
+  return LOOPBACK_LISTEN_HOSTS.has(candidate) ? candidate : "127.0.0.1";
+}
+
+function frameByteLength(parsed) {
+  if (parsed && typeof parsed.raw === "string") return Buffer.byteLength(parsed.raw);
+  try {
+    return Buffer.byteLength(JSON.stringify(parsed ?? ""));
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
+}
+
+function envelopeLeaksUpstream(payload) {
+  if (!payload || typeof payload !== "object") return containsUpstreamHost(payload);
+  if (payload.type === "snapshot") {
+    return (payload.items ?? []).some((item) => envelopeLeaksUpstream({ type: "headline", item }));
+  }
+  if (payload.type === "headline" && payload.item) {
+    const { content: _content, ...rest } = payload.item;
+    return containsUpstreamHost(rest);
+  }
+  return containsUpstreamHost(payload);
+}
+
+function sendJson(socket, payload) {
+  if (socket.readyState !== 1) return;
+  if (envelopeLeaksUpstream(payload)) return;
+  socket.send(JSON.stringify(payload));
+}
+
+export function createHeadlinesHub({
+  listenHost,
+  listenPort = 0,
+  path = HEADLINES_PATH,
+  security = resolveRelaySecurityConfig(),
+  ticketValidateUrl = process.env.TICKET_VALIDATE_URL || "http://127.0.0.1:8321/ws-ticket/validate",
+  fetchImpl = fetch,
+  connectUpstream = null,
+  maxClients = MAX_CLIENTS,
+  ringSize = RING_SIZE,
+  maxFrameBytes = MAX_FRAME_BYTES,
+  delayFn = reconnectDelayMs,
+} = {}) {
+  const host = resolveHubListenHost(listenHost, security.bindHost);
+  const ring = [];
+  const clients = new Set();
+  let upstream = null;
+  let closed = false;
+
+  function ingest(parsed) {
+    if (frameByteLength(parsed) > maxFrameBytes) return false;
+    const item = toHeadline(parsed);
+    if (!item) return false;
+    const { content: _content, ...meta } = item;
+    if (containsUpstreamHost(meta)) return false;
+    const existing = ring.findIndex((row) => row.id === item.id);
+    if (existing >= 0) ring.splice(existing, 1);
+    ring.push(item);
+    while (ring.length > ringSize) ring.shift();
+    for (const client of clients) sendJson(client, { type: "headline", item });
+    return true;
+  }
+
+  function ingestRaw(raw) {
+    const bytes = Buffer.isBuffer(raw) ? raw.length : Buffer.byteLength(String(raw));
+    if (bytes > maxFrameBytes) return false;
+    return ingest(parseFrame(raw));
+  }
+
+  function broadcastStatus(state) {
+    for (const client of clients) sendJson(client, { type: "status", state });
+  }
+
+  const httpServer = http.createServer((_req, res) => {
+    res.writeHead(426, { "Content-Type": "text/plain" });
+    res.end("WebSocket upgrade required");
+  });
+  const wss = new WebSocketServer({ noServer: true, maxPayload: maxFrameBytes });
+
+  httpServer.on("upgrade", async (req, socket, head) => {
+    const target = resolveUpgradeTarget(req);
+    if (!isOriginFormPath(req.url, path) || target.pathname !== path) {
+      socket.write("HTTP/1.1 404 Not Found\r\n\r\n");
+      socket.destroy();
+      return;
+    }
+    if (clients.size >= maxClients) {
+      socket.write("HTTP/1.1 503 Service Unavailable\r\n\r\n");
+      socket.destroy();
+      return;
+    }
+
+    const remoteAddr = socket.remoteAddress || "";
+    const skipTicket = shouldSkipTicketValidation({
+      clerkConfigured: security.clerkConfigured,
+      allowUnauthenticatedDev: security.allowUnauthenticatedDev,
+      remoteAddr,
+      headers: req.headers,
+    });
+    if (!skipTicket) {
+      const ticket = target.searchParams.get("ticket");
+      if (!ticket) {
+        socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
+        socket.destroy();
+        return;
+      }
+      try {
+        const res = await fetchImpl(ticketValidateUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ticket }),
+          signal: AbortSignal.timeout(TICKET_VALIDATION_TIMEOUT_MS),
+        });
+        if (!res.ok) {
+          socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
+          socket.destroy();
+          return;
+        }
+      } catch {
+        socket.write("HTTP/1.1 503 Service Unavailable\r\n\r\n");
+        socket.destroy();
+        return;
+      }
+    }
+
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      clients.add(ws);
+      sendJson(ws, { type: "snapshot", items: ring.slice() });
+      ws.on("close", () => clients.delete(ws));
+      ws.on("error", () => clients.delete(ws));
+      ws.on("message", () => {
+        // Client is receive-only. Drop inbound payloads.
+      });
+    });
+  });
+
+  function startUpstream() {
+    if (!connectUpstream || closed) return;
+    upstream = connectUpstream({
+      delayFn,
+      maxPayload: maxFrameBytes,
+      onMessage: (msg) => ingest(msg),
+      onStatus: (event) => {
+        if (event.event === "open") broadcastStatus("upstream-open");
+        if (event.event === "close") broadcastStatus("upstream-down");
+      },
+    });
+  }
+
+  function listen() {
+    return new Promise((resolve) => {
+      httpServer.listen(listenPort, host, () => {
+        startUpstream();
+        resolve();
+      });
+    });
+  }
+
+  async function stop() {
+    closed = true;
+    upstream?.stop?.();
+    for (const client of clients) {
+      try {
+        client.close();
+      } catch {
+        // already closing
+      }
+    }
+    clients.clear();
+    await new Promise((resolve) => httpServer.close(resolve));
+  }
+
+  return {
+    listen,
+    stop,
+    ingest,
+    ingestRaw,
+    get listenHost() {
+      return host;
+    },
+    get ring() {
+      return ring.slice();
+    },
+    get clientCount() {
+      return clients.size;
+    },
+    address() {
+      const addr = httpServer.address();
+      if (!addr || typeof addr === "string") return null;
+      return `ws://127.0.0.1:${addr.port}${path}`;
+    },
+  };
+}
+
+export async function startHeadlinesHub(overrides = {}) {
+  if (overrides.security?.requireClerk && !overrides.security.clerkConfigured) {
+    throw new Error("Headlines hub requires CLERK_JWKS_URL and CLERK_ISSUER");
+  }
+  const security = overrides.security || resolveRelaySecurityConfig();
+  if (security.requireClerk && !security.clerkConfigured) {
+    throw new Error("Headlines hub requires CLERK_JWKS_URL and CLERK_ISSUER");
+  }
+  const hub = createHeadlinesHub({
+    ...overrides,
+    security,
+    listenPort: overrides.listenPort ?? DEFAULT_LISTEN_PORT,
+    connectUpstream: overrides.connectUpstream === undefined ? connectMktnews : overrides.connectUpstream,
+  });
+  await hub.listen();
+  return hub;
+}

--- a/scripts/mktnews/hub.test.js
+++ b/scripts/mktnews/hub.test.js
@@ -1,0 +1,273 @@
+import crypto from "node:crypto";
+import net from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocket } from "ws";
+
+import { createHeadlinesHub } from "./hub.js";
+import { parseFrame } from "./protocol.js";
+import { RING_SIZE } from "./normalize.js";
+
+const FLASH = {
+  type: "flash",
+  data: {
+    id: "h1",
+    time: "2026-08-29T20:35:56.000Z",
+    important: 1,
+    data: { content: "Explosions heard in Kyiv." },
+    impact: [{ symbol: "WTI", impact: "bearish" }],
+  },
+};
+
+const AUTHLESS = {
+  clerkConfigured: false,
+  allowUnauthenticatedDev: true,
+  bindHost: "127.0.0.1",
+  requireClerk: false,
+};
+
+function waitOpen(ws) {
+  return new Promise((resolve, reject) => {
+    ws.once("open", resolve);
+    ws.once("error", reject);
+    ws.once("unexpected-response", (_req, res) => {
+      reject(Object.assign(new Error(`upgrade ${res.statusCode}`), { statusCode: res.statusCode }));
+    });
+  });
+}
+
+function collect(ws, n, timeoutMs = 1500) {
+  const messages = [];
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("timed out collecting frames")), timeoutMs);
+    ws.on("message", (data) => {
+      messages.push(JSON.parse(data.toString()));
+      if (messages.length >= n) {
+        clearTimeout(timer);
+        resolve(messages);
+      }
+    });
+  });
+}
+
+function listenPort(hub) {
+  return Number(new URL(hub.address()).port);
+}
+
+function rawUpgrade(port, requestTarget, extraHeaders = "") {
+  return new Promise((resolve, reject) => {
+    const socket = net.connect({ host: "127.0.0.1", port }, () => {
+      const key = crypto.randomBytes(16).toString("base64");
+      socket.write(
+        `GET ${requestTarget} HTTP/1.1\r\n` +
+          `Host: 127.0.0.1:${port}\r\n` +
+          "Upgrade: websocket\r\n" +
+          "Connection: Upgrade\r\n" +
+          `Sec-WebSocket-Key: ${key}\r\n` +
+          "Sec-WebSocket-Version: 13\r\n" +
+          extraHeaders +
+          "\r\n",
+      );
+    });
+    const timer = setTimeout(() => {
+      socket.destroy();
+      reject(new Error(`upgrade timeout for ${requestTarget}`));
+    }, 1500);
+    socket.once("data", (buf) => {
+      clearTimeout(timer);
+      const status = Number(String(buf).split(" ")[1]);
+      socket.destroy();
+      resolve(status);
+    });
+    socket.once("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+describe("createHeadlinesHub", () => {
+  const hubs = [];
+
+  afterEach(async () => {
+    while (hubs.length) await hubs.pop().stop();
+  });
+
+  async function boot(overrides = {}) {
+    const hub = createHeadlinesHub({
+      security: AUTHLESS,
+      listenHost: "127.0.0.1",
+      listenPort: 0,
+      connectUpstream: null,
+      ...overrides,
+    });
+    hubs.push(hub);
+    await hub.listen();
+    return hub;
+  }
+
+  it("sends a snapshot then live headlines, never time ticks or upstream hosts", async () => {
+    const hub = await boot();
+    hub.ingest(parseFrame(JSON.stringify(FLASH)));
+    hub.ingest(parseFrame('{"type":"time","data":99}'));
+    const ws = new WebSocket(hub.address());
+    const frames = await collect(ws, 1);
+    hub.ingest(
+      parseFrame(
+        JSON.stringify({
+          type: "flash",
+          data: { id: "h2", data: { content: "Jobless claims 218k vs 225k." } },
+        }),
+      ),
+    );
+    const next = await collect(ws, 1);
+    const live = [...frames, ...next];
+    ws.close();
+    expect(live[0]).toEqual({
+      type: "snapshot",
+      items: [
+        {
+          kind: "headline",
+          id: "h1",
+          time: "2026-08-29T20:35:56.000Z",
+          important: true,
+          content: "Explosions heard in Kyiv.",
+          impact: [{ symbol: "WTI", impact: "bearish" }],
+        },
+      ],
+    });
+    expect(live[live.length - 1].type).toBe("headline");
+    expect(JSON.stringify(live)).not.toMatch(/"type":"time"/);
+  });
+
+  it("still fans out a headline whose body mentions the upstream host", async () => {
+    const hub = await boot();
+    const ws = new WebSocket(hub.address());
+    const pending = collect(ws, 2);
+    await waitOpen(ws);
+    hub.ingest(
+      parseFrame(
+        JSON.stringify({
+          type: "flash",
+          data: { id: "mention", data: { content: "Screenshot from mktnews.net is circulating." } },
+        }),
+      ),
+    );
+    const frames = await pending;
+    ws.close();
+    const live = frames.find((row) => row.type === "headline");
+    expect(live.item.content).toContain("mktnews.net");
+  });
+
+  it("rejects the wrong path", async () => {
+    const hub = await boot();
+    const ws = new WebSocket(hub.address().replace("/ws-headlines", "/ws"));
+    await expect(waitOpen(ws)).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it("rejects a missing ticket when the handshake looks like a browser", async () => {
+    const hub = await boot();
+    const ws = new WebSocket(hub.address(), {
+      headers: { Origin: "http://localhost:3000" },
+    });
+    await expect(waitOpen(ws)).rejects.toMatchObject({ statusCode: 401 });
+  });
+
+  it("rejects loopback upgrades that arrived through a proxy", async () => {
+    const hub = await boot();
+    const ws = new WebSocket(hub.address(), {
+      headers: { "x-forwarded-for": "203.0.113.9" },
+    });
+    await expect(waitOpen(ws)).rejects.toMatchObject({ statusCode: 401 });
+  });
+
+  it("accepts a validated ticket from a browser handshake", async () => {
+    const fetchImpl = async () => ({ ok: true });
+    const hub = await boot({
+      security: { ...AUTHLESS, allowUnauthenticatedDev: false, clerkConfigured: true },
+      fetchImpl,
+    });
+    const ws = new WebSocket(`${hub.address()}?ticket=good`, {
+      headers: { Origin: "http://localhost:3000" },
+    });
+    const pending = collect(ws, 1);
+    await waitOpen(ws);
+    const [snap] = await pending;
+    ws.close();
+    expect(snap.type).toBe("snapshot");
+  });
+
+  it("caps the ring", async () => {
+    const hub = await boot({ ringSize: 3 });
+    for (let i = 0; i < 6; i += 1) {
+      hub.ingest(
+        parseFrame(
+          JSON.stringify({ type: "flash", data: { id: `id-${i}`, data: { content: `n${i}` } } }),
+        ),
+      );
+    }
+    expect(hub.ring.map((row) => row.id)).toEqual(["id-3", "id-4", "id-5"]);
+  });
+
+  it("drops oversized frames on ingest and ingestRaw", async () => {
+    const hub = await boot({ maxFrameBytes: 64 });
+    expect(hub.ingestRaw("x".repeat(200))).toBe(false);
+    const huge = parseFrame(
+      JSON.stringify({
+        type: "flash",
+        data: { id: "huge", data: { content: "K".repeat(200) } },
+      }),
+    );
+    expect(hub.ingest(huge)).toBe(false);
+    expect(hub.ring).toEqual([]);
+  });
+
+  it("binds loopback even if asked for a public host", async () => {
+    const hub = await boot({
+      listenHost: "0.0.0.0",
+      security: { ...AUTHLESS, bindHost: "0.0.0.0" },
+    });
+    expect(hub.listenHost).toBe("127.0.0.1");
+  });
+
+  it("refuses a connect storm past MAX_CLIENTS", async () => {
+    const hub = await boot({ maxClients: 1 });
+    const first = new WebSocket(hub.address());
+    await waitOpen(first);
+    const second = new WebSocket(hub.address());
+    await expect(waitOpen(second)).rejects.toMatchObject({ statusCode: 503 });
+    first.close();
+  });
+
+  it("ignores Host-header steering of the upgrade path", async () => {
+    const hub = await boot();
+    const ws = new WebSocket(hub.address().replace("/ws-headlines", "/"), {
+      headers: { Host: "api.mktnews.net" },
+    });
+    await expect(waitOpen(ws)).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it("rejects request-targets that are not origin-form /ws-headlines", async () => {
+    const hub = await boot();
+    const port = listenPort(hub);
+    const rejected = [
+      "/./ws-headlines",
+      "/x/../ws-headlines",
+      "ws-headlines",
+      "//api.mktnews.net/ws-headlines",
+      "http://api.mktnews.net/ws-headlines",
+      "/ws-headlinesX",
+      "/ws-headlines/extra",
+    ];
+    for (const target of rejected) {
+      expect(await rawUpgrade(port, target), target).not.toBe(101);
+    }
+    expect(await rawUpgrade(port, "/ws-headlines")).toBe(101);
+    expect(await rawUpgrade(port, "/ws-headlines?ticket=dev")).toBe(101);
+  });
+});
+
+describe("RING_SIZE", () => {
+  it("stays bounded", () => {
+    expect(RING_SIZE).toBe(50);
+  });
+});

--- a/scripts/mktnews/index.js
+++ b/scripts/mktnews/index.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * Tap the MKTNews flash websocket and print frames.
+ *
+ *   node scripts/mktnews/index.js
+ *   node scripts/mktnews/index.js --pretty
+ *   node scripts/mktnews/index.js --serve
+ *   node scripts/mktnews/index.js --all --seconds 20
+ *   node scripts/mktnews/index.js --max 5 --lang zh
+ *
+ * Default: JSONL on stdout, time heartbeats omitted. Status on stderr.
+ */
+import { parseArgs } from "./cli.js";
+import { connectMktnews } from "./client.js";
+import { formatMessage } from "./format.js";
+import { DEFAULT_LISTEN_PORT, startHeadlinesHub } from "./hub.js";
+
+export function runTap({
+  argv = process.argv.slice(2),
+  stdout = process.stdout,
+  stderr = process.stderr,
+  connect = connectMktnews,
+  exit = process.exit,
+  setTimer = setTimeout,
+} = {}) {
+  const opts = parseArgs(argv);
+  const controller = new AbortController();
+  let emitted = 0;
+  let client;
+
+  const stop = (code = 0) => {
+    client?.stop();
+    controller.abort();
+    exit(code);
+  };
+
+  client = connect({
+    url: opts.url,
+    signal: controller.signal,
+    onStatus: (event) => {
+      if (event.event === "open") {
+        stderr.write(`[mktnews] open ${event.url}\n`);
+      } else if (event.event === "close") {
+        stderr.write(`[mktnews] close ${event.code} ${event.reason}\n`);
+      } else if (event.event === "reconnect") {
+        stderr.write(`[mktnews] reconnect attempt=${event.attempt} delayMs=${event.delayMs}\n`);
+      } else if (event.event === "error") {
+        stderr.write(`[mktnews] error ${event.error}\n`);
+      }
+    },
+    onMessage: (msg) => {
+      const line = formatMessage(msg, { pretty: opts.pretty, all: opts.all });
+      if (line == null) return;
+      stdout.write(`${line}\n`);
+      emitted += 1;
+      if (opts.max != null && emitted >= opts.max) stop(0);
+    },
+  });
+
+  if (opts.seconds != null) {
+    setTimer(() => stop(0), opts.seconds * 1000);
+  }
+
+  return { stop, controller };
+}
+
+const isMain = process.argv[1] && process.argv[1].endsWith("mktnews/index.js");
+if (isMain) {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.serve) {
+    const hub = await startHeadlinesHub({
+      listenPort: opts.port ?? DEFAULT_LISTEN_PORT,
+    });
+    process.stderr.write(`[mktnews] hub ${hub.address()}\n`);
+    const shutdown = () => {
+      hub.stop().finally(() => process.exit(0));
+    };
+    process.on("SIGINT", shutdown);
+    process.on("SIGTERM", shutdown);
+  } else {
+    const handle = runTap();
+    process.on("SIGINT", () => handle.stop(0));
+    process.on("SIGTERM", () => handle.stop(0));
+  }
+}

--- a/scripts/mktnews/normalize.js
+++ b/scripts/mktnews/normalize.js
@@ -1,0 +1,46 @@
+export const RING_SIZE = 50;
+export const MAX_FRAME_BYTES = 64 * 1024;
+export const MAX_CONTENT_CHARS = 2_000;
+export const MAX_IMPACT = 8;
+
+function clip(text, max) {
+  const value = String(text ?? "").replace(/\s+/g, " ").trim();
+  if (value.length <= max) return value;
+  return value.slice(0, max);
+}
+
+function impacts(raw) {
+  if (!Array.isArray(raw)) return [];
+  const out = [];
+  for (const row of raw.slice(0, MAX_IMPACT)) {
+    if (!row || typeof row !== "object") continue;
+    const symbol = clip(row.symbol, 16);
+    const impact = clip(row.impact, 16);
+    if (!symbol && !impact) continue;
+    out.push({ symbol, impact });
+  }
+  return out;
+}
+
+export function toHeadline(msg) {
+  if (!msg || msg.kind === "time" || msg.kind === "raw") return null;
+  const row = msg.kind === "flash" || msg.kind === "headline" ? msg.data : null;
+  if (!row || typeof row !== "object" || Array.isArray(row)) return null;
+  const inner = row.data && typeof row.data === "object" ? row.data : {};
+  const content = clip(inner.content || inner.title || "", MAX_CONTENT_CHARS);
+  const id = clip(row.id, 80);
+  if (!id || !content) return null;
+  return {
+    kind: "headline",
+    id,
+    time: typeof row.time === "string" ? row.time : null,
+    important: Boolean(row.important),
+    content,
+    impact: impacts(row.impact),
+  };
+}
+
+export function containsUpstreamHost(value) {
+  const text = typeof value === "string" ? value : JSON.stringify(value);
+  return /mktnews\.net/i.test(text);
+}

--- a/scripts/mktnews/normalize.test.js
+++ b/scripts/mktnews/normalize.test.js
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { parseFrame } from "./protocol.js";
+import { MAX_CONTENT_CHARS, containsUpstreamHost, toHeadline } from "./normalize.js";
+
+const FLASH = parseFrame(
+  JSON.stringify({
+    type: "flash",
+    data: {
+      id: "01a04f36-dd6b-7118-83fb-bf77195e2f55",
+      type: 0,
+      time: "2026-08-29T20:35:56.000Z",
+      important: 1,
+      data: { title: null, content: "Explosions heard in Kyiv." },
+      impact: [{ impact: "bearish", symbol: "WTI" }],
+    },
+  }),
+);
+
+describe("toHeadline", () => {
+  it("drops time heartbeats", () => {
+    expect(toHeadline(parseFrame('{"type":"time","data":1}'))).toBeNull();
+  });
+
+  it("projects a client-safe headline", () => {
+    expect(toHeadline(FLASH)).toEqual({
+      kind: "headline",
+      id: "01a04f36-dd6b-7118-83fb-bf77195e2f55",
+      time: "2026-08-29T20:35:56.000Z",
+      important: true,
+      content: "Explosions heard in Kyiv.",
+      impact: [{ symbol: "WTI", impact: "bearish" }],
+    });
+  });
+
+  it("omits missing id or content", () => {
+    expect(toHeadline(parseFrame(JSON.stringify({ type: "flash", data: { id: "x", data: {} } })))).toBeNull();
+  });
+
+  it("clips oversized content", () => {
+    const msg = parseFrame(
+      JSON.stringify({
+        type: "flash",
+        data: { id: "big", data: { content: "K".repeat(MAX_CONTENT_CHARS + 40) } },
+      }),
+    );
+    expect(toHeadline(msg).content.length).toBe(MAX_CONTENT_CHARS);
+  });
+
+  it("does not copy raw upstream envelopes", () => {
+    const item = toHeadline(FLASH);
+    expect(item).not.toHaveProperty("raw");
+    expect(item).not.toHaveProperty("data");
+    expect(containsUpstreamHost(item)).toBe(false);
+  });
+});

--- a/scripts/mktnews/protocol.js
+++ b/scripts/mktnews/protocol.js
@@ -1,0 +1,54 @@
+export const DEFAULT_HOST = "wss://api.mktnews.net/";
+export const DEFAULT_LANG = "en";
+export const DEFAULT_URL = `${DEFAULT_HOST}?lang=${DEFAULT_LANG}`;
+export const DEFAULT_ORIGIN = "https://mktnews.net";
+export const DEFAULT_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+
+function decodeFrame(raw) {
+  if (Buffer.isBuffer(raw)) return raw.toString("utf8");
+  if (raw instanceof ArrayBuffer) return Buffer.from(raw).toString("utf8");
+  if (ArrayBuffer.isView(raw)) return Buffer.from(raw.buffer, raw.byteOffset, raw.byteLength).toString("utf8");
+  return String(raw);
+}
+
+function isFlashItem(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const inner = value.data;
+  if (!value.id || !inner || typeof inner !== "object") return false;
+  return "content" in inner || "title" in inner;
+}
+
+export function classifyMessage(msg) {
+  if (!msg || typeof msg !== "object") return "raw";
+  if (msg.kind) return msg.kind;
+  const value = msg.data ?? msg;
+  if (value && typeof value === "object" && value.type === "time" && typeof value.data === "number") {
+    return "time";
+  }
+  if (typeof msg.type === "string") return msg.type;
+  if (isFlashItem(value)) return "flash";
+  return "unknown";
+}
+
+export function parseFrame(raw) {
+  const text = decodeFrame(raw);
+  let value;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    return { kind: "raw", type: null, data: text, raw: text };
+  }
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    if (value.type === "time" && typeof value.data === "number") {
+      return { kind: "time", type: "time", data: value.data, raw: text };
+    }
+    if (typeof value.type === "string") {
+      return { kind: value.type, type: value.type, data: value.data ?? value, raw: text };
+    }
+    if (isFlashItem(value)) {
+      return { kind: "flash", type: value.type ?? 0, data: value, raw: text };
+    }
+  }
+  return { kind: "unknown", type: value?.type ?? null, data: value, raw: text };
+}

--- a/scripts/mktnews/protocol.test.js
+++ b/scripts/mktnews/protocol.test.js
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_URL,
+  classifyMessage,
+  parseFrame,
+} from "./protocol.js";
+
+describe("mktnews protocol", () => {
+  it("pins the public English websocket URL", () => {
+    expect(DEFAULT_URL).toBe("wss://api.mktnews.net/?lang=en");
+  });
+
+  it("classifies server time heartbeats", () => {
+    const msg = parseFrame('{"type":"time","data":1788035440035}');
+    expect(msg.kind).toBe("time");
+    expect(msg.type).toBe("time");
+    expect(msg.data).toBe(1788035440035);
+    expect(classifyMessage(msg)).toBe("time");
+  });
+
+  it("classifies flash envelopes", () => {
+    const raw = JSON.stringify({
+      type: "flash",
+      data: {
+        id: "01a04f36-dd6b-7118-83fb-bf77195e2f55",
+        type: 0,
+        time: "2026-08-29T20:29:50.000Z",
+        important: 1,
+        data: { title: null, content: "Hormuz oil-route report denied." },
+        impact: [{ impact: "bearish", symbol: "WTI" }],
+      },
+    });
+    const msg = parseFrame(raw);
+    expect(msg.kind).toBe("flash");
+    expect(msg.data.id).toBe("01a04f36-dd6b-7118-83fb-bf77195e2f55");
+    expect(msg.data.data.content).toContain("Hormuz");
+  });
+
+  it("classifies a bare flash item (no envelope type string)", () => {
+    const msg = parseFrame(
+      JSON.stringify({
+        id: "abc",
+        type: 0,
+        time: "2026-08-29T20:29:50.000Z",
+        important: 0,
+        data: { title: "", content: "UAE inspects Banque Misr branch." },
+      }),
+    );
+    expect(msg.kind).toBe("flash");
+    expect(msg.data.data.content).toContain("Banque Misr");
+  });
+
+  it("classifies news envelopes", () => {
+    const msg = parseFrame(
+      JSON.stringify({ type: "news", data: { id: "n1", title: "Summit" } }),
+    );
+    expect(msg.kind).toBe("news");
+    expect(msg.data.title).toBe("Summit");
+  });
+
+  it("returns raw for invalid JSON", () => {
+    const msg = parseFrame("not-json");
+    expect(msg.kind).toBe("raw");
+    expect(msg.raw).toBe("not-json");
+  });
+
+  it("decodes Buffer frames as utf8", () => {
+    const msg = parseFrame(Buffer.from('{"type":"time","data":1}'));
+    expect(msg.kind).toBe("time");
+    expect(msg.data).toBe(1);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
       "lib/tools/__tests__/**/*.test.ts",
       "site/lib/**/*.test.ts",
       "scripts/lib/**/*.test.js",
+      "scripts/mktnews/**/*.test.js",
       "web/tests/**/*.test.ts",
       "web/tests/**/*.test.tsx",
       // T-058: the PI extension security tests (browser command boundary,

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -2052,6 +2052,76 @@ body[data-mobile="true"] .dashboard-surface__feed {
   overflow-y: visible;
 }
 
+.feed-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--line-grid);
+  margin: 0 0 12px;
+}
+.feed-tabs__tab {
+  font-family: var(--font-mono);
+  font-size: var(--text-meta);
+  letter-spacing: var(--tracking-meta);
+  text-transform: uppercase;
+  color: var(--text-muted);
+  background: transparent;
+  border: 0;
+  border-right: 1px solid var(--line-grid);
+  padding: 8px 14px;
+  cursor: pointer;
+  min-height: var(--hit-min);
+}
+.feed-tabs__tab--on {
+  color: var(--text-primary);
+  background: var(--bg-panel-raised);
+  border-bottom: 1px solid var(--signal-core);
+  margin-bottom: -1px;
+}
+.headlines-tape {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.headlines-tape__row {
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr) auto;
+  gap: 10px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--line-grid);
+  align-items: start;
+}
+.headlines-tape__time {
+  font-family: var(--font-mono);
+  font-size: var(--text-meta);
+  font-variant-numeric: tabular-nums;
+  color: var(--text-muted);
+}
+.headlines-tape__body {
+  margin: 0;
+  font-size: var(--text-body);
+  line-height: 1.4;
+  color: var(--text-primary);
+}
+.headlines-tape__imp {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--warn);
+  border: 1px solid color-mix(in srgb, var(--warn) 40%, transparent);
+  border-radius: var(--radius-capsule);
+  padding: 1px 5px;
+  margin-right: 6px;
+}
+.headlines-tape__hit {
+  font-family: var(--font-mono);
+  font-size: var(--text-meta);
+  color: var(--fault);
+  white-space: nowrap;
+}
+.headlines-tape__hit--up {
+  color: var(--signal-strong);
+}
+
 .dashboard-surface__right {
   display: flex;
   flex-direction: column;

--- a/web/components/DashboardNewsFeed.tsx
+++ b/web/components/DashboardNewsFeed.tsx
@@ -16,6 +16,8 @@ import { useBookmarks } from "../lib/useBookmarks";
 import NewsfeedTagBar from "./NewsfeedTagBar";
 import NewsfeedLightbox, { type NewsfeedLightboxFocus } from "./NewsfeedLightbox";
 import StarToggle from "./StarToggle";
+import HeadlinesTape from "./dashboard/HeadlinesTape";
+import { useHeadlines } from "../lib/useHeadlines";
 import styles from "./DashboardNewsFeed.module.css";
 
 /** Chips beyond this count collapse behind a `+N` expander on mobile. */
@@ -91,6 +93,8 @@ function PaginationBar({
 
 export default function DashboardNewsFeed() {
   const { posts, loading, refreshing, error, lastUpdated, refresh } = useNewsfeedPosts();
+  const { items: headlines, status: headlinesStatus } = useHeadlines();
+  const [feedTab, setFeedTab] = useState<"commentary" | "headlines">("commentary");
   const [currentPage, setCurrentPage] = useState(1);
   const [lightboxFocus, setLightboxFocus] = useState<NewsfeedLightboxFocus | null>(null);
   const sectionRef = useRef<HTMLElement>(null);
@@ -241,8 +245,12 @@ export default function DashboardNewsFeed() {
 
   const lastSample = lastUpdated
     ? new Date(lastUpdated).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false })
-    : "—";
+    : "---";
   const captureBasis = error ? "fault" : loading ? "awaiting" : "scraper";
+  const commentaryOpen = feedTab === "commentary";
+  const live = commentaryOpen
+    ? !loading && !error && posts.length > 0
+    : headlinesStatus === "live";
 
   const paginationBar = showPagination ? (
     <PaginationBar
@@ -264,9 +272,10 @@ export default function DashboardNewsFeed() {
           <h3 className="panel-title">Live market analysis</h3>
         </div>
         <div className={`news-feed-actions ${styles.actions}`}>
-          {!loading && !error && posts.length > 0 ? (
+          {live ? (
             <span className={`news-feed-live-badge ${styles.liveBadge}`}>LIVE</span>
           ) : null}
+          {commentaryOpen ? (
           <button
             type="button"
             className={`news-feed-refresh news-feed-refresh--rail ${styles.refresh}`}
@@ -277,9 +286,47 @@ export default function DashboardNewsFeed() {
             <RefreshCw size={12} className={refreshing ? "spin" : ""} aria-hidden />
             {refreshing ? "Refreshing" : "Refresh"}
           </button>
+          ) : null}
         </div>
       </header>
+      <div
+        className="feed-tabs"
+        role="tablist"
+        aria-label="Feed source"
+      >
+        <button
+          type="button"
+          role="tab"
+          id="feed-tab-commentary"
+          data-testid="feed-tab-commentary"
+          aria-selected={commentaryOpen}
+          aria-controls="feed-panel-commentary"
+          className={`feed-tabs__tab${commentaryOpen ? " feed-tabs__tab--on" : ""}`}
+          onClick={() => setFeedTab("commentary")}
+        >
+          Commentary
+        </button>
+        <button
+          type="button"
+          role="tab"
+          id="feed-tab-headlines"
+          data-testid="feed-tab-headlines"
+          aria-selected={!commentaryOpen}
+          aria-controls="feed-panel-headlines"
+          className={`feed-tabs__tab${!commentaryOpen ? " feed-tabs__tab--on" : ""}`}
+          onClick={() => setFeedTab("headlines")}
+        >
+          Headlines
+        </button>
+      </div>
       <div className="dashboard-news__body section-body">
+        {commentaryOpen ? (
+          <div
+            id="feed-panel-commentary"
+            role="tabpanel"
+            aria-labelledby="feed-tab-commentary"
+            data-testid="feed-panel-commentary"
+          >
         <NewsfeedTagBar
           selectedTags={selectedTags}
           onRemove={toggleTag}
@@ -414,11 +461,22 @@ export default function DashboardNewsFeed() {
             {paginationBar}
           </>
         )}
+          </div>
+        ) : (
+          <div
+            id="feed-panel-headlines"
+            role="tabpanel"
+            aria-labelledby="feed-tab-headlines"
+            data-testid="feed-panel-headlines"
+          >
+            <HeadlinesTape items={headlines} status={headlinesStatus} />
+          </div>
+        )}
       </div>
       <footer className="panel-meta-rail" aria-label="Feed calibration">
         <div className="panel-meta-rail-item">
           <span className="k">source</span>
-          <span className="v">Market Ear</span>
+          <span className="v">{commentaryOpen ? "Market Ear" : "Headlines"}</span>
         </div>
         <div className="panel-meta-rail-item">
           <span className="k">capture.basis</span>

--- a/web/components/dashboard/HeadlinesTape.tsx
+++ b/web/components/dashboard/HeadlinesTape.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import type { Headline, HeadlinesStatus } from "@/lib/useHeadlines";
+
+function fmtTime(iso: string | null): string {
+  if (!iso) return "--";
+  const ms = Date.parse(iso);
+  if (!Number.isFinite(ms)) return iso;
+  return new Date(ms).toLocaleTimeString("en-US", {
+    hour12: false,
+    timeZone: "America/New_York",
+  });
+}
+
+export default function HeadlinesTape({
+  items,
+  status,
+}: {
+  items: Headline[];
+  status: HeadlinesStatus;
+}) {
+  if (status === "connecting" && items.length === 0) {
+    return <div className="news-feed-empty">Connecting to headlines…</div>;
+  }
+  if (status === "down" && items.length === 0) {
+    return <div className="news-feed-error">Headlines feed unavailable.</div>;
+  }
+  if (items.length === 0) {
+    return <div className="news-feed-empty">Waiting for headline prints.</div>;
+  }
+
+  const newestFirst = [...items].reverse();
+  return (
+    <ol className="headlines-tape" data-testid="headlines-tape">
+      {newestFirst.map((row) => (
+        <li
+          key={row.id}
+          className="headlines-tape__row"
+          data-testid="headlines-tape-row"
+          data-important={row.important ? "true" : "false"}
+        >
+          <time className="headlines-tape__time" dateTime={row.time ?? undefined}>
+            {fmtTime(row.time)}
+          </time>
+          <p className="headlines-tape__body">
+            {row.important ? <span className="headlines-tape__imp">Important</span> : null}
+            {row.content}
+          </p>
+          {row.impact[0] ? (
+            <span
+              className={`headlines-tape__hit${row.impact[0].impact === "bullish" ? " headlines-tape__hit--up" : ""}`}
+            >
+              {row.impact[0].symbol}
+              {row.impact[0].impact ? ` ${row.impact[0].impact}` : ""}
+            </span>
+          ) : null}
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/web/e2e/dashboard-feed-tabs.spec.ts
+++ b/web/e2e/dashboard-feed-tabs.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("dashboard feed tabs", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/api/newsfeed/posts**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          {
+            id: "p1",
+            title: "Commentary fixture",
+            content: "Body",
+            timestamp: new Date().toISOString(),
+            images: [],
+            tags: ["MACRO"],
+          },
+        ]),
+      }),
+    );
+  });
+
+  test("defaults to Commentary and never dials the upstream news host", async ({ page }) => {
+    const leaked: string[] = [];
+    page.on("websocket", (ws) => {
+      if (/mktnews\.net/i.test(ws.url())) leaked.push(ws.url());
+    });
+    page.on("request", (req) => {
+      if (/mktnews\.net/i.test(req.url())) leaked.push(req.url());
+    });
+
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/dashboard");
+
+    const tabs = page.getByRole("tab");
+    await expect(tabs).toHaveText(["Commentary", "Headlines"]);
+    await expect(page.getByRole("tab", { name: "Commentary" })).toHaveAttribute("aria-selected", "true");
+    await expect(page.getByText("Commentary fixture")).toBeVisible();
+
+    await page.getByRole("tab", { name: "Headlines" }).click();
+    await expect(page.getByRole("tab", { name: "Headlines" })).toHaveAttribute("aria-selected", "true");
+    await expect(page.getByTestId("feed-panel-headlines")).toBeVisible();
+    expect(leaked).toEqual([]);
+  });
+});

--- a/web/lib/headlinesSocket.ts
+++ b/web/lib/headlinesSocket.ts
@@ -1,0 +1,38 @@
+import { buildAuthenticatedWebSocketUrl } from "./realtimeSocketAuth";
+import type { RealtimeTokenGetter } from "./RealtimeAuthContext";
+
+function isLocalBrowserHost(hostname: string): boolean {
+  return hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1" ||
+    hostname === "[::1]";
+}
+
+export const HEADLINES_WS_PATH = "/ws-headlines";
+export const LOCAL_HEADLINES_WS_URL = `ws://localhost:8766${HEADLINES_WS_PATH}`;
+
+export function resolveHeadlinesWebSocketUrl(
+  explicitUrl: string | undefined =
+    process.env.NEXT_PUBLIC_HEADLINES_WS_URL ??
+    process.env.HEADLINES_WS_URL,
+): string {
+  const trimmed = explicitUrl?.trim();
+  if (trimmed && !headlinesUrlLeaksUpstream(trimmed)) return trimmed;
+  if (typeof window !== "undefined") {
+    const { protocol, host, hostname } = window.location;
+    if (!isLocalBrowserHost(hostname)) {
+      return `${protocol === "https:" ? "wss:" : "ws:"}//${host}${HEADLINES_WS_PATH}`;
+    }
+  }
+  return LOCAL_HEADLINES_WS_URL;
+}
+
+export async function buildHeadlinesWebSocketUrl(
+  getToken?: RealtimeTokenGetter,
+): Promise<string> {
+  return buildAuthenticatedWebSocketUrl(resolveHeadlinesWebSocketUrl(), getToken);
+}
+
+export function headlinesUrlLeaksUpstream(url: string): boolean {
+  return /mktnews\.net/i.test(url);
+}

--- a/web/lib/useHeadlines.ts
+++ b/web/lib/useHeadlines.ts
@@ -1,0 +1,126 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import {
+  buildHeadlinesWebSocketUrl,
+  headlinesUrlLeaksUpstream,
+} from "./headlinesSocket";
+import { useRealtimeAuth } from "./RealtimeAuthContext";
+
+function reconnectDelayMs(attempt: number): number {
+  const exponent = Math.min(Math.max(attempt, 0), 10);
+  const base = Math.min(5_000 * 2 ** exponent, 120_000);
+  return Math.min(Math.round(base * (1 + 0.2 * Math.random())), 120_000);
+}
+
+export type HeadlineImpact = { symbol: string; impact: string };
+
+export type Headline = {
+  kind: "headline";
+  id: string;
+  time: string | null;
+  important: boolean;
+  content: string;
+  impact: HeadlineImpact[];
+};
+
+export type HeadlinesStatus = "connecting" | "live" | "down";
+
+type ClientFrame =
+  | { type: "snapshot"; items: Headline[] }
+  | { type: "headline"; item: Headline }
+  | { type: "status"; state: string };
+
+export function useHeadlines() {
+  const getToken = useRealtimeAuth();
+  const [items, setItems] = useState<Headline[]>([]);
+  const [status, setStatus] = useState<HeadlinesStatus>("connecting");
+
+  useEffect(() => {
+    if (typeof WebSocket === "undefined") return;
+    let stopped = false;
+    let socket: WebSocket | null = null;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let attempt = 0;
+
+    const clearTimer = () => {
+      if (timer != null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    };
+
+    function applyFrame(frame: ClientFrame) {
+      if (frame.type === "snapshot" && Array.isArray(frame.items)) {
+        setItems(frame.items);
+        setStatus("live");
+        return;
+      }
+      if (frame.type === "headline" && frame.item?.id) {
+        setItems((prev) => {
+          const next = prev.filter((row) => row.id !== frame.item.id);
+          next.push(frame.item);
+          return next.slice(-50);
+        });
+        setStatus("live");
+        return;
+      }
+      if (frame.type === "status" && frame.state === "upstream-down") {
+        setStatus("down");
+      }
+    }
+
+    async function open() {
+      if (stopped) return;
+      try {
+        const url = await buildHeadlinesWebSocketUrl(getToken);
+        if (headlinesUrlLeaksUpstream(url)) {
+          setStatus("down");
+          return;
+        }
+        socket = new WebSocket(url);
+        socket.onopen = () => {
+          attempt = 0;
+        };
+        socket.onmessage = (event) => {
+          try {
+            applyFrame(JSON.parse(String(event.data)) as ClientFrame);
+          } catch {
+            // drop malformed frames
+          }
+        };
+        socket.onerror = () => {
+          setStatus("down");
+        };
+        socket.onclose = () => {
+          socket = null;
+          if (stopped) return;
+          setStatus("down");
+          const delay = reconnectDelayMs(attempt);
+          attempt += 1;
+          timer = setTimeout(() => {
+            void open();
+          }, delay);
+        };
+      } catch {
+        if (stopped) return;
+        setStatus("down");
+        const delay = reconnectDelayMs(attempt);
+        attempt += 1;
+        timer = setTimeout(() => {
+          void open();
+        }, delay);
+      }
+    }
+
+    void open();
+    return () => {
+      stopped = true;
+      clearTimer();
+      socket?.close();
+    };
+  }, [getToken]);
+
+  return { items, status };
+}

--- a/web/package.json
+++ b/web/package.json
@@ -7,9 +7,9 @@
   "scripts": {
     "dev": "bash ../scripts/dev",
     "dev:next": "next dev",
-    "dev:verbose": "concurrently -n next,ib,api,scraper -c cyan,yellow,green,magenta \"NEXT_DEBUG_LOGGING=1 next dev\" \"node ../scripts/ib_realtime_server.js --verbose\" \"python3.13 -m uvicorn scripts.api.server:app --host 127.0.0.1 --port 8321 --reload --app-dir .. --reload-dir ../scripts\" \"node ../scripts/newsfeed/index.js\"",
-    "dev:verbose:next": "concurrently -n next,ib,api,scraper -c cyan,yellow,green,magenta \"NEXT_DEBUG_LOGGING=1 next dev\" \"node ../scripts/ib_realtime_server.js\" \"python3.13 -m uvicorn scripts.api.server:app --host 127.0.0.1 --port 8321 --reload --app-dir .. --reload-dir ../scripts\" \"node ../scripts/newsfeed/index.js\"",
-    "dev:verbose:ib": "concurrently -n next,ib,api,scraper -c cyan,yellow,green,magenta \"next dev\" \"node ../scripts/ib_realtime_server.js --verbose\" \"python3.13 -m uvicorn scripts.api.server:app --host 127.0.0.1 --port 8321 --reload --app-dir .. --reload-dir ../scripts\" \"node ../scripts/newsfeed/index.js\"",
+    "dev:verbose": "concurrently -n next,ib,api,scraper,headlines -c cyan,yellow,green,magenta,white \"NEXT_DEBUG_LOGGING=1 next dev\" \"node ../scripts/ib_realtime_server.js --verbose\" \"python3.13 -m uvicorn scripts.api.server:app --host 127.0.0.1 --port 8321 --reload --app-dir .. --reload-dir ../scripts\" \"node ../scripts/newsfeed/index.js\" \"node ../scripts/mktnews/index.js --serve\"",
+    "dev:verbose:next": "concurrently -n next,ib,api,scraper,headlines -c cyan,yellow,green,magenta,white \"NEXT_DEBUG_LOGGING=1 next dev\" \"node ../scripts/ib_realtime_server.js\" \"python3.13 -m uvicorn scripts.api.server:app --host 127.0.0.1 --port 8321 --reload --app-dir .. --reload-dir ../scripts\" \"node ../scripts/newsfeed/index.js\" \"node ../scripts/mktnews/index.js --serve\"",
+    "dev:verbose:ib": "concurrently -n next,ib,api,scraper,headlines -c cyan,yellow,green,magenta,white \"next dev\" \"node ../scripts/ib_realtime_server.js --verbose\" \"python3.13 -m uvicorn scripts.api.server:app --host 127.0.0.1 --port 8321 --reload --app-dir .. --reload-dir ../scripts\" \"node ../scripts/newsfeed/index.js\" \"node ../scripts/mktnews/index.js --serve\"",
     "dev:prices": "node ../scripts/ib_realtime_server.js",
     "build": "next build --experimental-build-mode=compile && node scripts/audit-output-traces.mjs",
     "start": "next start",

--- a/web/tests/dashboard-feed-tabs.test.tsx
+++ b/web/tests/dashboard-feed-tabs.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import DashboardNewsFeed from "../components/DashboardNewsFeed";
+
+vi.mock("next/image", () => ({
+  default: ({ src, alt }: { src: string; alt: string }) =>
+    React.createElement("img", { src, alt }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn(), refresh: vi.fn() }),
+  usePathname: () => "/dashboard",
+  useSearchParams: () => new URLSearchParams(""),
+}));
+
+vi.mock("../lib/useNewsfeedPosts", () => ({
+  useNewsfeedPosts: () => ({
+    posts: [
+      {
+        id: "p1",
+        title: "What to watch",
+        content: "Commentary body",
+        href: "https://example.test/p1",
+        isoTimestamp: "2026-08-29T16:00:00.000Z",
+        timestamp: "2026-08-29T16:00:00.000Z",
+        images: [],
+        tags: ["MACRO"],
+      },
+    ],
+    loading: false,
+    refreshing: false,
+    error: null,
+    lastUpdated: "2026-08-29T16:00:00.000Z",
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock("../lib/useHeadlines", () => ({
+  useHeadlines: () => ({
+    items: [
+      {
+        kind: "headline",
+        id: "h1",
+        time: "2026-08-29T20:35:56.000Z",
+        important: true,
+        content: "Explosions heard in Kyiv.",
+        impact: [{ symbol: "WTI", impact: "bearish" }],
+      },
+    ],
+    status: "live",
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("dashboard feed tabs", () => {
+  it("defaults to Commentary as the first selected tab", () => {
+    render(<DashboardNewsFeed />);
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs.map((tab) => tab.textContent)).toEqual(["Commentary", "Headlines"]);
+    expect(tabs[0].getAttribute("aria-selected")).toBe("true");
+    expect(tabs[1].getAttribute("aria-selected")).toBe("false");
+    expect(screen.getByText("What to watch")).toBeTruthy();
+    expect(screen.queryByTestId("headlines-tape")).toBeNull();
+  });
+
+  it("shows the headlines tape on the second tab", () => {
+    render(<DashboardNewsFeed />);
+    fireEvent.click(screen.getByRole("tab", { name: "Headlines" }));
+    expect(screen.getByRole("tab", { name: "Headlines" }).getAttribute("aria-selected")).toBe("true");
+    expect(screen.getByTestId("headlines-tape").textContent).toContain("Explosions heard in Kyiv.");
+    expect(screen.queryByText("What to watch")).toBeNull();
+  });
+});

--- a/web/tests/headlines-socket-url.test.ts
+++ b/web/tests/headlines-socket-url.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  HEADLINES_WS_PATH,
+  LOCAL_HEADLINES_WS_URL,
+  headlinesUrlLeaksUpstream,
+  resolveHeadlinesWebSocketUrl,
+} from "../lib/headlinesSocket";
+
+describe("resolveHeadlinesWebSocketUrl", () => {
+  const originalWindow = globalThis.window;
+
+  afterEach(() => {
+    if (originalWindow) {
+      // @ts-expect-error restore jsdom window
+      globalThis.window = originalWindow;
+    }
+  });
+
+  it("uses the local Radon hub, never the upstream host", () => {
+    expect(resolveHeadlinesWebSocketUrl()).toBe(LOCAL_HEADLINES_WS_URL);
+    expect(LOCAL_HEADLINES_WS_URL).toContain(HEADLINES_WS_PATH);
+    expect(headlinesUrlLeaksUpstream(LOCAL_HEADLINES_WS_URL)).toBe(false);
+    expect(headlinesUrlLeaksUpstream("wss://api.mktnews.net/?lang=en")).toBe(true);
+    expect(resolveHeadlinesWebSocketUrl("wss://api.mktnews.net/?lang=en")).toBe(
+      LOCAL_HEADLINES_WS_URL,
+    );
+  });
+
+  it("on a hosted origin proxies through the same host path", () => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        location: { protocol: "https:", host: "app.radon.run", hostname: "app.radon.run" },
+      },
+    });
+    expect(resolveHeadlinesWebSocketUrl(undefined)).toBe("wss://app.radon.run/ws-headlines");
+    expect(headlinesUrlLeaksUpstream("wss://app.radon.run/ws-headlines")).toBe(false);
+  });
+});
+
+describe("Caddy /ws-headlines handle", () => {
+  it("is an exact path match, not a prefix", () => {
+    const caddy = readFileSync(
+      path.resolve(__dirname, "../../cloud/caddy/Caddyfile"),
+      "utf8",
+    );
+    const active = caddy
+      .split("\n")
+      .filter((line) => !line.trim().startsWith("#"))
+      .join("\n");
+    expect(active).toMatch(/handle \/ws-headlines\s*\{/);
+    expect(active).not.toMatch(/handle \/ws-headlines\*/);
+  });
+});


### PR DESCRIPTION
## Summary
- Dashboard Feed / 01 splits into **Commentary** (default, Market Ear) and **Headlines** (MKTNews tape).
- Browser connects only to Radon (`/ws-headlines`, same Clerk ticket as prices). A standalone loopback hub on `:8766` is the only process that dials `api.mktnews.net`.
- Hub is path-exact, ticket-gated via `wsTrust`, ring-capped, size-capped, loopback-only. Caddy matches `/ws-headlines` before `/ws*`.
- `radon-mktnews.service` is committed but `not-installed` until an operator enable.

## Test plan
- [x] `npx vitest run --config vitest.config.ts scripts/mktnews web/tests/headlines-socket-url.test.ts web/tests/dashboard-feed-tabs.test.tsx` (41 passed)
- [ ] `node scripts/mktnews/index.js --serve` then open `/dashboard`, confirm Commentary is selected, Headlines shows tape, no `mktnews.net` in DevTools WS
- [ ] Playwright `web/e2e/dashboard-feed-tabs.spec.ts`