### PR TITLE
fix(headlines): unblock CI so the hub can deploy

### DIFF
--- a/cloud/caddy/Caddyfile
+++ b/cloud/caddy/Caddyfile
@@ -31,7 +31,7 @@
     }
 
     handle /ws-headlines {
-        reverse_proxy localhost:8766
+        reverse_proxy 127.0.0.1:8766
     }
 
     handle /ws* {

--- a/cloud/scripts/setup-vps.sh
+++ b/cloud/scripts/setup-vps.sh
@@ -40,6 +40,7 @@ readonly SERVICE_FILES=(
   radon-monitor.service
   radon-health.service
   radon-newsfeed.service
+  radon-mktnews.service
   radon-refresh.service
   radon-refresh.timer
   radon-vcg-refresh.service

--- a/cloud/tests/test_caddyfile.py
+++ b/cloud/tests/test_caddyfile.py
@@ -84,7 +84,7 @@ class TestRouting:
         assert generic != -1
         assert headlines < generic, "/ws-headlines must win over /ws*"
         assert "handle /ws-headlines*" not in active
-        assert "localhost:8766" in active
+        assert "127.0.0.1:8766" in active
 
     def test_api_ib_route_to_8321(self, caddy_dir):
         content = read_caddyfile(caddy_dir)

--- a/cloud/tests/test_systemd_services.py
+++ b/cloud/tests/test_systemd_services.py
@@ -12,6 +12,7 @@ EXPECTED_SERVICE_FILES = [
     "radon-ib-gateway.service",
     "radon-ib-gateway-preheld-restart.service",
     "radon-monitor.service",
+    "radon-mktnews.service",
     "radon-newsfeed.service",
     "radon-nextjs.service",
     "radon-refresh.service",


### PR DESCRIPTION
## Summary
- Caddy headlines proxy dials `127.0.0.1:8766` (not `localhost`).
- `radon-mktnews.service` is in the systemd expected list and `setup-vps.sh`.
- Unblocks deploy of the already-merged Headlines tab + loopback hub.

## Test plan
- [ ] CI cloud al/mz + scripts-df green
- [ ] Deploy publishes Caddy `/ws-headlines` and Next.js tabs
- [ ] `/dashboard` Headlines talks to Radon `/ws-headlines`, hub stays on `:8766`