### PR TITLE
feat(headlines): persist the hub ring in Turso so restarts keep the tape

### DIFF
--- a/scripts/db/migrations/0062_headlines_ring.sql
+++ b/scripts/db/migrations/0062_headlines_ring.sql
@@ -1,0 +1,19 @@
+-- 0062_headlines_ring.sql — durable copy of the MKTNews hub's headline ring
+--
+-- The hub (scripts/mktnews/hub.js) keeps the last RING_SIZE prints in memory
+-- and serves them as the handshake snapshot; this table lets a restart
+-- rehydrate that ring instead of serving an empty tape. Each ingest upserts
+-- one row and prunes everything past the newest RING_SIZE, so the table
+-- never grows beyond the ring. Not an archive.
+
+CREATE TABLE IF NOT EXISTS headlines_ring (
+  id          TEXT PRIMARY KEY,
+  time        TEXT,
+  important   INTEGER NOT NULL DEFAULT 0,
+  content     TEXT NOT NULL,
+  impact      TEXT NOT NULL DEFAULT '[]',
+  received_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_headlines_ring_received
+  ON headlines_ring (received_at DESC);

--- a/scripts/db/writer.js
+++ b/scripts/db/writer.js
@@ -106,7 +106,7 @@ function recordOperationFailure(label, err) {
 
 // Every Turso operation goes through here: circuit check, then up to
 // 1 + retryBackoffMs.length attempts on transport errors.
-async function withDbBounds(label, run) {
+export async function withDbBounds(label, run) {
   assertCircuitAllowsRequest(label);
   let lastErr;
   for (let attempt = 0; attempt <= bounds.retryBackoffMs.length; attempt++) {

--- a/scripts/mktnews/hub.js
+++ b/scripts/mktnews/hub.js
@@ -72,6 +72,7 @@ export function createHeadlinesHub({
   maxFrameBytes = MAX_FRAME_BYTES,
   delayFn = reconnectDelayMs,
   loadHistory = null,
+  store = null,
 } = {}) {
   const host = resolveHubListenHost(listenHost, security.bindHost);
   const ring = [];
@@ -85,12 +86,37 @@ export function createHeadlinesHub({
     if (!item) return false;
     const { content: _content, ...meta } = item;
     if (containsUpstreamHost(meta)) return false;
+    pushToRing(item);
+    persist(item);
+    for (const client of clients) sendJson(client, { type: "headline", item });
+    return true;
+  }
+
+  function pushToRing(item) {
     const existing = ring.findIndex((row) => row.id === item.id);
     if (existing >= 0) ring.splice(existing, 1);
     ring.push(item);
     while (ring.length > ringSize) ring.shift();
-    for (const client of clients) sendJson(client, { type: "headline", item });
-    return true;
+  }
+
+  function persist(item) {
+    if (!store) return;
+    Promise.resolve()
+      .then(() => store.put(item))
+      .catch((err) => {
+        process.stderr.write(`[mktnews] ring persist failed: ${err?.message ?? err}\n`);
+      });
+  }
+
+  async function restoreRing() {
+    if (!store || closed) return;
+    try {
+      const items = await store.load();
+      if (!Array.isArray(items)) return;
+      for (const item of items) pushToRing(item);
+    } catch (err) {
+      process.stderr.write(`[mktnews] ring restore failed: ${err?.message ?? err}\n`);
+    }
   }
 
   function ingestRaw(raw) {
@@ -191,6 +217,7 @@ export function createHeadlinesHub({
   }
 
   async function listen() {
+    await restoreRing();
     await seedRing();
     return new Promise((resolve) => {
       httpServer.listen(listenPort, host, () => {

--- a/scripts/mktnews/hub.test.js
+++ b/scripts/mktnews/hub.test.js
@@ -313,6 +313,58 @@ describe("createHeadlinesHub", () => {
     expect(snap.type).toBe("snapshot");
   });
 
+  it("restores the ring from the store before the first snapshot, oldest-first", async () => {
+    const stored = [
+      { kind: "headline", id: "s1", time: null, important: false, content: "stored one", impact: [] },
+      { kind: "headline", id: "s2", time: null, important: true, content: "stored two", impact: [] },
+    ];
+    const puts = [];
+    const hub = await boot({
+      store: { load: async () => stored, put: async (item) => puts.push(item.id) },
+      loadHistory: async () => [
+        parseFrame(JSON.stringify({ type: "flash", data: { id: "u1", data: { content: "upstream" } } })),
+      ],
+    });
+    const ws = new WebSocket(hub.address());
+    const [snapshot] = await collect(ws, 1);
+    ws.close();
+    expect(snapshot.items.map((row) => row.id)).toEqual(["s1", "s2", "u1"]);
+    expect(puts).toEqual(["u1"]);
+  });
+
+  it("persists every ingested print through the store", async () => {
+    const puts = [];
+    const hub = await boot({ store: { load: async () => [], put: async (item) => puts.push(item) } });
+    hub.ingest(parseFrame(JSON.stringify(FLASH)));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(puts).toEqual([
+      {
+        kind: "headline",
+        id: "h1",
+        time: "2026-08-29T20:35:56.000Z",
+        important: true,
+        content: "Explosions heard in Kyiv.",
+        impact: [{ symbol: "WTI", impact: "bearish" }],
+      },
+    ]);
+  });
+
+  it("still boots and fans out when the store is down", async () => {
+    const hub = await boot({
+      store: {
+        load: async () => {
+          throw new Error("turso unreachable");
+        },
+        put: async () => {
+          throw new Error("turso unreachable");
+        },
+      },
+    });
+    expect(hub.ingest(parseFrame(JSON.stringify(FLASH)))).toBe(true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(hub.ring.map((row) => row.id)).toEqual(["h1"]);
+  });
+
   it("caps the ring", async () => {
     const hub = await boot({ ringSize: 3 });
     for (let i = 0; i < 6; i += 1) {

--- a/scripts/mktnews/index.js
+++ b/scripts/mktnews/index.js
@@ -14,6 +14,7 @@ import { parseArgs } from "./cli.js";
 import { connectMktnews } from "./client.js";
 import { formatMessage } from "./format.js";
 import { DEFAULT_LISTEN_PORT, startHeadlinesHub } from "./hub.js";
+import { createHeadlinesStore } from "./store.js";
 
 export function runTap({
   argv = process.argv.slice(2),
@@ -64,12 +65,19 @@ export function runTap({
   return { stop, controller };
 }
 
+function resolveRingStore() {
+  if (process.env.TURSO_DB_URL) return createHeadlinesStore();
+  process.stderr.write("[mktnews] TURSO_DB_URL unset; ring will not survive restarts\n");
+  return null;
+}
+
 const isMain = process.argv[1] && process.argv[1].endsWith("mktnews/index.js");
 if (isMain) {
   const opts = parseArgs(process.argv.slice(2));
   if (opts.serve) {
     const hub = await startHeadlinesHub({
       listenPort: opts.port ?? DEFAULT_LISTEN_PORT,
+      store: resolveRingStore(),
     });
     process.stderr.write(`[mktnews] hub ${hub.address()}\n`);
     const shutdown = () => {

--- a/scripts/mktnews/store.js
+++ b/scripts/mktnews/store.js
@@ -1,0 +1,79 @@
+import { getDb, withDbBounds } from "../db/writer.js";
+import { RING_SIZE } from "./normalize.js";
+
+const UPSERT_SQL = `INSERT INTO headlines_ring (id, time, important, content, impact, received_at)
+  VALUES (?, ?, ?, ?, ?, ?)
+  ON CONFLICT(id) DO UPDATE SET
+    time        = excluded.time,
+    important   = excluded.important,
+    content     = excluded.content,
+    impact      = excluded.impact,
+    received_at = excluded.received_at`;
+
+const PRUNE_SQL = `DELETE FROM headlines_ring WHERE id NOT IN (
+  SELECT id FROM headlines_ring ORDER BY received_at DESC, rowid DESC LIMIT ?)`;
+
+const NEWEST_SQL = `SELECT id, time, important, content, impact
+  FROM headlines_ring ORDER BY received_at DESC, rowid DESC LIMIT ?`;
+
+function parseImpact(raw) {
+  try {
+    const parsed = JSON.parse(raw ?? "[]");
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function rowToHeadline(row) {
+  return {
+    kind: "headline",
+    id: String(row.id),
+    time: row.time == null ? null : String(row.time),
+    important: Number(row.important) === 1,
+    content: String(row.content),
+    impact: parseImpact(row.impact),
+  };
+}
+
+// Durable mirror of the hub ring: `load()` returns the newest `ringSize`
+// headlines oldest-first (ring order); `put(item)` upserts one print and
+// prunes the table back to `ringSize` in the same write batch.
+export function createHeadlinesStore({
+  db = null,
+  ringSize = RING_SIZE,
+  now = () => new Date().toISOString(),
+} = {}) {
+  const client = () => db ?? getDb();
+
+  async function load() {
+    const result = await withDbBounds("headlinesRing.load", () =>
+      client().execute({ sql: NEWEST_SQL, args: [ringSize] }),
+    );
+    return result.rows.map(rowToHeadline).reverse();
+  }
+
+  async function put(item) {
+    await withDbBounds("headlinesRing.put", () =>
+      client().batch(
+        [
+          {
+            sql: UPSERT_SQL,
+            args: [
+              item.id,
+              item.time ?? null,
+              item.important ? 1 : 0,
+              item.content,
+              JSON.stringify(item.impact ?? []),
+              now(),
+            ],
+          },
+          { sql: PRUNE_SQL, args: [ringSize] },
+        ],
+        "write",
+      ),
+    );
+  }
+
+  return { load, put };
+}

--- a/scripts/mktnews/store.test.js
+++ b/scripts/mktnews/store.test.js
@@ -1,0 +1,81 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createClient } from "@libsql/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createHeadlinesStore } from "./store.js";
+
+const MIGRATION = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../db/migrations/0062_headlines_ring.sql",
+);
+
+function statements(sql) {
+  return sql
+    .split("\n")
+    .filter((line) => !line.trim().startsWith("--"))
+    .join("\n")
+    .split(/;\s*$/m)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function headline(id, extra = {}) {
+  return {
+    kind: "headline",
+    id,
+    time: `2026-08-30T03:00:0${id.slice(-1)}.000Z`,
+    important: false,
+    content: `print ${id}`,
+    impact: [],
+    ...extra,
+  };
+}
+
+describe("createHeadlinesStore", () => {
+  let db;
+  let tick;
+  let store;
+
+  beforeEach(async () => {
+    db = createClient({ url: ":memory:" });
+    for (const stmt of statements(fs.readFileSync(MIGRATION, "utf8"))) await db.execute(stmt);
+    tick = 0;
+    store = createHeadlinesStore({
+      db,
+      ringSize: 3,
+      now: () => `2026-08-30T04:00:${String(tick++).padStart(2, "0")}.000Z`,
+    });
+  });
+
+  afterEach(() => db.close());
+
+  it("loads the newest ringSize prints oldest-first and prunes the rest", async () => {
+    for (const id of ["h1", "h2", "h3", "h4"]) await store.put(headline(id));
+    expect((await store.load()).map((row) => row.id)).toEqual(["h2", "h3", "h4"]);
+    const count = await db.execute("SELECT COUNT(*) AS n FROM headlines_ring");
+    expect(Number(count.rows[0].n)).toBe(3);
+  });
+
+  it("re-putting an id moves it to the newest slot instead of duplicating", async () => {
+    for (const id of ["h1", "h2", "h3"]) await store.put(headline(id));
+    await store.put(headline("h1", { content: "print h1 (updated)" }));
+    const rows = await store.load();
+    expect(rows.map((row) => row.id)).toEqual(["h2", "h3", "h1"]);
+    expect(rows[2].content).toBe("print h1 (updated)");
+  });
+
+  it("round-trips the headline shape the hub fans out", async () => {
+    const item = headline("h7", {
+      important: true,
+      impact: [{ symbol: "WTI", impact: "bearish" }],
+    });
+    await store.put(item);
+    expect(await store.load()).toEqual([item]);
+  });
+
+  it("starts empty", async () => {
+    expect(await store.load()).toEqual([]);
+  });
+});

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -711,3 +711,12 @@ malformed pathspec — merge conflicts in files I never touched. Rules:
 ## 2026-08-29 - Done/Next format applies to background-job progress lines too
 
 - Second correction in one day: a background-job session narrated every step in prose ("Waiting on the ingestion implementer…", "Full vitest green: …") because the harness asks for narration. The harness "narrate" instruction sets WHEN to speak, not the SHAPE: every emitted message is still `**Done**` / `**Next**` bullets under 100 words. Fold the pre-tool line into a `**Done**` bullet or omit it.
+## 2026-08-29 - Every user-visible message is Done/Next, including mid-task and pre-tool-call lines
+
+- The format rule was followed on closing messages and dropped on every other turn: one-line narration before a tool call ("Pre-existing duplicate keys... bypassing"), progress lines after arming a monitor ("Checks running on #180; I'll merge when green"), and status replies to `Status` prompts all shipped as prose. The user reads ALL of them as output.
+- The rule at `CLAUDE.md` §Response Format says "Mid-task progress messages follow the same shape". A message that ends a turn while work continues in the background is a closing message. Use `**Done** / **Next**` there too; when nothing changed, one bullet.
+- The harness "say in a line what you're about to do" instruction does not override the repo format: fold that line into a single bullet or emit nothing and let the tool call's description carry it.
+
+## 2026-08-29 - Never round-trip a diff through `git diff > file` under the rtk hook
+
+- `git diff HEAD -- f > patch` was rewritten to `rtk git diff`, which emits a token-compacted summary, not a patch. The follow-up `git checkout HEAD -- f` then discarded the only copy of the edit. Use `rtk proxy git diff` (or `git stash`) when the bytes matter, and never checkout-revert a file before confirming the saved patch applies (`git apply --check`).


### PR DESCRIPTION
## What
The MKTNews hub ring (50 prints) lived only in process memory, so every deploy restarted `radon-mktnews` with an empty snapshot. This adds a `headlines_ring` table (migration `0062`) mirrored by `scripts/mktnews/store.js`:
- each ingest upserts the print and prunes the table back to `RING_SIZE` in one write batch, so the table never grows past the ring (not an archive)
- on boot the hub restores the ring from Turso before #177's upstream flash-history seed; store failures log and fall through so the hub still serves
- `withDbBounds` exported from `scripts/db/writer.js` so the store shares the circuit breaker
- `index.js --serve` wires the store only when `TURSO_DB_URL` is set

Migration applies via `radon-api.service` `ExecStartPre` (`migrate.py`); the hub unit is `After=radon-api.service`. Turso `MAX(version)` was 61 at authoring time, so 0062 is next.

## Verification
- Red: 2 hub tests failed without the hub wiring → green `npx vitest run scripts/mktnews` 50 passed (4 store tests run the real 0062 DDL on in-memory libsql)
- eslint clean on store/hub/index
- Post-deploy: `SELECT COUNT(*) FROM headlines_ring` > 0 and loopback snapshot non-empty after restart (checked in PR comment)

Also carries `tasks/lessons.md` (response-format-every-turn, rtk diff compaction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLh4Xvb7QoE61c8AjPTHVb