### PR TITLE
fix(api): trust Hetzner private-net for broker watchdog /health

### DIFF
--- a/scripts/api/auth.py
+++ b/scripts/api/auth.py
@@ -22,24 +22,30 @@ from fastapi import Request, HTTPException, Depends
 logger = logging.getLogger("radon.auth")
 
 _TAILNET = ipaddress.ip_network("100.64.0.0/10")
+# Hetzner Cloud Network radon-private (app 10.0.0.2, broker 10.0.0.4).
+# NIC attachment is the authenticated channel, same class as the tailnet.
+# Do not widen to all RFC1918 — docker0 is 172.17.0.0/16.
+_HETZNER_PRIVATE = ipaddress.ip_network("10.0.0.0/16")
 
 
 def is_local_or_tailnet(host: str | None) -> bool:
-    """True for loopback or Tailscale CGNAT (RFC 6598) addresses.
+    """True for loopback, Tailscale CGNAT, or the Hetzner private net.
 
     Tailnet membership is itself an authenticated channel, so tailnet peers
     are treated as 'local' for server-to-server calls — this is what lets
     the laptop's Next.js (in cloud-thin mode) reach the Hetzner FastAPI
-    without forwarding a Clerk JWT.
+    without forwarding a Clerk JWT. After the broker/app split the watchdog
+    on 10.0.0.4 probes FastAPI on 10.0.0.2 the same way.
     """
     if host in ("127.0.0.1", "::1"):
         return True
     if not host:
         return False
     try:
-        return ipaddress.ip_address(host) in _TAILNET
+        address = ipaddress.ip_address(host)
     except ValueError:
         return False
+    return address in _TAILNET or address in _HETZNER_PRIVATE
 
 
 # Headers a reverse proxy adds when it forwards a request. Caddy sets

--- a/scripts/api/server.py
+++ b/scripts/api/server.py
@@ -950,6 +950,7 @@ if "pytest" in sys.modules:
 # `--host 0.0.0.0 ... 100.112.32.16:8321`), which TrustedHostMiddleware cannot
 # express: it matches whole names or one leading "*." only, never a CIDR.
 _TAILNET_CGNAT = ipaddress.ip_network("100.64.0.0/10")
+_HETZNER_PRIVATE = ipaddress.ip_network("10.0.0.0/16")
 
 
 def split_host_header(raw_host: str) -> Tuple[str, str]:
@@ -974,17 +975,24 @@ def split_host_header(raw_host: str) -> Tuple[str, str]:
 def is_pinned_ip_literal(hostname: str) -> bool:
     """True for the IP literals this API legitimately answers on.
 
-    Loopback (the Next.js / relay / watchdog hop) and the Tailscale CGNAT range
-    (the cloud-thin laptop). Allowing IP literals does not reopen DNS rebinding:
-    a rebind needs a NAME whose resolution the attacker controls, and a literal
-    resolves only to itself. Any other literal — a public address, a routable
-    IPv6 — is not a caller we serve and falls through to the name pin.
+    Loopback (the Next.js / relay / watchdog hop), the Tailscale CGNAT range
+    (the cloud-thin laptop), and the Hetzner private net (broker watchdog at
+    10.0.0.4 hitting app 10.0.0.2). Allowing IP literals does not reopen DNS
+    rebinding: a rebind needs a NAME whose resolution the attacker controls,
+    and a literal resolves only to itself. Any other literal — a public
+    address, a routable IPv6, docker0 — is not a caller we serve and falls
+    through to the name pin.
     """
     try:
         address = ipaddress.ip_address(hostname)
     except ValueError:
         return False
-    return address.is_loopback or address.is_unspecified or address in _TAILNET_CGNAT
+    return (
+        address.is_loopback
+        or address.is_unspecified
+        or address in _TAILNET_CGNAT
+        or address in _HETZNER_PRIVATE
+    )
 
 
 # Carried on the per-request ASGI scope (never on scope["state"], which some

--- a/scripts/api/tests/test_auth.py
+++ b/scripts/api/tests/test_auth.py
@@ -168,6 +168,19 @@ class TestIsLocalOrTailnet:
     def test_garbage_false(self):
         assert is_local_or_tailnet("not-an-ip") is False
 
+    def test_hetzner_private_net_true(self):
+        # radon-private: app 10.0.0.2, broker 10.0.0.4. Same trust class as
+        # the tailnet — NIC attachment is the authenticated channel.
+        assert is_local_or_tailnet("10.0.0.2") is True
+        assert is_local_or_tailnet("10.0.0.4") is True
+        assert is_local_or_tailnet("10.0.255.255") is True
+
+    def test_other_rfc1918_false(self):
+        # docker0 is 172.17.0.0/16. Do not widen to all RFC1918.
+        assert is_local_or_tailnet("10.1.0.1") is False
+        assert is_local_or_tailnet("172.17.0.1") is False
+        assert is_local_or_tailnet("192.168.1.1") is False
+
 
 class TestIsTrustedLocalRequest:
     """The server-to-server bypass must apply ONLY to genuine local/tailnet
