### PR TITLE
fix(deploy): ship cloud/caddy/Caddyfile with the release

### DIFF
--- a/cloud/scripts/deploy.sh
+++ b/cloud/scripts/deploy.sh
@@ -310,6 +310,33 @@ sync_scheduled_units() {
   log_success "Scheduled units match the GitHub main tip allowlist"
 }
 
+# The Caddyfile was the one release artifact no deploy ever shipped. Editing
+# cloud/caddy/Caddyfile, merging it and watching CI go green published nothing,
+# so the repo and /etc/caddy silently diverged until someone ran publish-caddy
+# by hand. It cost two incidents on 2026-08-29: the assistant 504 fix
+# (response_header_timeout on /api/assistant) and the headlines websocket
+# dialling `localhost:8766` when the hub listens on 127.0.0.1 only, so Caddy
+# tried ::1 first and never reached it. Both fixes merged and neither reached
+# the edge. The helper validates the config before it installs and reloads
+# rather than restarts, so a bad Caddyfile fails here instead of taking the
+# edge down; a failure warns like the unit sync rather than failing a release
+# that is already serving.
+edge_config_publish_is_granted() {
+  sudo -n -l -- "$DEPLOY_ROOT_HELPER" publish-caddy >/dev/null 2>&1
+}
+
+publish_edge_config() {
+  if ! edge_config_publish_is_granted; then
+    log_warn "Caddy publish is not granted yet; run cloud/scripts/bootstrap-control-plane.sh once as root"
+    return 0
+  fi
+  if ! sudo "$DEPLOY_ROOT_HELPER" publish-caddy; then
+    log_error "Caddy publish failed"
+    return 1
+  fi
+  log_success "Edge config matches cloud/caddy/Caddyfile"
+}
+
 # Pull the target release's app image pair BEFORE teardown, while the current
 # release still serves. Without this every containerised deploy pulled a 4.8G
 # image after restart and failed the HTTP gate on a container still
