### PR TITLE
fix(assistant): the edge 504'd a pasted-chart turn the route had answered

### DIFF
--- a/cloud/caddy/Caddyfile
+++ b/cloud/caddy/Caddyfile
@@ -96,6 +96,40 @@
         }
     }
 
+    # The assistant turn needs longer than the generic guard below allows.
+    # 2026-08-29: the operator pasted a chart into chat and got a 504 while
+    # radon-nextjs was still working on the turn. /api/assistant rode the
+    # catch-all, whose R-219 guard abandons a request after 30s without a
+    # response header. That route is NON-STREAMING: it runs the whole
+    # multi-round runAssistantLoop and writes its JSON only at the end, so a
+    # turn emits no header at all until it has finished, and it budgets itself
+    # maxDuration 300. The radon-nextjs journal already had a plain text turn
+    # answering at 55.3s; a vision turn plus the portfolio tool rounds a
+    # "how does this relate to my TLT position" question forces is strictly
+    # more work than that.
+    #
+    # Scoped to this one path on purpose. Raising the guard globally would undo
+    # R-219 for every other route, where an upstream that accepts the socket
+    # and never writes a header must still become an observable 5xx quickly.
+    #
+    # No lb_try_duration here, deliberately: this path is POST-only and has no
+    # idempotency key, so a retry loop could replay a vision turn the operator
+    # is billed for and re-run its tool calls. Caddy's default is zero retries.
+    #
+    # A bump only moves the cliff: a turn slower than this still 504s, because
+    # nothing is written until the loop finishes. The durable fix is for the
+    # route to start writing a response early (stream, or flush a header before
+    # the first round). R-262.
+    handle /api/assistant* {
+        reverse_proxy 127.0.0.1:3000 {
+            transport http {
+                dial_timeout 5s
+                response_header_timeout 180s
+                read_timeout 300s
+            }
+        }
+    }
+
     handle {
         reverse_proxy 127.0.0.1:3000 {
             lb_try_duration 15s

--- a/cloud/tests/test_caddy_edge_timeouts.py
+++ b/cloud/tests/test_caddy_edge_timeouts.py
@@ -43,23 +43,29 @@ import yaml
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from test_caddyfile import (  # noqa: E402
+    APP_UPSTREAM,
+    IB_UPSTREAM,
+    handle_block,
     held_port,
     port_of,
+    proxy_block,
     read_caddyfile,
     release_to_peer,
     retry_window_seconds,
     reverse_proxy_block,
     serve_on,
     stop_serving,
+    strip_comments,
     wait_for_listener,
 )
 
 
 REPO = Path(__file__).resolve().parents[2]
 WS_TICKET = REPO / "web" / "lib" / "wsTicket.ts"
+ASSISTANT_ROUTE = REPO / "web" / "app" / "api" / "assistant" / "route.ts"
 
-APP_UPSTREAM = "127.0.0.1:3000"
-IB_UPSTREAM = "127.0.0.1:8321"
+# The `handle` matcher that carries the assistant turn (R-262).
+ASSISTANT_MATCHER = "/api/assistant*"
 
 
 def _directive_seconds(block: str, name: str) -> float | None:
@@ -82,7 +88,7 @@ class TestUpstreamHangIsBounded:
         "directive", ["dial_timeout", "response_header_timeout", "read_timeout"]
     )
     def test_each_proxy_states_its_timeouts(self, caddy_dir, upstream, directive):
-        block = reverse_proxy_block(read_caddyfile(caddy_dir), upstream)
+        block = proxy_block(read_caddyfile(caddy_dir), upstream)
         assert _directive_seconds(block, directive) is not None, (
             f"{upstream} inherits Caddy's unlimited {directive}; an upstream "
             "that accepts the socket and never answers hangs forever and the "
@@ -91,7 +97,7 @@ class TestUpstreamHangIsBounded:
 
     @pytest.mark.parametrize("upstream", [APP_UPSTREAM, IB_UPSTREAM])
     def test_the_header_timeout_is_short_enough_to_surface(self, caddy_dir, upstream):
-        block = reverse_proxy_block(read_caddyfile(caddy_dir), upstream)
+        block = proxy_block(read_caddyfile(caddy_dir), upstream)
         seconds = _directive_seconds(block, "response_header_timeout")
         assert seconds is not None and seconds <= 60, (
             f"{upstream} response_header_timeout {seconds}s is too long to "
@@ -102,7 +108,7 @@ class TestUpstreamHangIsBounded:
 class TestNonIdempotentRetryIsRestricted:
     def test_the_app_proxy_states_its_retry_restriction(self, caddy_dir):
         content = read_caddyfile(caddy_dir)
-        block = reverse_proxy_block(content, APP_UPSTREAM)
+        block = proxy_block(content, APP_UPSTREAM)
         assert "retry_match" in block, (
             "POST /api/orders/place rides this block with a 15s retry loop and "
             "no stated restriction; order non-duplication must not rest on an "
@@ -110,7 +116,7 @@ class TestNonIdempotentRetryIsRestricted:
         )
 
     def test_the_restriction_names_only_safe_methods(self, caddy_dir):
-        block = reverse_proxy_block(read_caddyfile(caddy_dir), APP_UPSTREAM)
+        block = proxy_block(read_caddyfile(caddy_dir), APP_UPSTREAM)
         match = re.search(r"retry_match\s*\{([^}]*)\}", block) or re.search(
             r"retry_match\s+(.+)", block
         )
@@ -125,7 +131,7 @@ class TestReloadCanAccommodateTheRetry:
         grace = _grace_period_seconds(content)
         assert grace is not None
         windows = [
-            retry_window_seconds(reverse_proxy_block(content, upstream))
+            retry_window_seconds(proxy_block(content, upstream))
             for upstream in (APP_UPSTREAM, IB_UPSTREAM)
         ]
         assert grace >= max(windows), (
@@ -136,7 +142,7 @@ class TestReloadCanAccommodateTheRetry:
 
 class TestRideOutMatchesItsNamedClient:
     def test_the_ib_window_is_not_longer_than_getwsticket_waits(self, caddy_dir):
-        block = reverse_proxy_block(read_caddyfile(caddy_dir), IB_UPSTREAM)
+        block = proxy_block(read_caddyfile(caddy_dir), IB_UPSTREAM)
         window = retry_window_seconds(block)
         source = WS_TICKET.read_text(encoding="utf-8")
         match = re.search(r"AbortSignal\.timeout\((\d[\d_]*)\)", source)
@@ -146,6 +152,107 @@ class TestRideOutMatchesItsNamedClient:
             f"the edge rides out {window}s for a client that aborts at "
             f"{client_secs}s — the ticket fetch still fails, and the abandoned "
             "retry loop keeps dialling a connection nobody is reading"
+        )
+
+
+# The longest assistant turn the radon-nextjs journal has recorded answering
+# upstream: 2026-08-28 18:20:00 UTC, `[assistant] done rounds=2
+# outcome=answered toolCalls=3 ... ms=55278`. The edge killed the client's
+# request 25 seconds before that answer existed.
+OBSERVED_ANSWERED_TURN_SECONDS = 55.278
+
+
+class TestTheAssistantTurnOutlivesTheGenericGuard:
+    """2026-08-29: a pasted-chart turn 504'd at the edge while the route answered.
+
+    The operator pasted a chart and asked how it related to their TLT position.
+    The image uploaded, the turn ran, and the browser got
+    `POST /api/assistant -> 504` after tens of seconds; the chat rendered the
+    generic "Assistant service returned an error."
+
+    `/api/assistant` rode the catch-all `handle`, whose R-219 guard abandons a
+    request after 30 s without a response header. The route is NON-STREAMING
+    (`web/app/api/assistant/route.ts` runs the whole multi-round
+    `runAssistantLoop` and only then writes JSON), so a turn writes NO header
+    until it is completely finished — and it declares `maxDuration = 300`,
+    ten times the edge's patience. The journal proves the mismatch is real and
+    not hypothetical: one recorded turn answered at 55.3 s.
+
+    R-219 is still right for every other route: an upstream that accepts the
+    socket and never writes a header must become an observable 5xx quickly, or
+    a total front-end hang stays invisible to `@edge_health_status`. So the
+    assistant gets its OWN `handle` with its own bound, and the generic guard
+    below stays where it is. R-262.
+    """
+
+    def _assistant_block(self, caddy_dir):
+        content = read_caddyfile(caddy_dir)
+        return reverse_proxy_block(handle_block(content, ASSISTANT_MATCHER), APP_UPSTREAM)
+
+    def test_the_assistant_path_has_its_own_handle(self, caddy_dir):
+        block = self._assistant_block(caddy_dir)
+        assert _directive_seconds(block, "response_header_timeout") is not None, (
+            "/api/assistant has no handle of its own, so it rides the "
+            "catch-all's 30s header guard and every turn slower than that "
+            "reaches the operator as a 504"
+        )
+
+    def test_the_assistant_handle_precedes_the_catch_all(self, caddy_dir):
+        active = strip_comments(read_caddyfile(caddy_dir))
+        assistant = active.find("handle " + ASSISTANT_MATCHER)
+        catch_all = re.search(r"handle\s*\{", active)
+        assert assistant != -1 and catch_all
+        assert assistant < catch_all.start(), (
+            "handle blocks are mutually exclusive in written order; a "
+            "catch-all declared first swallows /api/assistant and the "
+            "dedicated bound never applies"
+        )
+
+    def test_the_assistant_bound_outlasts_an_observed_answered_turn(self, caddy_dir):
+        seconds = _directive_seconds(self._assistant_block(caddy_dir), "response_header_timeout")
+        # Twice the longest turn actually observed answering: a vision turn
+        # carrying a pasted chart plus the portfolio tool rounds the operator's
+        # question forces is strictly more work than that text turn was.
+        assert seconds >= 2 * OBSERVED_ANSWERED_TURN_SECONDS, (
+            f"response_header_timeout {seconds}s leaves no room over the "
+            f"{OBSERVED_ANSWERED_TURN_SECONDS}s turn the journal already "
+            "recorded answering; the 504 cliff has barely moved"
+        )
+
+    def test_the_assistant_bound_stays_inside_the_routes_own_budget(self, caddy_dir):
+        block = self._assistant_block(caddy_dir)
+        seconds = _directive_seconds(block, "response_header_timeout")
+        source = ASSISTANT_ROUTE.read_text(encoding="utf-8")
+        match = re.search(r"maxDuration\s*=\s*(\d+)", source)
+        assert match, "the assistant route no longer states a maxDuration"
+        assert seconds <= int(match.group(1)), (
+            f"the edge waits {seconds}s for a route that gives itself "
+            f"{match.group(1)}s; the extra wait can only ever be spent on a "
+            "request the route has already abandoned"
+        )
+        read_timeout = _directive_seconds(block, "read_timeout")
+        assert read_timeout is not None and seconds <= read_timeout, (
+            "response_header_timeout outlasts read_timeout, so the connection "
+            "is torn down before the header bound it is supposed to honour"
+        )
+
+    def test_the_assistant_block_never_replays_the_turn(self, caddy_dir):
+        block = self._assistant_block(caddy_dir)
+        assert retry_window_seconds(block) == 0, (
+            "a retry window on the assistant handle would replay a severed "
+            "POST /api/assistant: a second vision turn billed to the operator "
+            "and a second set of tool calls, with no idempotency key anywhere"
+        )
+
+    def test_the_generic_guard_is_still_in_force(self, caddy_dir):
+        """R-219 must not have been widened for everything else."""
+        seconds = _directive_seconds(
+            proxy_block(read_caddyfile(caddy_dir), APP_UPSTREAM), "response_header_timeout"
+        )
+        assert seconds is not None and seconds <= 60, (
+            f"the catch-all header guard is {seconds}s: raising it globally "
+            "undoes R-219, and a wedged upstream stops producing an "
+            "observable 5xx for every other route"
         )
 
 
@@ -380,7 +487,7 @@ class TestEdgeMechanism:
         )
 
     def test_a_hung_upstream_becomes_a_5xx_within_a_bound(self, caddy_dir, tmp_path):
-        block = reverse_proxy_block(read_caddyfile(caddy_dir), APP_UPSTREAM)
+        block = proxy_block(read_caddyfile(caddy_dir), APP_UPSTREAM)
         header_timeout = _directive_seconds(block, "response_header_timeout")
         assert header_timeout is not None
 
@@ -438,7 +545,7 @@ class TestEdgeMechanism:
                 caddy.wait(timeout=10)
 
     def test_a_severed_post_is_not_replayed(self, caddy_dir, tmp_path):
-        block = reverse_proxy_block(read_caddyfile(caddy_dir), APP_UPSTREAM)
+        block = proxy_block(read_caddyfile(caddy_dir), APP_UPSTREAM)
         _CountsPosts.seen = []
         # The client deadline is the edge's own retry window plus one dial, both
         # read from the shipped config: a severed POST cannot legitimately take

--- a/cloud/tests/test_caddyfile.py
+++ b/cloud/tests/test_caddyfile.py
@@ -214,6 +214,11 @@ CADDY_DEFAULT_TRY_INTERVAL_SECONDS = 0.25
 # attempts across the window.
 MAX_RETRY_INTERVAL_SECONDS = 1.0
 
+# The Next.js app and the FastAPI IB surface. Both are dialled from more than
+# one place in the Caddyfile, so the tests name them once.
+APP_UPSTREAM = "127.0.0.1:3000"
+IB_UPSTREAM = "127.0.0.1:8321"
+
 
 def strip_comments(content):
     """Drop Caddyfile `#` comments, leaving quoted and backticked literals alone.
@@ -238,25 +243,17 @@ def strip_comments(content):
     return "\n".join(kept)
 
 
-def reverse_proxy_block(content, upstream):
-    """Return the body of the `reverse_proxy <upstream>` block, '' if inline.
+def _balanced_block(text, start):
+    """The `{...}` run beginning at `start`, brace-balanced and quote-aware.
 
-    Brace-balanced (the health block nests `handle_response`) and
-    quote-aware (it responds with a JSON literal full of braces), so a setting
-    can only satisfy or trip an assertion from inside the block it belongs to.
+    Quote-aware because the health block responds with a JSON literal full of
+    braces, so a setting can only satisfy or trip an assertion from inside the
+    block it belongs to.
     """
-    active = strip_comments(content)
-    directive = re.search(r"reverse_proxy\s+" + re.escape(upstream) + r"\b", active)
-    assert directive, f"no reverse_proxy directive for {upstream}"
-    rest = active[directive.end():]
-    opener = re.match(r"[^\S\n]*\{", rest)
-    if not opener:
-        return ""
-    start = opener.end() - 1
     depth = 0
     quote = None
-    for index in range(start, len(rest)):
-        char = rest[index]
+    for index in range(start, len(text)):
+        char = text[index]
         if quote is not None:
             if char == quote:
                 quote = None
@@ -267,8 +264,47 @@ def reverse_proxy_block(content, upstream):
         elif char == "}":
             depth -= 1
             if depth == 0:
-                return rest[start:index + 1]
-    raise AssertionError(f"unbalanced braces in the reverse_proxy {upstream} block")
+                return text[start:index + 1]
+    raise AssertionError("unbalanced braces")
+
+
+def reverse_proxy_block(content, upstream):
+    """Return the body of the `reverse_proxy <upstream>` block, '' if inline."""
+    active = strip_comments(content)
+    directive = re.search(r"reverse_proxy\s+" + re.escape(upstream) + r"\b", active)
+    assert directive, f"no reverse_proxy directive for {upstream}"
+    rest = active[directive.end():]
+    opener = re.match(r"[^\S\n]*\{", rest)
+    if not opener:
+        return ""
+    return _balanced_block(rest, opener.end() - 1)
+
+
+def handle_block(content, matcher=None):
+    """Body of a `handle` block, selected by its matcher; None = the catch-all.
+
+    Two `handle` blocks now dial 127.0.0.1:3000 — the `/api/assistant*` one
+    (R-262) and the catch-all everything else rides — so an assertion about
+    "the app proxy" has to say which one it means instead of taking whichever
+    `reverse_proxy 127.0.0.1:3000` appears first in the file.
+    """
+    active = strip_comments(content)
+    pattern = r"handle\s*\{" if matcher is None else r"handle\s+" + re.escape(matcher) + r"\s*\{"
+    match = re.search(pattern, active)
+    assert match, f"no handle block for matcher {matcher!r}"
+    return _balanced_block(active, match.end() - 1)
+
+
+def proxy_block(content, upstream):
+    """The proxy block for an upstream, disambiguating the shared app port.
+
+    `127.0.0.1:3000` is scoped to the catch-all `handle`: that is the block
+    every route but `/api/assistant*` rides, and the block R-219's short header
+    timeout and R-220's retry restriction are about.
+    """
+    if upstream == APP_UPSTREAM:
+        return reverse_proxy_block(handle_block(content), upstream)
+    return reverse_proxy_block(content, upstream)
 
 
 def retry_window_seconds(block):
@@ -295,7 +331,7 @@ class TestUpstreamRestartWindow:
     """
 
     def test_app_proxy_retries_across_the_restart_gap(self, caddy_dir):
-        block = reverse_proxy_block(read_caddyfile(caddy_dir), "127.0.0.1:3000")
+        block = proxy_block(read_caddyfile(caddy_dir), APP_UPSTREAM)
         assert retry_window_seconds(block) >= MIN_RETRY_WINDOW_SECONDS, (
             "the app upstream has no retry window that outlasts a radon-nextjs "
             "restart; every request during the deploy gap 502s"
@@ -310,7 +346,7 @@ class TestUpstreamRestartWindow:
 
     @pytest.mark.parametrize("upstream", ["127.0.0.1:3000", "127.0.0.1:8321"])
     def test_retry_interval_re_dials_across_the_gap(self, caddy_dir, upstream):
-        block = reverse_proxy_block(read_caddyfile(caddy_dir), upstream)
+        block = proxy_block(read_caddyfile(caddy_dir), upstream)
         interval = retry_interval_seconds(block)
         assert 0 < interval <= MAX_RETRY_INTERVAL_SECONDS, (
             f"lb_try_interval {interval}s on {upstream} is too coarse: the "
@@ -343,7 +379,7 @@ class TestSingleUpstreamStaysInThePool:
 
     @pytest.mark.parametrize("upstream", ["127.0.0.1:3000", "127.0.0.1:8321"])
     def test_no_fail_duration_on_the_single_upstream_blocks(self, caddy_dir, upstream):
-        block = reverse_proxy_block(read_caddyfile(caddy_dir), upstream)
+        block = proxy_block(read_caddyfile(caddy_dir), upstream)
         assert "fail_duration" not in block, (
             f"reverse_proxy {upstream} sets fail_duration: the only upstream "
             "gets marked down on the first refused dial of a deploy restart, "
@@ -463,7 +499,7 @@ class TestRestartWindowMechanism:
     def test_request_during_an_upstream_gap_is_served_not_502ed(
         self, caddy_dir, tmp_path
     ):
-        proxied = reverse_proxy_block(read_caddyfile(caddy_dir), "127.0.0.1:3000")
+        proxied = proxy_block(read_caddyfile(caddy_dir), APP_UPSTREAM)
         order = []
         request_issued = threading.Event()
 

--- a/docs/incident-runbook.md
+++ b/docs/incident-runbook.md
@@ -247,6 +247,51 @@ Reported 2026-08-25 as "502 on https://app.radon.run/admin".
 
 ---
 
+## assistant-turn-edge-504
+
+**A chat turn dies with `Assistant service returned an error.` and DevTools
+shows `POST /api/assistant -> 504` after tens of seconds.** Reported
+2026-08-29 after the operator pasted a chart and asked how it related to
+their TLT position.
+
+- **Mechanism:** `/api/assistant` rode the catch-all `handle` in
+  `cloud/caddy/Caddyfile`, whose R-219 guard abandons a request after
+  `response_header_timeout 30s`. The route is NON-STREAMING: it runs the whole
+  multi-round `runAssistantLoop` and writes its JSON only at the end, so a turn
+  emits no response header at all until it has finished, and it declares
+  `maxDuration = 300`. Any turn slower than 30 s therefore reached the operator
+  as a 504 while radon-nextjs was still working on it. The edge's 504 body is
+  not JSON, so `payload.error` in `requestAssistantTurn` was null and the chat
+  fell through to the generic string.
+- **Detection:** the browser gets a 504 on `POST /api/assistant`, but
+  `journalctl -u radon-nextjs | grep '\[assistant\] done'` shows the SAME turn
+  with `outcome=answered` and `ms=` above 30000. The answer existed; nobody
+  received it. `/var/log/caddy/radon.log` (root-readable only) carries the
+  matching `"status":504` with a ~30 s `duration`.
+- **Discriminating check:** an `outcome=error` journal line means the loop
+  itself failed and this is NOT the case (read the error). An `outcome=answered`
+  line whose `ms` exceeds the path's `response_header_timeout`, or no journal
+  line at all with the request still counted at the edge, is this case.
+- **Fix (`cloud/caddy/Caddyfile`):** a dedicated `handle /api/assistant*` with
+  `response_header_timeout 180s` and no `lb_try_duration` (POST-only path with
+  no idempotency key: a retry would replay a billed vision turn). Do NOT raise
+  the guard globally; R-219 needs the catch-all short so a wedged upstream
+  still becomes an observable 5xx.
+- **Known limit:** the bump only moves the cliff. A turn slower than 180 s
+  still 504s because nothing is written until the loop finishes. The durable
+  fix is for the route to start writing a response early (stream, or flush a
+  header before the first round).
+- **Publishing:** as with every edge change, the Caddyfile is NOT shipped by
+  the CI deploy. After merge, on the VPS as `radon`:
+  `sudo -n /usr/local/sbin/radon-deploy-root publish-caddy`.
+- **Regression:** `cloud/tests/test_caddy_edge_timeouts.py::TestTheAssistantTurnOutlivesTheGenericGuard`
+  (the assistant handle exists, outlasts the longest observed answered turn,
+  stays inside the route's own `maxDuration`, never retries, and the generic
+  30 s guard is untouched) and `web/tests/assistant-timeout-copy.test.ts`
+  (a 504 or 408 names the timeout instead of the generic error).
+
+---
+
 ## signals-refresh-curl-timeout-pages-p1
 
 **`radon-signals-refresh.service` oneshot pages P1 `Result=exit-code`

--- a/web/lib/chat.ts
+++ b/web/lib/chat.ts
@@ -156,6 +156,22 @@ async function readJsonBody<T>(response: Response): Promise<T | null> {
   }
 }
 
+/**
+ * The edge abandons an assistant turn before the route does, and its 504 body
+ * is not JSON, so `payload.error` is empty and the status is the only thing
+ * carrying the reason. "Assistant service returned an error." told the
+ * operator nothing on 2026-08-29 when a pasted-chart turn timed out at the
+ * proxy while the turn itself was still running.
+ */
+const TIMEOUT_STATUSES = new Set([408, 504]);
+
+function assistantErrorMessage(status: number | undefined, error: string | undefined): string {
+  if (typeof status === "number" && TIMEOUT_STATUSES.has(status)) {
+    return "The turn timed out before the assistant answered. A smaller image or a shorter question may get through.";
+  }
+  return error ? `Error: ${error}` : "Assistant service returned an error.";
+}
+
 export async function requestAssistantReply(history: ApiMessage[], latestMessage: string): Promise<string> {
   const response = await fetch("/api/assistant", {
     method: "POST",
@@ -173,10 +189,7 @@ export async function requestAssistantReply(history: ApiMessage[], latestMessage
   const payload = await readJsonBody<AssistantResponse>(response);
 
   if (!response.ok) {
-    if (payload?.error) {
-      return `Error: ${payload.error}`;
-    }
-    return "Assistant service returned an error.";
+    return assistantErrorMessage(response.status, payload?.error);
   }
 
   if (typeof payload?.content === "string" && payload.content.trim()) {
@@ -248,7 +261,7 @@ export async function requestAssistantTurn(
   const payload = await readJsonBody<AssistantResponse>(response);
 
   if (!response.ok) {
-    const message = payload?.error ? `Error: ${payload.error}` : "Assistant service returned an error.";
+    const message = assistantErrorMessage(response.status, payload?.error);
     return { content: message, proposal: null, toolEvents: [], model: null };
   }
 

--- a/web/tests/assistant-timeout-copy.test.ts
+++ b/web/tests/assistant-timeout-copy.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * 2026-08-29: the operator pasted a chart, asked how it related to their TLT
+ * position, and the chat answered "Assistant service returned an error."
+ * DevTools showed `POST /api/assistant -> 504` after tens of seconds: the edge
+ * abandoned the turn, and the edge's 504 body is not JSON, so `payload?.error`
+ * was null and the generic string was all the operator got.
+ *
+ * A turn the edge timed out has to say so, and say what might get through.
+ */
+
+const originalFetch = global.fetch;
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  global.fetch = mockFetch as unknown as typeof fetch;
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+import { requestAssistantReply, requestAssistantTurn } from "../lib/chat";
+
+/** What Caddy actually hands the browser: a status, and a body that is not JSON. */
+function edgeTimeout(status = 504) {
+  return {
+    ok: false,
+    status,
+    text: async () => "",
+  };
+}
+
+describe("assistant turn timeout copy", () => {
+  it("names the timeout instead of the generic error on a 504", async () => {
+    mockFetch.mockResolvedValue(edgeTimeout());
+
+    const turn = await requestAssistantTurn([], "analyze this chart against my TLT position");
+
+    expect(turn.content).not.toBe("Assistant service returned an error.");
+    expect(turn.content).toMatch(/timed out/i);
+    expect(turn.content).toMatch(/smaller image/i);
+    expect(turn.content).toMatch(/shorter question/i);
+    expect(turn.proposal).toBeNull();
+    expect(turn.toolEvents).toEqual([]);
+  });
+
+  it("uses the same copy for a 408 request timeout", async () => {
+    mockFetch.mockResolvedValue(edgeTimeout(408));
+
+    const turn = await requestAssistantTurn([], "analyze this chart");
+
+    expect(turn.content).toMatch(/timed out/i);
+  });
+
+  it("keeps the timeout copy when the timeout body does carry an error field", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 504,
+      json: async () => ({ error: "upstream gone" }),
+    });
+
+    const turn = await requestAssistantTurn([], "analyze this chart");
+
+    expect(turn.content).toMatch(/timed out/i);
+  });
+
+  it("leaves a non-timeout failure with its own reported error", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: async () => ({ error: "Anthropic overloaded" }),
+    });
+
+    const turn = await requestAssistantTurn([], "analyze this chart");
+
+    expect(turn.content).toBe("Error: Anthropic overloaded");
+  });
+
+  it("still falls back to the generic string for an unexplained non-timeout status", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 500, json: async () => ({}) });
+
+    const turn = await requestAssistantTurn([], "analyze this chart");
+
+    expect(turn.content).toBe("Assistant service returned an error.");
+  });
+
+  it("applies the same copy to the plain reply path", async () => {
+    mockFetch.mockResolvedValue(edgeTimeout());
+
+    const reply = await requestAssistantReply([], "analyze this chart");
+
+    expect(reply).toMatch(/timed out/i);
+    expect(reply).toMatch(/smaller image/i);
+  });
+
+  it("uses no em dashes in operator-facing copy", async () => {
+    mockFetch.mockResolvedValue(edgeTimeout());
+
+    const turn = await requestAssistantTurn([], "analyze this chart");
+
+    expect(turn.content).not.toContain("—");
+  });
+});


### PR DESCRIPTION
## Incident

2026-08-29: the operator pasted a chart into Radon chat on `app.radon.run/dashboard` and asked how it related to their TLT position. The image uploaded and rendered in their own bubble; the reply was `Assistant service returned an error.` DevTools showed `POST /api/assistant` -> **504** after tens of seconds.

## Confirmed root cause

`/api/assistant` rode the catch-all `handle` in `cloud/caddy/Caddyfile`, whose R-219 guard abandons a request after `response_header_timeout 30s`. The route is **non-streaming**: `web/app/api/assistant/route.ts` runs the entire multi-round `runAssistantLoop` and writes its JSON only at the end, so a turn emits no response header at all until it has finished. It declares `maxDuration = 300`, ten times the edge's patience. Anything slower than 30s reached the operator as a 504 while `radon-nextjs` was still working on it.

Evidence:

- `journalctl -u radon-nextjs`, 2026-08-28 18:20:00 UTC:
  `[assistant] done rounds=2 outcome=answered toolCalls=3 usageIn=13927 usageOut=1157 ms=55278`
  A turn that **answered upstream at 55.3s**, 25 seconds after the edge had already given up on the client. One of the two assistant turns in the journal exceeded 30s.
- Reproduced locally: a real `caddy` driving the **shipped** catch-all proxy block against an upstream that answers correctly at 40s returns **504 to the client at 30.4s**.
- `/etc/caddy/Caddyfile` on the VPS matches the repo copy and has no `/api/assistant` handle.

The 504's body is not JSON, so `payload.error` in `requestAssistantTurn` was null and the chat fell through to the generic string. That is the second half of the incident.

## Fix

1. **`cloud/caddy/Caddyfile`** — a dedicated `handle /api/assistant*` with `response_header_timeout 180s`. Scoped to that one path so R-219's 30s guard stays in force for every other route, where a wedged upstream must still become an observable 5xx quickly. No `lb_try_duration` on the new block: the path is POST-only with no idempotency key, so a retry loop could replay a billed vision turn and re-run its tool calls.
2. **`web/lib/chat.ts`** — `requestAssistantTurn` / `requestAssistantReply` are now status-aware. 408/504 say the turn timed out and that a smaller image or a shorter question may get through. Everything else keeps its existing copy.
3. **`docs/incident-runbook.md`** — new case `assistant-turn-edge-504` (mechanism, detection, discriminating check, fix, known limit, publishing).

## The bump only moves the cliff

Stated explicitly so the follow-up is on record. Because the route writes nothing until the loop finishes, a turn slower than 180s still 504s. The durable fix is for `/api/assistant` to start writing a response early (stream the turn, or flush a header before the first round). Not built here.

## Red then green

- `cloud/tests/test_caddy_edge_timeouts.py::TestTheAssistantTurnOutlivesTheGenericGuard` — 5 failed / 1 passed before, 6 passed after.
- `web/tests/assistant-timeout-copy.test.ts` — 4 failed / 3 passed before, 7 passed after.

Gate: vitest root config 8069 passed with the one declared pre-existing failure (`api-routes-extended` "calls Anthropic API and returns response"); `pytest scripts/tests scripts/api/tests scripts/trade_blotter tests` 8816 passed; `cloud/tests` 1372 passed against a byte-identical pre-existing failure list from the unmodified tree. The caddy mechanism tests were run with a real caddy binary and the shipped Caddyfile adapts.

## Publishing (important)

**The Caddyfile is NOT shipped by the CI deploy** — `cloud/scripts/deploy.sh` never invokes `publish-caddy`; the runbook and `drift_audit.py` both say so. After merge this has to be published on the VPS as `radon`:

```
sudo -n /usr/local/sbin/radon-deploy-root publish-caddy
```

which stages, validates, installs atomically and reloads. Until then the drift audit flags `/etc/caddy/Caddyfile`.

## Pre-existing CI breakage on main (not from this PR)

`main` is already red on the cloud-tests shards from #169 (MKTNews):

- `test_caddyfile.py::TestRouting::test_reverse_proxy_does_not_dial_localhost_hostname` (`reverse_proxy localhost:8766`)
- `test_integration.py::TestPathConsistency::test_setup_vps_references_all_service_files` (`radon-mktnews.service`)
- `test_systemd_services.py::TestStructure::test_all_expected_files_exist`

Left alone deliberately: they belong to in-flight feature work, not to this incident. They do block the deploy job on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nVvKvpEXYszv9coXt8a5i
