### PR TITLE
fix(R-262): stream POST /api/assistant so no header guard can 504 a running turn

### DIFF
--- a/cloud/caddy/Caddyfile
+++ b/cloud/caddy/Caddyfile
@@ -96,17 +96,33 @@
         }
     }
 
-    # The assistant turn needs longer than the generic guard below allows.
+    # The assistant turn is a Server-Sent Event stream.
     # 2026-08-29: the operator pasted a chart into chat and got a 504 while
     # radon-nextjs was still working on the turn. /api/assistant rode the
     # catch-all, whose R-219 guard abandons a request after 30s without a
-    # response header. That route is NON-STREAMING: it runs the whole
-    # multi-round runAssistantLoop and writes its JSON only at the end, so a
-    # turn emits no header at all until it has finished, and it budgets itself
-    # maxDuration 300. The radon-nextjs journal already had a plain text turn
-    # answering at 55.3s; a vision turn plus the portfolio tool rounds a
-    # "how does this relate to my TLT position" question forces is strictly
-    # more work than that.
+    # response header, and the route was NON-STREAMING: it ran the whole
+    # multi-round runAssistantLoop and wrote its JSON only at the end, so a
+    # turn emitted no header at all until it had finished. The first mitigation
+    # was a 180s bound here, which only moved the cliff.
+    #
+    # The route now writes `event: start` BEFORE awaiting the loop and
+    # heartbeats every 10s until it is done, so the response header exists
+    # within milliseconds of the request no matter how long the turn takes.
+    #
+    # flush_interval -1 states what must happen to those frames: forward every
+    # write immediately, never batch. Caddy already infers this from the
+    # text/event-stream content type, but inferring it means the fix silently
+    # depends on a header the route could change; say it instead. `encode zstd
+    # gzip` at the top of this site block does NOT hold the stream — its
+    # writer flushes through — which cloud/tests/test_caddy_edge_timeouts.py
+    # drives against a real caddy rather than assuming.
+    #
+    # response_header_timeout stays at 180s as a BACKSTOP, not as the
+    # mechanism: it now only bounds a radon-nextjs that dies before the stream
+    # opens, i.e. during Clerk verification, the durable rate limiter, or the
+    # demo quota check — all of which are DB round trips and all of which run
+    # before the header. It is under the route's own maxDuration 300, so the
+    # edge never waits on a request the route has already abandoned.
     #
     # Scoped to this one path on purpose. Raising the guard globally would undo
     # R-219 for every other route, where an upstream that accepts the socket
@@ -115,13 +131,11 @@
     # No lb_try_duration here, deliberately: this path is POST-only and has no
     # idempotency key, so a retry loop could replay a vision turn the operator
     # is billed for and re-run its tool calls. Caddy's default is zero retries.