@@ -1028,6 +1055,8 @@ recover_pending_transition() {
       sudo "$DEPLOY_ROOT_HELPER" commit-transition || return 1
       sync_scheduled_units || log_warn \
         "Scheduled unit sync failed after a verified release; the next deploy will republish them"
+      publish_edge_config || log_warn \
+        "Caddy publish failed after a verified release; the next deploy will republish it"
       DEPLOY_RELEASE_UNVERIFIED=0
       finalize_release_artifacts "$JOURNAL_STAGE_DIR" "$JOURNAL_BACKUP_DIR"
       log_success "Finalized previously verified release ${JOURNAL_REQUESTED_SHA:0:7}"
@@ -1584,6 +1613,8 @@ main() {
     if deploy_gate; then
       sync_scheduled_units || log_warn \
         "Scheduled unit sync failed on an already-green release; the next deploy will republish them"
+      publish_edge_config || log_warn \
+        "Caddy publish failed on an already-green release; the next deploy will republish it"
       trap - TERM INT HUP
       log_success "Deploy already green: $(short_log)"
       return 0
@@ -1640,6 +1671,8 @@ main() {
     # carry on; the next deploy publishes the units.
     sync_scheduled_units || log_warn \
       "Scheduled unit sync failed after a verified release; the next deploy will republish them"
+    publish_edge_config || log_warn \
+      "Caddy publish failed after a verified release; the next deploy will republish it"
     DEPLOY_RELEASE_UNVERIFIED=0
     finalize_release_artifacts
   fi

--- a/cloud/tests/test_caddy_edge_timeouts.py
+++ b/cloud/tests/test_caddy_edge_timeouts.py
@@ -579,3 +579,40 @@ class TestEdgeMechanism:
                 stop_serving(server)
                 caddy.terminate()
                 caddy.wait(timeout=10)
+
+
+class TestTheDeployPublishesTheEdgeConfig:
+    """cloud/caddy/Caddyfile was the one release artifact no deploy shipped.
+
+    Editing it, merging it and watching CI go green published nothing: the repo
+    and /etc/caddy diverged silently until someone ran publish-caddy by hand.
+    It cost two incidents on 2026-08-29 that were both already fixed in the
+    repo and both still broken in production — the assistant 504
+    (`response_header_timeout` on `/api/assistant`) and the headlines
+    websocket dialling `localhost:8766` when the hub listens on 127.0.0.1
+    only, so Caddy resolved ::1 first and never reached it.
+    """
+
+    def test_deploy_publishes_the_caddyfile_after_a_verified_release(self) -> None:
+        deploy = (REPO / "cloud/scripts/deploy.sh").read_text(encoding="utf-8")
+        assert "publish-caddy" in deploy, (
+            "cloud/scripts/deploy.sh never publishes cloud/caddy/Caddyfile, so an "
+            "edge fix can merge green and never reach production"
+        )
+        # Every site that syncs scheduled units has just finished verifying a
+        # release; the edge config belongs on exactly those paths.
+        sync_sites = deploy.count("sync_scheduled_units || log_warn")
+        publish_sites = deploy.count("publish_edge_config || log_warn")
+        assert publish_sites == sync_sites, (
+            f"{publish_sites} edge-config publishes for {sync_sites} unit syncs; "
+            "a verified release that syncs units must also publish the edge config"
+        )
+
+    def test_edge_publish_degrades_to_a_warning_rather_than_failing_a_release(
+        self,
+    ) -> None:
+        deploy = (REPO / "cloud/scripts/deploy.sh").read_text(encoding="utf-8")
+        assert "edge_config_publish_is_granted" in deploy, (
+            "publish-caddy must be grant-checked like sync-scheduled-units so a "
+            "host without the sudoers verb warns instead of failing the deploy"
+        )

--- a/cloud/tests/test_deploy_corrections.py
+++ b/cloud/tests/test_deploy_corrections.py
@@ -854,6 +854,11 @@ recover_pending_transition
             "/usr/local/sbin/radon-deploy-root commit-transition",
             "-n -l -- /usr/local/sbin/radon-deploy-root sync-scheduled-units",
             "/usr/local/sbin/radon-deploy-root sync-scheduled-units",
+            # The edge config publishes on the same verified-release path as
+            # the unit sync; before this, cloud/caddy/Caddyfile was the one
+            # release artifact no deploy shipped.
+            "-n -l -- /usr/local/sbin/radon-deploy-root publish-caddy",
+            "/usr/local/sbin/radon-deploy-root publish-caddy",
         ]
 
     def test_verified_journal_finalizes_when_unit_sync_refuses_stale_head(


### PR DESCRIPTION
The Caddyfile was the one release artifact no deploy ever published. Editing it, merging it and watching CI go green shipped nothing: the repo and `/etc/caddy` diverged silently until someone ran `publish-caddy` by hand.

That cost two incidents today, both fixed in the repo and both still broken in production hours later:

- **the assistant 504** — `response_header_timeout` on `/api/assistant`. Merged in #172, applied to the host by hand because CI could not carry it.
- **the headlines websocket** — the route dialled `localhost:8766` while the mktnews hub listens on `127.0.0.1:8766` only (`ss -lntp` on the host confirms a single v4 listener), so Caddy resolved `::1` first and never reached it. Merged in #173, still dialling `localhost` after the deploy containing the fix went green.

## The change

`deploy.sh` now calls `radon-deploy-root publish-caddy` at each of the three sites that already sync scheduled units, all of which run after a release has verified.

The verb is grant-checked exactly like `sync-scheduled-units`, so a host that has not taken the sudoers bundle warns instead of failing a release that is already serving. `/etc/sudoers.d/radon-caddy` already grants it. The helper validates the config before installing and reloads rather than restarts, so a bad Caddyfile fails at publish instead of taking the edge down.

## Tests

Two regressions in `cloud/tests/test_caddy_edge_timeouts.py`: one pins that the publish count matches the unit-sync count so a future call site cannot be added without the edge config, one pins the grant check so the publish can never hard-fail a verified release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nVvKvpEXYszv9coXt8a5i