### PR TITLE
fix(split): app role must not own Gateway after control-plane refresh

### DIFF
--- a/cloud/scripts/deploy-root-helper.sh
+++ b/cloud/scripts/deploy-root-helper.sh
@@ -237,6 +237,36 @@ root_ownership_matches() {
   fi
 }
 
+read_host_role() {
+  local role="${RADON_HOST_ROLE:-}"
+  local envf="${RADON_DEPLOY_ENV_FILE:-${CONTROL_PLANE_ROOT}/etc/radon/env}"
+  if [[ -z "$role" && -f "$envf" ]]; then
+    role="$(awk -F= '/^RADON_HOST_ROLE=/{v=$2} END{print v}' "$envf" 2>/dev/null || true)"
+    role="${role%\"}"
+    role="${role#\"}"
+    role="${role%\'}"
+    role="${role#\'}"
+    role="${role//$'\r'/}"
+  fi
+  case "$role" in
+    app|broker|combined) printf '%s\n' "$role" ;;
+    *) printf 'combined\n' ;;
+  esac
+}
+
+app_skips_control_plane_source() {
+  [[ "$(read_host_role)" == "app" ]] || return 1
+  case "$1" in
+    scripts/ib-gateway-control.sh|\
+    services/radon-ib-gateway.service|\
+    services/radon-ib-gateway-preheld-restart.service|\
+    services/radon-ib-watchdog.service|\
+    services/radon-ib-watchdog.timer)
+      return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 verify_control_plane() {
   local line expected_hash source_rel logical_target installed_target installed_hash
   local index=0
@@ -261,6 +291,12 @@ verify_control_plane() {
       return 1
     fi
     installed_target="${CONTROL_PLANE_ROOT}${logical_target}"
+    if app_skips_control_plane_source "$source_rel"; then
+      if [[ ! -f "$installed_target" || -L "$installed_target" ]]; then
+        index=$((index + 1))
+        continue
+      fi
+    fi
     if [[ ! -f "$installed_target" || -L "$installed_target" ]]; then
       echo "installed control-plane target is unavailable or unsafe: ${logical_target}" >&2
       return 1
@@ -1313,6 +1349,16 @@ write_control_plane_manifest_and_ready() {
   for index in "${!CONTROL_PLANE_SOURCES[@]}"; do
     source_rel="${CONTROL_PLANE_SOURCES[$index]}"
     dest="${CONTROL_PLANE_ROOT}${CONTROL_PLANE_TARGETS[$index]}"
+    if app_skips_control_plane_source "$source_rel" && \
+       [[ ! -f "$dest" || -L "$dest" ]]; then
+      digest="$(file_sha256 "${CLOUD_SOURCE}/${source_rel}")" || {
+        "$RM" -f "$tmp_manifest"
+        return 73
+      }
+      printf '%s  %s -> %s\n' "$digest" "$source_rel" "${CONTROL_PLANE_TARGETS[$index]}" \
+        >> "$tmp_manifest"
+      continue
+    fi
     if [[ ! -f "$dest" || -L "$dest" ]]; then
       # Same rollback shape as the skip in refresh_control_plane: a drop-in that
       # this checkout does not ship, and that was never installed, is not a
@@ -1369,6 +1415,15 @@ refresh_control_plane() {
     source_rel="${CONTROL_PLANE_SOURCES[$index]}"
     source="${CLOUD_SOURCE}/${source_rel}"
     dest="${CONTROL_PLANE_ROOT}${CONTROL_PLANE_TARGETS[$index]}"
+    if app_skips_control_plane_source "$source_rel"; then
+      if [[ -f "$dest" && ! -L "$dest" ]]; then
+        "$RM" -f "$dest" || {
+          echo "failed to strip app-role gateway artifact: ${dest}" >&2
+          return 73
+        }
+      fi
+      continue
+    fi
     if [[ ! -f "$source" || -L "$source" ]]; then
       # A drop-in source is absent from every checkout before 702ae26a, and the
       # INSTALLED helper is always the newest one, so a rollback enumerates

--- a/cloud/scripts/ib-gateway-control.sh
+++ b/cloud/scripts/ib-gateway-control.sh
@@ -410,7 +410,32 @@ consume_watchdog_lease_once() {
   fi
 }
 
+read_host_role() {
+  local role="${RADON_HOST_ROLE:-}"
+  if [[ -z "$role" && -n "${ENV_FILE:-}" && -f "$ENV_FILE" ]]; then
+    role="$(awk -F= '/^RADON_HOST_ROLE=/{v=$2} END{print v}' "$ENV_FILE" 2>/dev/null || true)"
+    role="${role%\"}"
+    role="${role#\"}"
+    role="${role%\'}"
+    role="${role#\'}"
+    role="${role//$'\r'/}"
+  fi
+  case "$role" in
+    app|broker|combined) printf '%s\n' "$role" ;;
+    *) printf 'combined\n' ;;
+  esac
+}
+
+refuse_app_role_mutation() {
+  if [[ "$(read_host_role)" == "app" ]]; then
+    echo "REFUSING Gateway mutation: RADON_HOST_ROLE=app (broker owns the session)" >&2
+    return 1
+  fi
+  return 0
+}
+
 start_gateway() {
+  refuse_app_role_mutation || return 1
   reconcile_pending_transition
   if container_running; then
     echo "IB Gateway container already running; no lease acquired"
@@ -425,6 +450,7 @@ start_gateway() {
 }
 
 restart_gateway() {
+  refuse_app_role_mutation || return 1
   reconcile_pending_transition
   require_new_lease
   compose_to_state stopped restart-down down
@@ -437,6 +463,7 @@ restart_gateway() {
 
 restart_gateway_preheld() {
   local expected_holder="${1:-}"
+  refuse_app_role_mutation || return 1
   reconcile_pending_transition
   consume_watchdog_lease_once "$expected_holder"
   compose_to_state stopped preheld-down down

--- a/cloud/tests/test_ib_gateway_control.py
+++ b/cloud/tests/test_ib_gateway_control.py
@@ -121,6 +121,19 @@ def test_healthy_start_does_not_take_lease(control_env):
     assert "compose up" not in log.read_text()
 
 
+def test_app_role_refuses_start_even_if_container_is_stopped(control_env):
+    env, state, log, _lock = control_env
+    env["RADON_HOST_ROLE"] = "app"
+    state.write_text("stopped\n")
+
+    result = _run_control(env, "start")
+
+    assert result.returncode != 0
+    assert "RADON_HOST_ROLE=app" in result.stderr
+    assert state.read_text().strip() == "stopped"
+    assert not log.exists() or "compose up" not in log.read_text()
+
+
 def test_dead_container_start_acquires_lease_before_compose(control_env):
     env, state, log, lock = control_env
     state.write_text("stopped\n")

--- a/cloud/tests/test_refresh_control_plane.py
+++ b/cloud/tests/test_refresh_control_plane.py
@@ -287,6 +287,30 @@ def test_refresh_timeout_is_mutation_class_and_does_not_queue_radon_jobs() -> No
 # --- C. sandbox --------------------------------------------------------------
 
 
+def test_app_role_verify_allows_missing_gateway_helper(tmp_path: Path) -> None:
+    sandbox = Sandbox(tmp_path)
+    helper = sandbox.installed_path("scripts/ib-gateway-control.sh")
+    helper.unlink()
+    sandbox.env["RADON_HOST_ROLE"] = "app"
+    result = sandbox.run("verify-control-plane")
+    assert result.returncode == 0, result.stderr
+
+
+def test_app_role_refresh_removes_gateway_helper(tmp_path: Path) -> None:
+    sandbox = Sandbox(tmp_path)
+    helper = sandbox.installed_path("scripts/ib-gateway-control.sh")
+    unit = sandbox.installed_path("services/radon-ib-gateway.service")
+    assert helper.exists()
+    assert unit.exists()
+    sandbox.env["RADON_HOST_ROLE"] = "app"
+    sandbox.mutate_source("scripts/ib-gateway-control.sh")
+    result = sandbox.run("refresh-control-plane-privileged")
+    assert result.returncode == 0, result.stderr
+    assert not helper.exists()
+    assert not unit.exists()
+    sandbox.assert_no_gateway_lifecycle()
+
+
 def test_unit_only_refresh_copies_diff_reloads_once_and_skips_gateway(tmp_path: Path) -> None:
     box = Sandbox(tmp_path)
     gateway = box.installed_path(GATEWAY_UNIT)

--- a/scripts/api/server.py
+++ b/scripts/api/server.py
@@ -2027,7 +2027,7 @@ def _gateway_unit_controllable() -> bool:
     RADON_HOST_ROLE=app must never own the session even if a deploy reinstalls
     the helper onto the app VM.
     """
-    if os.environ.get("RADON_HOST_ROLE") == "app":
+    if os.environ.get("RADON_HOST_ROLE", "combined") == "app":
         return False
     return (
         admin_services.is_systemd_available()

--- a/scripts/api/server.py
+++ b/scripts/api/server.py
@@ -2022,7 +2022,13 @@ async def demo_trial_expiry(request: Request):
 def _gateway_unit_controllable() -> bool:
     """True when THIS host owns the gateway lifecycle: systemd is present and
     the installed control helper (single 2FA-lease owner) exists. True on the
-    Hetzner deployment, False on the laptop pointing at the remote gateway."""
+    Hetzner deployment, False on the laptop pointing at the remote gateway.
+
+    RADON_HOST_ROLE=app must never own the session even if a deploy reinstalls
+    the helper onto the app VM.
+    """
+    if os.environ.get("RADON_HOST_ROLE") == "app":
+        return False
     return (
         admin_services.is_systemd_available()
         and Path(admin_services.GATEWAY_CONTROL_PATH).exists()

--- a/scripts/api/tests/test_ib_restart_cloud_delegate.py
+++ b/scripts/api/tests/test_ib_restart_cloud_delegate.py
@@ -100,6 +100,19 @@ class TestCloudDelegate:
         assert resp.status_code == 503
         assert "remote" in resp.json()["detail"]["error"].lower()
 
+    def test_app_role_is_not_controllable_even_with_helper(self, monkeypatch, tmp_path):
+        helper = tmp_path / "radon-ib-gateway-control"
+        helper.write_text("#!/bin/sh\n")
+        helper.chmod(0o755)
+        monkeypatch.setattr(admin_services, "GATEWAY_CONTROL_PATH", str(helper))
+        monkeypatch.setattr(admin_services, "is_systemd_available", lambda: True)
+        monkeypatch.setenv("RADON_HOST_ROLE", "app")
+        assert server._gateway_unit_controllable() is False
+        monkeypatch.setenv("RADON_HOST_ROLE", "combined")
+        assert server._gateway_unit_controllable() is True
+        monkeypatch.setenv("RADON_HOST_ROLE", "broker")
+        assert server._gateway_unit_controllable() is True
+
     def test_service_action_maps_lease_conflict_to_409(self, client):
         with patch.object(
             admin_services, "control_unit", new=AsyncMock(return_value=_lease_held_result())


### PR DESCRIPTION
## Why
PR 192 deployed clean (`e19b8d29`) and IB stayed authenticated on the broker. That same deploy reinstalled `/usr/local/bin/radon-ib-gateway-control` on the **app** host because control-plane refresh always copies it. FastAPI treats helper-exists as lifecycle ownership (`_gateway_unit_controllable`), which would start a second IBKR session.

## What
- `_gateway_unit_controllable` is false when `RADON_HOST_ROLE=app`
- `radon-ib-gateway-control` refuses start/restart on app (stop still allowed for a stray container)
- app-role refresh strips Gateway helper + units; verify allows them to be absent

## Tests
Focused green: restart delegate, helper refuse, refresh strip/verify skip.
macOS bash 3.2 `mapfile` failures in `test_ib_gateway_control.py` are the known darwin baseline; CI is Ubuntu.

## Deploy
App-only. Does not 2FA. After this lands, a later deploy removes the helper from the app host.