@@ -186,6 +199,13 @@ class TestIsTrustedLocalRequest:
 
     def test_tailnet_without_forwarding_is_trusted(self):
         assert is_trusted_local_request(_FakeRequest(host="100.100.5.5")) is True
+
+    def test_hetzner_private_without_forwarding_is_trusted(self):
+        assert is_trusted_local_request(_FakeRequest(host="10.0.0.4")) is True
+
+    def test_hetzner_private_with_forwarding_not_trusted(self):
+        req = _FakeRequest(host="10.0.0.4", extra_headers={"X-Forwarded-For": "8.8.8.8"})
+        assert is_trusted_local_request(req) is False
 
     def test_loopback_with_x_forwarded_for_not_trusted(self):
         req = _FakeRequest(host="127.0.0.1", extra_headers={"X-Forwarded-For": "8.8.8.8"})

--- a/scripts/api/tests/test_health_payload.py
+++ b/scripts/api/tests/test_health_payload.py
@@ -96,6 +96,19 @@ class TestHealthPayloadScoping:
 
         assert result["ib_gateway"]["auth_state"] == "awaiting_2fa"
 
+    @pytest.mark.asyncio
+    async def test_trusted_hetzner_private_caller_gets_full_payload(self, monkeypatch):
+        async def _gw(*args, **kwargs):
+            return {"auth_state": "authenticated", "host": "10.0.0.4"}
+
+        monkeypatch.setattr(server, "check_ib_gateway", _gw)
+        monkeypatch.setattr(server, "ib_pool", SimpleNamespace(status=lambda: {}))
+
+        req = _request("10.0.0.4")  # broker watchdog over radon-private
+        result = await server.health(req)
+
+        assert result["ib_gateway"]["auth_state"] == "authenticated"
+
 
 class TestHealthProbeBounding:
     """/health must NEVER hang. The IB gateway probe (check_ib_gateway) can block

--- a/scripts/tests/test_api_host_pin.py
+++ b/scripts/tests/test_api_host_pin.py
@@ -43,6 +43,8 @@ class TestLegitimateHostFormsAreServed:
             "[::1]:8321",  # how an IPv6 literal actually arrives
             "localhost:8321",
             "127.0.0.1:8321",
+            "10.0.0.2:8321",  # Hetzner private-net broker -> app /health
+            "10.0.0.4",
             "app.radon.run",
             "ib-gateway:8321",
         ],
@@ -61,6 +63,8 @@ class TestRebindingIsStillRefused:
             "100.128.0.1",  # one address past the CGNAT range
             "100.63.255.255",  # one address before it
             "203.0.113.9:8321",  # a public literal is not a tailnet peer
+            "10.1.0.1:8321",  # adjacent RFC1918, not radon-private
+            "172.17.0.1:8321",  # docker0
             "[2001:db8::1]:8321",  # a routable IPv6 literal is not loopback
         ],
     )


### PR DESCRIPTION
## Why
Broker/app split is live. Watchdog on `10.0.0.4` probes FastAPI on `10.0.0.2:8321/health`. That peer is not loopback or tailnet, so TrustedHost returns 400 and `/health` returns liveness-only. Watchdog then sits at `probe_unreachable:gateway_alive` and cannot see `auth_state`.

## What
Pin `10.0.0.0/16` (radon-private) the same way as Tailscale CGNAT for:
- `is_local_or_tailnet` (full `/health` payload, server-to-server bypass)
- `is_pinned_ip_literal` (Host `10.0.0.2` accepted)

Does **not** widen to `172.17.0.0/16` (docker0) or other RFC1918.

## Tests
`67 passed` on auth + health payload + host pin + loopback browser bypass.

## Deploy
App-only. Gateway stays on the broker; this restart does not 2FA.