### PR TITLE
fix(knowledge): retry FTS-only after a hybrid timeout, warm the embedder at boot

### DIFF
--- a/scripts/api/server.py
+++ b/scripts/api/server.py
@@ -800,6 +800,7 @@ async def lifespan(app: FastAPI):
     # Journal reconciliation still runs once at startup because trade-fill
     # rehydration is lifecycle-bound, not periodic.
     lifecycle_tasks.append(asyncio.create_task(_warm_journal_reconciliation_on_startup()))
+    lifecycle_tasks.append(asyncio.create_task(_warm_knowledge_embedder_on_startup()))
 
     try:
         yield
@@ -1350,6 +1351,19 @@ async def _warm_journal_reconciliation_on_startup() -> None:
         logger.info("Journal startup reconcile complete")
     else:
         logger.warning("Journal startup reconcile failed: %s", result.error)
+
+
+async def _warm_knowledge_embedder_on_startup() -> None:
+    """Load the ~67 MB fastembed ONNX model off the event loop at boot so the
+    first /knowledge request after a deploy does not pay the cold load plus
+    fastembed's Hugging Face cache checks in-request (2026-08-30 03:04Z).
+    get_embedder caches the result (or None) for every later call."""
+    if test_mode:
+        return  # demo VM never serves the corpus; don't hold the model in RAM
+    embedder = await asyncio.to_thread(get_embedder)
+    logger.info(
+        "knowledge: embedder %s", "warm" if embedder else "unavailable, FTS-only"
+    )
 
 
 # Phase 6: _warm_cri_cache_on_startup and _warm_gex_cache_on_startup were
@@ -6012,6 +6026,14 @@ def _knowledge_search_in_thread(
         except db_http.DbHttpError:
             if attempt >= _KNOWLEDGE_RETRIEVAL_ATTEMPTS:
                 raise
+            if query_embedding is not None:
+                # vector_top_k over the ANN index is the statement that blows
+                # the Hrana bound under load (0.3-1.6s normally, >4s on a
+                # cold or busy host; 2026-08-30 03:05Z post-deploy 503s).
+                # Retry without the leg that just timed out rather than
+                # re-running it.
+                logger.warning("knowledge: hybrid retrieval timed out; retrying FTS-only")
+                query_embedding = None
             time.sleep(_KNOWLEDGE_RETRY_BACKOFF_SECS)
     retrieval = "hybrid" if query_embedding is not None else "fts-only"
     return results, retrieval

--- a/scripts/api/tests/test_knowledge_routes.py
+++ b/scripts/api/tests/test_knowledge_routes.py
@@ -570,3 +570,57 @@ def test_build_embedder_keeps_explicit_cache_path(monkeypatch, capsys):
 
     assert embed_mod._build_embedder() is None
     assert os.environ["FASTEMBED_CACHE_PATH"] == "/custom/fastembed-cache"
+
+
+# ── FTS-only fallback + startup warm (2026-08-30 03:05Z post-deploy 503s) ──
+
+
+def test_search_retries_fts_only_after_hybrid_db_error(client, monkeypatch, no_backoff):
+    """The vector leg is the statement that blows the Hrana bound under
+    load; the retry must drop it instead of re-running it."""
+    from scripts.api import server
+
+    embeddings: list = []
+
+    def flaky_hybrid_search(db, query, *, query_embedding=None, **_kwargs):
+        embeddings.append(query_embedding)
+        if len(embeddings) == 1:
+            raise server.db_http.DbHttpError("timeout: _ssl.c:980 read timed out")
+        return [_kb_row()]
+
+    monkeypatch.setattr(server, "hybrid_search", flaky_hybrid_search)
+    monkeypatch.setattr(server, "get_embedder", lambda: lambda texts: [EMBEDDING for _ in texts])
+
+    response = client.post("/knowledge/search", json={"query": "3 DTE risk reversals"})
+
+    assert response.status_code == 200
+    assert embeddings == [EMBEDDING, None]
+    assert response.json()["retrieval"] == "fts-only"
+
+
+@pytest.mark.asyncio
+async def test_warm_knowledge_embedder_on_startup_loads_off_loop(monkeypatch):
+    from scripts.api import server
+
+    calls: list[str] = []
+    monkeypatch.setattr(server, "test_mode", False)
+    monkeypatch.setattr(server, "get_embedder", lambda: calls.append("built") or (lambda t: []))
+
+    await server._warm_knowledge_embedder_on_startup()
+
+    assert calls == ["built"]
+
+
+@pytest.mark.asyncio
+async def test_warm_knowledge_embedder_skipped_in_test_mode(monkeypatch):
+    from scripts.api import server
+
+    monkeypatch.setattr(server, "test_mode", True)
+    monkeypatch.setattr(server, "get_embedder", lambda: pytest.fail("demo VM must not load the model"))
+
+    await server._warm_knowledge_embedder_on_startup()
+
+
+def test_lifespan_schedules_knowledge_embedder_warm():
+    source = (Path(__file__).resolve().parents[1] / "server.py").read_text(encoding="utf-8")
+    assert "asyncio.create_task(_warm_knowledge_embedder_on_startup())" in source


### PR DESCRIPTION
## Summary
- 2026-08-30 03:05Z (11 min after the `f79593fd` deploy) two `/knowledge/search` calls 503'd with `TimeoutError: The read operation timed out` and the assistant reported "Knowledge base is down". Timing the legs on the VPS: FTS 0.2-0.6s, candidate fetch 0.1-0.4s, `vector_top_k` 0.3-1.6s normally and >4s cold/busy, i.e. the vector leg is what blows the 4s Hrana bound, and the retry re-ran it.
- Retry now drops the vector leg: attempt 2 runs FTS-only and the response reports `retrieval: "fts-only"` instead of a 503. Both attempts failing still 503s.
- Lifespan warms `get_embedder()` off the event loop so the first post-deploy request no longer pays the ~67 MB ONNX load plus fastembed's Hugging Face cache checks in-request. Skipped in `test_mode` (demo VM never serves the corpus).

## Test plan
- [x] Red: 4 new tests fail on main (`test_search_retries_fts_only_after_hybrid_db_error`, two `_warm_knowledge_embedder_on_startup` tests, lifespan pin)
- [x] Green: `pytest scripts/api/tests/test_knowledge_routes.py scripts/tests/test_knowledge_*.py` → 199 passed; `test_journal_reconcile_startup_gate.py` passes
- [ ] After deploy: `docker logs radon-api.service | grep "knowledge: embedder warm"` within seconds of boot; a search during load logs `retrying FTS-only` and returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tL6SCTsyQuEFAoVwfzj8r