-    #
-    # A bump only moves the cliff: a turn slower than this still 504s, because
-    # nothing is written until the loop finishes. The durable fix is for the
-    # route to start writing a response early (stream, or flush a header before
-    # the first round). R-262.
+    # R-262.
     handle /api/assistant* {
         reverse_proxy 127.0.0.1:3000 {
+            flush_interval -1
+
             transport http {
                 dial_timeout 5s
                 response_header_timeout 180s

--- a/cloud/tests/test_caddy_edge_timeouts.py
+++ b/cloud/tests/test_caddy_edge_timeouts.py
@@ -362,7 +362,13 @@ def _caddy_env(tmp_path):
     }
 
 
-def _run_caddy(tmp_path, proxy_sock, upstream_port, block):
+def _run_caddy(tmp_path, proxy_sock, upstream_port, block, site_prelude=""):
+    """Run a real caddy with `block` as the proxy body.
+
+    `site_prelude` injects site-level directives ahead of the handle — the
+    shipped site block puts `encode zstd gzip` in front of every proxy, and a
+    compressor that buffers is invisible to a test that omits it.
+    """
     _require_caddy()
     # caddy binds the listener itself, so the reservation is given up at the
     # last possible moment instead of at draw time.
@@ -371,6 +377,7 @@ def _run_caddy(tmp_path, proxy_sock, upstream_port, block):
     config.write_text(
         "{\n\tadmin off\n\tgrace_period 20s\n}\n\n"
         f"http://127.0.0.1:{proxy_port} {{\n"
+        f"{site_prelude}"
         "\thandle {\n"
         f"\t\treverse_proxy 127.0.0.1:{upstream_port} {block}\n"
         "\t}\n}\n"
@@ -616,3 +623,234 @@ class TestTheDeployPublishesTheEdgeConfig:
             "publish-caddy must be grant-checked like sync-scheduled-units so a "
             "host without the sudoers verb warns instead of failing the deploy"
         )
+
+
+# ── The assistant turn streams (R-262 durable fix) ───────────────────────
+#
+# Raising `response_header_timeout` only moved the cliff: the route wrote
+# nothing until `runAssistantLoop` finished, so any turn slower than the bound
+# still 504'd. The route now opens a `text/event-stream` and flushes a `start`
+# frame BEFORE the loop is awaited, so the response header exists within
+# milliseconds no matter how long the turn takes.
+
+# One `start` frame is a few dozen bytes, well under `encode`'s 512-byte
+# minimum_length. A compressor that waits for its buffer to fill, or a proxy
+# that batches writes, re-creates the exact bug being fixed here.
+STREAM_FIRST_BYTE_BUDGET_SECONDS = 5
+
+
+class _StreamsStartThenAnswersLate(http.server.BaseHTTPRequestHandler):
+    """The streaming route: header + `start` immediately, `done` much later.
+
+    `Connection: close` rather than a Content-Length or hand-rolled chunking:
+    the body is EOF-delimited, which is what a ReadableStream response looks
+    like to Caddy's transport, and it keeps the stub honest about never
+    knowing its own length up front.
+    """
+
+    protocol_version = "HTTP/1.1"
+    release = threading.Event()
+    START_FRAME = b"event: start\ndata: {}\n\n"
+    DONE_FRAME = b'event: done\ndata: {"content":"answered"}\n\n'
+
+    def do_POST(self):
+        # Drain the turn's JSON body. Closing a socket with unread request
+        # bytes still in it makes the kernel send RST rather than FIN, Caddy
+        # reads that as a severed upstream, and the client sees a truncated
+        # chunked stream instead of the clean end of a finished turn.
+        length = int(self.headers.get("Content-Length") or 0)
+        if length:
+            self.rfile.read(length)
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache, no-transform")
+        self.send_header("Connection", "close")
+        self.end_headers()
+        with contextlib.suppress(OSError):
+            self.wfile.write(type(self).START_FRAME)
+            self.wfile.flush()
+        type(self).release.wait(300)
+        with contextlib.suppress(OSError):
+            self.wfile.write(type(self).DONE_FRAME)
+            self.wfile.flush()
+        self.close_connection = True
+
+    def log_message(self, *args):
+        pass
+
+    def handle_one_request(self):
+        with contextlib.suppress(OSError):
+            super().handle_one_request()
+
+
+def _assistant_proxy_block(caddy_dir):
+    content = read_caddyfile(caddy_dir)
+    return reverse_proxy_block(handle_block(content, ASSISTANT_MATCHER), APP_UPSTREAM)
+
+
+class TestTheAssistantHandleStatesItStreams:
+    def test_the_assistant_handle_flushes_every_write(self, caddy_dir):
+        block = _assistant_proxy_block(caddy_dir)
+        assert re.search(r"flush_interval\s+-1\b", block), (
+            "the assistant handle does not state flush_interval -1, so whether "
+            "the SSE frames reach the browser as they are written rests on "
+            "Caddy's content-type auto-detection; a stream that sits in the "
+            "proxy's buffer is the 504 all over again"
+        )
+
+    def test_the_route_writes_its_header_before_the_loop(self):
+        source = ASSISTANT_ROUTE.read_text(encoding="utf-8")
+        assert "text/event-stream" in source, (
+            "the assistant route does not answer with an event stream, so it "
+            "still writes nothing until runAssistantLoop resolves and any turn "
+            "slower than the edge's header bound reaches the operator as a 504"
+        )
+
+
+@pytest.mark.skipif(
+    os.environ.get("RADON_SKIP_CADDY_E2E") == "1",
+    reason="RADON_SKIP_CADDY_E2E=1 local-dev escape (T-205). CI installs caddy.",
+)
+class TestTheAssistantStreamMechanism:
+    """The money test: a real caddy in front of a deliberately slow upstream.
+
+    `test_a_hung_upstream_becomes_a_5xx_within_a_bound` above already proves
+    the other half — an upstream that writes NO header inside the guard, which
+    is what `/api/assistant` was until this change, becomes a 504. These drive
+    the same guard with the streaming shape and assert the opposite outcome, so
+    the pair is the before and after of the 2026-08-29 incident.
+    """
+
+    def test_a_streaming_turn_survives_the_generic_header_guard(
+        self, caddy_dir, tmp_path
+    ):
+        """The turn no longer depends on a bespoke bound to reach the operator.
+
+        Driven through the CATCH-ALL block on purpose: that is the 30 s guard
+        `/api/assistant` rode on 2026-08-29, and a turn that answers only after
+        it expires has to succeed anyway now that the header is written first.
+        """
+        block = proxy_block(read_caddyfile(caddy_dir), APP_UPSTREAM)
+        guard = _directive_seconds(block, "response_header_timeout")
+        assert guard is not None
+
+        stub = _StreamsStartThenAnswersLate
+        stub.release = threading.Event()
+        # The answer lands AFTER the guard the incident died on.
+        answer_at = threading.Timer(guard + LATE_HEADER_MARGIN_SECONDS, stub.release.set)
+
+        with held_port() as upstream_sock, held_port() as proxy_sock:
+            server = serve_on(upstream_sock, stub)
+            proxy_port = port_of(proxy_sock)
+            caddy = _run_caddy(tmp_path, proxy_sock, port_of(upstream_sock), block)
+            try:
+                assert wait_for_listener(proxy_port, time.monotonic() + 10)
+                answer_at.start()
+                request = urllib.request.Request(
+                    f"http://127.0.0.1:{proxy_port}/api/assistant",
+                    data=b'{"messages":[{"role":"user","content":"hi"}]}',
+                    headers={
+                        "Content-Type": "application/json",
+                        "Accept": "text/event-stream",
+                    },
+                    method="POST",
+                )
+                started = time.monotonic()
+                try:
+                    response = urllib.request.urlopen(
+                        request, timeout=guard + LATE_HEADER_MARGIN_SECONDS * 3
+                    )
+                except urllib.error.HTTPError as exc:
+                    pytest.fail(
+                        f"the edge answered {exc.code} instead of streaming the "
+                        "turn: the route wrote no header before the loop ran, "
+                        "which is exactly the 2026-08-29 incident"
+                    )
+                with response:
+                    assert response.status == 200
+                    header_at = time.monotonic() - started
+                    first = response.read(len(stub.START_FRAME))
+                    first_byte_at = time.monotonic() - started
+                    body = first + response.read()
+
+                assert first == stub.START_FRAME, (
+                    f"the first thing off the wire was {first!r}, not the start "
+                    "frame; something between the route and the client is "
+                    "holding the stream"
+                )
+                assert first_byte_at < STREAM_FIRST_BYTE_BUDGET_SECONDS, (
+                    f"the first byte took {first_byte_at:.1f}s against a "
+                    f"{guard}s guard; the stream is being buffered, so a slower "
+                    "turn still 504s"
+                )
+                assert header_at < STREAM_FIRST_BYTE_BUDGET_SECONDS
+                assert stub.DONE_FRAME in body, (
+                    "the connection did not carry the turn's answer through to "
+                    f"the end: {body!r}"
+                )
+            finally:
+                answer_at.cancel()
+                stub.release.set()
+                stop_serving(server)
+                caddy.terminate()
+                caddy.wait(timeout=10)
+
+    def test_the_shipped_assistant_handle_does_not_buffer_the_stream(
+        self, caddy_dir, tmp_path
+    ):
+        """`encode zstd gzip` sits in front of this path in the real site block.
+
+        A compressor that waits for `minimum_length` (512 bytes by default)
+        before deciding whether to compress would hold a ~24-byte `start` frame
+        until the turn finished, reintroducing the bug in the one place nobody
+        would look for it. So this drives the SHIPPED assistant proxy block with
+        the site's own `encode` directive in front of it.
+        """
+        block = _assistant_proxy_block(caddy_dir)
+        stub = _StreamsStartThenAnswersLate
+        stub.release = threading.Event()
+        answer_at = threading.Timer(
+            STREAM_FIRST_BYTE_BUDGET_SECONDS * 2, stub.release.set
+        )
+
+        with held_port() as upstream_sock, held_port() as proxy_sock:
+            server = serve_on(upstream_sock, stub)
+            proxy_port = port_of(proxy_sock)
+            caddy = _run_caddy(
+                tmp_path,
+                proxy_sock,
+                port_of(upstream_sock),
+                block,
+                site_prelude="\tencode zstd gzip\n",
+            )
+            try:
+                assert wait_for_listener(proxy_port, time.monotonic() + 10)
+                answer_at.start()
+                request = urllib.request.Request(
+                    f"http://127.0.0.1:{proxy_port}/api/assistant",
+                    data=b'{"messages":[{"role":"user","content":"hi"}]}',
+                    headers={
+                        "Content-Type": "application/json",
+                        "Accept": "text/event-stream",
+                        # What a browser sends. Without it `encode` is a no-op
+                        # and the buffering question is never asked.
+                        "Accept-Encoding": "gzip",
+                    },
+                    method="POST",
+                )
+                started = time.monotonic()
+                with urllib.request.urlopen(request, timeout=60) as response:
+                    assert response.status == 200
+                    first = response.read(len(stub.START_FRAME))
+                    first_byte_at = time.monotonic() - started
+                assert first == stub.START_FRAME, first
+                assert first_byte_at < STREAM_FIRST_BYTE_BUDGET_SECONDS, (
+                    f"the shipped assistant handle held the start frame for "
+                    f"{first_byte_at:.1f}s; the turn is buffered at the edge"
+                )
+            finally:
+                answer_at.cancel()
+                stub.release.set()
+                stop_serving(server)
+                caddy.terminate()
+                caddy.wait(timeout=10)

--- a/docs/incident-runbook.md
+++ b/docs/incident-runbook.md
@@ -277,17 +277,34 @@ their TLT position.
   no idempotency key: a retry would replay a billed vision turn). Do NOT raise
   the guard globally; R-219 needs the catch-all short so a wedged upstream
   still becomes an observable 5xx.
-- **Known limit:** the bump only moves the cliff. A turn slower than 180 s
-  still 504s because nothing is written until the loop finishes. The durable
-  fix is for the route to start writing a response early (stream, or flush a
-  header before the first round).
+- **Durable fix (shipped after the bump):** the route STREAMS. It answers
+  `text/event-stream` and writes `event: start` before `runAssistantLoop` is
+  awaited, then a `heartbeat` every 10 s, a `tool` frame per completed tool
+  call, and a terminal `done` (or `error`) frame. The response header therefore
+  exists within milliseconds of the request no matter how long the turn takes,
+  so no header guard anywhere can abandon a running turn.
+  `flush_interval -1` on the assistant handle states that every frame is
+  forwarded as written. Two consequences worth knowing at 3am:
+  - Once the header is flushed there is no status left to set. A mid-turn
+    failure is an `error` FRAME on a **200**, not a 502. Every rejection that
+    still carries a status (`requireRouteAccess`, `enforceDemoAiQuota`, the
+    empty-turn guard) runs BEFORE the stream opens.
+  - A stream that ends with no `done` frame is a failure. The client renders
+    "The connection dropped and the turn did not finish." — never an empty
+    assistant bubble.
 - **Publishing:** as with every edge change, the Caddyfile is NOT shipped by
   the CI deploy. After merge, on the VPS as `radon`:
   `sudo -n /usr/local/sbin/radon-deploy-root publish-caddy`.
 - **Regression:** `cloud/tests/test_caddy_edge_timeouts.py::TestTheAssistantTurnOutlivesTheGenericGuard`
   (the assistant handle exists, outlasts the longest observed answered turn,
   stays inside the route's own `maxDuration`, never retries, and the generic
-  30 s guard is untouched) and `web/tests/assistant-timeout-copy.test.ts`
+  30 s guard is untouched), `::TestTheAssistantHandleStatesItStreams` and
+  `::TestTheAssistantStreamMechanism` (a real caddy carries a streaming turn's
+  first byte through in well under the guard, with the site's `encode` in
+  front of it), `web/tests/assistant-stream-route.test.ts` (start flushed
+  before the loop resolves; heartbeats; error-as-frame; pre-stream statuses
+  intact), `web/tests/assistant-stream-client.test.ts` (a truncated stream is
+  an error, never an empty bubble) and `web/tests/assistant-timeout-copy.test.ts`
   (a 504 or 408 names the timeout instead of the generic error).
 
 ---

