### PR TITLE
fix(cloud): hand docker an unquoted copy of /etc/radon/env

### DIFF
--- a/cloud/scripts/radon-app-runtime.sh
+++ b/cloud/scripts/radon-app-runtime.sh
@@ -248,6 +248,26 @@ start_notify_proxy() {
   return 71
 }
 
+# docker --env-file takes each line VERBATIM: there is no shell quoting, so
+# XAI_API_KEY='xai-…' reached the container WITH its quotes and xAI answered
+# 400 "Incorrect API key" (2026-08-30; six secrets in /etc/radon/env are
+# single-quoted because `set -a; . file` consumers need $-bearing values
+# quoted, see CLAUDE.md). Strip one matching pair of surrounding quotes per
+# line into a root-only copy under the runtime dir and hand docker that; the
+# host file stays the secret of record and is never rewritten.
+render_env_file() {
+  local unit="$1" out="${NOTIFY_PROXY_DIR}/${unit}.env"
+  mkdir -p "$NOTIFY_PROXY_DIR"
+  (
+    umask 077
+    sed -E \
+      -e "s/^([A-Za-z_][A-Za-z0-9_]*=)'(.*)'[[:space:]]*\$/\1\2/" \
+      -e 's/^([A-Za-z_][A-Za-z0-9_]*=)"(.*)"[[:space:]]*$/\1\2/' \
+      "$ENV_FILE" > "$out"
+  )
+  printf '%s\n' "$out"
+}
+
 cmd_run() {
   local unit="${1:-}"
   local ids image workdir
@@ -306,7 +326,7 @@ cmd_run() {
     --security-opt no-new-privileges \
     --cgroupns host \
     --cgroup-parent=system.slice \
-    --env-file "$ENV_FILE" \
+    --env-file "$(render_env_file "$unit")" \
     --env RADON_DB_NO_REPLICA=1 \
     --env PYTHONPATH=/home/radon/radon/scripts \
     -w "$workdir" \

--- a/cloud/tests/test_app_runtime.py
+++ b/cloud/tests/test_app_runtime.py
@@ -619,3 +619,45 @@ def test_run_newsfeed_points_media_delivery_at_the_mounted_volume(tmp_path: Path
     assert result.returncode == 0, result.stderr
     log = result.docker_log.read_text(encoding="utf-8")  # type: ignore[attr-defined]
     assert "RADON_MEDIA_REMOTE=/var/lib/radon/media/" in log, log
+
+
+# docker --env-file takes lines verbatim (no shell quoting), so a secret the
+# host file single-quotes for `set -a; . file` consumers reached the container
+# WITH its quotes: XAI_API_KEY='xai-…' → xAI 400 "Incorrect API key"
+# (2026-08-30 04:16Z, six quoted secrets in /etc/radon/env).
+
+
+def test_run_hands_docker_an_unquoted_root_only_copy_of_the_env_file(
+    tmp_path: Path,
+) -> None:
+    host_env = tmp_path / "secrets.env"
+    host_env.write_text(
+        "NODE_ENV=production\n"
+        "# comment stays\n"
+        "XAI_API_KEY='xai-abc$1'\n"
+        'TWS_PASSWORD="p@ss word"\n'
+        "MENTHORQ_PASS='it''s'\n"
+        "PLAIN=unquoted\n",
+        encoding="utf-8",
+    )
+    result = _run(
+        tmp_path, ["run", "radon-nextjs.service"],
+        extra_env={"RADON_TEST_ENV_FILE": str(host_env)},
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+
+    match = re.search(r"--env-file (\S+)", _run_line(result))
+    assert match, _run_line(result)
+    rendered = Path(match.group(1))
+    assert rendered != host_env
+    assert stat.S_IMODE(rendered.stat().st_mode) == 0o600
+    assert rendered.read_text(encoding="utf-8") == (
+        "NODE_ENV=production\n"
+        "# comment stays\n"
+        "XAI_API_KEY=xai-abc$1\n"
+        "TWS_PASSWORD=p@ss word\n"
+        "MENTHORQ_PASS=it''s\n"
+        "PLAIN=unquoted\n"
+    )
+    # The host file is the secret of record and is never rewritten.
+    assert "XAI_API_KEY='xai-abc$1'" in host_env.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Chat with model Grok 4.6 failed `xAI Grok request failed (400) Incorrect API key` (2026-08-30 04:16Z). Inside `radon-nextjs.service` the key is `'xai-…'` with literal single quotes: docker `--env-file` takes lines verbatim, and `/etc/radon/env` single-quotes six secrets (`TWS_PASSWORD`, `IB_FLEX_TOKEN`, `MENTHORQ_PASS`, `EQUIBLES_API_KEY`, `XAI_API_KEY`, `OPENAI_API_KEY`) for the `set -a; . file` consumers per CLAUDE.md.
- `radon-app-runtime` now renders a root-only 0600 copy under its runtime dir with one matching pair of surrounding quotes stripped per line and hands docker that. Host file untouched.
- Likely also clears `menthorq-login-probe` and `equibles-short-crowding` errors in `service_health`.

## Test plan
- [x] Red: `test_run_hands_docker_an_unquoted_root_only_copy_of_the_env_file` fails on main
- [x] Green: `pytest cloud/tests/test_app_runtime.py cloud/tests/test_app_plane_cutover_safety.py cloud/tests/test_deploy_and_setup.py` → 95 passed, 2 skipped
- [ ] After deploy: `docker exec radon-nextjs.service printenv XAI_API_KEY | cut -c1-4` → `xai-`; Grok 4.6 answers in the chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tL6SCTsyQuEFAoVwfzj8r
