### PR TITLE
fix(vol-cone): stop weekend false "outage" collapse on /api/vol-cone

### DIFF
--- a/scripts/watchdog/services.py
+++ b/scripts/watchdog/services.py
@@ -237,15 +237,17 @@ SCHEDULED_SERVICES: dict[str, FreshnessWindow] = {
     # requires_ib stays False.
     "ivrank":           {"open": 26 * _HOUR, "closed": 26 * _HOUR, "requires_ib": False},
     # vol-cone — radon-vol-cone.timer, Mon-Fri 20:45 UTC after the 16:45 ET
-    # close grace. UW greeks only — no IB. 26h open catches a missed weekday;
-    # 3d closed covers Fri 20:45 UTC → Mon 20:45 UTC.
-    "vol-cone":         {"open": 26 * _HOUR, "closed": 3 * _DAY, "requires_ib": False},
+    # close grace. UW greeks only — no IB. 26h open catches a missed weekday.
+    # The holiday-Monday heartbeat lands Fri 20:45 UTC + 72h + jitter, so a
+    # 3d closed window sat exactly on the longest healthy gap; 4d per the
+    # cash-flow-sync precedent (weekend plus one holiday-drift day).
+    "vol-cone":         {"open": 26 * _HOUR, "closed": 4 * _DAY, "requires_ib": False},
     # vol-cone-intraday — radon-vol-cone-intraday.timer, every 15m during ET
     # trading hours. Ranks a live UW sample against the stored cone so the
     # tab is tradeable during the session instead of a day stale. 45m open
-    # tolerates one missed cycle; 3d closed covers Fri 16:00 ET -> Mon open,
-    # since a market-hours-only writer is silent by design off-session.
-    "vol-cone-intraday": {"open": 45 * _MIN, "closed": 3 * _DAY, "requires_ib": False},
+    # tolerates one missed cycle; 4d closed matches its EOD parent, since a
+    # market-hours-only writer is silent by design off-session.
+    "vol-cone-intraday": {"open": 45 * _MIN, "closed": 4 * _DAY, "requires_ib": False},
     # skew — radon-skew.timer fires every 5 minutes during RTH plus a daily
     # 21:45 UTC finalization. 10m open = two timer cycles, so one slow or
     # skipped run never flips skew to stale.

--- a/web/app/api/vol-cone/route.ts
+++ b/web/app/api/vol-cone/route.ts
@@ -4,6 +4,7 @@ import { join } from "path";
 import { getRequestId, setCacheResponseHeaders } from "@/lib/apiContracts";
 import { getDb } from "@/lib/db";
 import { contentTimestampMs, dbFirstRead, type TimestampedRead, staleCollapse, isMissingPayload } from "@/lib/dbFirstRead";
+import { getFreshnessWindowMs } from "@/lib/serviceHealthWindows";
 // Disable Next.js static caching: this handler reads live disk state
 // (data/*.json, cache files). Without this, the framework freezes the
 // first response and serves stale data until the dev server restarts.
@@ -27,9 +28,13 @@ const MISSING_VOL_CONE = {
 
 // radon-vol-cone-intraday.timer refreshes the snapshot every 15m during ET
 // trading hours and radon-vol-cone.timer writes the completed session at
-// 20:45 UTC Mon-Fri. Two days is the overnight/weekend floor: older than
-// that and both writers are down.
-const MAX_AGE_MS = 48 * 60 * 60_000;
+// 20:45 UTC Mon-Fri (holiday firings heartbeat). Both writers are Mon-Fri
+// only, so Friday's EOD snapshot is legitimately the newest until Monday —
+// a private 48h budget here collapsed that healthy snapshot into the
+// "outage, not an empty result" banner every Sunday evening while the
+// watchdog's own window still read the writer as fine. Share the catalog's
+// closed window so the panel and the watchdog agree (R-450 pattern).
+const MAX_AGE_MS = getFreshnessWindowMs("vol-cone", "closed");
 
 async function readVolConeFromDb(): Promise<TimestampedRead<Record<string, unknown>> | null> {
   const db = getDb();

--- a/web/lib/serviceHealthWindows.ts
+++ b/web/lib/serviceHealthWindows.ts
@@ -262,13 +262,18 @@ export const SERVICE_FRESHNESS_WINDOWS: Record<string, Window> = {
   // Turso skew_history transform only — no IB.
   "skew2d": { open: 26 * HOUR, extended: 26 * HOUR, closed: 26 * HOUR, category: "scheduled", requires_ib: false },
 
-  // ``vol-cone`` — daily 20:45 UTC timer, UW-only, 26h open / 3d closed.
-  "vol-cone": { open: 26 * HOUR, extended: 3 * DAY, closed: 3 * DAY, category: "scheduled", requires_ib: false },
+  // ``vol-cone`` — daily 20:45 UTC Mon-Fri timer, UW-only, 26h open. The
+  // holiday-Monday heartbeat lands Fri 20:45 UTC + 72h + RandomizedDelaySec
+  // + run time, so the previous 3d closed window sat exactly on the longest
+  // healthy gap; 4d per the cash-flow-sync precedent (weekend + one
+  // holiday-drift day). /api/vol-cone shares this closed window as its
+  // serve budget, so tightening it re-opens the Sunday-night false outage.
+  "vol-cone": { open: 26 * HOUR, extended: 4 * DAY, closed: 4 * DAY, category: "scheduled", requires_ib: false },
 
   // ``vol-cone-intraday`` — 15m live UW sample during ET trading hours; a
   // market-hours-only writer is silent by design off-session, so extended
-  // and closed carry the same 3d floor as its EOD parent.
-  "vol-cone-intraday": { open: 45 * MIN, extended: 3 * DAY, closed: 3 * DAY, category: "scheduled", requires_ib: false },
+  // and closed carry the same 4d floor as its EOD parent.
+  "vol-cone-intraday": { open: 45 * MIN, extended: 4 * DAY, closed: 4 * DAY, category: "scheduled", requires_ib: false },
 
   // ``knowledge-ingest`` — hourly knowledge-base ingest oneshot
   // (scripts/knowledge/ingest.py via radon-knowledge.timer, 24/7; no

--- a/web/tests/service-health-windows.test.ts
+++ b/web/tests/service-health-windows.test.ts
@@ -661,13 +661,16 @@ describe("unregistered-writer regression — informed-flow and portfolio-archive
   });
 
   // ``vol-cone`` — radon-vol-cone.timer fires daily 20:45 UTC Mon-Fri
-  // (16:45 ET after the close grace). UW greeks only — no IB.
-  it("vol-cone is scheduled, 26h open, 3d closed/extended, requires_ib false", () => {
+  // (16:45 ET after the close grace). UW greeks only — no IB. The holiday
+  // Monday heartbeat lands Fri 20:45 UTC + 72h + RandomizedDelaySec + run
+  // time, so a 3d window sat exactly on the boundary; 4d per the
+  // cash-flow-sync precedent.
+  it("vol-cone is scheduled, 26h open, 4d closed/extended, requires_ib false", () => {
     expect(SERVICE_FRESHNESS_WINDOWS["vol-cone"]).toBeDefined();
     expect(getServiceCategory("vol-cone")).toBe("scheduled");
     expect(getFreshnessWindowMs("vol-cone", "open")).toBe(26 * HOUR);
-    expect(getFreshnessWindowMs("vol-cone", "extended")).toBe(3 * DAY);
-    expect(getFreshnessWindowMs("vol-cone", "closed")).toBe(3 * DAY);
+    expect(getFreshnessWindowMs("vol-cone", "extended")).toBe(4 * DAY);
+    expect(getFreshnessWindowMs("vol-cone", "closed")).toBe(4 * DAY);
     expect(requiresIb("vol-cone")).toBe(false);
   });
 });
@@ -932,12 +935,12 @@ describe("vol-cone-intraday freshness window", () => {
   const MIN = 60_000;
   const DAY = 24 * 60 * 60_000;
 
-  it("is scheduled, 45m open, 3d closed/extended, requires_ib false", () => {
+  it("is scheduled, 45m open, 4d closed/extended, requires_ib false", () => {
     expect(SERVICE_FRESHNESS_WINDOWS["vol-cone-intraday"]).toBeDefined();
     expect(getServiceCategory("vol-cone-intraday")).toBe("scheduled");
     expect(getFreshnessWindowMs("vol-cone-intraday", "open")).toBe(45 * MIN);
-    expect(getFreshnessWindowMs("vol-cone-intraday", "extended")).toBe(3 * DAY);
-    expect(getFreshnessWindowMs("vol-cone-intraday", "closed")).toBe(3 * DAY);
+    expect(getFreshnessWindowMs("vol-cone-intraday", "extended")).toBe(4 * DAY);
+    expect(getFreshnessWindowMs("vol-cone-intraday", "closed")).toBe(4 * DAY);
     expect(requiresIb("vol-cone-intraday")).toBe(false);
   });
 });

--- a/web/tests/vol-cone-api.test.ts
+++ b/web/tests/vol-cone-api.test.ts
@@ -135,6 +135,33 @@ describe("GET /api/vol-cone", () => {
     });
   });
 
+  // The writers are Mon-Fri only (intraday RTH + EOD 20:45 UTC), so the
+  // longest healthy quiet period is Fri 20:45 UTC -> Mon 20:45 UTC + jitter
+  // on a holiday Monday (~73h). A 48h budget collapsed Friday's healthy
+  // snapshot into the "outage, not an empty result" banner every Sunday
+  // evening (screenshot 2026-08-31 02:26 UTC, snapshot 2026-08-28 20:45 UTC).
+  it("serves a weekend-aged snapshot (60h) instead of collapsing to missing", async () => {
+    const sundayAge = new Date(Date.now() - 60 * 60 * 60_000).toISOString();
+    await insertSnapshot(buildPayload({ scan_time: sundayAge }), sundayAge);
+
+    const { GET } = await import("../app/api/vol-cone/route");
+    const json = await jsonOf(await GET());
+    expect(json.missing).toBeUndefined();
+    expect(json.count).toBe(2);
+  });
+
+  it("still collapses a snapshot past the closed window, keeping its scan_time", async () => {
+    const deadAge = new Date(Date.now() - 5 * 24 * 60 * 60_000).toISOString();
+    await insertSnapshot(buildPayload({ scan_time: deadAge }), deadAge);
+
+    const { GET } = await import("../app/api/vol-cone/route");
+    const json = await jsonOf(await GET());
+    expect(json.missing).toBe(true);
+    expect(json.stale).toBe(true);
+    expect(json.scan_time).toBe(deadAge);
+    expect(json.hits).toEqual([]);
+  });
+
   it("only reads the vol-cone service's snapshots", async () => {
     await db.execute({
       sql: `INSERT INTO scan_snapshots (service, scan_time, payload) VALUES ('skew', ?, ?)`,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Incident

The dashboard's Vol Cone tab rendered the R-245 outage banner ("VOL CONE DATA UNAVAILABLE — THE LAST SCAN PRODUCED NO PAYLOAD. THIS IS AN OUTAGE, NOT AN EMPTY RESULT") on Sunday evening 2026-08-31 02:26 UTC, with the meta rail showing `SAMPLE Aug 28 13:45` (Friday's 20:45 UTC EOD write rendered in PT) and `SCANNED — CANDIDATES —`.

## Cause

`/api/vol-cone` carried a private 48h `MAX_AGE_MS`, but both writers are Mon-Fri only (`radon-vol-cone-intraday.timer` RTH sample + `radon-vol-cone.timer` EOD 20:45 UTC). Friday's EOD snapshot is legitimately the newest write until Monday, so from Sunday ~20:45 UTC until Monday's first scan the route collapsed a healthy snapshot through `staleCollapse` into `missing: true`, and `ScannerHero`'s `coneMissing` branch painted it as an outage — **every weekend**. Meanwhile the watchdog's own `vol-cone` window (3d closed) still read the writer as fine, so the two surfaces disagreed about the same snapshot (the exact class R-450 fixed for dispersion).

## Fix

- `web/app/api/vol-cone/route.ts` — serve budget now shares the catalog's closed window via `getFreshnessWindowMs("vol-cone", "closed")` (R-450 dispersion pattern), so the panel and the watchdog can never disagree again.
- `web/lib/serviceHealthWindows.ts` + `scripts/watchdog/services.py` — `vol-cone` / `vol-cone-intraday` closed+extended widen 3d → 4d. 3d sat exactly on the longest healthy gap: the holiday-Monday heartbeat lands Fri 20:45 UTC + 72h + `RandomizedDelaySec=60` + run time. Labor Day 2026-09-07 (next Monday) would have re-tripped the banner even at 3d. 4d follows the `cash-flow-sync` precedent (Fri→Mon gap plus one holiday-drift day).

## Red/green

- New in `web/tests/vol-cone-api.test.ts`: a 60h (Sunday-night) snapshot serves with `missing` undefined — **failed on the 48h budget, passes now**; a 5d snapshot still collapses with `stale: true` and its `scan_time` provenance preserved (R-194 contract).
- `web/tests/service-health-windows.test.ts` pins updated to 4d.

## Evidence

- Focused vitest (vol-cone-api, service-health-windows, panel-fault-visibility, serving-honesty-delta, vol-cone-panel, scanner-hero): `198 passed`
- Full web suite: `7901 passed, 10 skipped` (one `rel148-prefill-label` suite fails only when vitest is launched from `web/` cwd; passes from repo root — pre-existing cwd artifact, untouched)
- Watchdog pytest: `317 passed` (includes the Python↔TS `requires_ib` drift contract)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a055a3-789f-7875-81c9-7c0f5f8ec93c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a055a3-789f-7875-81c9-7c0f5f8ec93c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

