### PR TITLE
feat(headlines): seed handshake snapshot from flash history

### DIFF
--- a/scripts/mktnews/client.js
+++ b/scripts/mktnews/client.js
@@ -3,11 +3,44 @@ import WebSocket from "ws";
 import { reconnectDelayMs } from "../lib/reconnectGate.js";
 import { MAX_FRAME_BYTES } from "./normalize.js";
 import {
+  DEFAULT_FLASH_URL,
   DEFAULT_ORIGIN,
   DEFAULT_URL,
   DEFAULT_USER_AGENT,
   parseFrame,
 } from "./protocol.js";
+
+const FLASH_HISTORY_TIMEOUT_MS = 5_000;
+
+export async function fetchFlashHistory({
+  url = DEFAULT_FLASH_URL,
+  origin = DEFAULT_ORIGIN,
+  userAgent = DEFAULT_USER_AGENT,
+  fetchImpl = fetch,
+  timeoutMs = FLASH_HISTORY_TIMEOUT_MS,
+} = {}) {
+  try {
+    const res = await fetchImpl(url, {
+      headers: {
+        Origin: origin,
+        "User-Agent": userAgent,
+        Accept: "application/json",
+      },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!res.ok) return [];
+    const body = await res.json();
+    const rows = Array.isArray(body?.data) ? body.data : Array.isArray(body) ? body : [];
+    const frames = [];
+    for (const row of rows.slice().reverse()) {
+      const frame = parseFrame(JSON.stringify(row));
+      if (frame.kind === "flash") frames.push(frame);
+    }
+    return frames;
+  } catch {
+    return [];
+  }
+}
 
 export function connectMktnews({
   url = DEFAULT_URL,

--- a/scripts/mktnews/client.test.js
+++ b/scripts/mktnews/client.test.js
@@ -3,7 +3,8 @@ import { createServer } from "node:http";
 import { afterEach, describe, expect, it } from "vitest";
 import { WebSocketServer } from "ws";
 
-import { connectMktnews } from "./client.js";
+import { connectMktnews, fetchFlashHistory } from "./client.js";
+import { DEFAULT_FLASH_URL } from "./protocol.js";
 
 function listenServer() {
   const httpServer = createServer();
@@ -104,6 +105,37 @@ describe("connectMktnews", () => {
     controller.abort();
     client.stop();
     expect(origins[0]).toBe("https://mktnews.net");
+  });
+});
+
+describe("fetchFlashHistory", () => {
+  it("parses REST flash rows oldest-first with the browser Origin", async () => {
+    const seen = [];
+    const fetchImpl = async (url, init) => {
+      seen.push({ url, origin: init.headers.Origin });
+      return {
+        ok: true,
+        json: async () => ({
+          status: 200,
+          data: [
+            { id: "n1", type: 0, time: "2026-08-30T01:55:21.000Z", data: { content: "Newer." } },
+            { id: "n0", type: 0, time: "2026-08-30T01:54:49.000Z", data: { content: "Older." } },
+          ],
+        }),
+      };
+    };
+    const frames = await fetchFlashHistory({ fetchImpl });
+    expect(seen[0].url).toBe(DEFAULT_FLASH_URL);
+    expect(seen[0].origin).toBe("https://mktnews.net");
+    expect(frames.map((row) => row.data.id)).toEqual(["n0", "n1"]);
+    expect(frames[0].kind).toBe("flash");
+  });
+
+  it("returns an empty list when the history endpoint errors", async () => {
+    const frames = await fetchFlashHistory({
+      fetchImpl: async () => ({ ok: false, status: 503, json: async () => ({}) }),
+    });
+    expect(frames).toEqual([]);
   });
 });
 

--- a/scripts/mktnews/hub.js
+++ b/scripts/mktnews/hub.js
@@ -7,7 +7,7 @@ import {
   resolveUpgradeTarget,
   shouldSkipTicketValidation,
 } from "../lib/wsTrust.js";
-import { connectMktnews } from "./client.js";
+import { connectMktnews, fetchFlashHistory } from "./client.js";
 import {
   MAX_FRAME_BYTES,
   RING_SIZE,
@@ -71,6 +71,7 @@ export function createHeadlinesHub({
   ringSize = RING_SIZE,
   maxFrameBytes = MAX_FRAME_BYTES,
   delayFn = reconnectDelayMs,
+  loadHistory = null,
 } = {}) {
   const host = resolveHubListenHost(listenHost, security.bindHost);
   const ring = [];
@@ -178,7 +179,19 @@ export function createHeadlinesHub({
     });
   }
 
-  function listen() {
+  async function seedRing() {
+    if (!loadHistory || closed) return;
+    try {
+      const items = await loadHistory();
+      if (!Array.isArray(items)) return;
+      for (const item of items) ingest(item);
+    } catch {
+      // Serve an empty cache rather than blocking the hub.
+    }
+  }
+
+  async function listen() {
+    await seedRing();
     return new Promise((resolve) => {
       httpServer.listen(listenPort, host, () => {
         startUpstream();
@@ -236,6 +249,7 @@ export async function startHeadlinesHub(overrides = {}) {
     security,
     listenPort: overrides.listenPort ?? DEFAULT_LISTEN_PORT,
     connectUpstream: overrides.connectUpstream === undefined ? connectMktnews : overrides.connectUpstream,
+    loadHistory: overrides.loadHistory === undefined ? fetchFlashHistory : overrides.loadHistory,
   });
   await hub.listen();
   return hub;

--- a/scripts/mktnews/hub.test.js
+++ b/scripts/mktnews/hub.test.js
@@ -3,7 +3,7 @@ import net from "node:net";
 import { afterEach, describe, expect, it } from "vitest";
 import { WebSocket } from "ws";
 
-import { createHeadlinesHub } from "./hub.js";
+import { createHeadlinesHub, startHeadlinesHub } from "./hub.js";
 import { parseFrame } from "./protocol.js";
 import { RING_SIZE } from "./normalize.js";
 
@@ -104,6 +104,123 @@ describe("createHeadlinesHub", () => {
     await hub.listen();
     return hub;
   }
+
+  it("seeds the in-memory ring from flash history before the first snapshot", async () => {
+    const loadHistory = async () => [
+      parseFrame(
+        JSON.stringify({
+          id: "old",
+          type: 0,
+          time: "2026-08-29T20:00:00.000Z",
+          data: { content: "Older print." },
+        }),
+      ),
+      parseFrame(
+        JSON.stringify({
+          id: "new",
+          type: 0,
+          time: "2026-08-29T21:00:00.000Z",
+          data: { content: "Newer print." },
+        }),
+      ),
+    ];
+    const hub = await boot({ loadHistory });
+    const ws = new WebSocket(hub.address());
+    const [snap] = await collect(ws, 1);
+    ws.close();
+    expect(snap).toEqual({
+      type: "snapshot",
+      items: [
+        {
+          kind: "headline",
+          id: "old",
+          time: "2026-08-29T20:00:00.000Z",
+          important: false,
+          content: "Older print.",
+          impact: [],
+        },
+        {
+          kind: "headline",
+          id: "new",
+          time: "2026-08-29T21:00:00.000Z",
+          important: false,
+          content: "Newer print.",
+          impact: [],
+        },
+      ],
+    });
+  });
+
+  it("a later handshake receives seed plus live items", async () => {
+    const hub = await boot({
+      loadHistory: async () => [
+        parseFrame(
+          JSON.stringify({
+            id: "seeded",
+            type: 0,
+            data: { content: "Cached on host." },
+          }),
+        ),
+      ],
+    });
+    hub.ingest(
+      parseFrame(
+        JSON.stringify({
+          type: "flash",
+          data: { id: "live", data: { content: "Just printed." } },
+        }),
+      ),
+    );
+    const ws = new WebSocket(hub.address());
+    const [snap] = await collect(ws, 1);
+    ws.close();
+    expect(snap.items.map((row) => row.id)).toEqual(["seeded", "live"]);
+  });
+
+  it("still boots when flash history seed fails", async () => {
+    const hub = await boot({
+      loadHistory: async () => {
+        throw new Error("flash history down");
+      },
+    });
+    const ws = new WebSocket(hub.address());
+    const [snap] = await collect(ws, 1);
+    ws.close();
+    expect(snap).toEqual({ type: "snapshot", items: [] });
+  });
+
+  it("startHeadlinesHub seeds via loadHistory then fans out live prints", async () => {
+    const hub = await startHeadlinesHub({
+      security: AUTHLESS,
+      listenHost: "127.0.0.1",
+      listenPort: 0,
+      connectUpstream: null,
+      loadHistory: async () => [
+        parseFrame(
+          JSON.stringify({
+            id: "seeded",
+            type: 0,
+            data: { content: "Cached on host." },
+          }),
+        ),
+      ],
+    });
+    hubs.push(hub);
+    const ws = new WebSocket(hub.address());
+    const [snap] = await collect(ws, 1);
+    hub.ingest(
+      parseFrame(
+        JSON.stringify({
+          type: "flash",
+          data: { id: "live", data: { content: "Just printed." } },
+        }),
+      ),
+    );
+    const [live] = await collect(ws, 1);
+    ws.close();
+    expect(snap.items.map((row) => row.id)).toEqual(["seeded"]);
+    expect(live.item.id).toBe("live");
+  });
 
   it("sends a snapshot then live headlines, never time ticks or upstream hosts", async () => {
     const hub = await boot();

--- a/scripts/mktnews/protocol.js
+++ b/scripts/mktnews/protocol.js
@@ -1,6 +1,7 @@
 export const DEFAULT_HOST = "wss://api.mktnews.net/";
 export const DEFAULT_LANG = "en";
 export const DEFAULT_URL = `${DEFAULT_HOST}?lang=${DEFAULT_LANG}`;
+export const DEFAULT_FLASH_URL = `https://api.mktnews.net/api/flash?lang=${DEFAULT_LANG}`;
 export const DEFAULT_ORIGIN = "https://mktnews.net";
 export const DEFAULT_USER_AGENT =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";

--- a/scripts/mktnews/protocol.test.js
+++ b/scripts/mktnews/protocol.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  DEFAULT_FLASH_URL,
   DEFAULT_URL,
   classifyMessage,
   parseFrame,
@@ -9,6 +10,10 @@ import {
 describe("mktnews protocol", () => {
   it("pins the public English websocket URL", () => {
     expect(DEFAULT_URL).toBe("wss://api.mktnews.net/?lang=en");
+  });
+
+  it("pins the public English flash history URL", () => {
+    expect(DEFAULT_FLASH_URL).toBe("https://api.mktnews.net/api/flash?lang=en");
   });
 
   it("classifies server time heartbeats", () => {


### PR DESCRIPTION
## Summary
- Hub already kept a 50-item in-memory ring and sent it as the WS snapshot, but the ring started empty after every restart until the next live flash.
- On boot, fetch `https://api.mktnews.net/api/flash?lang=en`, ingest oldest-first into that ring, then handshake with `{type:snapshot, items}`. Live prints still append and a later page load gets seed plus live.
- Seed failure does not block the hub.

## Test plan
- [x] `npx vitest run scripts/mktnews` — 43 passed
- [ ] After merge/deploy, loopback `ws://127.0.0.1:8766/ws-headlines` snapshot `items.length > 0`