### PR TITLE
fix(split): operator CLI and admin Gateway controls follow host role

### DIFF
--- a/cloud/scripts/operator-radon.sh
+++ b/cloud/scripts/operator-radon.sh
@@ -304,7 +304,6 @@ case "$HOST_ROLE" in
   broker)
     REQUIRED_UNITS=(
       radon-ib-gateway.service
-      radon-health.service
     )
     ;;
   *)
@@ -432,6 +431,16 @@ systemctl_many() {
   return "$rc"
 }
 
+emit_stack_result() {
+  local verb="$1"
+  local count="$2"
+  if [[ "$HOST_ROLE" == "app" ]]; then
+    echo "${verb} ${count} app-plane radon units. Gateway stays on the broker."
+  else
+    echo "${verb} Gateway and ${count} radon units"
+  fi
+}
+
 case "$requested_action" in
   stop)
     STOP_UNITS=()
@@ -447,7 +456,7 @@ case "$requested_action" in
     if [[ "$HOST_ROLE" != "app" ]]; then
       gateway_control stop
     fi
-    echo "stopped Gateway and ${#STOP_UNITS[@]} active radon units"
+    emit_stack_result "stopped" "${#STOP_UNITS[@]}"
     ;;
   start)
     if [[ -f "$TOPOLOGY_PATH" ]]; then
@@ -466,7 +475,7 @@ case "$requested_action" in
     fi
     systemctl_many start "${START_UNITS[@]}"
     rm -f "$TOPOLOGY_PATH"
-    echo "started Gateway and ${#START_UNITS[@]} radon units"
+    emit_stack_result "started" "${#START_UNITS[@]}"
     ;;
   restart)
     mapfile -t RESTART_UNITS < <(
@@ -480,13 +489,15 @@ case "$requested_action" in
       gateway_control restart
     fi
     systemctl_many restart "${RESTART_UNITS[@]}"
-    echo "restarted Gateway and ${#RESTART_UNITS[@]} radon units"
+    emit_stack_result "restarted" "${#RESTART_UNITS[@]}"
     ;;
   status)
     run_bounded "$SYSTEMCTL_QUERY_TIMEOUT_SECS" \
       systemctl list-units 'radon-*' --all --no-pager --no-legend
     gateway_status=0
-    if [[ "$HOST_ROLE" != "app" ]]; then
+    if [[ "$HOST_ROLE" == "app" ]]; then
+      echo "ib-gateway-container: broker (not this host)"
+    else
       printf 'ib-gateway-container: '
       gateway_control status || gateway_status=$?
     fi

--- a/cloud/tests/test_host_role_split.py
+++ b/cloud/tests/test_host_role_split.py
@@ -247,11 +247,29 @@ class TestOperatorHostRole:
         assert "radon-ib-gateway.service" in broker
         assert "radon-nextjs.service" not in broker
 
+    def test_broker_role_does_not_require_health(self):
+        body = OPERATOR.read_text(encoding="utf-8")
+        match = re.search(
+            r"broker\)\s*REQUIRED_UNITS=\((.*?)\)\s*;;",
+            body,
+            re.DOTALL,
+        )
+        assert match, "broker REQUIRED_UNITS block missing"
+        required = match.group(1)
+        assert "radon-ib-gateway.service" in required
+        assert "radon-health.service" not in required
+        assert "radon-api.service" not in required
+
     def test_app_role_skips_gateway_control(self):
         body = OPERATOR.read_text(encoding="utf-8")
         assert 'HOST_ROLE" != "app"' in body or "HOST_ROLE != app" in body.replace(
             " ", ""
         )
+
+    def test_app_role_copy_does_not_claim_gateway_cycle(self):
+        body = OPERATOR.read_text(encoding="utf-8")
+        assert "Gateway stays on the broker" in body
+        assert "app-plane radon units" in body
 
 
 class TestDeployHostRole:

--- a/docs/spof-host-split.md
+++ b/docs/spof-host-split.md
@@ -108,6 +108,15 @@ App VM (current box):
 Move window is off RTH plus one Mobile tap on the broker. App deploy must
 leave `auth_state=authenticated` on 4001.
 
+Operator commands after the cut:
+
+- App: `ssh root@ib-gateway radon {start|stop|restart|status}`
+  App-plane only. Does not cycle Gateway.
+- Broker: `ssh root@<broker> radon {start|stop|restart|status}`
+  Gateway via `radon-ib-gateway-control`. Does not require radon-health.
+- Admin page Force 2FA / Stop / Start Gateway is hidden on the app host.
+  Do not POST `/api/admin/services/radon-ib-gateway.service/*` there.
+
 Do not put the broker in Falkenstein. Do not run two Gateways. Do not
 restore a broker snapshot beside a live broker. Do not start a standby
 FastAPI pool against a live Gateway.

