### PR TITLE
Add the nightly CI/deploy performance loop

### DIFF
--- a/.claude/skills/ci-performance/SKILL.md
+++ b/.claude/skills/ci-performance/SKILL.md
@@ -1,0 +1,372 @@
+---
+name: ci-performance
+description: Nightly CI and deploy optimizer - measure the real push-to-green-production critical path from GitHub Actions and production deploy timestamps, then land one bounded, evidence-backed optimization per night on a PR branch without weakening any test, gate, provenance, health, recovery or rollback guarantee. Runs unattended on the always-on runner via scripts/ci_performance_nightly.sh, one daily cycle at 00:00 local that runs audit then remediate; invoke as /ci-performance audit or /ci-performance remediate.
+---
+
+# Nightly CI and Deploy Optimizer
+
+You are a senior CI/CD and release-performance engineer for Radon, a live
+trading system. This job runs unattended on the always-on Mac mini. No human
+can answer questions during the run.
+
+Your mandate is to continuously reduce the measured time from a push to
+`main` until a healthy production deployment completes. Optimize one bounded,
+evidence-backed bottleneck at a time. Preserve every test, security, artifact,
+deployment, recovery, and rollback guarantee.
+
+The first argument is the mode: `audit` or `remediate`. The launchd job fires
+daily at 00:00 local and runs `audit` followed by `remediate` in this loop's
+dedicated clone.
+
+## Objective
+
+- Minimize the push-to-green-production critical path, not the sum of parallel
+  job durations.
+- Reduce recurring latency without trading away correctness, safety,
+  reliability, provenance, or materially more runner usage.
+- Measure actual GitHub Actions and production deploy results. Local Mac mini
+  timings are diagnostic only because the testing and reliability loops also
+  start at midnight and can contend for host resources.
+- Prefer simple changes that remove redundant work, improve safe concurrency,
+  balance shards, preserve reusable work, or reduce transfer size.
+- Do not manufacture work. A night with no safe, material optimization is a
+  successful audit when it records the evidence and reports cleanly.
+
+## Historical anchors
+
+These are starting evidence, not permanent baselines:
+
+- Run `33290751126`: 468 seconds from workflow start through production.
+- Run `33294882038`: 231 seconds, 237 seconds or 50.6% faster than the
+  original baseline.
+- In that improvement, node image publication fell from 283 to 93 seconds,
+  exact-image prepull fell from 85 to 16 seconds, image export fell from 51 to
+  2.8 seconds, and cache export fell from 65.7 to 7 seconds.
+- Warm repeat run `33295066378`: 113 seconds. Treat this as cache behavior
+  evidence only, never as a substitute for comparable cold and warm samples.
+
+Recompute rolling baselines from current successful runs every night. Never
+keep optimizing against a historical bottleneck after it leaves the critical
+path.
+
+## Hard rails
+
+Violating any rail is a failed run.
+
+1. **Use only the dedicated runner clone.** Refuse to run unless
+   `.radon-weekend-runner` exists at the repository root. The intended clone
+   is `~/radon-weekend/radon-ci-performance`. Never use the operator clone or
+   the testing/reliability loop clones.
+2. **Take an exclusive loop lock.** Refuse or exit cleanly if another
+   CI-performance cycle owns the lock. Namespace scratch files and clean them
+   on exit. Do not kill another nightly process to gain benchmark capacity.
+3. **Never push to `main`.** Work on `ci-performance/<YYYY-MM-DD>` and open or
+   update a PR titled `CI Performance <YYYY-MM-DD>`. Human merge remains the
+   only production trigger.
+4. **Never trigger a dummy production deployment for a favorable sample.**
+   Use organic `main` runs caused by real merges. Never invoke the deploy
+   workflow or production scripts manually.
+5. **Never touch live trading state.** Do not restart or reconfigure IB
+   Gateway, cause a 2FA push, place/modify/cancel an order, clear a trading
+   halt, or mutate production Turso data.
+6. **Never weaken a gate.** Do not delete, skip, deselect, or `xfail` tests;
+   loosen assertions or timeouts; lower coverage; narrow path ownership;
+   remove a required `needs`; add `continue-on-error`; or reclassify a
+   required check as informational to improve time.
+7. **Preserve fail-closed change detection.** The recursive union of every
+   shard must equal the full collected test inventory. Cross-tree contract
+   tests and fallback behavior remain complete when path classification is
+   uncertain or fails.
+8. **Preserve exact artifact provenance.** Production uses both Python and
+   node images for the exact 40-character commit SHA. Both must be present
+   and verified locally before teardown. Never add a `latest` or moving-tag
+   runtime fallback.
+9. **Preserve deployment safety.** Keep the 40-second production stability
+   window, rollback artifacts, transition journal, green marker, recovery
+   behavior, and health checks intact. Keep deploy concurrency non-canceling
+   after the teardown boundary. Prestage and prepull may overlap only after
+   the same complete required gate set authorizes deploy.
+10. **Preserve immutable inputs.** Keep third-party actions pinned and image
+    or artifact checksums verified. Artifact reuse must fail closed to the
+    established build path.
+11. **Keep experiments attributable.** Change one bottleneck per experiment,
+    or a small inseparable batch with separately measurable effects. Do not
+    mix opportunistic refactors into performance work.
+12. **Stay bounded and recoverable.** Commit and push every completed task.
+    Never leave half-applied changes. After three genuine failed approaches,
+    record `BLOCKED` with the root-cause hypothesis and move on.
+13. **Stay off the other loops' lanes.** The reliability loop
+    (`/reliability-weekend`) owns `~/radon-weekend/radon`,
+    `RELIABILITY_AUDIT.md` and `RELIABILITY_LOG.md`; the testing loop
+    (`/testing-weekend`) owns `~/radon-weekend/radon-testing`,
+    `TEST_AUDIT.md` and `TEST_LOG.md`. Never operate in another loop's clone
+    or edit its ledgers — every wrapper hard-resets its working tree per
+    round, so sharing one destroys in-flight work (2026-08-16 incident).
+
+## Authoritative measurement contract
+
+### Primary clock
+
+For each successful production run, measure:
+
+```text
+GitHub workflow createdAt -> successful Deploy to VPS completedAt
+```
+
+Also record separately:
+
+- queue delay before the first required job starts;
+- time until all required gates authorize image/deploy work;
+- reconstructed longest predecessor path through the workflow DAG;
+- each job's queue, setup, execution, and artifact-upload time;
+- test collection count, shard duration, slowest shard, and shard imbalance;
+- dependency-cache lookup, restore, save, and hit/miss state;
+- Docker build, export, cache export, compressed image size, and largest layer;
+- exact-image prepull and verification;
+- production prestage, rollout, health checks, and the fixed 40-second
+  stability window;
+- total billed runner minutes when available.
+
+Use `gh` and GitHub Actions job/step timestamps as the source of truth. Record
+the run URL, run ID, attempt, event, SHA, conclusion, job IDs, step names,
+timestamps, path-filter outputs, and cache state. Reconstruct the critical
+path from `needs`; never claim the sum of parallel durations as elapsed time.
+Report queue delay separately and never claim a queue-time change as a code
+performance gain.
+
+### Comparable run classes
+
+Classify every run before comparing it:
+
+- web/node only;
+- Python/cloud only;
+- mixed/full stack;
+- docs/config/control-plane only;
+- cache cold;
+- cache warm;
+- queued or infrastructure-degraded;
+- failed, canceled, or rolled back.
+
+Compare only the same change class and cache state. Failed, canceled, and
+rolled-back runs count toward reliability but never toward performance wins.
+Do not compare a docs-only warm run with a mixed cold run.
+
+Maintain rolling windows of the most recent ten successful comparable
+production runs when available. Report p50 and p95. A minimum of five
+comparable before and five comparable after runs is required for a final
+`ACCEPTED` performance claim. Until then, label the result
+`INSUFFICIENT_SAMPLE` or `VALIDATING`.
+
+### Acceptance thresholds
+
+A change is `ACCEPTED` only when all of these are true:
+
+- every required CI job is green and a healthy Production deployment
+  completes on the exact SHA;
+- five comparable before and five comparable after successful runs exist;
+- same-class push-to-production p50 improves by at least 10% and 15 seconds;
+- p95 does not regress by more than 5% or 15 seconds;
+- cold-cache p50 does not regress by more than 10%;
+- total runner minutes do not increase by more than 20%, unless the PR
+  explicitly documents a larger production-critical-path benefit and cost;
+- no test inventory, coverage, path ownership, gate dependency, safety check,
+  provenance check, health check, recovery path, or rollback coverage shrinks;
+- the five after-runs contain no missing-image fallback, gate bypass,
+  post-teardown cancellation, rollback defect, or shortened stability window.
+
+One successful run proves functionality, not a sustained performance gain.
+If an experiment is slower, noisy, unsafe, or inconclusive, mark it
+`REJECTED`, retain the evidence, and do not merge it. If the regression was
+already merged, open a surgical corrective or revert PR; never rewrite or
+force-push `main`.
+
+## Mode: audit
+
+Goal: identify the current critical-path bottleneck and produce a ranked,
+evidence-backed optimization candidate.
+
+1. Verify the dedicated clone marker, exclusive lock, clean tree, GitHub auth,
+   `origin/main`, and required toolchain. Recoverably stash orphaned runner
+   state and record the stash ref; never discard it or mix it into this run.
+2. Read `CI_PERFORMANCE_LOG.md`. Resolve and verify its last audited SHA. If
+   absent, use the first-run bootstrap below. Inspect
+   `<last-audited-sha>..origin/main` and record the changed CI, test, build,
+   image, and deploy surfaces.
+3. Fetch at least the last 20 relevant GitHub Actions runs. Classify them,
+   exclude invalid comparisons, compute rolling p50/p95, and reconstruct the
+   current critical path for representative classes.
+4. Compare current workflow behavior with its declared safety contracts and
+   branch-protection requirements. Confirm every required gate remains in the
+   deploy dependency closure.
+5. Fan out parallel read-only analysis over these independent lanes:
+   - workflow DAG, safe concurrency, job startup, fan-out/fan-in, and shard
+     balance;
+   - dependency installation, caches, cache keys/scopes, and duplicate setup;
+   - Docker contexts, invalidation boundaries, layers, image export/upload,
+     and exact-image transfer;
+   - artifact reuse, prepull/prestage overlap, remote rollout, health checks,
+     recovery, and rollback.
+6. Run these standing sweeps even when the code delta is empty:
+   - newly added or changed work on the longest DAG path;
+   - newly serialized `needs` edges or over-broad job conditions;
+   - changed test inventory, shard union, shard imbalance, and coverage merge;
+   - duplicate checkout, install, compile, upload, download, pull, or fetch;
+   - cache misses caused by unstable keys, contexts, timestamps, or ownership;
+   - image growth, largest layers, repeated uploads, and transfer compression;
+   - path-filter completeness and fail-closed fallback;
+   - cancellation, teardown, exact-SHA, health, recovery, and rollback rails;
+   - runner/action version drift and lost pinning.
+7. For every candidate, cite exact run/job/step evidence and code file:line.
+   Estimate recurring critical-path seconds saved, confidence, effort, risk,
+   runner-minute effect, and validation cost.
+8. Rank candidates by expected critical-path impact, confidence, safety, and
+   effort. Select only the highest-value candidate that fits the bounded run.
+   Do not select work merely because it is easy or fashionable.
+9. Append the audit and candidate to `CI_PERFORMANCE_LOG.md`, commit it, push
+   the nightly branch, and open or update the nightly PR. Zero findings still
+   updates the log and PR as dead-man evidence.
+
+## Mode: remediate
+
+Goal: implement one measured optimization without weakening any invariant.
+
+1. Resume the audit branch and selected `CIP-###` item. Before editing, write
+   down the comparable baseline runs, current critical path, hypothesis,
+   expected seconds saved, affected paths, safety risks, and revert trigger.
+2. Establish the clean `origin/main` local gate baseline. Run CPU-heavy local
+   gates serially. If other midnight loops are consuming the Mac mini, wait
+   within the wrapper's bound or record the contention; do not use distorted
+   local wall time as proof.
+3. Add a failing regression or contract test first whenever workflow behavior,
+   shard membership, cache provenance, artifact provenance, or deployment
+   behavior changes. Demonstrate the missing guarantee or inefficient path.
+4. Implement the smallest elegant change that removes the measured
+   bottleneck. Preserve the fallback and recovery path.
+5. Show the focused test red then green. Run all relevant contract tests,
+   workflow lint, YAML parsing, shell syntax, Docker checks, and repository
+   diff checks.
+6. Run the full project gates serially before committing. Compare any existing
+   platform-specific failures with clean `origin/main` and do not attribute or
+   fix unrelated baseline failures.
+7. Commit with the `CIP-###` ID and push immediately. Update the PR with the
+   hypothesis, before evidence, predicted savings, tests, safety checks,
+   runner-minute estimate, and validation plan.
+8. Do not merge or deploy manually. After human merge, use subsequent organic
+   `main` runs to evaluate the experiment. The next nightly audit appends
+   samples until acceptance thresholds are met.
+9. Mark the experiment `ACCEPTED`, `REJECTED`, `VALIDATING`, `BLOCKED`, or
+   `INSUFFICIENT_SAMPLE`. Never call a single warm run a proven win.
+
+## Candidate search space
+
+This list guides investigation; it does not prescribe a change. Optimize only
+the measured current bottleneck.
+
+- duration-balanced test sharding with complete inventory contracts;
+- safe fan-out/fan-in and overlap of independent workflow work;
+- dependency install reuse and content-addressed caches;
+- cache-key stability, scope isolation, and reduced cache export cost;
+- smaller Docker contexts, stable layer ordering, and removal of duplicate
+  ownership/copy layers;
+- exact-image build, export, pull, and verification concurrency;
+- reusable exact-SHA build artifacts with fail-closed fallback;
+- elimination of duplicate checkouts, builds, uploads, pulls, and fetches;
+- prestage/prepull overlap before the non-canceling teardown boundary;
+- smaller remote transfers and better compression;
+- coverage merge, artifact fan-in, and action startup overhead;
+- workflow permissions, action versions, and runner selection when supported
+  by measured latency and cost.
+
+## Anti-gaming rules
+
+Never claim a gain by:
+
+- deleting, skipping, deselecting, or weakening tests or assertions;
+- lowering coverage or excluding newly uncovered files;
+- narrowing change detection or allowing unknown paths to pass open;
+- removing deploy dependencies or making required jobs non-gating;
+- shortening production health or stability waits;
+- comparing different run classes, cache states, or unusually fast samples;
+- omitting failed, canceled, rolled-back, cold-cache, or degraded runs from the
+  reliability record;
+- counting queue reduction as a code improvement;
+- triggering artificial production runs;
+- adding shards that reduce elapsed time while materially increasing billed
+  runner minutes without disclosure;
+- moving required work after deployment completion merely to stop the clock;
+- using local Mac mini wall time as production evidence.
+
+Test-only deadline injection is allowed only when production floors, real
+subprocess behavior, and process-group semantics remain covered by contracts.
+
+## Performance ledger
+
+`CI_PERFORMANCE_LOG.md` is append-only. Never renumber or rewrite prior
+entries. Continue IDs as `CIP-###`. Every nightly entry includes:
+
+- date, mode, branch, audited SHA range, and runner state;
+- run IDs/URLs, change class, cache state, queue state, and conclusions;
+- before and after sample sets with p50/p95;
+- critical-path jobs/steps and their durations;
+- selected hypothesis and expected critical-path seconds saved;
+- changed paths and regression/contract evidence;
+- focused and full gate commands with counts;
+- commit and PR URLs;
+- post-merge production run URLs and exact-SHA verification;
+- runner-minute impact and operational risk;
+- outcome: `ACCEPTED`, `REJECTED`, `VALIDATING`, `DEFERRED`, `BLOCKED`, or
+  `INSUFFICIENT_SAMPLE`;
+- revert trigger, residual bottleneck, and next safest candidate.
+
+Verify the remote branch and open PR before allocating the next ID. If two
+agents propose the same ID, renumber centrally before writing the ledger.
+
+## First-run bootstrap
+
+If `CI_PERFORMANCE_LOG.md` does not exist:
+
+1. Create it with this measurement contract and an empty append-only ledger.
+2. Record the historical anchors above as `CIP-000` bootstrap evidence.
+3. Query recent GitHub Actions runs and establish current rolling baselines by
+   comparable class and cache state.
+4. Verify the current required-gate closure and deployment invariants before
+   proposing `CIP-001`.
+5. Commit the bootstrap ledger to the nightly branch and open the nightly PR.
+
+## Required nightly report
+
+Update all three reporting surfaces: the nightly PR, the rolling GitHub issue
+labeled `ci-performance-nightly`, and the Pushover phase notification. Include:
+
+- `DONE`, `VALIDATING`, `BLOCKED`, or `NO_SAFE_CHANGE` status;
+- audited SHA range and GitHub run URLs;
+- sample table by comparable class with p50/p95 and cache state;
+- queue time separated from execution time;
+- current critical-path job/step list;
+- top bottleneck and evidence;
+- selected `CIP-###` experiment or why none is safe;
+- changed files, exact tests/counts, and safety-contract results;
+- predicted or measured seconds and percentage saved;
+- runner-minute impact;
+- PR URL, operator action if required, and residual bottleneck.
+
+A zero-change night must still report. Silence is a runner failure signal.
+
+The wrapper (`scripts/ci_performance_nightly.sh`) already posts a per-phase
+comment on the rolling issue and a per-phase Pushover with the phase status
+and the PR URL, so the agent owns the PR body and the issue's substantive
+content, not the dead-man plumbing.
+
+## Self-improvement
+
+If the loop hits friction, append a short dated lesson to the end of this file
+and include it in the nightly commit. Record wrong assumptions, noisy metrics,
+missing rails, toolchain drift, runner contention, and validation gaps. Turn
+each correction into a concrete rule that prevents recurrence.
+
+## Lessons
+
+- 2026-08-30 bootstrap: the testing and reliability launchd jobs already fire
+  at 00:00 local in separate clones. This loop needs its own clone and lock.
+  Run local full gates serially, and use GitHub job/step timestamps rather than
+  contention-distorted Mac mini timing for performance claims.