--- a/web/app/api/assistant/route.ts
+++ b/web/app/api/assistant/route.ts
@@ -204,6 +204,19 @@ function toTelemetryToolCalls(toolEvents: ToolEvent[]): AssistantTurnToolCall[] 
 
 export const radonCapability = "internal";
 
+/**
+ * Gap between `heartbeat` frames while the loop works. Nothing downstream
+ * needs the payload; the point is that the connection is never idle long
+ * enough for an intermediary to reclaim it.
+ */
+export const ASSISTANT_HEARTBEAT_MS = 10_000;
+
+type SseEvent = "start" | "heartbeat" | "tool" | "done" | "error";
+
+function sseFrame(event: SseEvent, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
 export async function POST(request: NextRequest): Promise<Response> {
   const access = await requireRouteAccess(request, {
     rate: { key: "assistant:route", limit: 10, windowMs: 60_000 },
@@ -235,47 +248,122 @@ export async function POST(request: NextRequest): Promise<Response> {
   const quota = await enforceDemoAiQuota("assistant");
   if (quota) return quota;
 
+  // ── Everything above this line still carries a real HTTP status. ──────
+  //
+  // Below it the response header is already on the wire, so a failure can
+  // only be an `error` FRAME on a 200. Nothing that needs 400/401/429 may
+  // move down here. R-262.
+
   const t0 = Date.now();
-  try {
-    const system = `${SYSTEM_PROMPT} Today is ${etCalendarDateString(new Date())} (America/New_York).`;
-    const selection = await resolveModelSelection(body?.model);
-    const result = await runAssistantLoop(toTurns(messages), system, access.principal, selection);
+  const encoder = new TextEncoder();
+  let heartbeat: ReturnType<typeof setInterval> | null = null;
 
-    const content =
-      mock && !result.proposal && isProviderMockContent(result.content)
-        ? `Mock Grok response: ${fallbackReply(lastUserContent(messages))}`
-        : result.content;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      // Enqueue is best-effort from here on: the operator can close the tab
+      // mid-turn, and a dead controller must not take the loop down with it.
+      const send = (event: SseEvent, data: unknown) => {
+        try {
+          controller.enqueue(encoder.encode(sseFrame(event, data)));
+        } catch {
+          /* client hung up */
+        }
+      };
 
-    const outcome = result.proposal ? "proposal" : result.outcome;
-    console.log(
-      `[assistant] done rounds=${result.rounds} outcome=${outcome} toolCalls=${result.toolEvents.length} usageIn=${result.usage.inputTokens} usageOut=${result.usage.outputTokens} ms=${Date.now() - t0}`,
-    );
-    recordAssistantTurn({
-      ts: new Date().toISOString(),
-      userMsg: lastUserContent(messages),
-      rounds: result.rounds,
-      toolCalls: toTelemetryToolCalls(result.toolEvents),
-      usage: result.usage,
-      outcome,
-    });
+      // THE FIX. 2026-08-29: the route ran the whole multi-round loop and
+      // wrote nothing until it finished, so Caddy's header guard abandoned a
+      // still-running turn and the operator got a 504. This frame — written
+      // synchronously, before anything is awaited — is what makes the header
+      // exist no matter how long the turn takes.
+      send("start", { ts: new Date().toISOString() });
+      heartbeat = setInterval(
+        () => send("heartbeat", { ms: Date.now() - t0 }),
+        ASSISTANT_HEARTBEAT_MS,
+      );
 
-    return NextResponse.json({
-      content,
-      model: result.model,
-      toolEvents: result.toolEvents,
-      proposal: result.proposal ?? null,
-      rounds: result.rounds,
-    });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "Unknown assistant error.";
-    console.log(`[assistant] done rounds=0 outcome=error toolCalls=0 usageIn=0 usageOut=0 ms=${Date.now() - t0}`);
-    recordAssistantTurn({
-      ts: new Date().toISOString(),
-      userMsg: lastUserContent(messages),
-      rounds: 0,
-      toolCalls: [],
-      outcome: "error",
-    });
-    return NextResponse.json({ error: message }, { status: 502 });
-  }
+      const finish = () => {
+        if (heartbeat) clearInterval(heartbeat);
+        heartbeat = null;
+        try {
+          controller.close();
+        } catch {
+          /* already closed */
+        }
+      };
+
+      // Deliberately NOT awaited: `start` has to return so the header flushes.
+      void (async () => {
+        try {
+          const system = `${SYSTEM_PROMPT} Today is ${etCalendarDateString(new Date())} (America/New_York).`;
+          const selection = await resolveModelSelection(body?.model);
+          const result = await runAssistantLoop(
+            toTurns(messages),
+            system,
+            access.principal,
+            selection,
+            (event) => send("tool", event),
+          );
+
+          const content =
+            mock && !result.proposal && isProviderMockContent(result.content)
+              ? `Mock Grok response: ${fallbackReply(lastUserContent(messages))}`
+              : result.content;
+
+          const outcome = result.proposal ? "proposal" : result.outcome;
+          console.log(
+            `[assistant] done rounds=${result.rounds} outcome=${outcome} toolCalls=${result.toolEvents.length} usageIn=${result.usage.inputTokens} usageOut=${result.usage.outputTokens} ms=${Date.now() - t0}`,
+          );
+          recordAssistantTurn({
+            ts: new Date().toISOString(),
+            userMsg: lastUserContent(messages),
+            rounds: result.rounds,
+            toolCalls: toTelemetryToolCalls(result.toolEvents),
+            usage: result.usage,
+            outcome,
+          });
+
+          send("done", {
+            content,
+            model: result.model,
+            toolEvents: result.toolEvents,
+            proposal: result.proposal ?? null,
+            rounds: result.rounds,
+          });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "Unknown assistant error.";
+          console.log(
+            `[assistant] done rounds=0 outcome=error toolCalls=0 usageIn=0 usageOut=0 ms=${Date.now() - t0}`,
+          );
+          recordAssistantTurn({
+            ts: new Date().toISOString(),
+            userMsg: lastUserContent(messages),
+            rounds: 0,
+            toolCalls: [],
+            outcome: "error",
+          });
+          send("error", { error: message });
+        } finally {
+          finish();
+        }
+      })();
+    },
+    cancel() {
+      if (heartbeat) clearInterval(heartbeat);
+      heartbeat = null;
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      // `no-transform` keeps an intermediary from rewriting or compressing
+      // the body, which is another way of saying buffering it.
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      // nginx-family proxies honour this; Caddy uses flush_interval instead
+      // (cloud/caddy/Caddyfile), and neither costs anything to state.
+      "X-Accel-Buffering": "no",
+    },
+  });
 }

--- a/web/components/ChatPanel.tsx
+++ b/web/components/ChatPanel.tsx
@@ -318,7 +318,20 @@ export default function ChatPanel({
           signal: streamAbortRef.current?.signal,
         });
       } else {
-        const turn = await requestAssistantTurn(conversation, cleaned, attachments, modelId);
+        // The route streams its envelope: `start` lands within milliseconds of
+        // the request, and each tool call lands as the loop completes it. Both
+        // are wired live so a 55s turn reads as alive rather than as a panel
+        // that has stopped responding. R-262.
+        const turn = await requestAssistantTurn(
+          conversation,
+          cleaned,
+          attachments,
+          modelId,
+          (event) => {
+            if (event.type === "start") setStatus("streaming");
+            else setTurnTools((current) => [...current, event.event]);
+          },
+        );
         setTurnTools(turn.toolEvents);
         setTurnModel(turn.model);
         setStatus("streaming");

--- a/web/lib/assistant/loop.ts
+++ b/web/lib/assistant/loop.ts
@@ -269,10 +269,25 @@ export async function runAssistantLoop(
   system: string,
   principal: AssistantPrincipal,
   selection: AssistantModelSelection = {},
+  /**
+   * Called as each tool call settles, so the route can write it to the open
+   * event stream instead of the client waiting for the whole turn. Optional:
+   * the returned `toolEvents` stays the authoritative list.
+   */
+  onToolEvent?: (event: ToolEvent) => void,
 ): Promise<AssistantLoopResult> {
   if (!principal?.userId) throw new Error("Verified assistant principal required");
   const messages: LoopMessage[] = turns.map((turn) => ({ role: turn.role, content: turn.content }));
   const toolEvents: ToolEvent[] = [];
+  // A client that has already hung up must never fail the turn it is watching.
+  const emit = (event: ToolEvent) => {
+    toolEvents.push(event);
+    try {
+      onToolEvent?.(event);
+    } catch {
+      /* the stream is gone; the loop still owes its caller a result */
+    }
+  };
   const spawnBudget = createAssistantTurnBudget();
   const priorResults = new Map<string, string>();
   const usage: LlmUsage = { inputTokens: 0, outputTokens: 0 };
@@ -350,7 +365,7 @@ export async function runAssistantLoop(
           deferred: true,
           reason: "Complete prerequisite reads, then submit a fresh validated proposal.",
         });
-        toolEvents.push({
+        emit({
           name: call.name,
           input: call.input,
           ok: false,
@@ -362,7 +377,7 @@ export async function runAssistantLoop(
       const key = callKey(call);
       const prior = priorResults.get(key);
       if (prior !== undefined) {
-        toolEvents.push({ name: call.name, input: call.input, ok: true, repeated: true });
+        emit({ name: call.name, input: call.input, ok: true, repeated: true });
         results.push({
           type: "tool_result",
           tool_use_id: call.id,
@@ -383,7 +398,7 @@ export async function runAssistantLoop(
         knowledgeBoundaryReached = true;
       }
       priorResults.set(key, content);
-      toolEvents.push({ name: call.name, input: call.input, ok: result.ok, error: result.error });
+      emit({ name: call.name, input: call.input, ok: result.ok, error: result.error });
       results.push({
         type: "tool_result",
         tool_use_id: call.id,

--- a/web/lib/chat.ts
+++ b/web/lib/chat.ts
@@ -172,31 +172,15 @@ function assistantErrorMessage(status: number | undefined, error: string | undef
   return error ? `Error: ${error}` : "Assistant service returned an error.";
 }
 
+/**
+ * Text-only assistant turn. Delegates to {@link requestAssistantTurn} so there
+ * is ONE reader of the endpoint: the route answers `text/event-stream` now, and
+ * a second call site parsing the body as JSON would silently fall back to
+ * canned copy on every real turn.
+ */
 export async function requestAssistantReply(history: ApiMessage[], latestMessage: string): Promise<string> {
-  const response = await fetch("/api/assistant", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      messages: [
-        ...history,
-        { role: "user", content: latestMessage },
-      ],
-    }),
-  });
-
-  const payload = await readJsonBody<AssistantResponse>(response);
-
-  if (!response.ok) {
-    return assistantErrorMessage(response.status, payload?.error);
-  }
-
-  if (typeof payload?.content === "string" && payload.content.trim()) {
-    return formatAssistantPayload(payload.content);
-  }
-
-  return fallbackReply(latestMessage);
+  const turn = await requestAssistantTurn(history, latestMessage);
+  return turn.content;
 }
 
 /**
@@ -234,6 +218,115 @@ export type AssistantTurn = {
   model: string | null;
 };
 
+/** Live progress from the open turn, before its final payload exists. */
+export type AssistantStreamEvent =
+  | { type: "start" }
+  | { type: "tool"; event: AssistantToolEvent };
+
+/**
+ * A stream that ends without a `done` frame — killed upstream, severed
+ * connection, a proxy that gave up mid-body. It MUST read as a failure: an
+ * empty assistant bubble is worse than the 504 this replaced, because nothing
+ * on screen says the turn did not finish.
+ */
+const TRUNCATED_STREAM_MESSAGE =
+  "The connection dropped and the turn did not finish. No order was placed. Ask again.";
+
+function parseFrameData(raw: string): unknown {
+  try {
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Reads the `/api/assistant` event stream. Frames are `event:`/`data:` lines
+ * terminated by a blank line, and arrive on arbitrary chunk boundaries, so the
+ * buffer is split on the terminator rather than per read.
+ */
+async function readAssistantStream(
+  body: ReadableStream<Uint8Array>,
+  latestMessage: string,
+  onEvent?: (event: AssistantStreamEvent) => void,
+): Promise<AssistantTurn> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  const streamedTools: AssistantToolEvent[] = [];
+  let buffer = "";
+  let settled: AssistantTurn | null = null;
+  let failure: string | null = null;
+
+  const handle = (event: string, raw: string) => {
+    if (event === "start") {
+      onEvent?.({ type: "start" });
+      return;
+    }
+    if (event === "tool") {
+      const parsed = parseFrameData(raw) as AssistantToolEvent | null;
+      if (parsed) {
+        streamedTools.push(parsed);
+        onEvent?.({ type: "tool", event: parsed });
+      }
+      return;
+    }
+    if (event === "error") {
+      const parsed = parseFrameData(raw) as { error?: string } | null;
+      failure = assistantErrorMessage(undefined, parsed?.error);
+      return;
+    }
+    if (event === "done") {
+      const payload = parseFrameData(raw) as AssistantResponse | null;
+      settled = {
+        content:
+          typeof payload?.content === "string" && payload.content.trim()
+            ? formatAssistantPayload(payload.content)
+            : fallbackReply(latestMessage),
+        proposal: payload?.proposal ?? null,
+        toolEvents: Array.isArray(payload?.toolEvents) ? payload.toolEvents : streamedTools,
+        model: typeof payload?.model === "string" ? payload.model : null,
+      };
+    }
+  };
+
+  const drainFrames = () => {
+    let boundary = buffer.indexOf("\n\n");
+    while (boundary !== -1) {
+      const chunk = buffer.slice(0, boundary);
+      buffer = buffer.slice(boundary + 2);
+      let event = "";
+      const dataLines: string[] = [];
+      for (const line of chunk.split("\n")) {
+        if (line.startsWith("event: ")) event = line.slice(7).trim();
+        else if (line.startsWith("data: ")) dataLines.push(line.slice(6));
+      }
+      if (event) handle(event, dataLines.join("\n"));
+      boundary = buffer.indexOf("\n\n");
+    }
+  };
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (value) {
+        buffer += decoder.decode(value, { stream: true });
+        drainFrames();
+      }
+      if (done) break;
+    }
+  } catch {
+    // A read that throws is the same failure as a stream that stops early.
+  }
+
+  if (settled) return settled;
+  return {
+    content: failure ?? TRUNCATED_STREAM_MESSAGE,
+    proposal: null,
+    toolEvents: streamedTools,
+    model: null,
+  };
+}
+
 /**
  * Like {@link requestAssistantReply} but preserves the structured order
  * proposal (F7). The agentic loop returns a `place_order` proposal instead of
@@ -246,10 +339,12 @@ export async function requestAssistantTurn(
   attachments: ChatImageAttachment[] = [],
   /** Catalog model id from the composer's picker. "" leaves the choice to the server. */
   model = "",
+  /** Live progress while the turn is still open — flips the panel to alive. */
+  onEvent?: (event: AssistantStreamEvent) => void,
 ): Promise<AssistantTurn> {
   const response = await fetch("/api/assistant", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", Accept: "text/event-stream" },
     body: JSON.stringify({
       messages: [...history, buildUserMessage(latestMessage, attachments)],
       // Omitted rather than sent empty: the route treats an absent model as
@@ -258,12 +353,19 @@ export async function requestAssistantTurn(
     }),
   });
 
-  const payload = await readJsonBody<AssistantResponse>(response);
-
+  // Every rejection that carries a status is written before the stream opens,
+  // so a non-2xx is still a JSON body.
   if (!response.ok) {
-    const message = assistantErrorMessage(response.status, payload?.error);
+    const failed = await readJsonBody<AssistantResponse>(response);
+    const message = assistantErrorMessage(response.status, failed?.error);
     return { content: message, proposal: null, toolEvents: [], model: null };
   }
+
+  if (response.headers?.get?.("content-type")?.includes("text/event-stream") && response.body) {
+    return readAssistantStream(response.body, latestMessage, onEvent);
+  }
+
+  const payload = await readJsonBody<AssistantResponse>(response);
 
   const content =
     typeof payload?.content === "string" && payload.content.trim()

--- a/web/tests/api-routes-extended.test.ts
+++ b/web/tests/api-routes-extended.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
+import { assistantDonePayload, drainAssistantStream } from "./assistantStream";
+
 /**
  * Extended API route tests — heavy mocking of external services.
  *
@@ -1526,7 +1528,7 @@ describe("POST /api/assistant — extended", () => {
     );
     expect(res.status).toBe(200);
 
-    const body = await res.json();
+    const body = await assistantDonePayload<{ model: string; content: string }>(res);
     expect(body.model).toBe("mock");
     expect(body.content).toContain("Mock Grok response");
   });
@@ -1597,7 +1599,7 @@ describe("POST /api/assistant — extended", () => {
     );
     expect(res.status).toBe(200);
 
-    const body = await res.json();
+    const body = await assistantDonePayload<{ content: string; model: string }>(res);
     expect(body.content).toBe("AAPL shows strong accumulation");
     expect(body.model).toBe("claude-sonnet-4-5-20250929");
   });
@@ -1622,10 +1624,15 @@ describe("POST /api/assistant — extended", () => {
         }),
       }) as any,
     );
-    expect(res.status).toBe(502);
+    // The header is flushed before the loop runs, so a provider failure can
+    // no longer carry a status. It arrives as an `error` frame on the 200 the
+    // stream already committed to. R-262.
+    expect(res.status).toBe(200);
 
-    const body = await res.json();
-    expect(body.error).toContain("500");
+    const frames = await drainAssistantStream(res);
+    const failure = frames.find((frame) => frame.event === "error");
+    expect((failure?.data as { error: string }).error).toContain("500");
+    expect(frames.some((frame) => frame.event === "done")).toBe(false);
   });
 
   it("returns 400 for invalid JSON payload (non-mock)", async () => {

--- a/web/tests/assistant-image-content-blocks.test.ts
+++ b/web/tests/assistant-image-content-blocks.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { drainAssistantStream } from "./assistantStream";
+
 /**
  * Pasted-image attachments on the assistant turn.
  *
@@ -68,7 +70,13 @@ describe("assistant route image content blocks", () => {
 
   async function post(messages: unknown[]): Promise<Response> {
     const { POST } = await import("@/app/api/assistant/route");
-    return POST(postRequest({ messages }) as never);
+    const res = await POST(postRequest({ messages }) as never);
+    // The route answers as soon as the header is flushed and runs the loop on
+    // the open stream, so nothing about the turn is settled until it closes.
+    if (res.headers.get("content-type")?.includes("text/event-stream")) {
+      await drainAssistantStream(res.clone());
+    }
+    return res;
   }
 
   function turns(): Array<{ role: string; content: unknown }> {

--- a/web/tests/assistant-model-selection.test.ts
+++ b/web/tests/assistant-model-selection.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { assistantDonePayload, drainAssistantStream } from "./assistantStream";
+
 /**
  * Model selection on the assistant request path.
  *
@@ -85,6 +87,7 @@ describe("assistant model selection", () => {
     );
 
     expect(res.status).toBe(200);
+    await drainAssistantStream(res);
     expect(validateModelId).toHaveBeenCalledWith("claude-opus-5");
     expect(chat).toHaveBeenCalledTimes(1);
     expect(chat.mock.calls[0][0]).toMatchObject({ model: "claude-opus-5", provider: "anthropic" });
@@ -103,7 +106,7 @@ describe("assistant model selection", () => {
     );
 
     expect(res.status).toBe(200);
-    const body = await res.json();
+    const body = await assistantDonePayload<{ content: string }>(res);
     expect(body.content).toBeTruthy();
 
     expect(chat).toHaveBeenCalledTimes(1);
@@ -120,6 +123,7 @@ describe("assistant model selection", () => {
     const res = await POST(postRequest({ messages: [{ role: "user", content: "How is SPY flow?" }] }) as never);
 
     expect(res.status).toBe(200);
+    await drainAssistantStream(res);
     expect(validateModelId).not.toHaveBeenCalled();
     expect(chat).toHaveBeenCalledTimes(1);
     const request = chat.mock.calls[0][0] as Record<string, unknown>;
@@ -141,6 +145,7 @@ describe("assistant model selection", () => {
     );
 
     expect(res.status).toBe(200);
+    await drainAssistantStream(res);
     const request = chat.mock.calls[0][0] as Record<string, unknown>;
     expect(request).not.toHaveProperty("model");
   });

--- a/web/tests/assistant-stream-client.test.ts
+++ b/web/tests/assistant-stream-client.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { requestAssistantTurn } from "@/lib/chat";
+
+/**
+ * Client half of the streamed assistant turn (R-262).
+ *
+ * `requestAssistantTurn` now reads `text/event-stream` off the response body.
+ * The failure this has to make impossible: a stream that ends WITHOUT a `done`
+ * frame — a killed radon-nextjs, a severed connection, a proxy that gives up
+ * mid-body — must surface as an error the operator can see. Rendering it as an
+ * empty assistant bubble is a worse bug than the 504 it replaces, because
+ * nothing on screen says the turn failed.
+ */
+
+function sseResponse(frames: string[], init: ResponseInit = {}): Response {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const encoder = new TextEncoder();
+      for (const frame of frames) controller.enqueue(encoder.encode(frame));
+      controller.close();
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+    ...init,
+  });
+}
+
+function frame(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+const DONE = {
+  content: "Flow is neutral.",
+  model: "grok-4.6",
+  toolEvents: [{ name: "get_flow", input: {}, ok: true }],
+  proposal: null,
+  rounds: 2,
+};
+
+describe("requestAssistantTurn consumes the event stream", () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("asks for the stream and returns the done payload", async () => {
+    fetchMock.mockResolvedValue(
+      sseResponse([frame("start", {}), frame("heartbeat", { ms: 10 }), frame("done", DONE)]),
+    );
+
+    const turn = await requestAssistantTurn([], "How is SPY flow?");
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(new Headers(init.headers).get("accept")).toContain("text/event-stream");
+    expect(turn.content).toContain("Flow is neutral.");
+    expect(turn.model).toBe("grok-4.6");
+    expect(turn.toolEvents).toHaveLength(1);
+    expect(turn.proposal).toBeNull();
+  });
+
+  it("reports start and each tool event as it arrives", async () => {
+    fetchMock.mockResolvedValue(
+      sseResponse([
+        frame("start", {}),
+        frame("tool", { name: "get_portfolio", input: {}, ok: true }),
+        frame("tool", { name: "get_quote", input: { ticker: "TLT" }, ok: true }),
+        frame("done", DONE),
+      ]),
+    );
+
+    const seen: string[] = [];
+    await requestAssistantTurn([], "hi", [], "", (event) =>
+      seen.push(event.type === "tool" ? `tool:${event.event.name}` : event.type),
+    );
+
+    expect(seen).toEqual(["start", "tool:get_portfolio", "tool:get_quote"]);
+  });
+
+  it("surfaces a truncated stream as an error and never as an empty bubble", async () => {
+    fetchMock.mockResolvedValue(
+      sseResponse([frame("start", {}), frame("tool", { name: "get_flow", input: {}, ok: true })]),
+    );
+
+    const turn = await requestAssistantTurn([], "How is SPY flow?");
+
+    expect(turn.content.trim()).not.toBe("");
+    expect(turn.content.toLowerCase()).toContain("did not finish");
+    expect(turn.proposal).toBeNull();
+    // The tool events that DID arrive are kept: the trace should not lose the
+    // work the turn is known to have done.
+    expect(turn.toolEvents).toHaveLength(1);
+  });
+
+  it("surfaces a mid-turn error frame", async () => {
+    fetchMock.mockResolvedValue(
+      sseResponse([frame("start", {}), frame("error", { error: "provider exploded" })]),
+    );
+
+    const turn = await requestAssistantTurn([], "How is SPY flow?");
+
+    expect(turn.content).toContain("provider exploded");
+  });
+
+  it("frames split across chunk boundaries are still parsed", async () => {
+    const whole = frame("start", {}) + frame("done", DONE);
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        const bytes = new TextEncoder().encode(whole);
+        controller.enqueue(bytes.slice(0, 9));
+        controller.enqueue(bytes.slice(9, 40));
+        controller.enqueue(bytes.slice(40));
+        controller.close();
+      },
+    });
+    fetchMock.mockResolvedValue(
+      new Response(body, { status: 200, headers: { "Content-Type": "text/event-stream" } }),
+    );
+
+    const turn = await requestAssistantTurn([], "hi");
+    expect(turn.content).toContain("Flow is neutral.");
+  });
+
+  it("still reads a plain JSON body", async () => {
+    // Pre-stream rejections and non-streaming harnesses keep the old shape.
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ content: "Read." }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const turn = await requestAssistantTurn([], "hi");
+    expect(turn.content).toContain("Read.");
+  });
+
+  it("keeps the edge-timeout copy for a pre-stream 504", async () => {
+    fetchMock.mockResolvedValue(new Response("<html>gateway timeout</html>", { status: 504 }));
+
+    const turn = await requestAssistantTurn([], "hi");
+    expect(turn.content).toContain("timed out");
+  });
+});

--- a/web/tests/assistant-stream-route.test.ts
+++ b/web/tests/assistant-stream-route.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { parseSseFrames } from "./assistantStream";
+
+/**
+ * `/api/assistant` streams its envelope (R-262).
+ *
+ * 2026-08-29: a pasted-chart turn reached the operator as a 504 while
+ * radon-nextjs was still working on it. The route ran the whole multi-round
+ * `runAssistantLoop` and wrote its JSON only at the end, so NOTHING reached the
+ * edge until the turn was finished and Caddy's header guard abandoned it. The
+ * journal had already recorded a plain text turn answering at 55.3 s.
+ *
+ * Raising the guard only moves the cliff. The fix is that the header exists
+ * before the loop is awaited:
+ *
+ *   start      flushed BEFORE `runAssistantLoop` — the whole fix
+ *   heartbeat  every ~10 s, so no intermediary idles the connection out
+ *   tool       one per tool call, as the loop completes it
+ *   done       the AssistantResponse payload, unchanged in shape
+ *   error      a mid-turn failure
+ *
+ * The subtlety: once the header is flushed there is no HTTP status left to
+ * set. Every rejection that carries one — access, quota, the empty-turn guard —
+ * must therefore run BEFORE the stream opens, and everything after it is an
+ * `error` frame on a 200.
+ */
+
+const ENV_KEYS = ["ASSISTANT_MOCK", "NODE_ENV", "ANTHROPIC_API_KEY"];
+
+function postRequest(body: unknown): Request {
+  return new Request("http://localhost/api/assistant", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const HELLO = [{ role: "user", content: "How is SPY flow?" }];
+
+type Deferred<T> = { promise: Promise<T>; resolve: (value: T) => void; reject: (error: Error) => void };
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function loopResult(overrides: Record<string, unknown> = {}) {
+  return {
+    content: "Flow is neutral.",
+    model: "mock",
+    toolEvents: [],
+    rounds: 1,
+    usage: { inputTokens: 1, outputTokens: 1 },
+    outcome: "answered" as const,
+    ...overrides,
+  };
+}
+
+describe("assistant route streams its envelope", () => {
+  const saved: Record<string, string | undefined> = {};
+  let runAssistantLoop: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    for (const key of ENV_KEYS) saved[key] = process.env[key];
+    process.env.ASSISTANT_MOCK = "1";
+    runAssistantLoop = vi.fn(async () => loopResult());
+    vi.doMock("@/lib/assistant/loop", async () => {
+      const actual = await vi.importActual<typeof import("@/lib/assistant/loop")>(
+        "@/lib/assistant/loop",
+      );
+      return { ...actual, runAssistantLoop };
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.doUnmock("@/lib/assistant/loop");
+    vi.doUnmock("@/lib/routeAccess");
+    vi.doUnmock("@/lib/demo/enforceAiQuota");
+    for (const key of ENV_KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  async function post(body: unknown = { messages: HELLO }): Promise<Response> {
+    const { POST } = await import("@/app/api/assistant/route");
+    return POST(postRequest(body) as never);
+  }
+
+  it("answers with an event stream", async () => {
+    const res = await post();
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+    // A proxy that transforms or caches this body reintroduces the buffering
+    // the stream exists to avoid.
+    expect(res.headers.get("cache-control")).toContain("no-transform");
+    await res.text();
+  });
+
+  it("flushes the start event BEFORE the loop resolves", async () => {
+    // The whole fix. A loop that never settles stands in for the 55.3 s turn
+    // the journal recorded: the header and first frame must exist anyway.
+    const hanging = deferred<ReturnType<typeof loopResult>>();
+    runAssistantLoop.mockImplementation(() => hanging.promise);
+
+    const res = await post();
+    expect(res.status).toBe(200);
+
+    const reader = res.body!.getReader();
+    const first = new TextDecoder().decode((await reader.read()).value);
+    expect(first).toContain("event: start");
+
+    hanging.resolve(loopResult());
+    await reader.cancel();
+  });
+
+  it("keeps sending heartbeats while a slow loop runs", async () => {
+    vi.useFakeTimers();
+    const hanging = deferred<ReturnType<typeof loopResult>>();
+    runAssistantLoop.mockImplementation(() => hanging.promise);
+
+    const res = await post();
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    // Drain the start frame first so the reads below can only be heartbeats.
+    expect(decoder.decode((await reader.read()).value)).toContain("event: start");
+
+    const { ASSISTANT_HEARTBEAT_MS } = await import("@/app/api/assistant/route");
+    await vi.advanceTimersByTimeAsync(ASSISTANT_HEARTBEAT_MS + 1);
+    expect(decoder.decode((await reader.read()).value)).toContain("event: heartbeat");
+    await vi.advanceTimersByTimeAsync(ASSISTANT_HEARTBEAT_MS + 1);
+    expect(decoder.decode((await reader.read()).value)).toContain("event: heartbeat");
+
+    hanging.resolve(loopResult());
+    await reader.cancel();
+  });
+
+  it("emits a tool event as the loop completes each call", async () => {
+    runAssistantLoop.mockImplementation(
+      async (
+        _turns: unknown,
+        _system: unknown,
+        _principal: unknown,
+        _selection: unknown,
+        onToolEvent?: (event: unknown) => void,
+      ) => {
+        onToolEvent?.({ name: "get_portfolio", input: {}, ok: true });
+        onToolEvent?.({ name: "get_quote", input: { ticker: "TLT" }, ok: true });
+        return loopResult({
+          toolEvents: [
+            { name: "get_portfolio", input: {}, ok: true },
+            { name: "get_quote", input: { ticker: "TLT" }, ok: true },
+          ],
+        });
+      },
+    );
+
+    const frames = parseSseFrames(await (await post()).text());
+    const tools = frames.filter((frame) => frame.event === "tool");
+    expect(tools.map((frame) => (frame.data as { name: string }).name)).toEqual([
+      "get_portfolio",
+      "get_quote",
+    ]);
+    // The trailing payload still carries the authoritative list.
+    expect((frames.at(-1)!.data as { toolEvents: unknown[] }).toolEvents).toHaveLength(2);
+  });
+
+  it("closes with a done frame carrying the unchanged payload shape", async () => {
+    runAssistantLoop.mockResolvedValue(
+      loopResult({ content: "Flow is neutral.", model: "grok-4.6", rounds: 2 }),
+    );
+    const frames = parseSseFrames(await (await post()).text());
+    expect(frames[0].event).toBe("start");
+    const done = frames.at(-1)!;
+    expect(done.event).toBe("done");
+    expect(done.data).toEqual({
+      content: "Flow is neutral.",
+      model: "grok-4.6",
+      toolEvents: [],
+      proposal: null,
+      rounds: 2,
+    });
+  });
+
+  it("reports a mid-turn failure as an error frame, not a status", async () => {
+    // The header is already on the wire by the time the loop throws, so there
+    // is no status left to set. A 502 here would be a lie the client cannot
+    // read.
+    runAssistantLoop.mockRejectedValue(new Error("provider exploded"));
+    const res = await post();
+    expect(res.status).toBe(200);
+    const frames = parseSseFrames(await res.text());
+    expect(frames.map((frame) => frame.event)).toContain("error");
+    expect((frames.at(-1)!.data as { error: string }).error).toBe("provider exploded");
+    expect(frames.some((frame) => frame.event === "done")).toBe(false);
+  });
+
+  describe("rejections that carry a status run before the stream opens", () => {
+    it("still 400s an empty turn", async () => {
+      const res = await post({ messages: [] });
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: "No messages supplied." });
+      expect(runAssistantLoop).not.toHaveBeenCalled();
+    });
+
+    it("still 401s when route access is refused", async () => {
+      vi.doMock("@/lib/routeAccess", () => ({
+        requireRouteAccess: vi.fn(async () => ({
+          ok: false,
+          response: new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 }),
+        })),
+      }));
+      const res = await post();
+      expect(res.status).toBe(401);
+      expect(runAssistantLoop).not.toHaveBeenCalled();
+    });
+
+    it("still 429s when the demo AI quota is exhausted", async () => {
+      vi.doMock("@/lib/demo/enforceAiQuota", () => ({
+        enforceDemoAiQuota: vi.fn(async () =>
+          new Response(JSON.stringify({ error: "Demo AI limit reached" }), { status: 429 }),
+        ),
+      }));
+      const res = await post();
+      expect(res.status).toBe(429);
+      expect(runAssistantLoop).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/web/tests/assistant-telemetry.test.ts
+++ b/web/tests/assistant-telemetry.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { assistantDonePayload } from "./assistantStream";
+
 /**
  * Item 5 — assistant telemetry.
  *
@@ -137,7 +139,7 @@ describe("assistant telemetry", () => {
     const res = await POST(postRequest({ messages: [{ role: "user", content: "How is SPY flow?" }] }) as never);
 
     expect(res.status).toBe(200);
-    const body = await res.json();
+    const body = await assistantDonePayload<{ content: string; rounds: number }>(res);
     expect(body.content).toBe("SPY flow is bullish accumulation.");
 
     await vi.waitFor(() => expect(dbExecute).toHaveBeenCalledTimes(1));
@@ -174,7 +176,7 @@ describe("assistant telemetry", () => {
     const res = await POST(postRequest({ messages: [{ role: "user", content: "How is SPY flow?" }] }) as never);
 
     expect(res.status).toBe(200);
-    const body = await res.json();
+    const body = await assistantDonePayload<{ content: string; rounds: number }>(res);
     expect(body.content).toBe("SPY flow is bullish accumulation.");
     expect(body.rounds).toBe(1);
 

--- a/web/tests/assistant-tool-loop.test.ts
+++ b/web/tests/assistant-tool-loop.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { assistantDonePayload } from "./assistantStream";
+
 /**
  * F7 — Agentic tool-calling assistant loop.
  *
@@ -107,7 +109,7 @@ describe("assistant tool-calling loop", () => {
     const res = await POST(postRequest({ messages: [{ role: "user", content: "How is SPY flow?" }] }) as never);
 
     expect(res.status).toBe(200);
-    const body = await res.json();
+    const body = await assistantDonePayload(res);
 
     expect(chat).toHaveBeenCalledTimes(2);
     expect(executeTool).toHaveBeenCalledTimes(1);
@@ -164,7 +166,7 @@ describe("assistant tool-calling loop", () => {
     const res = await POST(postRequest({ messages: [{ role: "user", content: "Buy 1 SPY call" }] }) as never);
 
     expect(res.status).toBe(200);
-    const body = await res.json();
+    const body = await assistantDonePayload(res);
 
     // Destructive tool must NOT be auto-executed.
     expect(executeTool).not.toHaveBeenCalled();

--- a/web/tests/assistantStream.ts
+++ b/web/tests/assistantStream.ts
@@ -1,0 +1,55 @@
+/**
+ * Test-side reader for the `/api/assistant` event stream.
+ *
+ * The route answers `text/event-stream` so the response header is flushed
+ * before `runAssistantLoop` is awaited (R-262). Tests that used to call
+ * `res.json()` read the terminal `done` frame through here instead.
+ */
+
+export type AssistantSseFrame = { event: string; data: unknown };
+
+export function parseSseFrames(raw: string): AssistantSseFrame[] {
+  const frames: AssistantSseFrame[] = [];
+  for (const chunk of raw.split("\n\n")) {
+    if (!chunk.trim()) continue;
+    let event = "";
+    const dataLines: string[] = [];
+    for (const line of chunk.split("\n")) {
+      if (line.startsWith("event: ")) event = line.slice(7).trim();
+      else if (line.startsWith("data: ")) dataLines.push(line.slice(6));
+    }
+    if (!event) continue;
+    const data = dataLines.join("\n");
+    let parsed: unknown = null;
+    try {
+      parsed = data ? JSON.parse(data) : null;
+    } catch {
+      parsed = data;
+    }
+    frames.push({ event, data: parsed });
+  }
+  return frames;
+}
+
+/** Every frame the turn wrote. Waits for the stream to close. */
+export async function drainAssistantStream(res: Response): Promise<AssistantSseFrame[]> {
+  return parseSseFrames(await res.text());
+}
+
+/**
+ * The turn's terminal payload — the same object shape the route used to return
+ * as JSON. Throws when the stream ended without one, because a turn that
+ * silently produced nothing is the failure mode this contract exists to catch.
+ */
+export async function assistantDonePayload<T = Record<string, unknown>>(
+  res: Response,
+): Promise<T> {
+  const frames = await drainAssistantStream(res);
+  const done = frames.find((frame) => frame.event === "done");
+  if (!done) {
+    throw new Error(
+      `assistant stream ended without a done frame: ${JSON.stringify(frames)}`,
+    );
+  }
+  return done.data as T;
+}

--- a/web/tests/integration.test.ts
+++ b/web/tests/integration.test.ts
@@ -158,7 +158,8 @@ test("assistant API route returns mock response when mock mode is enabled", asyn
     });
 
     const response = await mod.POST(req);
-    const body = await response.json();
+    const { assistantDonePayload } = await import("./assistantStream");
+    const body = await assistantDonePayload<{ content: string; model: string }>(response);
 
     expect(response.status).toBe(200);
     expect(typeof body.content).toBe("string");


### PR DESCRIPTION
## Why

2026-08-29: the operator pasted a chart into chat and got `Assistant service returned an error.` with `POST /api/assistant -> 504`. `journalctl -u radon-nextjs` showed the same turn answering at **55.3s** — the answer existed, nobody received it.

`/api/assistant` ran the whole multi-round `runAssistantLoop` and wrote its JSON only at the end, so it emitted **no response header at all** until the turn was finished. The same-day mitigation (a dedicated `handle /api/assistant*` with `response_header_timeout 180s`) only moved the cliff: a slower turn still 504s.

## What shipped

Server-Sent Events. `event: start` is written **synchronously, before `runAssistantLoop` is awaited** — that is the whole fix. Then `heartbeat` every 10s, a `tool` frame per completed tool call, and a terminal `done` (unchanged `AssistantResponse` shape) or `error`.

The subtlety: once the header is flushed there is no status left to set. Every rejection that carries one (`requireRouteAccess`, `enforceDemoAiQuota`, the empty-turn and last-message guards) runs **before** the stream opens; a mid-turn failure is an `error` frame on a 200. The client treats an `error` frame *and* a stream that ends without `done` as failures — a truncated stream renders "The connection dropped and the turn did not finish", never an empty assistant bubble.

SSE over NDJSON specifically because Caddy auto-detects the content type and flushes per write; `flush_interval -1` is stated on the handle anyway so the fix does not silently depend on a header the route could change. `encode zstd gzip` does **not** hold the stream — the new mechanism test drives a real caddy with the site's own `encode` in front of the shipped handle rather than assuming it.

`response_header_timeout 180s` **stays**, reclassified from mechanism to backstop: it now only bounds a radon-nextjs that dies before the stream opens (Clerk verification, the durable rate limiter and the demo quota are all DB round trips ahead of the header), and it stays under the route's own `maxDuration 300`.

Scope: the envelope, not tokens. `chat()` still returns a complete string and the loop is multi-round; `streamMessage`'s typewriter keeps rendering the final text.

## Files

| File | Change |
|---|---|
| `web/app/api/assistant/route.ts` | the stream. Pre-stream guards, telemetry, `ASSISTANT_MOCK`, image validation and model selection preserved |
| `web/lib/assistant/loop.ts` | optional `onToolEvent` sink; returned `toolEvents` stays authoritative |
| `web/lib/chat.ts` | `requestAssistantTurn` reads the stream via `getReader()`; `requestAssistantReply` delegates to it |
| `web/components/ChatPanel.tsx` | `streaming` on `start`, live tool events into `EngineTrace` |
| `cloud/caddy/Caddyfile` | `flush_interval -1` on the assistant handle |
| `docs/incident-runbook.md` | `assistant-turn-edge-504` now records the durable fix |

## Tests, red first

Red before the change:

```
FAILED TestTheAssistantHandleStatesItStreams::test_the_assistant_handle_flushes_every_write
FAILED TestTheAssistantHandleStatesItStreams::test_the_route_writes_its_header_before_the_loop
web/tests/assistant-stream-route.test.ts   11 failed | 5 passed
```

Green after: `59 passed` across `test_caddy_edge_timeouts.py` + `test_caddyfile.py`, `16 passed` across the two new vitest files.

The caddy money test (`TestTheAssistantStreamMechanism`) stands up a real caddy in front of a deliberately slow upstream and asserts a 200 whose first byte lands in under 5s while the turn's answer arrives only **after** the 30s guard the incident died on. Its mirror image — an upstream that writes no header inside the guard, i.e. what this route was — is already pinned by `test_a_hung_upstream_becomes_a_5xx_within_a_bound`, so the pair is the before and after of the incident.

## Gate

- `npx vitest run` from the repo root: **8173 passed, 1 failed** — only the known pre-existing `api-routes-extended.test.ts > "calls Anthropic API and returns response"` (verified failing identically on `19e6c7c9`).
- `pytest -q` from the root: **8878 passed, 1 skipped**.
- `pytest cloud/tests`: the 35 macOS-local failures in `test_bootstrap_control_plane.py` / `test_ib_gateway_control.py` / `test_integration.py` are identical on `19e6c7c9`; no caddy test fails.
- `eslint` and `tsc --noEmit` clean on every changed file (the two `turnSteps.ts` TS1117 errors are pre-existing and untouched).

## After merge

`cloud/caddy/Caddyfile` ships with the deploy as of `19e6c7c9` — look for `Edge config matches cloud/caddy/Caddyfile` in the deploy log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nVvKvpEXYszv9coXt8a5i