--- a/scripts/api/server.py
+++ b/scripts/api/server.py
@@ -1911,6 +1911,7 @@ async def health(request: Request):
     return {
         "status": "ok",
         "test_mode": test_mode,
+        "host_role": admin_services.host_role(),
         "ib_gateway": gw,
         "ib_pool": pool_status or {},
         "uw": uw_available,
@@ -2112,6 +2113,7 @@ async def admin_services_list():
     units = await admin_services.list_units_with_status()
     return {
         "supported": supported,
+        "host_role": admin_services.host_role(),
         "units": [u.to_dict() for u in units],
     }
 

--- a/scripts/api/services.py
+++ b/scripts/api/services.py
@@ -100,6 +100,14 @@ def is_valid_unit(unit: str) -> bool:
     return unit not in _INTERNAL_UNITS and bool(_UNIT_PATTERN.match(unit))
 
 
+def host_role() -> str:
+    """RADON_HOST_ROLE for this process. Unset or garbage is combined."""
+    raw = (os.environ.get("RADON_HOST_ROLE") or "combined").strip().strip("\"'")
+    if raw in {"app", "broker", "combined"}:
+        return raw
+    return "combined"
+
+
 def is_systemd_available() -> bool:
     """True when this host can run ``systemctl`` against ``radon-*`` units.
 
@@ -327,6 +335,10 @@ async def show_unit(unit: str) -> UnitStatus:
     if unit != GATEWAY_UNIT:
         return status
 
+    if host_role() == "app":
+        status.can_control = False
+        return status
+
     # A Type=oneshot/RemainAfterExit wrapper can stay active (exited) after
     # the Docker container dies. Never surface that stale unit state as a
     # healthy Gateway; ask the authoritative helper for the real container.
@@ -494,6 +506,14 @@ def is_gateway_control_available() -> bool:
 
 async def _control_gateway(action: str) -> ActionResult:
     """Delegate Gateway lifecycle to the helper that owns lease acquisition."""
+    if host_role() == "app":
+        return ActionResult(
+            GATEWAY_UNIT,
+            action,
+            False,
+            "RADON_HOST_ROLE=app. Gateway lifecycle is on the broker.",
+            -1,
+        )
     if not is_gateway_control_available():
         return ActionResult(
             GATEWAY_UNIT,

--- a/scripts/api/tests/test_health_payload.py
+++ b/scripts/api/tests/test_health_payload.py
@@ -32,7 +32,7 @@ def _request(host, extra_headers=None):
 
 
 # Fields that must never reach an untrusted caller.
-_SENSITIVE_KEYS = {"ib_gateway", "ib_pool", "auth_state", "managed_accounts", "restart_backoff"}
+_SENSITIVE_KEYS = {"ib_gateway", "ib_pool", "auth_state", "managed_accounts", "restart_backoff", "host_role"}
 
 
 class TestHealthPayloadScoping:
@@ -79,6 +79,7 @@ class TestHealthPayloadScoping:
         result = await server.health(req)
 
         assert result["status"] == "ok"
+        assert result["host_role"] in {"app", "broker", "combined"}
         assert result["ib_gateway"]["auth_state"] == "authenticated"
         assert result["ib_gateway"]["managed_accounts"] == ["U1234567"]
         assert result["ib_pool"] == {"sync": {"connected": True}}

--- a/scripts/api/tests/test_ib_restart_cloud_delegate.py
+++ b/scripts/api/tests/test_ib_restart_cloud_delegate.py
@@ -113,6 +113,27 @@ class TestCloudDelegate:
         monkeypatch.setenv("RADON_HOST_ROLE", "broker")
         assert server._gateway_unit_controllable() is True
 
+    def test_app_role_admin_gateway_restart_does_not_touch_helper(
+        self, client, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("RADON_HOST_ROLE", "app")
+        log = tmp_path / "gateway-helper.log"
+        helper = tmp_path / "radon-ib-gateway-control"
+        helper.write_text(
+            "#!/bin/sh\n"
+            f"printf '%s\\n' \"$*\" >> '{log}'\n"
+            "exit 0\n"
+        )
+        helper.chmod(0o755)
+        monkeypatch.setattr(admin_services, "GATEWAY_CONTROL_PATH", str(helper))
+        monkeypatch.setattr(admin_services, "is_systemd_available", lambda: True)
+        resp = client.post("/admin/services/radon-ib-gateway.service/restart")
+        assert resp.status_code == 400
+        detail = resp.json()["detail"]
+        assert detail["ok"] is False
+        assert "broker" in detail["detail"].lower()
+        assert not log.exists()
+
     def test_service_action_maps_lease_conflict_to_409(self, client):
         with patch.object(
             admin_services, "control_unit", new=AsyncMock(return_value=_lease_held_result())

--- a/scripts/api/tests/test_services.py
+++ b/scripts/api/tests/test_services.py
@@ -401,6 +401,20 @@ class TestControlUnitGatewayPushLock:
         assert helper_log.read_text().splitlines() == ["restart"]
         assert calls == []
 
+    def test_app_role_refuses_gateway_even_with_helper(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("RADON_HOST_ROLE", "app")
+        helper_log = self._install_helper(tmp_path, monkeypatch)
+        calls: list = []
+        result = self._control(self.GATEWAY, "restart", calls)
+
+        assert result.ok is False
+        assert result.returncode == -1
+        assert "broker" in result.detail.lower()
+        assert not helper_log.exists() or helper_log.read_text() == ""
+        assert calls == []
+
     def test_helper_deploy_lock_refusal_maps_to_conflict(
         self, tmp_path: Path, monkeypatch
     ) -> None:

--- a/web/components/admin/AdminWorkspace.tsx
+++ b/web/components/admin/AdminWorkspace.tsx
@@ -478,6 +478,7 @@ export default function AdminWorkspace() {
               onRestartStack={restartStack}
               gatewayUnit={units.find((u) => u.unit === "radon-ib-gateway.service") ?? null}
               servicesSupported={services?.supported ?? false}
+              hostRole={services?.host_role ?? health?.host_role}
               onStopGateway={stopGateway}
               onStartGateway={restartStack}
               // Stopping the gateway cascade-stops radon-api — the very service

--- a/web/components/admin/Ib2faControls.tsx
+++ b/web/components/admin/Ib2faControls.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import type { AdminHealthPayload, UnitStatus } from "@/lib/adminTypes";
+import type { AdminHealthPayload, HostRole, UnitStatus } from "@/lib/adminTypes";
 import {
   forcePushDisabledReason,
   gatewayPowerState,
@@ -36,6 +36,8 @@ type Ib2faControlsProps = {
    *  unreachable, which is exactly what a gateway stop causes (cascade). The
    *  cached unit row then reads a stale value; treat the gateway as unknown. */
   apiUnreachable?: boolean;
+  /** App hosts must not cycle the broker Gateway. Unset means combined. */
+  hostRole?: HostRole;
   onAfter?: () => void;
 };
 
@@ -54,6 +56,7 @@ export default function Ib2faControls({
   onStopGateway,
   onStartGateway,
   apiUnreachable = false,
+  hostRole,
   onAfter,
 }: Ib2faControlsProps) {
   const [showForceConfirm, setShowForceConfirm] = useState(false);
@@ -103,6 +106,7 @@ export default function Ib2faControls({
     return () => clearTimeout(timer);
   }, [optimisticPower, polledPowerState]);
 
+  const ownsGatewayLifecycle = hostRole !== "app";
   const gatewayDependents = unitDependents(GATEWAY_UNIT);
   // Start triggers a fresh 2FA login, so gate it on the same push lock as
   // Force 2FA to keep two pushes from racing (feedback_2fa_push_stacking).
@@ -214,6 +218,7 @@ export default function Ib2faControls({
       </header>
 
       <div className="admin-actions-row">
+        {ownsGatewayLifecycle ? (
         <button
           type="button"
           className="admin-btn admin-btn-primary"
@@ -224,6 +229,7 @@ export default function Ib2faControls({
         >
           Force 2FA Push
         </button>
+        ) : null}
 
         <button
           type="button"
@@ -241,19 +247,30 @@ export default function Ib2faControls({
           className="admin-btn admin-btn-danger"
           onClick={() => setShowRestartConfirm(true)}
           disabled={pendingRestart}
-          title="Run radon restart on the VPS: stops then starts every radon-* unit in order"
+          title={
+            ownsGatewayLifecycle
+              ? "Run radon restart on the VPS: stops then starts every radon-* unit in order"
+              : "Run radon restart on this app host. Gateway stays on the broker."
+          }
           data-testid="restart-stack-button"
         >
           {pendingRestart ? "Restarting..." : "Restart All Services"}
         </button>
       </div>
 
-      {disableReason && (
+      {ownsGatewayLifecycle && disableReason && (
         <p className="admin-card-note" data-testid="force-2fa-disabled-reason">
           {disableReason}
         </p>
       )}
 
+      {!ownsGatewayLifecycle ? (
+        <p className="admin-card-note" data-testid="gateway-broker-note">
+          Gateway lifecycle is on the broker. This app host cannot Force 2FA, stop, or start IB Gateway. SSH to the broker and run radon-ib-gateway-control.
+        </p>
+      ) : null}
+
+      {ownsGatewayLifecycle ? (
       <div className="admin-gateway-power" data-testid="gateway-power">
         <span className="admin-card-note-inline">Gateway power</span>
         <p
@@ -285,6 +302,7 @@ export default function Ib2faControls({
           </p>
         )}
       </div>
+      ) : null}
 
       <ConfirmDialog
         open={showForceConfirm}
@@ -308,7 +326,11 @@ export default function Ib2faControls({
       <ConfirmDialog
         open={showRestartConfirm}
         title="Restart all radon services?"
-        body="Runs radon restart on the VPS: stops every radon-* systemd unit, then starts them in dependency order (IB Gateway first). Takes about 60 to 90 seconds. The page will briefly lose its connection while FastAPI cycles. IB Gateway will need a fresh 2FA approval on your phone when it comes back up."
+        body={
+          ownsGatewayLifecycle
+            ? "Runs radon restart on the VPS: stops every radon-* systemd unit, then starts them in dependency order (IB Gateway first). Takes about 60 to 90 seconds. The page will briefly lose its connection while FastAPI cycles. IB Gateway will need a fresh 2FA approval on your phone when it comes back up."
+            : "Runs radon restart on this app host. App-plane units only. Gateway stays on the broker. The page will briefly lose its connection while FastAPI cycles."
+        }
         confirmLabel="Restart all"
         destructive
         pending={pendingRestart}

--- a/web/lib/adminTypes.ts
+++ b/web/lib/adminTypes.ts
@@ -49,8 +49,11 @@ export type IbGatewayHealth = {
   container_health?: string;
 };
 
+export type HostRole = "app" | "broker" | "combined";
+
 export type AdminHealthPayload = {
   status: string;
+  host_role?: HostRole;
   ib_gateway: IbGatewayHealth;
   ib_pool: IbPoolStatus;
   uw?: boolean;
@@ -74,6 +77,7 @@ export type UnitStatus = {
 
 export type ServicesListResponse = {
   supported: boolean;
+  host_role?: HostRole;
   units: UnitStatus[];
 };
 

--- a/web/tests/admin-action-request-assertions.test.tsx
+++ b/web/tests/admin-action-request-assertions.test.tsx
@@ -199,6 +199,40 @@ describe("admin destructive actions reach the wire", () => {
     expect(sent[0].cache).toBe("no-store");
   });
 
+  it("sends no Gateway mutation when the host role is app", async () => {
+    const calls: RecordedCall[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        calls.push({ url, method: init?.method ?? "GET", cache: init?.cache });
+        if (url.endsWith("/api/admin/services") && (init?.method ?? "GET") === "GET") {
+          return jsonResponse({ ...SERVICES, host_role: "app" });
+        }
+        if (init?.method === "POST") {
+          return jsonResponse({ ok: true, detail: "done", returncode: 0 });
+        }
+        return jsonResponse(HEALTHY);
+      }),
+    );
+    render(<AdminWorkspace />);
+    await settle();
+
+    expect(screen.queryByTestId("force-2fa-button")).toBeNull();
+    expect(screen.queryByTestId("gateway-power-button")).toBeNull();
+    expect(screen.getByTestId("gateway-broker-note").textContent).toMatch(/broker/i);
+    expect(posts(calls)).toHaveLength(0);
+
+    await click("restart-stack-button");
+    expect(posts(calls)).toHaveLength(0);
+    await click("admin-confirm-action");
+    const sent = posts(calls);
+    expect(sent).toHaveLength(1);
+    expect(sent[0].url).toBe("/api/admin/stack/restart");
+    expect(sent.some((c) => c.url.includes("radon-ib-gateway"))).toBe(false);
+    expect(sent.some((c) => c.url === "/api/admin/ib/restart")).toBe(false);
+  });
+
   it("stops a service on the stop path, not the restart path", async () => {
     const calls = await renderWorkspace();
 


### PR DESCRIPTION
## Why
After the app/broker cut, `radon start` on the broker refused because it required `radon-health.service` (not installed there). App `radon` copy claimed it started Gateway. Admin Force 2FA / Stop / Start still POSTed Gateway mutations at the app host.

## What
- Broker required units: Gateway only
- App CLI copy: app-plane units, Gateway stays on the broker
- FastAPI `_control_gateway` refuses `RADON_HOST_ROLE=app` even with a helper
- `GET /admin/services` and trusted `/health` expose `host_role`
- Admin UI hides Force 2FA and Gateway power on app; Restart All Services stays app-plane

## Tests
- cloud host-role operator pins
- API helper is not invoked on app role (wire)
- admin action assertions: no Gateway POST when `host_role=app`; stack restart still hits `/api/admin/stack/restart`