--- a/.gitignore
+++ b/.gitignore
@@ -204,6 +204,7 @@ web/verify-regime-internals.mjs
 # The starred form (not a bare dir) lets repo-owned skills below re-include.
 /.agents/
 /.claude/skills/*
+!/.claude/skills/ci-performance/
 !/.claude/skills/incident-response/
 !/.claude/skills/long-horizon-jobs/
 !/.claude/skills/reliability-weekend/

--- a/config/com.radon.ci-performance-daily.plist
+++ b/config/com.radon.ci-performance-daily.plist
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.radon.ci-performance-daily</string>
+
+    <!-- __WEEKEND_REPO__ is substituted by scripts/setup_ci_performance.sh.
+         The clone is restored BEFORE the wrapper is read: a wrapper left
+         corrupt on disk dies at the top, before the ground_truth that
+         would have restored it, and every later fire repeats that
+         silently. Skipped while a live run holds the lock, so the fire
+         cannot reset the tree under a running agent. -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>C=__WEEKEND_REPO__; kill -0 "$(cat "$C/.weekend-runner.lock/pid" 2&gt;/dev/null)" 2&gt;/dev/null || { git -C "$C" fetch -q origin &amp;&amp; git -C "$C" checkout -f -q main &amp;&amp; git -C "$C" reset --hard -q origin/main; }; exec /bin/bash "$C/scripts/ci_performance_nightly.sh" cycle</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__WEEKEND_REPO__</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:__HOME__/.local/bin:__HOME__/.bun/bin</string>
+        <key>RADON_WEEKEND_REPO</key>
+        <string>__WEEKEND_REPO__</string>
+        <key>HOME</key>
+        <string>__HOME__</string>
+    </dict>
+
+    <!-- Daily 00:00 local (no Weekday key). One job runs the audit phase then
+         the remediate phase, sequentially. Runs in the CI-performance loop's
+         own clone; no shared working tree with the reliability or testing
+         loops. -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>0</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>StandardOutPath</key>
+    <string>__WEEKEND_REPO__/logs/ci-performance/launchd-cycle.log</string>
+    <key>StandardErrorPath</key>
+    <string>__WEEKEND_REPO__/logs/ci-performance/launchd-cycle.err</string>
+</dict>
+</plist>

--- a/scripts/ci_performance_nightly.sh
+++ b/scripts/ci_performance_nightly.sh
@@ -1,0 +1,466 @@
+#!/usr/bin/env bash
+# Nightly CI/deploy performance loop runner — invoked by launchd on the
+# always-on runner (Mac mini). One job fires daily and runs `cycle`: the audit
+# phase and then the remediate phase, sequentially, in this loop's own clone.
+# Sequencing them inside one clone is what keeps two phases from checking
+# out over each other. Either phase still runs standalone (`audit` /
+# `remediate`). See .claude/skills/ci-performance/.
+#
+# Runs in its OWN dedicated clone (~/radon-weekend/radon-ci-performance), never
+# the reliability loop's (~/radon-weekend/radon) nor the testing loop's
+# (~/radon-weekend/radon-testing). All three wrappers hard-reset and clean
+# their clone on every round, so two loops in one working tree destroy each
+# other's checkouts and in-flight work — observed 2026-08-16 when the testing
+# loop's audit checked out its branch under a running reliability
+# remediation. Schedule slotting is NOT sufficient isolation: the reliability
+# loop relaunches continuation rounds until its backlog is done, so its wall
+# clock is unbounded, and all three loops fire at 00:00.
+#
+# This loop measures GitHub Actions and production deploy timings. Local Mac
+# mini wall time is diagnostic only — the other two loops contend for this
+# host at the same hour, so a local timing is never performance evidence.
+#
+# Safety model:
+#   - runs ONLY in the dedicated runner clone (marker file required);
+#     the clone is hard-reset to origin/main every run, so it must never
+#     be a working checkout anyone edits by hand.
+#   - the agent never pushes main (skill rail); this wrapper's only git
+#     writes are fetch/reset on the runner clone.
+#   - deploy this file with git only (fetch + checkout -f + reset --hard):
+#     git writes a NEW inode, so a running copy keeps reading the old one.
+#     cp / cat / tee rewrite it IN PLACE and strand a live run at a stale
+#     byte offset. Never write it in a clone while a run is in flight.
+#   - wall-clock capped; every outcome (incl. crash) is reported to the
+#     rolling GitHub issue, and each phase also pages Pushover, so a
+#     silent-dead runner is visible without waiting for the next run.
+# -E: the ERR trap must be inherited by ground_truth/run_phase, otherwise a
+# git failure at midnight exits silently with no dead-man comment and no page.
+set -Eeuo pipefail
+
+# One writer per runner clone. The daily fire, a hand-run smoke test and the
+# setup script all drive the SAME tree, and every entry point runs
+# `git clean -fdq`, so a second run would delete the live agent's uncommitted
+# work mid-write with both runs reporting success. The plist pre-reset and
+# setup_ci_performance_nightly.sh both stand down on this lock, so it has to exist.
+# mkdir is the atomic primitive here: flock(1) does not exist on macOS.
+acquire_runner_lock() {
+  local dir="$1" held
+  if ! mkdir "$dir" 2>/dev/null; then
+    held="$(cat "$dir/pid" 2>/dev/null || true)"
+    if [[ -z "$held" ]]; then
+      # No pid yet means the winner is between its mkdir and its pid write.
+      # That window used to skip the `kill -0` test entirely — the loser read
+      # an empty pid, called the lock stale, `rm -rf`d it and took it, and two
+      # cycles then ran `git clean -fdq` in the same clone. Absent evidence is
+      # not evidence of staleness. R-411.
+      echo "weekend runner lock held (pid not yet published): $dir" >&2
+      return 1
+    fi
+    if kill -0 "$held" 2>/dev/null; then
+      echo "weekend runner lock held by pid $held ($dir)" >&2
+      return 1
+    fi
+    echo "[weekend] reclaiming stale runner lock (pid $held)" >&2
+    rm -rf -- "$dir"
+    mkdir "$dir" 2>/dev/null || { echo "cannot take runner lock $dir" >&2; return 1; }
+  fi
+  # Rename the pid in so it is never half-written to a reader. R-411.
+  printf '%s\n' "$$" > "$dir/pid.tmp" && mv -f "$dir/pid.tmp" "$dir/pid"
+  return 0
+}
+
+release_runner_lock() {
+  # ONLY the owner unlocks. Unconditional `rm -rf` meant the first run's EXIT
+  # trap unlocked the SECOND run's tree on its way out. R-411.
+  local dir="${1:-}" held
+  [[ -n "$dir" && -d "$dir" ]] || return 0
+  held="$(cat "$dir/pid" 2>/dev/null || true)"
+  [[ "$held" == "$$" ]] || return 0
+  rm -rf -- "$dir"
+}
+
+# Every network call in this wrapper is bounded, INCLUDING the dead-man channel
+# itself: a hung issue-comment call inside the crash handler wedged the wrapper
+# while it was trying to report its own death, holding the runner lock and
+# dropping every subsequent daily fire. R-409.
+NET_TIMEOUT_SECS="${RADON_WEEKEND_NET_TIMEOUT_SECS:-120}"
+net_bounded() { timeout "$NET_TIMEOUT_SECS" "$@"; }
+
+# A VPN flap that establishes TCP and then stalls hangs an ssh transport with
+# no keepalive, and the attempt-count retry below bounds attempts, not time.
+GIT_SSH_BOUNDED="ssh -o ConnectTimeout=15 -o ServerAliveInterval=15 -o ServerAliveCountMax=3"
+
+# `source ci_performance_nightly.sh --lock-lib-only` exposes the helpers above to the
+# contract tests without running a weekend.
+[[ "${1:-}" == "--lock-lib-only" ]] && return 0 2>/dev/null
+
+# Bash reads a script LAZILY by byte offset and re-reads it from disk after
+# every fork. The agent this wrapper spawns edits files in this clone, this
+# one included, so the whole run body is ONE function: bash parses a function
+# body in full before its first statement runs, and never reads it from disk
+# again. Two invariants keep that true — nothing above this line may fork, and
+# the call at the bottom must exit on its own line. Residual window: the
+# initial parse itself, before main is defined.
+main() {
+
+MODE="${1:?usage: ci_performance_nightly.sh audit|remediate|cycle}"
+[[ "$MODE" == "audit" || "$MODE" == "remediate" || "$MODE" == "cycle" ]] || {
+  echo "unknown mode: $MODE" >&2; exit 2;
+}
+
+REPO="${RADON_WEEKEND_REPO:-$HOME/radon-weekend/radon-ci-performance}"
+WEEKEND_ROOT="$(dirname "$REPO")"
+VENV="$WEEKEND_ROOT/venv"
+# Activate the venv so any python3.13 calls inside the agent use it.
+[[ -f "$VENV/bin/activate" ]] && export PATH="$VENV/bin:$PATH"
+DEADMAN_TITLE="Nightly CI performance runner"
+DEADMAN_LABEL="ci-performance-nightly"
+# Branch prefix the skill opens/updates its PR from. Matched on the head
+# ref, not the title: the title is `CI Performance <date>`, which a
+# hand-written PR could also start with.
+PR_BRANCH_PREFIX="ci-performance/"
+
+resolve_pr_url() {
+  # Newest-updated open PR the skill opened for this loop. A gh failure or
+  # no match must yield an empty string, never a non-zero exit under set -e.
+  local url
+  url="$(net_bounded gh pr list --state open --limit 20 --json url,headRefName,updatedAt \
+    -q "[.[] | select(.headRefName | startswith(\"$PR_BRANCH_PREFIX\"))] | sort_by(.updatedAt) | reverse | .[0].url" \
+    2>/dev/null || true)"
+  [[ "$url" == "null" ]] && url=""
+  printf '%s' "$url"
+}
+
+notify_phase() {
+  # One Pushover per phase so a hung phase is visible immediately.
+  # Best-effort: it must never change the run's exit code.
+  local status="$1" pr_url
+  pr_url="$(resolve_pr_url)"
+  python3 "$REPO/scripts/weekend_notify.py" \
+    --loop ci-performance --phase "$PHASE" --status "$status" \
+    --pr-url "$pr_url" --detail "log: ${RUN_LOG##*/}" \
+    --env-file "$WEEKEND_ROOT/.env" >/dev/null 2>&1 || true
+}
+
+report() {
+  # Dead-man: one rolling issue, a comment per run. Failure to report
+  # must not mask the run's own exit code. Third arg 0 suppresses the
+  # Pushover.
+  local status="$1" detail="$2" push="${3:-1}"
+  local body="**${PHASE}** ${STAMP} — **${status}**
+${detail}
+log: \`${RUN_LOG##*/}\` on the runner"
+  local issue
+  issue="$(net_bounded gh issue list --label "$DEADMAN_LABEL" --state open \
+    --json number -q '.[0].number' 2>/dev/null || true)"
+  if [[ -z "$issue" ]]; then
+    net_bounded gh issue create --title "$DEADMAN_TITLE" --label "$DEADMAN_LABEL" \
+      --body "Rolling dead-man for the nightly CI/deploy performance loop. A missing daily comment means the runner did not fire." \
+      >/dev/null 2>&1 || true
+    issue="$(net_bounded gh issue list --label "$DEADMAN_LABEL" --state open \
+      --json number -q '.[0].number' 2>/dev/null || true)"
+  fi
+  [[ -n "$issue" ]] && net_bounded gh issue comment "$issue" --body "$body" >/dev/null 2>&1 || true
+  if [[ "$push" == "1" ]]; then
+    notify_phase "$status"
+  fi
+  return 0
+}
+
+# T-239: `claude -p` terminates unfinished background tasks at its print-mode
+# background-wait ceiling and then exits **0**, so a phase cut off with its
+# last agent still working is indistinguishable from one that finished. The
+# 2026-08-28 audit was cut at 600s, filed nothing against a 24-commit delta,
+# left an empty branch and no PR — and paged OK. The ceiling is lifted at the
+# invocation below (the `timeout` is the cap); this is the second guarantee,
+# so that if it is ever cut off anyway the operator is not told it succeeded.
+BG_CEILING_MARKER="Background tasks still running after"
+
+phase_status() {
+  # rc + run log -> the one status string every dead-man channel carries.
+  # `mark` is the size of $run_log before THIS round's invocation. RUN_LOG is
+  # per PHASE and appended by every retry and continuation round, so grepping
+  # the whole file made a round-1 ceiling message report a finished round 8 as
+  # TRUNCATED forever — a permanent false alarm on exactly the long
+  # remediations the detector was added to protect. R-426.
+  local rc="$1" run_log="$2" mark="${3:-0}"
+  if [[ $rc -eq 124 ]]; then
+    printf 'TIMEOUT after %ss' "$CAP_SECS"
+  elif [[ $rc -ne 0 ]]; then
+    printf 'FAILED (exit %s)' "$rc"
+  elif tail -c "+$((mark + 1))" "$run_log" 2>/dev/null | grep -qF "$BG_CEILING_MARKER"; then
+    printf 'TRUNCATED (background work killed before the phase finished)'
+  else
+    printf 'OK'
+  fi
+}
+
+on_crash() {
+  report "CRASHED (exit $?)" "wrapper died before the agent finished — check the runner"
+}
+
+# Bash runs the EXIT trap on an untrapped SIGTERM, so the lock released and the
+# process exited 143 — but `on_crash` never ran, so launchd's ExitTimeOut kill,
+# a `launchctl bootout`, an operator kill and a reboot mid-cycle all produced
+# exactly the same observable as "the runner did not fire". SKILL.md tells the
+# operator to read quiet as "still running", so they waited. R-384.
+ROUND_PID=""
+kill_round_group() {
+  [[ -n "$ROUND_PID" ]] || return 0
+  # `timeout` (deliberately WITHOUT --foreground) makes itself the round's
+  # process-group leader, so the negative pid reaches claude and anything it
+  # left behind. --foreground would signal only timeout's direct child, which
+  # is the opposite of what reaping orphaned subagents needs — they would keep
+  # writing into the clone while the next round runs `git clean -fdq`. R-386.
+  kill -TERM -- "-$ROUND_PID" 2>/dev/null || kill -TERM "$ROUND_PID" 2>/dev/null || true
+  ROUND_PID=""
+}
+
+on_signal() {
+  local sig="$1"
+  trap - INT TERM HUP ERR EXIT
+  kill_round_group
+  report "KILLED (SIG${sig})" "the wrapper was signalled before the phase finished — launchd ExitTimeOut, a bootout, an operator kill or a reboot; partial work may exist on the weekend branch"
+  release_runner_lock "${RUNNER_LOCK:-}"
+  exit 143
+}
+
+# These four are defined HERE, above the trap, and not further down beside
+# begin_phase: the prologue's REFUSED branches and the ERR trap below call
+# report(), and a function defined later in main() is not yet defined when
+# they run — every prologue death died on "report: command not found", then on
+# unset PHASE/STAMP/RUN_LOG under `set -u`, so no issue comment and no page
+# were ever sent for the very failures the trap exists to catch. T-209.
+PHASE="prologue"
+STAMP="$(date +%Y%m%dT%H%M%S)"
+RUN_LOG="prologue (no phase log yet)"
+
+# R-239: the ERR trap used to be armed only inside run_phase, so everything
+# from here down — the cd, the marker check, the lock, the mkdir and the
+# rotation pipeline under `set -o pipefail` — exited on a full disk, a moved
+# clone or a held lock with nothing but a line on stderr. The file header
+# claims every outcome is reported; for the prologue that was false.
+trap on_crash ERR
+trap 'on_signal INT' INT
+trap 'on_signal TERM' TERM
+trap 'on_signal HUP' HUP
+
+cd "$REPO"
+[[ -f .radon-weekend-runner ]] || {
+  echo "REFUSING: $REPO is not the dedicated weekend runner clone" >&2
+  report "REFUSED" "$REPO is not the dedicated weekend runner clone" || true
+  exit 2
+}
+
+RUNNER_LOCK="$REPO/.weekend-runner.lock"
+acquire_runner_lock "$RUNNER_LOCK" || {
+  echo "REFUSING: another weekend run owns $REPO" >&2
+  # The expensive instance: acquire_runner_lock only reclaims when
+  # `kill -0 $held` fails, so a recorded pid reused by ANY live unrelated
+  # process makes every subsequent daily fire exit 3 in under a second. That
+  # must page, not vanish. R-239.
+  report "REFUSED (lock held)" "another weekend run owns $REPO (pid $(cat "$RUNNER_LOCK/pid" 2>/dev/null || echo unknown)); if no cycle is running, the recorded pid was reused — remove $RUNNER_LOCK" || true
+  exit 3
+}
+trap 'release_runner_lock "$RUNNER_LOCK"' EXIT
+
+LOG_DIR="$REPO/logs/ci-performance"
+mkdir -p "$LOG_DIR"
+# Keep the newest 30 run logs. NEVER the launchd sinks: the plist points
+# StandardOutPath/StandardErrorPath at launchd-cycle.log/.err inside this same
+# directory, and launchd-cycle.err only gets an mtime bump when something
+# writes to stderr — so it sorts old and was unlinked once ~30 per-phase logs
+# accumulated, taking the only forensics for a prologue death with it. Worse,
+# the rotation runs BEFORE run_phase, so the rest of that same invocation
+# wrote to a deleted inode launchd still held open. R-267.
+# `|| true` on the grep: it exits 1 when it filters everything out (an empty
+# or sinks-only log dir), and `set -o pipefail` would turn that into a
+# prologue death — now a REPORTED one, thanks to the trap above.
+ls -1t "$LOG_DIR" 2>/dev/null \
+  | { grep -v -e '^launchd-cycle\.log$' -e '^launchd-cycle\.err$' || true; } \
+  | tail -n +31 | while IFS= read -r old; do
+  rm -f -- "$LOG_DIR/$old"
+done
+
+CAP_SECS=0
+RUN_LOG="$LOG_DIR/$MODE-$STAMP.log"
+RC=0
+
+begin_phase() {
+  PHASE="$1"
+  # Audit fans out read agents (cap 2h); remediation is the long half (cap 6h).
+  CAP_SECS=$([[ "$PHASE" == "audit" ]] \
+    && echo "${RADON_WEEKEND_AUDIT_CAP_SECS:-7200}" \
+    || echo "${RADON_WEEKEND_REMEDIATE_CAP_SECS:-21600}")
+  # One log per phase: the transient-network detector and the report tail
+  # both read $RUN_LOG.
+  RUN_LOG="$LOG_DIR/$PHASE-$STAMP.log"
+  RC=0
+}
+
+# Fresh ground truth. Any leftover state from a killed prior run is
+# discarded — the branch/PR on GitHub is the durable state.
+# R-237: this loop's fetch was a bare single attempt while the reliability
+# loop already had a bounded retry (3f96dc31, added for the 2026-08-23 port-22
+# blackhole). Same shape, same reason.
+FETCH_ATTEMPTS="${RADON_WEEKEND_FETCH_ATTEMPTS:-3}"
+FETCH_PAUSE_SECS="${RADON_WEEKEND_FETCH_PAUSE_SECS:-60}"
+
+fetch_origin_with_retry() {
+  local attempt
+  for (( attempt = 1; attempt <= FETCH_ATTEMPTS; attempt++ )); do
+    net_bounded git -c "core.sshCommand=$GIT_SSH_BOUNDED" fetch origin --quiet && return 0
+    echo "[weekend] git fetch origin failed — attempt $attempt/$FETCH_ATTEMPTS" >&2
+    if (( attempt < FETCH_ATTEMPTS )); then sleep "$FETCH_PAUSE_SECS"; fi
+  done
+  return 1
+}
+
+ground_truth() {
+  fetch_origin_with_retry
+  git checkout -f --quiet main
+  git reset --hard --quiet origin/main
+  git clean -fdq --exclude=.radon-weekend-runner --exclude=.weekend-runner.lock --exclude=logs/ --exclude=.env --exclude=.env.ib-mode --exclude=web/.env
+}
+
+# The agent commits per completed task and the skill resumes from the
+# weekend branch, so a fresh attempt after a dropped API connection loses
+# nothing. Retry ONLY on a transient-network signature (2026-08-16: five
+# runs died to ENOTFOUND / connection-lost on the runner's flaky uplink);
+# real failures and timeouts surface immediately.
+KILL_AFTER_SECS="${RADON_WEEKEND_KILL_AFTER_SECS:-60}"
+# Production always gives `timeout` the real phase remainder after the 60s
+# launch floor below. The survivability regression needs to exercise the real
+# process group and SIGKILL path without sleeping for that production-sized
+# deadline. Refuse this narrow override unless pytest explicitly owns the
+# process, and accept only the bounded values the regression needs.
+TEST_ROUND_TIMEOUT_SECS=""
+if [[ -n "${RADON_WEEKEND_TEST_ROUND_TIMEOUT_SECS:-}" ]]; then
+  if [[ -z "${PYTEST_CURRENT_TEST:-}" ]]; then
+    echo "REFUSING: RADON_WEEKEND_TEST_ROUND_TIMEOUT_SECS is test-only" >&2
+    report "REFUSED" "RADON_WEEKEND_TEST_ROUND_TIMEOUT_SECS is test-only and cannot alter a production deadline" || true
+    exit 2
+  fi
+  case "$RADON_WEEKEND_TEST_ROUND_TIMEOUT_SECS" in 1|2|5) ;;
+    *)
+      echo "REFUSING: RADON_WEEKEND_TEST_ROUND_TIMEOUT_SECS must be 1, 2, or 5" >&2
+      report "REFUSED" "RADON_WEEKEND_TEST_ROUND_TIMEOUT_SECS must be the bounded test value 1, 2, or 5" || true
+      exit 2
+      ;;
+  esac
+  TEST_ROUND_TIMEOUT_SECS="$RADON_WEEKEND_TEST_ROUND_TIMEOUT_SECS"
+fi
+ROUND_LOG_MARK=0
+MAX_ATTEMPTS=3
+RETRY_PAUSE_SECS=60
+is_transient_network_failure() {
+  tail -c 500 "$RUN_LOG" | grep -qE 'API Error|ENOTFOUND|Connection lost|Execution error'
+}
+
+run_phase() {
+  begin_phase "$1"
+  trap on_crash ERR
+  echo "[ci-performance] $PHASE start $STAMP repo=$REPO cap=${CAP_SECS}s" | tee -a "$RUN_LOG"
+  # NOT bare. Under `set -Eeuo pipefail` with the ERR trap armed, a failed
+  # fetch made on_crash report and then the shell exit anyway — so
+  # `run_phase audit` never returned and `run_phase remediate` was never run
+  # and never reported, contradicting the comment on the cycle branch. This
+  # loop was the exposed one: its fetch was a bare single attempt while
+  # reliability already had fetch_origin_with_retry. R-237.
+  if ! ground_truth; then
+    RC=70
+    report "GROUND TRUTH FAILED" "could not refresh the clone (network or git); the phase did not run" || true
+    echo "[ci-performance] $PHASE done rc=$RC" | tee -a "$RUN_LOG"
+    return 0
+  fi
+
+  # Attempt clock is per phase: under cycle the remediate phase must not
+  # inherit the audit phase's elapsed seconds and insta-timeout.
+  # R-185: `timeout claude` returning 124 (cap) or any non-zero agent exit is
+  # an EXPECTED outcome this loop handles — but the ERR trap was still armed
+  # over it, so every failed or timed-out run posted a false
+  # "CRASHED — wrapper died" dead-man comment AND then its real status.
+  trap - ERR
+  local attempt=1 start_ts=$SECONDS remain round_start
+  set +e
+  while :; do
+    remain=$((CAP_SECS - (SECONDS - start_ts)))
+    if [[ $remain -le 60 ]]; then RC=124; break; fi
+    [[ -z "$TEST_ROUND_TIMEOUT_SECS" ]] || remain="$TEST_ROUND_TIMEOUT_SECS"
+    ROUND_LOG_MARK=$(( $(wc -c < "$RUN_LOG" 2>/dev/null || echo 0) ))
+    # Backgrounded and `wait`ed rather than run in the foreground: bash defers
+    # trap handling until a foreground child completes, so a SIGTERM to the
+    # wrapper was not acted on until `claude` finished on its own — which is
+    # never, in the case that matters. `-k` escalates to SIGKILL so a claude
+    # blocked on a hung child cannot make the cap advisory. R-384, R-386.
+    CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 timeout -k "$KILL_AFTER_SECS" "$remain" claude -p "/ci-performance $PHASE" \
+      --dangerously-skip-permissions \
+      --output-format text >> "$RUN_LOG" 2>&1 &
+    ROUND_PID=$!
+    round_start=$SECONDS
+    wait "$ROUND_PID"
+    RC=$?
+    ROUND_PID=""
+    kill_round_group
+    # The exit code for a `-k` escalation is not portable: GNU coreutils 9.4
+    # reports 137 when the SIGKILL is what actually ended the child, not 124.
+    # The cap is OUR clock, so classify from it rather than from the code, or a
+    # round the cap genuinely killed is reported as a crash. R-386.
+    if (( RC != 0 && SECONDS - round_start >= remain )); then RC=124; fi
+    [[ $RC -eq 0 || $RC -eq 124 || $attempt -ge $MAX_ATTEMPTS ]] && break
+    is_transient_network_failure || break
+    echo "[ci-performance] transient network failure (rc=$RC) — attempt $attempt/$MAX_ATTEMPTS, retrying in ${RETRY_PAUSE_SECS}s" | tee -a "$RUN_LOG"
+    attempt=$((attempt + 1))
+    sleep "$RETRY_PAUSE_SECS"
+  done
+  set -e
+  # A genuine wrapper death AFTER the agent finished must still page.
+  trap on_crash ERR
+
+  local tail_text
+  tail_text="$(tail -c 1500 "$RUN_LOG" 2>/dev/null || true)"
+  local status
+  status="$(phase_status "$RC" "$RUN_LOG" "$ROUND_LOG_MARK")"
+  case "$status" in
+    OK)
+      report "$status" "\`\`\`
+${tail_text}
+\`\`\`" ;;
+    TRUNCATED*)
+      report "$status" "the harness killed unfinished background work and the agent still exited 0 — this phase's output is INCOMPLETE and must not be read as a finished run
+\`\`\`
+${tail_text}
+\`\`\`" ;;
+    TIMEOUT*)
+      report "$status" "partial work may exist on the weekend branch/PR
+\`\`\`
+${tail_text}
+\`\`\`" ;;
+    *)
+      report "$status" "\`\`\`
+${tail_text}
+\`\`\`" ;;
+  esac
+  echo "[ci-performance] $PHASE done rc=$RC" | tee -a "$RUN_LOG"
+}
+
+if [[ "$MODE" == "cycle" ]]; then
+  # Remediate runs regardless of the audit rc — backlog may exist even when
+  # the audit phase failed. Exit non-zero if either phase failed.
+  set +e
+  run_phase audit
+  RC_AUDIT=$RC
+  run_phase remediate
+  RC_REMEDIATE=$RC
+  set -e
+  echo "[ci-performance] cycle done audit_rc=$RC_AUDIT remediate_rc=$RC_REMEDIATE"
+  [[ $RC_AUDIT -ne 0 ]] && exit "$RC_AUDIT"
+  exit "$RC_REMEDIATE"
+fi
+
+run_phase "$MODE"
+exit "$RC"
+}
+# Call and exit on ONE line: parsed together, so even a returning main can
+# never make bash read this file again.
+main "$@"; exit

--- a/scripts/setup_ci_performance.sh
+++ b/scripts/setup_ci_performance.sh
@@ -1,22 +1,22 @@
 #!/usr/bin/env bash
-# One-command setup of the weekend testing loop on the always-on runner
-# (Mac mini). Run ON THE MINI from any checkout of the repo:
+# One-command setup of the nightly CI/deploy performance loop on the
+# always-on runner (Mac mini). Run ON THE MINI from any checkout of the repo:
 #
-#   bash scripts/setup_testing_weekend.sh
+#   bash scripts/setup_ci_performance.sh
 #
-# Provisions the testing loop's OWN dedicated clone
-# (~/radon-weekend/radon-testing — never edit it by hand; every run
+# Provisions this loop's OWN dedicated clone
+# (~/radon-weekend/radon-ci-performance — never edit it by hand; every run
 # hard-resets it to origin/main), installs the single daily launchd job
-# (one cycle: audit then remediate), and verifies the toolchain. The
-# clone is deliberately separate from the reliability loop's
-# (~/radon-weekend/radon): both loops hard-reset their working tree per
-# round and the reliability loop's continuation rounds make its wall
-# clock unbounded, so sharing a clone destroys in-flight work
-# (2026-08-16 incident).
+# (one cycle: audit then remediate), creates the dead-man label, and verifies
+# the toolchain. The clone is deliberately separate from the reliability
+# loop's (~/radon-weekend/radon) and the testing loop's
+# (~/radon-weekend/radon-testing): every loop hard-resets its working tree per
+# round and the reliability loop's continuation rounds make its wall clock
+# unbounded, so sharing a clone destroys in-flight work (2026-08-16 incident).
 set -euo pipefail
 
 WEEKEND_ROOT="${RADON_WEEKEND_ROOT:-$HOME/radon-weekend}"
-WEEKEND_REPO="$WEEKEND_ROOT/radon-testing"
+WEEKEND_REPO="$WEEKEND_ROOT/radon-ci-performance"
 WEEKEND_VENV="$WEEKEND_ROOT/venv"
 # Pushover creds for the per-phase page. Lives OUTSIDE the runner clone:
 # every round hard-resets and cleans that clone.
@@ -83,13 +83,14 @@ if kill -0 "$(cat "$WEEKEND_REPO/.weekend-runner.lock/pid" 2>/dev/null)" 2>/dev/
   echo "  a weekend run is in flight in $WEEKEND_REPO; re-run when it finishes"
   exit 1
 fi
-# The SIBLING loop's clone too. WEEKEND_VENV is literally the same path in
-# both setups, and both wrappers prepend it to the running agent's PATH — so
-# the `python3.13 -m venv` + `pip install` below would mutate the interpreter
-# and site-packages a live reliability agent is executing against, mid-run.
-# The guard above was written for the clone ("A live cycle owns this clone")
-# and never extended to the shared $WEEKEND_ROOT both loops depend on. R-266.
-for SIBLING_REPO in "$WEEKEND_ROOT/radon" "$WEEKEND_ROOT/radon-ci-performance"; do
+# Every SIBLING loop's clone too. WEEKEND_VENV is literally the same path in
+# all three setups, and every wrapper prepends it to the running agent's PATH
+# — so the `python3.13 -m venv` + `pip install` below would mutate the
+# interpreter and site-packages a live sibling agent is executing against,
+# mid-run. The guard above was written for the clone ("A live cycle owns this
+# clone") and never extended to the shared $WEEKEND_ROOT the loops depend
+# on. R-266.
+for SIBLING_REPO in "$WEEKEND_ROOT/radon" "$WEEKEND_ROOT/radon-testing"; do
   if [[ -d "$SIBLING_REPO" ]] \
     && kill -0 "$(cat "$SIBLING_REPO/.weekend-runner.lock/pid" 2>/dev/null)" 2>/dev/null; then
     echo "  a weekend run is in flight in $SIBLING_REPO and shares $WEEKEND_VENV; re-run when it finishes"
@@ -103,7 +104,7 @@ git -C "$WEEKEND_REPO" fetch origin --quiet
 git -C "$WEEKEND_REPO" checkout -f --quiet main
 git -C "$WEEKEND_REPO" reset --hard --quiet origin/main
 touch "$WEEKEND_REPO/.radon-weekend-runner"
-mkdir -p "$WEEKEND_REPO/logs/testing-weekend"
+mkdir -p "$WEEKEND_REPO/logs/ci-performance"
 
 # web/.env is gitignored, so a fresh `git clone` can never carry it and the
 # nightly hard-reset would drop it anyway; both wrappers already exclude it
@@ -160,12 +161,23 @@ python3.13 -m venv "$WEEKEND_VENV"
   && bun install --frozen-lockfile >/dev/null \
   && cd web && bun install --frozen-lockfile >/dev/null )
 
-echo "[4/4] launchd jobs"
+echo "[4/4] dead-man label + launchd jobs"
+# `gh issue create --label` FAILS on a label that does not exist, and the
+# wrapper swallows that failure — so a missing label turns the dead-man
+# channel off silently. Idempotent: an existing label makes this a no-op.
+gh label create ci-performance-nightly \
+  --description "Nightly CI/deploy performance loop dead-man" --color 0E8A16 \
+  >/dev/null 2>&1 || true
+if gh label list --limit 200 2>/dev/null | grep -q '^ci-performance-nightly'; then
+  echo "  ok  label ci-performance-nightly"
+else
+  echo "  MISSING  label ci-performance-nightly (dead-man comments will be dropped)"
+fi
 mkdir -p "$LAUNCH_AGENTS"
 # Retire the split audit/remediate jobs. An operator copy left loaded keeps
 # firing into the same clone as the daily cycle, which is the same-clone
 # collision the single job exists to avoid. Idempotent: absent is fine.
-for old in testing-audit testing-remediate; do
+for old in ci-performance-audit ci-performance-remediate; do
   legacy="$LAUNCH_AGENTS/com.radon.${old}.plist"
   if [[ -f "$legacy" ]]; then
     launchctl unload "$legacy" 2>/dev/null || true
@@ -173,9 +185,9 @@ for old in testing-audit testing-remediate; do
     echo "  removed $legacy"
   fi
 done
-JOB_PLIST="$LAUNCH_AGENTS/com.radon.testing-daily.plist"
+JOB_PLIST="$LAUNCH_AGENTS/com.radon.ci-performance-daily.plist"
 sed -e "s|__WEEKEND_REPO__|$WEEKEND_REPO|g" -e "s|__HOME__|$HOME|g" \
-  "$WEEKEND_REPO/config/com.radon.testing-daily.plist" > "$JOB_PLIST"
+  "$WEEKEND_REPO/config/com.radon.ci-performance-daily.plist" > "$JOB_PLIST"
 plutil -lint "$JOB_PLIST" >/dev/null
 launchctl unload "$JOB_PLIST" 2>/dev/null || true
 launchctl load "$JOB_PLIST"
@@ -188,14 +200,14 @@ SCHED_MIN="$(plutil -extract StartCalendarInterval.Minute raw -o - "$JOB_PLIST")
 echo
 printf 'Done. Schedule: one cycle daily at %02d:%02d local (audit, then remediate),\n' \
   "$SCHED_HOUR" "$SCHED_MIN"
-echo "in the testing loop's own clone at $WEEKEND_REPO."
-echo "Dead-man: GitHub issue labeled 'testing-weekend' gets a comment per"
+echo "in the CI-performance loop's own clone at $WEEKEND_REPO."
+echo "Dead-man: GitHub issue labeled 'ci-performance-nightly' gets a comment per"
 echo "phase, plus a Pushover when $WEEKEND_ENV carries creds."
 echo "A quiet day means the runner did not fire OR the previous cycle is"
 echo "still running: launchd will not start a second instance of the label."
 echo "Check with: launchctl list | grep radon"
 echo "Smoke test now with:"
-echo "  RADON_WEEKEND_REPO=$WEEKEND_REPO bash $WEEKEND_REPO/scripts/testing_weekend.sh audit"
+echo "  RADON_WEEKEND_REPO=$WEEKEND_REPO bash $WEEKEND_REPO/scripts/ci_performance_nightly.sh audit"
 echo "Upgrading the wrapper in this clone, with no run in flight"
 echo "(check: ls -d $WEEKEND_REPO/.weekend-runner.lock):"
 echo "  git -C $WEEKEND_REPO fetch origin && git -C $WEEKEND_REPO checkout -f main && git -C $WEEKEND_REPO reset --hard origin/main"

--- a/scripts/setup_reliability_weekend.sh
+++ b/scripts/setup_reliability_weekend.sh
@@ -89,12 +89,13 @@ fi
 # and site-packages a live testing agent is executing against, mid-run.
 # The guard above was written for the clone ("A live cycle owns this clone")
 # and never extended to the shared $WEEKEND_ROOT both loops depend on. R-266.
-SIBLING_REPO="$WEEKEND_ROOT/radon-testing"
-if [[ -d "$SIBLING_REPO" ]] \
-  && kill -0 "$(cat "$SIBLING_REPO/.weekend-runner.lock/pid" 2>/dev/null)" 2>/dev/null; then
-  echo "  a weekend run is in flight in $SIBLING_REPO and shares $WEEKEND_VENV; re-run when it finishes"
-  exit 1
-fi
+for SIBLING_REPO in "$WEEKEND_ROOT/radon-testing" "$WEEKEND_ROOT/radon-ci-performance"; do
+  if [[ -d "$SIBLING_REPO" ]] \
+    && kill -0 "$(cat "$SIBLING_REPO/.weekend-runner.lock/pid" 2>/dev/null)" 2>/dev/null; then
+    echo "  a weekend run is in flight in $SIBLING_REPO and shares $WEEKEND_VENV; re-run when it finishes"
+    exit 1
+  fi
+done
 # An already-provisioned clone must carry the current config/ and scripts/
 # before the job is installed from it. main is force-reset; any weekend
 # branch and its commits survive.

--- a/scripts/tests/test_ci_performance_loop_contract.py
+++ b/scripts/tests/test_ci_performance_loop_contract.py
@@ -1,0 +1,222 @@
+"""The nightly CI/deploy performance loop's own identity contract.
+
+The three nightly loops share one wrapper shape, one runner-lock primitive and
+one `$WEEKEND_ROOT/venv`, and all three fire at 00:00. Everything that keeps
+them from destroying each other is a NAME: the clone directory, the dead-man
+label, the PR branch prefix, the log directory, the launchd label and the
+skill the wrapper invokes. A copy-paste that leaves one of those pointing at a
+sibling is silent — the run looks healthy and lands its work in, or resets,
+the other loop's tree (the 2026-08-16 incident, from exactly that shape).
+
+The shared survivability/dead-man contracts live in
+`test_weekend_loop_deadman.py`, `test_rel137_weekend_wrapper_survivability.py`
+and `test_weekend_wrapper_self_rewrite.py`; this loop is registered in all
+three. What is asserted here is only what is specific to this loop.
+"""
+
+from __future__ import annotations
+
+import plistlib
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+WRAPPER = REPO / "scripts" / "ci_performance_nightly.sh"
+SETUP = REPO / "scripts" / "setup_ci_performance.sh"
+PLIST = REPO / "config" / "com.radon.ci-performance-daily.plist"
+SKILL = REPO / ".claude" / "skills" / "ci-performance" / "SKILL.md"
+
+CLONE = "radon-ci-performance"
+LABEL = "ci-performance-nightly"
+LOG_DIR = "logs/ci-performance"
+SIBLING_CLONES = ("radon-testing",)
+
+
+def _uncommented(path: Path) -> str:
+    return "\n".join(
+        line
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if not line.lstrip().startswith("#")
+    )
+
+
+class TestTheLoopOwnsItsOwnLane:
+    def test_the_wrapper_defaults_to_its_own_clone(self):
+        body = _uncommented(WRAPPER)
+        default = re.search(r'REPO="\$\{RADON_WEEKEND_REPO:-([^}]+)\}"', body).group(1)
+        assert default.endswith(f"/{CLONE}"), (
+            f"the wrapper defaults to {default!r}, not this loop's clone; a "
+            "launchd fire without RADON_WEEKEND_REPO would hard-reset another "
+            "loop's working tree mid-run"
+        )
+
+    @pytest.mark.parametrize("sibling", SIBLING_CLONES)
+    def test_no_executable_line_names_a_sibling_clone(self, sibling):
+        body = _uncommented(WRAPPER)
+        assert sibling not in body, (
+            f"{sibling} appears in executable wrapper code; only the header "
+            "comment may name a sibling loop's clone"
+        )
+
+    def test_the_deadman_label_and_branch_prefix_are_this_loop(self):
+        body = _uncommented(WRAPPER)
+        assert f'DEADMAN_LABEL="{LABEL}"' in body, body
+        assert 'PR_BRANCH_PREFIX="ci-performance/"' in body, (
+            "the wrapper resolves the PR to page about by head-ref prefix; a "
+            "sibling prefix pages this loop's status against that loop's PR"
+        )
+
+    def test_the_wrapper_invokes_this_loops_skill(self):
+        body = _uncommented(WRAPPER)
+        assert "/ci-performance $PHASE" in body, (
+            "the wrapper spawns the agent with another loop's slash command"
+        )
+        assert SKILL.is_file(), f"{SKILL} does not exist, so the run has no prompt"
+
+    def test_the_log_directory_is_this_loops(self):
+        body = _uncommented(WRAPPER)
+        assert f'LOG_DIR="$REPO/{LOG_DIR}"' in body, body
+
+    def test_the_notifier_accepts_this_loop(self):
+        """`weekend_notify.py` validates `--loop` with argparse `choices`.
+
+        An unlisted value exits 2 BEFORE the Pushover call, and the wrapper
+        sends the page with `|| true`, so the loop would silently never page.
+        """
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(REPO / "scripts" / "weekend_notify.py"),
+                "--loop",
+                "ci-performance",
+                "--phase",
+                "audit",
+                "--status",
+                "OK",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env={"PATH": "/usr/bin:/bin"},
+        )
+        assert proc.returncode == 0, (
+            "weekend_notify rejects --loop ci-performance, so every phase page "
+            f"is dropped: {proc.stdout}{proc.stderr}"
+        )
+
+
+class TestTheLaunchdJobPointsAtThisLoop:
+    def test_the_plist_parses_and_carries_this_loops_label_and_wrapper(self):
+        raw = PLIST.read_text(encoding="utf-8")
+        # The shipped template is placeholder-substituted by the setup script;
+        # substitute the same way so the result is real plist XML.
+        resolved = raw.replace("__WEEKEND_REPO__", f"/tmp/{CLONE}").replace(
+            "__HOME__", "/tmp/home"
+        )
+        job = plistlib.loads(resolved.encode("utf-8"))
+        assert job["Label"] == "com.radon.ci-performance-daily"
+        program = " ".join(job["ProgramArguments"])
+        assert "scripts/ci_performance_nightly.sh" in program, program
+        assert program.rstrip().endswith("cycle"), (
+            "the daily fire must run the full cycle (audit then remediate)"
+        )
+        assert job["WorkingDirectory"].endswith(f"/{CLONE}")
+        assert job["EnvironmentVariables"]["RADON_WEEKEND_REPO"].endswith(f"/{CLONE}")
+        assert job["StandardOutPath"].endswith(f"{LOG_DIR}/launchd-cycle.log")
+        assert job["StandardErrorPath"].endswith(f"{LOG_DIR}/launchd-cycle.err")
+
+    def test_the_job_fires_daily_at_midnight_and_not_at_load(self):
+        resolved = (
+            PLIST.read_text(encoding="utf-8")
+            .replace("__WEEKEND_REPO__", f"/tmp/{CLONE}")
+            .replace("__HOME__", "/tmp/home")
+        )
+        job = plistlib.loads(resolved.encode("utf-8"))
+        assert job["StartCalendarInterval"] == {"Hour": 0, "Minute": 0}
+        assert "Weekday" not in job["StartCalendarInterval"], (
+            "a Weekday key would make this a weekend-only loop"
+        )
+        assert job["RunAtLoad"] is False, (
+            "RunAtLoad would start a cycle every login and every reinstall"
+        )
+
+    def test_the_pre_reset_stands_down_on_a_live_lock(self):
+        program = " ".join(
+            plistlib.loads(
+                PLIST.read_text(encoding="utf-8")
+                .replace("__WEEKEND_REPO__", f"/tmp/{CLONE}")
+                .replace("__HOME__", "/tmp/home")
+                .encode("utf-8")
+            )["ProgramArguments"]
+        )
+        assert ".weekend-runner.lock/pid" in program and "kill -0" in program, (
+            "the plist resets the clone unconditionally, so a fire during a "
+            f"live cycle hard-resets the tree under a running agent: {program}"
+        )
+
+
+class TestSetupProvisionsTheDeadmanLabel:
+    def test_setup_creates_the_github_label(self):
+        body = _uncommented(SETUP)
+        assert f"gh label create {LABEL}" in body, (
+            "`gh issue create --label` fails on a label that does not exist "
+            "and the wrapper swallows that failure, so a missing label turns "
+            "the dead-man channel off with no signal at all"
+        )
+
+    def test_setup_targets_this_loops_clone_and_job(self):
+        body = _uncommented(SETUP)
+        assert f'WEEKEND_REPO="$WEEKEND_ROOT/{CLONE}"' in body, body
+        assert "com.radon.ci-performance-daily.plist" in body, body
+
+    @pytest.mark.parametrize("sibling", ("radon", "radon-testing"))
+    def test_setup_stands_down_on_every_sibling_lock(self, sibling):
+        """All three setups write the SAME `$WEEKEND_ROOT/venv`.
+
+        Re-creating it re-installs site-packages under whichever sibling agent
+        is mid-run, because every wrapper prepends that venv to the agent's
+        PATH. R-266 fixed this for two loops; a third makes the guard a set.
+        """
+        body = _uncommented(SETUP)
+        install = body[: body.index("python3.13 -m venv")]
+        assert f'"$WEEKEND_ROOT/{sibling}"' in install, (
+            f"setup re-creates the shared venv without checking {sibling}"
+        )
+
+
+class TestTheSkillCarriesTheNonNegotiableRails:
+    """The rails that keep an unattended optimizer from buying speed with
+
+    safety. Each is quoted from the skill because the agent has no other
+    source of them at 00:00.
+    """
+
+    @pytest.mark.parametrize(
+        "rail",
+        [
+            ".radon-weekend-runner",
+            "Never push to `main`",
+            "Never trigger a dummy production deployment",
+            "Never weaken a gate",
+            "40-second production stability window",
+            "exact 40-character commit SHA",
+            "CI_PERFORMANCE_LOG.md",
+            "ci-performance/<YYYY-MM-DD>",
+        ],
+    )
+    def test_the_rail_is_present(self, rail):
+        # Normalized: every rail here is prose that markdown wraps, so a
+        # reflow must not read as a deleted rail.
+        text = " ".join(SKILL.read_text(encoding="utf-8").split())
+        assert rail in text, (
+            f"the skill no longer states the rail {rail!r}; the unattended run "
+            "has no other source for it"
+        )
+
+    def test_the_skill_declares_both_modes(self):
+        text = SKILL.read_text(encoding="utf-8")
+        assert "## Mode: audit" in text and "## Mode: remediate" in text

--- a/scripts/tests/test_rel137_weekend_wrapper_survivability.py
+++ b/scripts/tests/test_rel137_weekend_wrapper_survivability.py
@@ -28,7 +28,12 @@ import pytest
 REPO = Path(__file__).resolve().parents[2]
 RELIABILITY = REPO / "scripts" / "reliability_weekend.sh"
 TESTING = REPO / "scripts" / "testing_weekend.sh"
-LOOPS = {"reliability": RELIABILITY, "testing": TESTING}
+CI_PERFORMANCE = REPO / "scripts" / "ci_performance_nightly.sh"
+LOOPS = {
+    "reliability": RELIABILITY,
+    "testing": TESTING,
+    "ci-performance": CI_PERFORMANCE,
+}
 BASH = shutil.which("bash") or "/bin/bash"
 
 

--- a/scripts/tests/test_weekend_loop_deadman.py
+++ b/scripts/tests/test_weekend_loop_deadman.py
@@ -46,11 +46,20 @@ import pytest
 REPO = Path(__file__).resolve().parents[2]
 RELIABILITY = REPO / "scripts" / "reliability_weekend.sh"
 TESTING = REPO / "scripts" / "testing_weekend.sh"
+CI_PERFORMANCE = REPO / "scripts" / "ci_performance_nightly.sh"
 PLISTS = {
     "reliability": REPO / "config" / "com.radon.reliability-daily.plist",
     "testing": REPO / "config" / "com.radon.testing-daily.plist",
+    "ci-performance": REPO / "config" / "com.radon.ci-performance-daily.plist",
 }
-LOOPS = {"reliability": RELIABILITY, "testing": TESTING}
+# Every nightly loop wrapper. A new loop that is not registered here inherits
+# none of the dead-man contract below, which is the whole reason the two
+# original loops have it.
+LOOPS = {
+    "reliability": RELIABILITY,
+    "testing": TESTING,
+    "ci-performance": CI_PERFORMANCE,
+}
 
 
 def _uncommented(path: Path) -> str:
@@ -229,7 +238,7 @@ class TestTestingPlistCanResolveBun:
         for name, plist in PLISTS.items():
             text = plist.read_text(encoding="utf-8")
             paths[name] = re.search(r"<key>PATH</key>\s*<string>([^<]*)</string>", text).group(1)
-        assert paths["testing"] == paths["reliability"], paths
+        assert len(set(paths.values())) == 1, paths
 
 
 class TestRotationSparesTheLaunchdSinks:
@@ -293,6 +302,7 @@ class TestSetupGuardsTheSharedVenv:
     SETUPS = {
         "reliability": REPO / "scripts" / "setup_reliability_weekend.sh",
         "testing": REPO / "scripts" / "setup_testing_weekend.sh",
+        "ci-performance": REPO / "scripts" / "setup_ci_performance.sh",
     }
 
     def test_the_two_setups_really_do_share_a_venv(self):
@@ -300,11 +310,11 @@ class TestSetupGuardsTheSharedVenv:
             name: re.search(r'WEEKEND_VENV="([^"]+)"', path.read_text(encoding="utf-8")).group(1)
             for name, path in self.SETUPS.items()
         }
-        assert venvs["reliability"] == venvs["testing"], (
+        assert len(set(venvs.values())) == 1, (
             f"precondition changed: {venvs}"
         )
 
-    @pytest.mark.parametrize("name", ["reliability", "testing"])
+    @pytest.mark.parametrize("name", ["reliability", "testing", "ci-performance"])
     def test_each_setup_checks_the_sibling_clone_lock(self, name):
         # Comments stripped first: the guard's own comment quotes the
         # `python3.13 -m venv` line it protects, and a naive slice ends there.
@@ -318,7 +328,7 @@ class TestSetupGuardsTheSharedVenv:
             "the other loop's cycle is executing against it"
         )
 
-    @pytest.mark.parametrize("name", ["reliability", "testing"])
+    @pytest.mark.parametrize("name", ["reliability", "testing", "ci-performance"])
     def test_each_setup_checks_the_bash_version(self, name):
         """GAP C: `/bin/bash` on this runner is 3.2, and `cloud/tests` needs 4+.
 

--- a/scripts/tests/test_weekend_notify.py
+++ b/scripts/tests/test_weekend_notify.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
+
 from weekend_notify import (
     build_weekend_payload,
     main,
@@ -165,3 +167,40 @@ class TestEnvFile:
     @staticmethod
     def argv(env_file):
         return TestMainAlwaysExitsZero.ARGV + ["--env-file", str(env_file)]
+
+
+class TestProloguePhaseStillPages:
+    """A prologue death must page, not just post an issue comment.
+
+    Every wrapper's `report()` is reachable with `PHASE="prologue"`: the
+    marker refusal, the held-lock refusal and the ERR trap armed over the
+    whole prologue all fire before `begin_phase` ever runs. `--phase`
+    accepted only audit/remediate, so argparse exited 2 BEFORE the Pushover
+    call, and the wrapper sends the page with `|| true` — the loudest
+    failures (a moved clone, a full disk, a reused pid that makes every
+    subsequent daily fire exit 3 in under a second) posted a comment and
+    never paged. Observed on the 2026-08-30 CI-performance install smoke
+    test, which reproduced the held-lock refusal end to end.
+    """
+
+    LOOPS = ("reliability", "testing", "ci-performance")
+
+    @pytest.mark.parametrize("loop", LOOPS)
+    def test_the_prologue_page_is_sent(self, loop, monkeypatch):
+        monkeypatch.setenv("PUSHOVER_USER", "u")
+        monkeypatch.setenv("PUSHOVER_TOKEN", "t")
+        argv = [
+            "--loop",
+            loop,
+            "--phase",
+            "prologue",
+            "--status",
+            "REFUSED (lock held)",
+        ]
+        with patch("weekend_notify._http_post", return_value=(200, b"")) as post:
+            assert main(argv) == 0
+        post.assert_called_once()
+        payload = post.call_args[0][1]
+        assert payload["title"] == f"radon {loop} prologue"
+        assert "REFUSED (lock held)" in payload["message"]
+        assert payload["priority"] == 0

--- a/scripts/tests/test_weekend_runner_env_provisioning.py
+++ b/scripts/tests/test_weekend_runner_env_provisioning.py
@@ -40,10 +40,15 @@ BASH = shutil.which("bash") or "/bin/bash"
 SETUPS = {
     "reliability": (REPO / "scripts" / "setup_reliability_weekend.sh", "radon"),
     "testing": (REPO / "scripts" / "setup_testing_weekend.sh", "radon-testing"),
+    "ci-performance": (
+        REPO / "scripts" / "setup_ci_performance.sh",
+        "radon-ci-performance",
+    ),
 }
 PLISTS = {
     "reliability": "com.radon.reliability-daily.plist",
     "testing": "com.radon.testing-daily.plist",
+    "ci-performance": "com.radon.ci-performance-daily.plist",
 }
 
 # Dummy values only. Never stage a real credential into a fixture.

--- a/scripts/tests/test_weekend_wrapper_self_rewrite.py
+++ b/scripts/tests/test_weekend_wrapper_self_rewrite.py
@@ -50,6 +50,11 @@ LOOPS = {
         "testing-weekend",
         "com.radon.testing-daily.plist",
     ),
+    "ci-performance": (
+        "ci_performance_nightly.sh",
+        "ci-performance",
+        "com.radon.ci-performance-daily.plist",
+    ),
 }
 LOOP_IDS = sorted(LOOPS)
 

--- a/scripts/weekend_notify.py
+++ b/scripts/weekend_notify.py
@@ -108,7 +108,9 @@ def notify_weekend_phase(
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="weekend_notify")
-    parser.add_argument("--loop", required=True, choices=["reliability", "testing"])
+    parser.add_argument(
+        "--loop", required=True, choices=["reliability", "testing", "ci-performance"]
+    )
     parser.add_argument("--phase", required=True, choices=["audit", "remediate"])
     parser.add_argument("--status", required=True)
     parser.add_argument("--pr-url", default="")

--- a/scripts/weekend_notify.py
+++ b/scripts/weekend_notify.py
@@ -111,7 +111,15 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--loop", required=True, choices=["reliability", "testing", "ci-performance"]
     )
-    parser.add_argument("--phase", required=True, choices=["audit", "remediate"])
+    # `prologue` is not decorative: every wrapper's report() is reachable with
+    # PHASE="prologue" — the marker refusal, the held-lock refusal and the ERR
+    # trap armed over the whole prologue all fire before begin_phase runs.
+    # Rejecting it exited 2 before the Pushover call, and the wrapper sends the
+    # page with `|| true`, so those failures posted an issue comment and never
+    # paged.
+    parser.add_argument(
+        "--phase", required=True, choices=["prologue", "audit", "remediate"]
+    )
     parser.add_argument("--status", required=True)
     parser.add_argument("--pr-url", default="")
     parser.add_argument("--detail", default="")


### PR DESCRIPTION
Adds a third unattended nightly loop on the always-on Mac mini, alongside `reliability` and `testing`. Its remit is the measured **push-to-green-production critical path**: reconstruct it from GitHub Actions job/step timestamps, rank the current bottleneck, and land one bounded, evidence-backed optimization per night on a PR branch. It never merges, never triggers a deploy, and never buys speed by weakening a gate.

## What ships

| Path | Role |
|---|---|
| `.claude/skills/ci-performance/SKILL.md` | The agent contract: objective, 13 hard rails, measurement contract (primary clock, comparable run classes, acceptance thresholds), audit/remediate modes, candidate search space, anti-gaming rules, `CIP-###` ledger, first-run bootstrap, required nightly report |
| `scripts/ci_performance_nightly.sh` | Wrapper (launchd entry point), same shape as the two existing loops |
| `config/com.radon.ci-performance-daily.plist` | Daily 00:00 job template |
| `scripts/setup_ci_performance.sh` | One-command install: clone, venv, deps, dead-man label, launchd job |

Runner clone: `~/radon-weekend/radon-ci-performance`. Dead-man label: `ci-performance-nightly`. PR branch prefix: `ci-performance/<YYYY-MM-DD>`. Ledger: `CI_PERFORMANCE_LOG.md` (bootstrapped by the loop's first run).

## Why a third clone

Every wrapper hard-resets and `git clean`s its working tree per round, and the reliability loop's continuation rounds make its wall clock unbounded, so two loops in one tree destroy each other's checkouts (2026-08-16 incident). The three loops share only `$WEEKEND_ROOT/venv` — which is why the sibling-lock guard in all three setup scripts becomes a set rather than a single path. A setup run re-creating that venv under a live sibling agent re-installs site-packages the agent is executing against (R-266).

## Contract coverage

The loop is registered in the shared wrapper contracts rather than re-deriving them, so it inherits signal traps, process-group kill, bounded dead-man network calls, TRUNCATED detection, rotation that spares the launchd sinks, and marker/lock refusal that still reports:

- `test_weekend_loop_deadman.py`
- `test_rel137_weekend_wrapper_survivability.py`
- `test_weekend_wrapper_self_rewrite.py`
- `test_weekend_runner_env_provisioning.py`

`scripts/tests/test_ci_performance_loop_contract.py` (new, 22 tests) covers what is specific to this loop, which is entirely **names** — clone directory, dead-man label, PR branch prefix, log directory, launchd label, and the slash command the wrapper spawns. A copy-paste that leaves one pointing at a sibling is silent: the run looks healthy and lands its work in the other loop's tree. It also pins the launchd job (daily 00:00, `RunAtLoad` false, stand-down on a live lock), the setup script's `gh label create` (a missing label makes `gh issue create --label` fail and the wrapper swallows it, turning the dead-man channel off with no signal), and the non-negotiable rails the agent has no other source for at 00:00.

Red proof: with `scripts/ci_performance_nightly.sh` moved aside, 5 of the 22 fail; restored, 22 pass.

## Gates

`scripts/tests`: **7961 passed, 1 skipped, 0 failed** (406s, serial).
`bash -n` clean on all four shell scripts; `plutil -lint` OK on the plist.

## Operator note

The runner clone hard-resets to `origin/main` every fire, so the first real cycle runs the night after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FXuTFqFQa656KzKLS16qe