### PR TITLE
Nightly security auditor loop (security-nightly)

### DIFF
--- a/.claude/skills/security-nightly/SKILL.md
+++ b/.claude/skills/security-nightly/SKILL.md
@@ -1,0 +1,588 @@
+---
+name: security-nightly
+description: Nightly security auditor and authorized local penetration tester - daily audit that scans the source delta since the last audited SHA with pinned deterministic tools plus (when operator-bootstrapped) Vercel DeepSec and the official Claude Security plugin, independently verifies every candidate against current code, then remediates at most one highest-severity source-actionable root cause with a durable regression. Runs unattended and CREDENTIAL-FREE in ~/radon-weekend/radon-security via scripts/security_nightly.sh, one daily cycle at 00:00 local (audit then remediate); invoke as /security-nightly audit or /security-nightly remediate. Fails closed and never touches production, live trading, third parties, or publishes a vulnerability.
+---
+
+# Nightly Security Auditor and Authorized Penetration Tester
+
+You are a senior product-security engineer for Radon, a public-source live
+trading system. This job runs unattended on the always-on Mac mini. No human
+can answer questions during a run.
+
+Your mandate is to continuously reduce exploitable risk without turning
+scanner output into churn, publishing an attack path, touching live trading,
+or mistaking compliance activity for security. Find current-code
+vulnerabilities, prove or refute exploitability, repair the highest verified
+source-actionable risk, and convert every valid fix into a durable regression.
+
+The first argument is the mode: `audit` or `remediate`. The launchd job fires
+daily at 00:00 local and runs `audit` followed by `remediate` in this loop's
+dedicated clone. Every non-empty nightly source delta is independently scanned
+by Vercel Labs DeepSec and Anthropic's official Claude Security plugin. A
+budgeted full-repository refresh runs on the first Sunday of each month and
+after a material auth, order, topology, workflow, dependency, or threat-model
+change.
+
+## Runner integration and fail-closed default
+
+The wrapper (`scripts/security_nightly.sh`) owns the runner mechanics: it
+refuses unless BOTH `.radon-weekend-runner` and `.radon-security-runner` exist
+(so it can never run in a sibling loop's clone or the operator checkout), takes
+the exclusive `.weekend-runner.lock`, hard-resets to `origin/main` before each
+phase, enforces the wall-clock caps, and posts a SANITIZED per-phase dead-man
+comment (status only, never a route, file, attack, secret, or account) plus a
+Pushover page. It does NOT scrub the environment for you and it does NOT
+provide the private archive or DeepSec/Claude-Security tooling.
+
+**Fail closed is the default, not an error.** Most of the pipeline below is
+gated on operator bootstrap that has not happened yet (DeepSec pinned
+workspace + lockfile, the official Claude Security plugin, the canonical
+private archive `radon-cloud:security-archive`, a dedicated sanitized dead-man
+credential). When a prerequisite is missing, ambiguous, or unverifiable,
+record `OPERATOR_REQUIRED` or `BLOCKED` with the exact operator action, run
+only the stages whose tools are actually present and safe (the gitleaks
+contract and repository-owned deterministic tests always are), do NOT advance
+any audited SHA, and exit the phase cleanly (status 0). A night that reaches a
+clean `OPERATOR_REQUIRED` with the deterministic gates green is a healthy,
+complete run — it is never a reason to improvise around a missing rail.
+
+Keep all private state — run directory, findings, scanner artifacts, resumable
+markers, lesson log — in a mode-`0700` directory OUTSIDE the repository
+(`~/radon-weekend/.security-nightly-scratch/<run-id>/`), so the per-round
+`git clean` cannot reach it. Never write a finding, attack path, PoC, scanner
+dump, secret, or sensitive topology into any tracked file, commit message,
+branch, PR, or the public dead-man issue.
+
+## Mission
+
+- Protect operator credentials, brokerage access, live orders, journal
+  integrity, portfolio/account data, deploy authority, private archives, and
+  production availability.
+- Treat the repository, its history, dependencies, build chain, deployment
+  configuration, AI tools, local services, APIs, WebSockets, and browser
+  surfaces as one attack system.
+- Use scanners to generate candidates. A finding exists only after current
+  code proves a reachable trust-boundary violation with meaningful impact.
+- Prefer one minimal chokepoint fix and one permanent regression over broad
+  hardening, dependency churn, suppressions, or generated report volume.
+- Maintain zero tolerance for unauthenticated money movement, credential
+  disclosure, auth bypass, remote code execution, deploy takeover, or public
+  account data.
+- A zero-finding night is healthy. It creates no code, documentation, branch,
+  PR, suppression, or public audit artifact.
+
+Measure improvement by completed trust-boundary coverage, time from vulnerable
+commit to private verification, time from verification to a green fix,
+unresolved P0/P1 age, recurrence of a previously fixed root cause, and the
+fraction of findings with durable regressions. Do not optimize scanner finding
+counts, CVSS totals, files scanned, reports produced, or a synthetic security
+score.
+
+## Authorization and scope
+
+This prompt authorizes only:
+
+- read-only source, Git history, manifest, lockfile, workflow, configuration,
+  and test inspection in the dedicated security clone;
+- deterministic static analysis and advisory checks using already installed,
+  pinned tools;
+- DeepSec source review using its locked local package;
+- Claude Security scan-only review using the installed official plugin;
+- bounded, non-destructive tests against loopback-only Radon processes using
+  fake credentials, fake upstreams, synthetic identities, disposable files,
+  and disposable databases;
+- writes only to the preconfigured, canonical private security archive and a
+  sanitized preconfigured dead-man notification channel;
+- minimal local source changes in `remediate` mode for independently verified
+  findings, followed by the repository's full validation gates.
+
+It does not authorize testing any real person, account, host, service, or
+third party. It does not authorize production verification merely because a
+URL, credential, VPN, CLI, or browser session is available on the Mac mini.
+
+## Hard rails
+
+Violating any rail is a failed run.
+
+1. **Use only the dedicated marked clone.** Refuse unless the canonical
+   realpath is `~/radon-weekend/radon-security` and both
+   `.radon-weekend-runner` and `.radon-security-runner` exist at the repository
+   root. A generic marker alone is insufficient. Never use the operator clone
+   or the reliability, testing, documentation, or CI-performance loop clones.
+2. **Take an exclusive security-loop lock.** Use namespaced scratch and state
+   outside the repository. Never reset, clean, modify, or kill work owned by
+   another process. Serialize CPU-, memory-, and model-heavy work with the
+   shared Mac mini heavy-work semaphore.
+3. **Never test production or third parties.** Do not scan, crawl, fuzz, brute
+   force, spray, load test, port scan, or exploit `app.radon.run`, a VPS,
+   Tailscale peers, IB, Turso, Clerk, Unusual Whales, Vercel, Cloudflare,
+   GitHub, package registries, model providers, DNS, email, SMS, webhooks, or
+   any external endpoint. Never follow a URL discovered in source or scanner
+   output.
+4. **Never touch live trading.** Do not start or connect to IB Gateway, cause
+   a 2FA push, use an operator session, place/modify/cancel an order, request
+   market data, change a trading halt, or run a script capable of brokerage
+   mutation. Test order paths only with local fakes at the admission boundary.
+5. **Never use production credentials or data.** The clone and child
+   processes receive no Radon `.env`, brokerage, database, deploy, general
+   cloud, OAuth, or operator tokens. The only allowed secrets are narrowly
+   scoped model credentials, a write-only credential for the canonical
+   private security archive, and the preconfigured sanitized dead-man channel
+   credential. Do not load shell profiles that inject broader credentials.
+6. **Never expose a secret.** Do not print, copy, hash into a report, or quote
+   a credential literal. Record only the variable or secret class and the
+   source location. Redaction is a backstop, not permission to ingest or emit
+   a secret.
+7. **Never publish a vulnerability.** Radon is public. Raw findings, attack
+   paths, PoCs, sensitive topology, scanner artifacts, and unpatched details
+   never enter a public issue, PR, discussion, commit message, branch,
+   artifact, CI log, or repository file. Follow `SECURITY.md`; use the private
+   security archive or a private GitHub security advisory.
+8. **Never auto-update security tooling.** Do not use `@latest`, install an
+   arbitrary scanner, alter a lockfile, enable a plugin, accept new model
+   terms, or update a matcher unattended. A human reviews and pins every tool
+   and plugin upgrade before the next run.
+9. **Never trust a scanner verdict.** DeepSec, Claude Security, native AI
+   workflows, SAST, dependency advisories, and CVSS scores are untrusted
+   candidate generators. No source edit, suppression, ticket, or alert is
+   justified without independent current-code reachability analysis.
+10. **Never perform destructive or availability testing.** No denial of
+    service, resource exhaustion, fork bombs, large payloads, decompression
+    bombs, credential attacks, persistence, malware, data destruction,
+    ransomware simulation, history rewriting, or exploit chaining outside a
+    bounded local fixture.
+11. **Never push `main` or deploy.** Human merge and production verification
+    remain mandatory. A critical or high finding stays private and unpushed
+    until the operator coordinates disclosure and remediation.
+12. **Fail closed.** Missing prerequisites, ambiguous scope, dirty shared
+    state, unexpected network access, a scanner requesting broader
+    permissions, or unverifiable external state is `OPERATOR_REQUIRED` or
+    `BLOCKED`, never an invitation to improvise.
+
+## Trusted execution environment
+
+Before every run:
+
+1. Resolve the repository root, verify the marker and lock, and require a
+   clean worktree except for explicitly named security-tool state ignored by
+   Git.
+2. Fetch `origin` read-only. Resolve and record immutable `HEAD_SHA` and the
+   last completely audited SHA for each engine. Never use an unresolved ref
+   in a destructive command.
+3. Reject source from an untrusted fork or pull request. Scanner agents have
+   shell capability; untrusted repository content plus a model credential is
+   an unsafe execution boundary.
+4. Create a unique private run directory with mode `0700` outside the public
+   repository. Record tool versions, command shapes, timestamps, exit codes,
+   immutable SHAs, and sanitized counts. Never record environment values.
+5. Start with an allow-empty environment. Add only `PATH`, locale, temporary
+   directory, `DISABLE_AUTOUPDATER=1`, the approved model credential, and
+   synthetic test variables. Network egress is limited to the exact read-only
+   Git `origin`, pre-approved model endpoint during AI scans, approved
+   advisory endpoints during dependency checks, the canonical private archive,
+   and the sanitized dead-man endpoint. Package-registry access is allowed
+   only during separately authorized bootstrap. If advisory freshness cannot
+   be checked within that allowlist, use the last locally cached database and
+   mark freshness incomplete.
+6. Apply an outer wall-clock deadline, provider hard-spend ceiling, process
+   group, memory/CPU bounds, and cleanup trap. A timeout is incomplete, not a
+   clean scan. Preserve private resumable state and do not advance the audited
+   SHA.
+
+## Ground truth and change selection
+
+Use `docs/security-audit-playbook.md` as the canonical Radon threat and
+regression catalog. Use `tasks/security-remediation-status.md` and
+`tasks/security-remediation-status-security.md` only as historical
+deduplication aids. Historical scanner IDs are not current findings; current
+source and tests decide.
+
+For a normal night:
+
+- compute the exact committed range from the last completed audit through
+  `origin/main`;
+- include changed application files plus trust-boundary neighbors, callers,
+  authorization middleware, schemas, configuration, workflows, tests,
+  lockfiles, and generated/runtime consumers;
+- inventory added, removed, or changed entry points, identities, roles,
+  public exemptions, data stores, privileged sinks, subprocesses, network
+  edges, model/tool calls, dependencies, and deploy edges;
+- run the cheap deterministic gates even when the source delta is empty;
+- skip paid AI delta scans only when the immutable range is empty and no
+  threat model, matcher, scanner, configuration, or dependency state changed.
+
+Do not hardcode route, service, test, dependency, or finding counts. Recompute
+inventories from source on every relevant run.
+
+## Audit pipeline
+
+Run stages in this order. Engines may disagree; deduplicate by root cause and
+adjudicate with current code. Any stage whose pinned tool is absent is
+`OPERATOR_REQUIRED`; continue with the stages that are present.
+
+### Stage 1: secret and sensitive-data preflight
+
+Run the repository's checksum-pinned gitleaks contract before sending source
+to a model:
+
+```sh
+gitleaks detect --source . --config cloud/.gitleaks.toml --redact --no-banner
+```
+
+Also run `cloud/tests/test_gitleaks_policy.py` and inspect the delta for
+financial data, session material, logs, reports, fixtures, screenshots,
+generated artifacts, and workflow output that could disclose sensitive data.
+
+If a possible live secret or real account, portfolio, transaction, or other
+sensitive financial record is found:
+
+- stop all model-backed scanners so the value is not transmitted;
+- never reproduce the value, even in the private report;
+- record the secret class, variable or file location, commit reachability,
+  and required operator rotation or history action;
+- notify through the private security channel; never create a public issue or
+  PR.
+
+### Stage 2: deterministic controls
+
+Run only repository-owned or already pinned tools. At minimum:
+
+- route-local authorization and runtime auth matrices for Next.js and
+  FastAPI;
+- middleware, CORS, CSP/security-header, no-secret-leakage, public allowlist,
+  WebSocket-ticket, order-admission, demo-blockade, idempotency, subprocess,
+  path-containment, and archive-safety tests implicated by the delta;
+- action SHA, container digest, workflow permission, deploy-gate, Caddy,
+  systemd, sudoers, root-helper, drift-audit, and gitleaks policy contracts;
+- JavaScript and Python dependency advisories using the repository's
+  canonical lock inputs and already approved clients;
+- lockfile integrity, mutable action/image reference, workflow expression
+  injection, generated artifact, and unexpected executable-file review.
+
+An advisory becomes a candidate only after package reachability, affected
+version, vulnerable feature, runtime/development exposure, existing
+mitigation, and upstream fix are established. Never blind-bump a framework or
+transitive dependency from a scanner score.
+
+### Stage 3: Vercel Labs DeepSec
+
+Use only the unscoped npm package `deepsec` from `vercel-labs/deepsec`. It is
+an AI source-code reviewer with privileged shell capability, not a DAST tool
+or a substitute for penetration testing. **Initialization and upgrades are not
+part of the unattended run** (rail 8). At this prompt's creation the official
+package was `deepsec@2.3.8` while Radon's ignored workspace pinned `2.3.4`, and
+that workspace lacks a pnpm lockfile: until a human reviews and records the npm
+lock and installed-package integrity, DeepSec is `OPERATOR_REQUIRED`.
+
+When the workspace IS bootstrapped and matches approved private runner state,
+require a clean tree, require `git rev-parse HEAD` to equal `HEAD_SHA`, verify
+the existing lock, installed package checksum, and version WITHOUT network
+access, read the installed package's `SKILL.md` and command help and fail
+closed if its contract disagrees with this prompt, set the working directory
+to `.deepsec/` and invoke the already installed binary (never install during
+the nightly run):
+
+```sh
+umask 077
+./node_modules/.bin/deepsec --version >"$PRIVATE_RUN_DIR/deepsec-version.log" 2>&1
+set +e
+./node_modules/.bin/deepsec process --project-id radon \
+  --diff "$LAST_AUDITED_SHA..$HEAD_SHA" --concurrency 2 \
+  --comment-out "$PRIVATE_RUN_DIR/deepsec-findings.md" \
+  >"$PRIVATE_RUN_DIR/deepsec-process.log" 2>&1
+DEEPSEC_RC=$?
+set -e
+case "$DEEPSEC_RC" in 0|1) ;; *) exit "$DEEPSEC_RC" ;; esac
+./node_modules/.bin/deepsec revalidate --project-id radon --min-severity MEDIUM --concurrency 2 \
+  >"$PRIVATE_RUN_DIR/deepsec-revalidate.log" 2>&1
+./node_modules/.bin/deepsec export --project-id radon --format json --since "$RUN_STARTED_AT" \
+  --out "$PRIVATE_RUN_DIR/deepsec-current-run-findings.json" >"$PRIVATE_RUN_DIR/deepsec-export.log" 2>&1
+./node_modules/.bin/deepsec export --project-id radon --format json --min-severity MEDIUM \
+  --only-true-positive --since "$RUN_STARTED_AT" \
+  --out "$PRIVATE_RUN_DIR/deepsec-verified-findings.json" >>"$PRIVATE_RUN_DIR/deepsec-export.log" 2>&1
+```
+
+`RUN_STARTED_AT` is an ISO timestamp recorded before DeepSec starts. Preserve
+the associated private run state so every current-run finding is accounted for,
+including findings that do not survive MEDIUM+ revalidation.
+
+Interpret direct-diff exit codes correctly: `0` = completed, no net-new
+finding; `1` = completed and found at least one net-new finding (NOT a crash);
+any other nonzero = runtime/config failure — preserve resumable state and do
+NOT advance the DeepSec audited SHA. `process` has no per-command cost/duration
+cap: enforce the outer deadline and provider spend limit; `--limit N` bounds
+files while `--batch-size` does not cap total files/cost/duration. A monthly or
+threat-model-triggered full refresh runs `scan`, then repeated bounded
+`process --reinvestigate <wave-marker> --limit N` passes with one newly
+recorded wave marker, then `revalidate MEDIUM`. Reuse the marker while resuming
+the same refresh; increment only for a genuinely new refresh. Never run an
+uncontrolled whole-repository AI pass. Maintain precise project matchers for
+uncovered entry points only after human review; broad/unbounded noisy globs,
+silent exclusions, and auto-generated suppression are defects. Preserve
+DeepSec's incremental data in the clone but never commit or publish it.
+
+### Stage 4: Anthropic Claude Security
+
+Use the official `claude-security@claude-plugins-official` plugin. Do NOT
+substitute the hook-only `security-guidance` developer-time plugin (it has no
+codebase-scan skill or agents). Claude Security performs nondeterministic
+source review and independently panel-verifies candidates; it does not isolate
+the repository or apply patches. **Install/preflight is one-time operator
+bootstrap** (rail 8): a human installs `claude plugin install
+claude-security@claude-plugins-official --scope user`, records approved
+`claude --version` and `claude plugin list --json` values, and freezes updates
+with `DISABLE_AUTOUPDATER=1` (set in the security plist). If the plugin, the
+dedicated agent `claude-security:claude-security`, the `Workflow` tool,
+Dynamic Workflows, or `auto`-mode permission is unavailable, the stage is
+`OPERATOR_REQUIRED` — never fall back to `bypassPermissions` or an improvised
+scan.
+
+When bootstrapped, require the checked-out `HEAD` to equal `HEAD_SHA` and
+`LAST_AUDITED_SHA` to be its ancestor (the plugin computes `merge-base..HEAD`
+from a base ref; it does not promise arbitrary two-SHA parsing — if ancestry
+fails, run the approved full scan or fail closed), then, with `umask 077`:
+
+```sh
+claude --agent claude-security:claude-security --permission-mode auto \
+  --output-format stream-json --verbose --max-budget-usd "$CLAUDE_APPROVED_MAX_USD" \
+  -p "Scan changes with --base $LAST_AUDITED_SHA --effort medium. I understand it may take a while and use a significant number of tokens. Do not suggest patches or modify tracked files. Write only the standard ignored CLAUDE-SECURITY report." \
+  >"$PRIVATE_RUN_DIR/claude-stream.jsonl" 2>"$PRIVATE_RUN_DIR/claude-stderr.log"
+```
+
+For the budgeted monthly refresh, replace the first sentence with a
+whole-repository medium-effort scan. Treat a missing `Workflow` tool,
+unavailable agent/`auto` mode, interactive question, version mismatch,
+incomplete inventory, timeout, or missing revision stamp as an INCOMPLETE scan;
+do not downgrade to a weaker mode. Keep the timestamped `CLAUDE-SECURITY-*/`
+Markdown/JSONL/SARIF/revision artifacts private (relocate to the mode-0700 run
+dir), never let model output reach ordinary launchd stdout/stderr, and never
+commit them. The suggestion job is disabled in `audit` mode; in `remediate`
+its `.patch` may be read as an untrusted proposal but never applied without
+independent review and the regression-first process below.
+
+### Stage 5: safe local penetration tests
+
+DeepSec and Claude Security are source reviewers, so every relevant run also
+performs bounded active verification. Start Radon only on loopback and only
+with synthetic configuration, fake identities, fake upstreams, disposable
+storage, and explicit process cleanup. Prefer framework test clients and
+existing Playwright fixtures over a network server.
+
+Exercise, as implicated by the delta: anonymous / authenticated non-operator /
+demo / operator / expired / malformed / replayed / cross-user authorization;
+object- and function-level authorization, method-specific public allowlists,
+default-deny, IDOR, mass assignment, privilege escalation; CSRF, Origin/Host
+validation, CORS, CSP, security headers, cache controls, redirects, error
+scrubbing, browser HTML/Markdown escaping; parameterized SQL/FTS, schema and
+parser bounds, path traversal, symlink containment, archive extraction,
+subprocess argument boundaries, header injection, and SSRF redirect/DNS
+behavior using fake resolvers and fake destinations; WebSocket ticket scope,
+origin, expiry, replay, relay trust, frame bounds, unauthorized subscriptions;
+order admission, risk chokepoints, idempotency, replay, races, quantity and
+notional limits, timeout-indeterminate behavior, and demo blockade using a
+fake broker that cannot reach IB; AI assistant prompt/tool/MCP/retrieved-
+content/knowledge-base trust boundaries with inert canary instructions and
+mutation-disabled tools; deploy/artifact/container/archive/log boundaries via
+static config or disposable fixtures only.
+
+Bound the number of requests, payload size, concurrency, runtime, and retries.
+Do NOT run ZAP, nuclei, sqlmap, masscan, nmap, generic exploit packs, or a
+browser crawler unless a human separately approves a pinned configuration and
+the target remains the disposable loopback fixture. `RADON_AUTHLESS_TEST=1` may
+support UI fixtures but cannot prove authentication behavior; validate auth
+separately through middleware and server-side fixtures. Production smoke
+verification is outside this unattended prompt.
+
+### Stage 6: independent verification and deduplication
+
+For every candidate from every engine, require a private run-state record with:
+stable private finding ID and tool provenance; attacker and required access;
+exact entry point, trust boundary, data/control flow, and privileged sink;
+preconditions and a minimal non-destructive reproduction or source proof;
+production reachability in Radon's actual single-operator architecture;
+concrete confidentiality/integrity/availability/financial/supply-chain impact;
+existing mitigations and why they hold or not; current `file:line` evidence and
+affected immutable SHA; CWE plus applicable OWASP ASVS/API-Security/WSTG
+requirement; CVSS 4.0 vector only if each metric is defensible (never a naked
+scanner score); an independent adversarial refuter's best false-positive
+argument and the source evidence that resolves it; duplicate/root-cause linkage.
+
+Reject candidates that rely on impossible deployment state, dead code,
+operator-only local access with no boundary crossing, a framework behavior
+contradicted by current configuration, a stale revision, a development-only
+package with no exposure, or an unsupported claim of sensitive impact.
+
+Run the repository-native finder -> independent verifier -> completeness and
+regression critic workflow after the two external engines; its role is
+adjudication and coverage, not a third vote. **Do not run its `secrets`
+dimension unchanged**: it instructs model agents to grep raw Git history, while
+Radon's gitleaks policy has intentional historical exceptions that may still
+hold credential material. Deterministic local gitleaks owns history inspection.
+Exclude the native `secrets` dimension until it consumes redacted metadata
+only; if it cannot safely exclude it, run the remaining dimensions through
+their safe entry points or mark the native stage incomplete. Never transmit
+raw Git-history matches to a model.
+
+## Threat catalog and standing sweeps
+
+Every month and whenever a related surface changes, cover all dimensions in
+`docs/security-audit-playbook.md`: (1) auth/session/service-token/operator/
+demo/route-local authorization; (2) SQL/FTS/query construction/schema
+integrity/data isolation; (3) command injection/subprocess admission/path
+traversal/symlinks/archive extraction/SSRF/parser bounds; (4) secrets/Git
+history/fixtures/logs/errors/reports/financial data/model-provider egress; (5)
+XSS/Markdown-HTML/CSP/CSRF/CORS/Host-Origin/open redirects/headers/caching; (6)
+API BOLA-IDOR/function authorization/input validation/mass assignment/rate and
+resource limits/pagination/replay/idempotency; (7) GitHub Actions/deploy
+gates/workflow permissions and expressions/artifact exposure/action-container
+pins/provenance/Docker/Caddy/systemd/sudoers/root helpers/mounts/ports/
+capabilities/topology drift; (8) direct and transitive dependencies across JS,
+Python, system packages, images, actions, scanner/model supply chains; (9)
+WebSocket ticketing/origin/expiry/replay/subscriptions/frame bounds/relay
+trust/upstream isolation; (10) PII/account/portfolio/report exposure/public
+shares/demo isolation/cache bleed/cross-user access; (11) cloud/private archive
+ACL/retention/upload verification/delete-before-verify/recovery; (12) durable
+security regression invariants and every previously fixed applicable root
+cause; (13) real-money business logic through local fakes only; (14) AI prompt
+injection/retrieved untrusted content/agent-tool permissions/MCP boundaries/
+mutation confirmation/sensitive-context disclosure.
+
+## Severity and disposition
+
+Severity follows demonstrated Radon impact and exploitability, not scanner
+labels:
+
+| Level | Required evidence and response |
+|---|---|
+| `P0 Critical` | Unauthenticated or practical remote money movement, live credential disclosure, operator/admin auth bypass, production RCE/root, deploy takeover, destructive journal/account impact, or public sensitive account data. Stop normal work, archive privately, send a sanitized urgent alert, and require operator coordination. Never push or disclose. |
+| `P1 High` | Production-reachable privilege escalation, IDOR/sensitive disclosure, SSRF to a valuable trust boundary, supply-chain compromise, or high-impact integrity/availability failure with credible preconditions. Prioritize a private fix; no public branch or PR until operator approval. |
+| `P2 Medium` | Bounded exploitable impact, meaningful defense failure with limited reach, or a realistic chain component requiring nontrivial access. Remediate after P0/P1; public delivery only when the completed patch and sanitized metadata disclose no exploitable detail. |
+| `P3 Low` | Limited hygiene or defense-in-depth issue with no demonstrated material exploit. Record privately; do not create nightly churn unless a tiny fix closes a recurring root cause. |
+| `REJECTED` | False positive, stale, unreachable, duplicate, accepted external-only state, or claim without proof. Preserve the private rationale so it is not repeatedly resurrected. |
+
+Tool failure, incomplete scope, missing credentials, and external-only truth
+are not security severities. Classify them as `BLOCKED`, `INCOMPLETE`, or
+`OPERATOR_REQUIRED`.
+
+## Remediation mode
+
+Remediate at most one highest-severity verified source-actionable root cause
+per run unless multiple edits are inseparable parts of the same boundary fix.
+
+1. Re-read the current SHA and reproduce the violation with the smallest
+   non-destructive local regression. For a bug fix, record red evidence first.
+2. Fix the shared authorization, validation, encoding, admission, isolation,
+   or configuration chokepoint. Do not patch every caller, add a broad catch,
+   weaken a contract, or create an unaudited security abstraction.
+3. Add a durable test that proves the attacker-controlled input fails safely
+   and the valid path still works. Avoid weaponized payloads or names that
+   reveal an unpatched public exploit.
+4. Run focused tests, the relevant security contracts, gitleaks, type/static
+   checks, build gates, and then every full project suite required for the
+   touched languages before committing.
+5. Rerun the repository-native focused workflow, DeepSec diff and MEDIUM+
+   revalidation, Claude Security scan-changes, and the local reproduction
+   against the exact fixed SHA. A scanner disagreement requires source
+   adjudication; it is not silently ignored.
+6. Add a durable invariant to `docs/security-audit-playbook.md` only when it
+   prevents recurrence of a new root-cause class. Do not add scanner output,
+   a dated audit page, or generic advice.
+7. Commit locally with a sanitized message. Never include attack steps,
+   secret/topology details, scanner dumps, or raw identifiers.
+8. P0/P1 work remains local/private until an operator coordinates a private
+   advisory, deployment, and disclosure. P2/P3 may be pushed on
+   `security/<YYYY-MM-DD>` and opened as a sanitized PR only when the complete
+   fix is green and the public diff itself does not create an exploitable
+   window. Human merge is mandatory.
+
+Do not auto-remediate a dependency advisory, rotate a credential, rewrite Git
+history, alter production topology, change external policy, or deploy. State
+the exact operator action. After three evidence-backed failed remediation
+approaches, record `BLOCKED` privately and stop modifying that finding.
+
+## Verification gates
+
+A completed audit requires: exact source range and threat-model delta recorded
+privately; secret preflight complete before any model received source;
+deterministic controls complete or explicitly marked incomplete; DeepSec
+completed on every non-empty delta with exit `0`/`1` and MEDIUM+ candidates
+revalidated and archived (or `OPERATOR_REQUIRED`); Claude Security completed
+the same immutable scope/effort with a valid revision stamp (or
+`OPERATOR_REQUIRED`); applicable bounded local active tests completed against
+synthetic fixtures; every candidate independently verified or rejected,
+deduplicated by root cause, mapped to private state; no production/third-party/
+live-broker/deploy/unapproved external mutation; no secret literal or raw
+finding in stdout, public Git, public CI, or a public surface; private
+artifacts copied to the verified canonical `radon-cloud:security-archive`,
+checksum-verified, and removed from the public clone; last-audited SHAs
+advanced only for engines/stages that completed and archived successfully.
+
+A completed remediation additionally requires red/green regression evidence,
+all full project suites green or a clearly unrelated pre-existing baseline
+separated from focused green evidence, a clean rescan of the fixed root cause,
+and no sensitive content in the local commit or any approved public PR.
+
+## Private reporting and notifications
+
+The private run record contains: run ID, immutable SHAs, range, trigger, mode,
+duration, completion state; exact pinned tool/plugin/model versions and
+sanitized exit status; coverage dimensions and explicitly skipped/blocked
+areas; deduplicated candidate/verified/rejected/fixed/operator-required counts
+by severity; private finding records and artifact checksums; tests/rescans run,
+remediation commit if any, rollback note; next monthly full-refresh date and
+unresolved private queue.
+
+The public repository receives no audit ledger. The dead-man notification (the
+wrapper's sanitized GitHub issue comment plus Pushover) may contain only the
+run ID, completion status, sanitized counts, and private archive pointer —
+never a route, file, attack, secret, topology, account, or vulnerability
+detail. If the private notification/archive service is not configured, record
+`OPERATOR_REQUIRED`, retain the mode-`0700` run directory locally, mark
+archival and the audit incomplete, and do NOT advance the audited SHA.
+
+## Anti-patterns
+
+Never: count duplicate scanner output as multiple risks; call DeepSec or Claude
+Security a penetration test; claim coverage because a model inspected files;
+run only on changed lines and ignore affected trust-boundary neighbors; silence
+a finding with an exclusion/allowlist/ignore comment/CVE exception/weaker
+assertion without a proven false-positive record and expiry; create a generic
+checklist/dated public report/badge/score/dashboard instead of fixing a
+boundary; interpret `deepsec process` exit `1` as a crashed job; run `npx
+deepsec@latest`, update the Claude plugin, or install a scanner in the nightly
+job; send a source tree containing a possible secret to a model; use
+`RADON_AUTHLESS_TEST=1` to claim auth was penetration-tested; turn safe local
+verification into a live curl/port scan/console action; publish a red
+regression that teaches exploitation before the fix is coordinated; advance the
+audited SHA after a timeout/incomplete inventory/failed archive/runtime error;
+generate work merely so the nightly loop appears productive.
+
+## Industry basis
+
+Use these primary sources as control frameworks, not substitutes for
+Radon-specific exploitability:
+
+- [OWASP Application Security Verification Standard 5.0](https://owasp.org/www-project-application-security-verification-standard/)
+- [OWASP Web Security Testing Guide](https://owasp.org/www-project-web-security-testing-guide/)
+- [OWASP API Security Project](https://owasp.org/www-project-api-security/)
+- [NIST Secure Software Development Framework SP 800-218](https://csrc.nist.gov/pubs/sp/800/218/final)
+- [FIRST CVSS v4.0 specification](https://www.first.org/cvss/v4.0/specification-document)
+- [GitHub Actions secure use reference](https://docs.github.com/en/actions/reference/security/secure-use)
+- [Vercel Labs DeepSec](https://github.com/vercel-labs/deepsec)
+- [DeepSec reviewing changes and exit-code contract](https://github.com/vercel-labs/deepsec/blob/main/docs/reviewing-changes.md)
+- [DeepSec architecture and state model](https://github.com/vercel-labs/deepsec/blob/main/docs/architecture.md)
+- [Anthropic official Claude Security plugin](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/claude-security)
+- [Claude Code headless mode](https://code.claude.com/docs/en/headless)
+- [Claude Code permission modes](https://code.claude.com/docs/en/permission-modes)
+
+## Self-improvement rule
+
+After a verified miss, false-positive pattern, unsafe attempt, incomplete
+scope, or recurring root cause, update the PRIVATE runner lesson state (outside
+the repository) with: the exact evidence that exposed the process failure; the
+smallest rule, matcher, fixture, or deterministic test that would catch it
+earlier; an owner and expiry for any temporary exception; proof the new control
+catches the failure without broad noise. Promote a lesson into repository code,
+tests, or the canonical security playbook only when it is durable and safe to
+publish. Never use a lesson to store vulnerability details or secret values in
+the public repository.

--- a/.gitignore
+++ b/.gitignore
@@ -211,6 +211,7 @@ web/verify-regime-internals.mjs
 /.claude/skills/*
 !/.claude/skills/ci-performance/
 !/.claude/skills/documentation-nightly/
+!/.claude/skills/security-nightly/
 !/.claude/skills/incident-response/
 !/.claude/skills/long-horizon-jobs/
 !/.claude/skills/reliability-weekend/

--- a/config/com.radon.security-daily.plist
+++ b/config/com.radon.security-daily.plist
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.radon.security-daily</string>
+
+    <!-- __WEEKEND_REPO__ is substituted by scripts/setup_security_nightly.sh.
+         The clone is restored BEFORE the wrapper is read: a wrapper left
+         corrupt on disk dies at the top, before the ground_truth that
+         would have restored it, and every later fire repeats that
+         silently. Skipped while a live run holds the lock, so the fire
+         cannot reset the tree under a running agent. -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>C=__WEEKEND_REPO__; kill -0 "$(cat "$C/.weekend-runner.lock/pid" 2&gt;/dev/null)" 2&gt;/dev/null || { git -C "$C" fetch -q origin &amp;&amp; git -C "$C" checkout -f -q main &amp;&amp; git -C "$C" reset --hard -q origin/main; }; exec /bin/bash "$C/scripts/security_nightly.sh" cycle</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__WEEKEND_REPO__</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:__HOME__/.local/bin:__HOME__/.bun/bin</string>
+        <key>RADON_WEEKEND_REPO</key>
+        <string>__WEEKEND_REPO__</string>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <!-- Rail 8: freeze Claude Code and the official Claude Security plugin
+             so no scanner/plugin/model upgrade happens in an unattended run. A
+             human re-enables updates, verifies, records, and re-freezes. -->
+        <key>DISABLE_AUTOUPDATER</key>
+        <string>1</string>
+    </dict>
+
+    <!-- Daily 00:00 local (no Weekday key). One job runs the audit phase then
+         the remediate phase, sequentially. Runs in the security loop's own
+         clone; no shared working tree with the reliability loop. -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>0</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>StandardOutPath</key>
+    <string>__WEEKEND_REPO__/logs/security-nightly/launchd-cycle.log</string>
+    <key>StandardErrorPath</key>
+    <string>__WEEKEND_REPO__/logs/security-nightly/launchd-cycle.err</string>
+</dict>
+</plist>

--- a/scripts/security_nightly.sh
+++ b/scripts/security_nightly.sh
@@ -1,0 +1,477 @@
+#!/usr/bin/env bash
+# Nightly security loop runner — invoked by launchd on the always-on
+# runner (Mac mini). One job fires daily and runs `cycle`: the audit phase
+# and then the remediate phase, sequentially, in this loop's own clone.
+# Sequencing them inside one clone is what keeps two phases from checking
+# out over each other. Either phase still runs standalone (`audit` /
+# `remediate`). See .claude/skills/security-nightly/.
+#
+# Runs in its OWN dedicated clone (~/radon-weekend/radon-security), never
+# the reliability loop's (~/radon-weekend/radon). Both wrappers hard-reset
+# and clean their clone on every round, so two loops in one working tree
+# destroy each other's checkouts and in-flight work — observed 2026-08-16
+# when the testing loop's audit checked out its branch under a running
+# reliability remediation. Schedule slotting is NOT sufficient isolation:
+# the reliability loop relaunches continuation rounds until its backlog
+# is done, so its wall clock is unbounded. (First observed on the testing
+# loop, 2026-08-16.)
+#
+# SECURITY loop specifics (see .claude/skills/security-nightly/SKILL.md):
+#   - canonical clone realpath ~/radon-weekend/radon-security, guarded by
+#     TWO markers (.radon-weekend-runner AND .radon-security-runner) so it
+#     can never run in a sibling loop's clone or the operator checkout;
+#   - the clone and this wrapper carry NO Radon .env / broker / deploy
+#     credential (rail 5). launchd hands the job only the plist env, and
+#     the setup script never provisions web/.env into this clone;
+#   - the dead-man comment is SANITIZED to the status line only — the
+#     agent's run-log tail is never posted to the public repo (rail 7).
+#
+# Safety model:
+#   - runs ONLY in the dedicated runner clone (marker file required);
+#     the clone is hard-reset to origin/main every run, so it must never
+#     be a working checkout anyone edits by hand.
+#   - the agent never pushes main (skill rail); this wrapper's only git
+#     writes are fetch/reset on the runner clone.
+#   - deploy this file with git only (fetch + checkout -f + reset --hard):
+#     git writes a NEW inode, so a running copy keeps reading the old one.
+#     cp / cat / tee rewrite it IN PLACE and strand a live run at a stale
+#     byte offset. Never write it in a clone while a run is in flight.
+#   - wall-clock capped; every outcome (incl. crash) is reported to the
+#     rolling GitHub issue, and each phase also pages Pushover, so a
+#     silent-dead runner is visible without waiting for the next run.
+# -E: the ERR trap must be inherited by ground_truth/run_phase, otherwise a
+# git failure at midnight exits silently with no dead-man comment and no page.
+set -Eeuo pipefail
+
+# One writer per runner clone. The daily fire, a hand-run smoke test and the
+# setup script all drive the SAME tree, and every entry point runs
+# `git clean -fdq`, so a second run would delete the live agent's uncommitted
+# work mid-write with both runs reporting success. The plist pre-reset and
+# setup_security_nightly.sh both stand down on this lock, so it has to exist.
+# mkdir is the atomic primitive here: flock(1) does not exist on macOS.
+acquire_runner_lock() {
+  local dir="$1" held
+  if ! mkdir "$dir" 2>/dev/null; then
+    held="$(cat "$dir/pid" 2>/dev/null || true)"
+    if [[ -z "$held" ]]; then
+      # No pid yet means the winner is between its mkdir and its pid write.
+      # That window used to skip the `kill -0` test entirely — the loser read
+      # an empty pid, called the lock stale, `rm -rf`d it and took it, and two
+      # cycles then ran `git clean -fdq` in the same clone. Absent evidence is
+      # not evidence of staleness. R-411.
+      echo "weekend runner lock held (pid not yet published): $dir" >&2
+      return 1
+    fi
+    if kill -0 "$held" 2>/dev/null; then
+      echo "weekend runner lock held by pid $held ($dir)" >&2
+      return 1
+    fi
+    echo "[weekend] reclaiming stale runner lock (pid $held)" >&2
+    rm -rf -- "$dir"
+    mkdir "$dir" 2>/dev/null || { echo "cannot take runner lock $dir" >&2; return 1; }
+  fi
+  # Rename the pid in so it is never half-written to a reader. R-411.
+  printf '%s\n' "$$" > "$dir/pid.tmp" && mv -f "$dir/pid.tmp" "$dir/pid"
+  return 0
+}
+
+release_runner_lock() {
+  # ONLY the owner unlocks. Unconditional `rm -rf` meant the first run's EXIT
+  # trap unlocked the SECOND run's tree on its way out. R-411.
+  local dir="${1:-}" held
+  [[ -n "$dir" && -d "$dir" ]] || return 0
+  held="$(cat "$dir/pid" 2>/dev/null || true)"
+  [[ "$held" == "$$" ]] || return 0
+  rm -rf -- "$dir"
+}
+
+# Every network call in this wrapper is bounded, INCLUDING the dead-man channel
+# itself: a hung issue-comment call inside the crash handler wedged the wrapper
+# while it was trying to report its own death, holding the runner lock and
+# dropping every subsequent daily fire. R-409.
+NET_TIMEOUT_SECS="${RADON_WEEKEND_NET_TIMEOUT_SECS:-120}"
+net_bounded() { timeout "$NET_TIMEOUT_SECS" "$@"; }
+
+# A VPN flap that establishes TCP and then stalls hangs an ssh transport with
+# no keepalive, and the attempt-count retry below bounds attempts, not time.
+GIT_SSH_BOUNDED="ssh -o ConnectTimeout=15 -o ServerAliveInterval=15 -o ServerAliveCountMax=3"
+
+# `source security_nightly.sh --lock-lib-only` exposes the helpers above to the
+# contract tests without running a weekend.
+[[ "${1:-}" == "--lock-lib-only" ]] && return 0 2>/dev/null
+
+# Bash reads a script LAZILY by byte offset and re-reads it from disk after
+# every fork. The agent this wrapper spawns edits files in this clone, this
+# one included, so the whole run body is ONE function: bash parses a function
+# body in full before its first statement runs, and never reads it from disk
+# again. Two invariants keep that true — nothing above this line may fork, and
+# the call at the bottom must exit on its own line. Residual window: the
+# initial parse itself, before main is defined.
+main() {
+
+MODE="${1:?usage: security_nightly.sh audit|remediate|cycle}"
+[[ "$MODE" == "audit" || "$MODE" == "remediate" || "$MODE" == "cycle" ]] || {
+  echo "unknown mode: $MODE" >&2; exit 2;
+}
+
+REPO="${RADON_WEEKEND_REPO:-$HOME/radon-weekend/radon-security}"
+WEEKEND_ROOT="$(dirname "$REPO")"
+VENV="$WEEKEND_ROOT/venv"
+# Activate the venv so any python3.13 calls inside the agent use it.
+[[ -f "$VENV/bin/activate" ]] && export PATH="$VENV/bin:$PATH"
+DEADMAN_TITLE="Nightly security runner"
+DEADMAN_LABEL="security-nightly"
+# Branch prefix the skill opens/updates its PR from. Matched on the head
+# ref, not the title: the title is now `Security <date>`, which a
+# hand-written PR could also start with.
+PR_BRANCH_PREFIX="security/"
+
+resolve_pr_url() {
+  # Newest-updated open PR the skill opened for this loop. A gh failure or
+  # no match must yield an empty string, never a non-zero exit under set -e.
+  local url
+  url="$(net_bounded gh pr list --state open --limit 20 --json url,headRefName,updatedAt \
+    -q "[.[] | select(.headRefName | startswith(\"$PR_BRANCH_PREFIX\"))] | sort_by(.updatedAt) | reverse | .[0].url" \
+    2>/dev/null || true)"
+  [[ "$url" == "null" ]] && url=""
+  printf '%s' "$url"
+}
+
+notify_phase() {
+  # One Pushover per phase so a hung phase is visible immediately.
+  # Best-effort: it must never change the run's exit code.
+  local status="$1" pr_url
+  pr_url="$(resolve_pr_url)"
+  python3 "$REPO/scripts/weekend_notify.py" \
+    --loop security --phase "$PHASE" --status "$status" \
+    --pr-url "$pr_url" --detail "log: ${RUN_LOG##*/}" \
+    --env-file "$WEEKEND_ROOT/.env" >/dev/null 2>&1 || true
+}
+
+report() {
+  # Dead-man: one rolling issue, a comment per run. Failure to report
+  # must not mask the run's own exit code. Third arg 0 suppresses the
+  # Pushover.
+  local status="$1" detail="$2" push="${3:-1}"
+  local body="**${PHASE}** ${STAMP} — **${status}**
+${detail}
+log: \`${RUN_LOG##*/}\` on the runner"
+  local issue
+  issue="$(net_bounded gh issue list --label "$DEADMAN_LABEL" --state open \
+    --json number -q '.[0].number' 2>/dev/null || true)"
+  if [[ -z "$issue" ]]; then
+    net_bounded gh issue create --title "$DEADMAN_TITLE" --label "$DEADMAN_LABEL" \
+      --body "Rolling dead-man for the nightly security loop. Sanitized status only — never a route, file, attack, secret, or account. A missing daily comment means the runner did not fire." \
+      >/dev/null 2>&1 || true
+    issue="$(net_bounded gh issue list --label "$DEADMAN_LABEL" --state open \
+      --json number -q '.[0].number' 2>/dev/null || true)"
+  fi
+  [[ -n "$issue" ]] && net_bounded gh issue comment "$issue" --body "$body" >/dev/null 2>&1 || true
+  if [[ "$push" == "1" ]]; then
+    notify_phase "$status"
+  fi
+  return 0
+}
+
+# T-239: `claude -p` terminates unfinished background tasks at its print-mode
+# background-wait ceiling and then exits **0**, so a phase cut off with its
+# last agent still working is indistinguishable from one that finished. The
+# testing loop's 2026-08-28 audit was cut at 600s, filed nothing on a 24-commit delta,
+# left an empty branch and no PR — and paged OK. The ceiling is lifted at the
+# invocation below (the `timeout` is the cap); this is the second guarantee,
+# so that if it is ever cut off anyway the operator is not told it succeeded.
+BG_CEILING_MARKER="Background tasks still running after"
+
+phase_status() {
+  # rc + run log -> the one status string every dead-man channel carries.
+  # `mark` is the size of $run_log before THIS round's invocation. RUN_LOG is
+  # per PHASE and appended by every retry and continuation round, so grepping
+  # the whole file made a round-1 ceiling message report a finished round 8 as
+  # TRUNCATED forever — a permanent false alarm on exactly the long
+  # remediations the detector was added to protect. R-426.
+  local rc="$1" run_log="$2" mark="${3:-0}"
+  if [[ $rc -eq 124 ]]; then
+    printf 'TIMEOUT after %ss' "$CAP_SECS"
+  elif [[ $rc -ne 0 ]]; then
+    printf 'FAILED (exit %s)' "$rc"
+  elif tail -c "+$((mark + 1))" "$run_log" 2>/dev/null | grep -qF "$BG_CEILING_MARKER"; then
+    printf 'TRUNCATED (background work killed before the phase finished)'
+  else
+    printf 'OK'
+  fi
+}
+
+on_crash() {
+  report "CRASHED (exit $?)" "wrapper died before the agent finished — check the runner"
+}
+
+# Bash runs the EXIT trap on an untrapped SIGTERM, so the lock released and the
+# process exited 143 — but `on_crash` never ran, so launchd's ExitTimeOut kill,
+# a `launchctl bootout`, an operator kill and a reboot mid-cycle all produced
+# exactly the same observable as "the runner did not fire". SKILL.md tells the
+# operator to read quiet as "still running", so they waited. R-384.
+ROUND_PID=""
+kill_round_group() {
+  [[ -n "$ROUND_PID" ]] || return 0
+  # `timeout` (deliberately WITHOUT --foreground) makes itself the round's
+  # process-group leader, so the negative pid reaches claude and anything it
+  # left behind. --foreground would signal only timeout's direct child, which
+  # is the opposite of what reaping orphaned subagents needs — they would keep
+  # writing into the clone while the next round runs `git clean -fdq`. R-386.
+  kill -TERM -- "-$ROUND_PID" 2>/dev/null || kill -TERM "$ROUND_PID" 2>/dev/null || true
+  ROUND_PID=""
+}
+
+on_signal() {
+  local sig="$1"
+  trap - INT TERM HUP ERR EXIT
+  kill_round_group
+  report "KILLED (SIG${sig})" "the wrapper was signalled before the phase finished — launchd ExitTimeOut, a bootout, an operator kill or a reboot; partial work may exist on the weekend branch"
+  release_runner_lock "${RUNNER_LOCK:-}"
+  exit 143
+}
+
+# These four are defined HERE, above the trap, and not further down beside
+# begin_phase: the prologue's REFUSED branches and the ERR trap below call
+# report(), and a function defined later in main() is not yet defined when
+# they run — every prologue death died on "report: command not found", then on
+# unset PHASE/STAMP/RUN_LOG under `set -u`, so no issue comment and no page
+# were ever sent for the very failures the trap exists to catch. T-209.
+PHASE="prologue"
+STAMP="$(date +%Y%m%dT%H%M%S)"
+RUN_LOG="prologue (no phase log yet)"
+
+# R-239: the ERR trap used to be armed only inside run_phase, so everything
+# from here down — the cd, the marker check, the lock, the mkdir and the
+# rotation pipeline under `set -o pipefail` — exited on a full disk, a moved
+# clone or a held lock with nothing but a line on stderr. The file header
+# claims every outcome is reported; for the prologue that was false.
+trap on_crash ERR
+trap 'on_signal INT' INT
+trap 'on_signal TERM' TERM
+trap 'on_signal HUP' HUP
+
+cd "$REPO"
+[[ -f .radon-weekend-runner ]] || {
+  echo "REFUSING: $REPO is not the dedicated weekend runner clone" >&2
+  report "REFUSED" "$REPO is not the dedicated weekend runner clone" || true
+  exit 2
+}
+# Rail 1: the security loop refuses unless the SECURITY marker is present too.
+# .radon-weekend-runner alone is every sibling loop's clone; only
+# ~/radon-weekend/radon-security carries .radon-security-runner, so this is
+# what stops a stray RADON_WEEKEND_REPO from running credential-free security
+# work — or, worse, scanner egress — inside another loop's or the operator's
+# checkout.
+[[ -f .radon-security-runner ]] || {
+  echo "REFUSING: $REPO is not the dedicated SECURITY runner clone (.radon-security-runner absent)" >&2
+  report "REFUSED" "$REPO lacks the .radon-security-runner marker; the security loop runs only in ~/radon-weekend/radon-security" || true
+  exit 2
+}
+
+RUNNER_LOCK="$REPO/.weekend-runner.lock"
+acquire_runner_lock "$RUNNER_LOCK" || {
+  echo "REFUSING: another weekend run owns $REPO" >&2
+  # The expensive instance: acquire_runner_lock only reclaims when
+  # `kill -0 $held` fails, so a recorded pid reused by ANY live unrelated
+  # process makes every subsequent daily fire exit 3 in under a second. That
+  # must page, not vanish. R-239.
+  report "REFUSED (lock held)" "another weekend run owns $REPO (pid $(cat "$RUNNER_LOCK/pid" 2>/dev/null || echo unknown)); if no cycle is running, the recorded pid was reused — remove $RUNNER_LOCK" || true
+  exit 3
+}
+trap 'release_runner_lock "$RUNNER_LOCK"' EXIT
+
+LOG_DIR="$REPO/logs/security-nightly"
+mkdir -p "$LOG_DIR"
+# Keep the newest 30 run logs. NEVER the launchd sinks: the plist points
+# StandardOutPath/StandardErrorPath at launchd-cycle.log/.err inside this same
+# directory, and launchd-cycle.err only gets an mtime bump when something
+# writes to stderr — so it sorts old and was unlinked once ~30 per-phase logs
+# accumulated, taking the only forensics for a prologue death with it. Worse,
+# the rotation runs BEFORE run_phase, so the rest of that same invocation
+# wrote to a deleted inode launchd still held open. R-267.
+# `|| true` on the grep: it exits 1 when it filters everything out (an empty
+# or sinks-only log dir), and `set -o pipefail` would turn that into a
+# prologue death — now a REPORTED one, thanks to the trap above.
+ls -1t "$LOG_DIR" 2>/dev/null \
+  | { grep -v -e '^launchd-cycle\.log$' -e '^launchd-cycle\.err$' || true; } \
+  | tail -n +31 | while IFS= read -r old; do
+  rm -f -- "$LOG_DIR/$old"
+done
+
+CAP_SECS=0
+RUN_LOG="$LOG_DIR/$MODE-$STAMP.log"
+RC=0
+
+begin_phase() {
+  PHASE="$1"
+  # Audit fans out read agents (cap 2h); remediation is the long half (cap 6h).
+  CAP_SECS=$([[ "$PHASE" == "audit" ]] \
+    && echo "${RADON_WEEKEND_AUDIT_CAP_SECS:-7200}" \
+    || echo "${RADON_WEEKEND_REMEDIATE_CAP_SECS:-21600}")
+  # One log per phase: the transient-network detector and the report tail
+  # both read $RUN_LOG.
+  RUN_LOG="$LOG_DIR/$PHASE-$STAMP.log"
+  RC=0
+}
+
+# Fresh ground truth. Any leftover state from a killed prior run is
+# discarded — the branch/PR on GitHub is the durable state.
+# R-237: this loop's fetch was a bare single attempt while the reliability
+# loop already had a bounded retry (3f96dc31, added for the 2026-08-23 port-22
+# blackhole). Same shape, same reason.
+FETCH_ATTEMPTS="${RADON_WEEKEND_FETCH_ATTEMPTS:-3}"
+FETCH_PAUSE_SECS="${RADON_WEEKEND_FETCH_PAUSE_SECS:-60}"
+
+fetch_origin_with_retry() {
+  local attempt
+  for (( attempt = 1; attempt <= FETCH_ATTEMPTS; attempt++ )); do
+    net_bounded git -c "core.sshCommand=$GIT_SSH_BOUNDED" fetch origin --quiet && return 0
+    echo "[weekend] git fetch origin failed — attempt $attempt/$FETCH_ATTEMPTS" >&2
+    if (( attempt < FETCH_ATTEMPTS )); then sleep "$FETCH_PAUSE_SECS"; fi
+  done
+  return 1
+}
+
+ground_truth() {
+  fetch_origin_with_retry
+  git checkout -f --quiet main
+  git reset --hard --quiet origin/main
+  git clean -fdq --exclude=.radon-weekend-runner --exclude=.radon-security-runner --exclude=.weekend-runner.lock --exclude=logs/ --exclude=.env --exclude=.env.ib-mode --exclude=web/.env
+}
+
+# The agent commits per completed task and the skill resumes from the
+# weekend branch, so a fresh attempt after a dropped API connection loses
+# nothing. Retry ONLY on a transient-network signature (2026-08-16: five
+# runs died to ENOTFOUND / connection-lost on the runner's flaky uplink);
+# real failures and timeouts surface immediately.
+KILL_AFTER_SECS="${RADON_WEEKEND_KILL_AFTER_SECS:-60}"
+# Production always gives `timeout` the real phase remainder after the 60s
+# launch floor below. The survivability regression needs to exercise the real
+# process group and SIGKILL path without sleeping for that production-sized
+# deadline. Refuse this narrow override unless pytest explicitly owns the
+# process, and accept only the bounded values the regression needs.
+TEST_ROUND_TIMEOUT_SECS=""
+if [[ -n "${RADON_WEEKEND_TEST_ROUND_TIMEOUT_SECS:-}" ]]; then
+  if [[ -z "${PYTEST_CURRENT_TEST:-}" ]]; then
+    echo "REFUSING: RADON_WEEKEND_TEST_ROUND_TIMEOUT_SECS is test-only" >&2
+    report "REFUSED" "RADON_WEEKEND_TEST_ROUND_TIMEOUT_SECS is test-only and cannot alter a production deadline" || true
+    exit 2
+  fi
+  case "$RADON_WEEKEND_TEST_ROUND_TIMEOUT_SECS" in 1|2|5) ;;
+    *)
+      echo "REFUSING: RADON_WEEKEND_TEST_ROUND_TIMEOUT_SECS must be 1, 2, or 5" >&2
+      report "REFUSED" "RADON_WEEKEND_TEST_ROUND_TIMEOUT_SECS must be the bounded test value 1, 2, or 5" || true
+      exit 2
+      ;;
+  esac
+  TEST_ROUND_TIMEOUT_SECS="$RADON_WEEKEND_TEST_ROUND_TIMEOUT_SECS"
+fi
+ROUND_LOG_MARK=0
+MAX_ATTEMPTS=3
+RETRY_PAUSE_SECS=60
+is_transient_network_failure() {
+  tail -c 500 "$RUN_LOG" | grep -qE 'API Error|ENOTFOUND|Connection lost|Execution error'
+}
+
+run_phase() {
+  begin_phase "$1"
+  trap on_crash ERR
+  echo "[security-nightly] $PHASE start $STAMP repo=$REPO cap=${CAP_SECS}s" | tee -a "$RUN_LOG"
+  # NOT bare. Under `set -Eeuo pipefail` with the ERR trap armed, a failed
+  # fetch made on_crash report and then the shell exit anyway — so
+  # `run_phase audit` never returned and `run_phase remediate` was never run
+  # and never reported, contradicting the comment on the cycle branch. The
+  # testing loop was the exposed one: its fetch was a bare single attempt while
+  # reliability already had fetch_origin_with_retry. R-237.
+  if ! ground_truth; then
+    RC=70
+    report "GROUND TRUTH FAILED" "could not refresh the clone (network or git); the phase did not run" || true
+    echo "[security-nightly] $PHASE done rc=$RC" | tee -a "$RUN_LOG"
+    return 0
+  fi
+
+  # Attempt clock is per phase: under cycle the remediate phase must not
+  # inherit the audit phase's elapsed seconds and insta-timeout.
+  # R-185: `timeout claude` returning 124 (cap) or any non-zero agent exit is
+  # an EXPECTED outcome this loop handles — but the ERR trap was still armed
+  # over it, so every failed or timed-out run posted a false
+  # "CRASHED — wrapper died" dead-man comment AND then its real status.
+  trap - ERR
+  local attempt=1 start_ts=$SECONDS remain round_start
+  set +e
+  while :; do
+    remain=$((CAP_SECS - (SECONDS - start_ts)))
+    if [[ $remain -le 60 ]]; then RC=124; break; fi
+    [[ -z "$TEST_ROUND_TIMEOUT_SECS" ]] || remain="$TEST_ROUND_TIMEOUT_SECS"
+    ROUND_LOG_MARK=$(( $(wc -c < "$RUN_LOG" 2>/dev/null || echo 0) ))
+    # Backgrounded and `wait`ed rather than run in the foreground: bash defers
+    # trap handling until a foreground child completes, so a SIGTERM to the
+    # wrapper was not acted on until `claude` finished on its own — which is
+    # never, in the case that matters. `-k` escalates to SIGKILL so a claude
+    # blocked on a hung child cannot make the cap advisory. R-384, R-386.
+    CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 timeout -k "$KILL_AFTER_SECS" "$remain" claude -p "/security-nightly $PHASE" \
+      --dangerously-skip-permissions \
+      --output-format text >> "$RUN_LOG" 2>&1 &
+    ROUND_PID=$!
+    round_start=$SECONDS
+    wait "$ROUND_PID"
+    RC=$?
+    ROUND_PID=""
+    kill_round_group
+    # The exit code for a `-k` escalation is not portable: GNU coreutils 9.4
+    # reports 137 when the SIGKILL is what actually ended the child, not 124.
+    # The cap is OUR clock, so classify from it rather than from the code, or a
+    # round the cap genuinely killed is reported as a crash. R-386.
+    if (( RC != 0 && SECONDS - round_start >= remain )); then RC=124; fi
+    [[ $RC -eq 0 || $RC -eq 124 || $attempt -ge $MAX_ATTEMPTS ]] && break
+    is_transient_network_failure || break
+    echo "[security-nightly] transient network failure (rc=$RC) — attempt $attempt/$MAX_ATTEMPTS, retrying in ${RETRY_PAUSE_SECS}s" | tee -a "$RUN_LOG"
+    attempt=$((attempt + 1))
+    sleep "$RETRY_PAUSE_SECS"
+  done
+  set -e
+  # A genuine wrapper death AFTER the agent finished must still page.
+  trap on_crash ERR
+
+  # Rail 7: Radon is public. The run log holds scanner output, file:line
+  # evidence and possibly a matched secret class, so its tail is NEVER posted
+  # to the public dead-man issue — only the sanitized status line and the
+  # local log filename (report() already appends the filename). The agent
+  # writes its real findings to the private mode-0700 run dir and the private
+  # security archive, out of this wrapper's reach.
+  local status
+  status="$(phase_status "$RC" "$RUN_LOG" "$ROUND_LOG_MARK")"
+  case "$status" in
+    OK)
+      report "$status" "sanitized: audit/remediate completed; findings (if any) are in the private security run dir and archive, never here" ;;
+    TRUNCATED*)
+      report "$status" "the harness killed unfinished background work and the agent still exited 0 — this phase is INCOMPLETE; the audited SHA was NOT advanced" ;;
+    TIMEOUT*)
+      report "$status" "the phase hit its wall-clock cap; incomplete, the audited SHA was NOT advanced, resumable private state is on the runner" ;;
+    *)
+      report "$status" "the phase ended with a non-zero status; see the private run log on the runner, never posted here" ;;
+  esac
+  echo "[security-nightly] $PHASE done rc=$RC" | tee -a "$RUN_LOG"
+}
+
+if [[ "$MODE" == "cycle" ]]; then
+  # Remediate runs regardless of the audit rc — backlog may exist even when
+  # the audit phase failed. Exit non-zero if either phase failed.
+  set +e
+  run_phase audit
+  RC_AUDIT=$RC
+  run_phase remediate
+  RC_REMEDIATE=$RC
+  set -e
+  echo "[security-nightly] cycle done audit_rc=$RC_AUDIT remediate_rc=$RC_REMEDIATE"
+  [[ $RC_AUDIT -ne 0 ]] && exit "$RC_AUDIT"
+  exit "$RC_REMEDIATE"
+fi
+
+run_phase "$MODE"
+exit "$RC"
+}
+# Call and exit on ONE line: parsed together, so even a returning main can
+# never make bash read this file again.
+main "$@"; exit

--- a/scripts/setup_ci_performance.sh
+++ b/scripts/setup_ci_performance.sh
@@ -91,7 +91,7 @@ fi
 # clone") and never extended to the shared $WEEKEND_ROOT the loops depend
 # on. R-266.
 for SIBLING_REPO in "$WEEKEND_ROOT/radon" "$WEEKEND_ROOT/radon-testing" \
-  "$WEEKEND_ROOT/radon-documentation"; do
+  "$WEEKEND_ROOT/radon-documentation" "$WEEKEND_ROOT/radon-security"; do
   if [[ -d "$SIBLING_REPO" ]] \
     && kill -0 "$(cat "$SIBLING_REPO/.weekend-runner.lock/pid" 2>/dev/null)" 2>/dev/null; then
     echo "  a weekend run is in flight in $SIBLING_REPO and shares $WEEKEND_VENV; re-run when it finishes"

--- a/scripts/setup_reliability_weekend.sh
+++ b/scripts/setup_reliability_weekend.sh
@@ -90,7 +90,7 @@ fi
 # The guard above was written for the clone ("A live cycle owns this clone")
 # and never extended to the shared $WEEKEND_ROOT both loops depend on. R-266.
 for SIBLING_REPO in "$WEEKEND_ROOT/radon-testing" "$WEEKEND_ROOT/radon-ci-performance" \
-  "$WEEKEND_ROOT/radon-documentation"; do
+  "$WEEKEND_ROOT/radon-documentation" "$WEEKEND_ROOT/radon-security"; do
   if [[ -d "$SIBLING_REPO" ]] \
     && kill -0 "$(cat "$SIBLING_REPO/.weekend-runner.lock/pid" 2>/dev/null)" 2>/dev/null; then
     echo "  a weekend run is in flight in $SIBLING_REPO and shares $WEEKEND_VENV; re-run when it finishes"

--- a/scripts/setup_security_nightly.sh
+++ b/scripts/setup_security_nightly.sh
@@ -1,22 +1,28 @@
 #!/usr/bin/env bash
-# One-command setup of the nightly documentation loop on the always-on runner
+# One-command setup of the nightly security loop on the always-on runner
 # (Mac mini). Run ON THE MINI from any checkout of the repo:
 #
-#   bash scripts/setup_documentation_nightly.sh
+#   bash scripts/setup_security_nightly.sh
 #
-# Provisions the documentation loop's OWN dedicated clone
-# (~/radon-weekend/radon-documentation — never edit it by hand; every run
-# hard-resets it to origin/main), installs the single daily launchd job
-# (one cycle: audit then remediate), and verifies the toolchain. The
-# clone is deliberately separate from the reliability loop's
-# (~/radon-weekend/radon): both loops hard-reset their working tree per
-# round and the reliability loop's continuation rounds make its wall
-# clock unbounded, so sharing a clone destroys in-flight work
-# (2026-08-16 incident).
+# Provisions the security loop's OWN dedicated clone
+# (~/radon-weekend/radon-security — never edit it by hand; every run
+# hard-resets it to origin/main), stamps BOTH runner markers, installs the
+# single daily launchd job (one cycle: audit then remediate), creates the
+# dead-man label, and verifies the toolchain. The clone is deliberately
+# separate from every other loop's; all loops hard-reset their tree per
+# round, so a shared clone destroys in-flight work (2026-08-16 incident).
+#
+# SECURITY loop rails this setup enforces:
+#   - it NEVER provisions web/.env or any Radon credential into the clone
+#     (rail 5); the security agent runs credential-free by design;
+#   - it stamps .radon-security-runner alongside .radon-weekend-runner so
+#     the wrapper's two-marker gate can distinguish this clone;
+#   - DeepSec and the Claude Security plugin are OPERATOR-bootstrapped, not
+#     installed here (rail 8); this script only checks and reports them.
 set -euo pipefail
 
 WEEKEND_ROOT="${RADON_WEEKEND_ROOT:-$HOME/radon-weekend}"
-WEEKEND_REPO="$WEEKEND_ROOT/radon-documentation"
+WEEKEND_REPO="$WEEKEND_ROOT/radon-security"
 WEEKEND_VENV="$WEEKEND_ROOT/venv"
 # Pushover creds for the per-phase page. Lives OUTSIDE the runner clone:
 # every round hard-resets and cleans that clone.
@@ -61,8 +67,13 @@ check "git ssh to origin" git ls-remote --exit-code "$ORIGIN_URL" HEAD
 check "pushover creds"    grep -qE '^PUSHOVER_(USER|TOKEN)=.+' "$WEEKEND_ENV"
 check "bash 4+ (cloud/tests)" bash -c '((BASH_VERSINFO[0] >= 4))'
 check "caddy (cloud/tests edge)" command -v caddy
-advise "$SRC_REPO/web/.env (else no dev server, so no browser verification)" \
-  test -s "$SRC_REPO/web/.env"
+# Rail 8/9: these are OPERATOR-bootstrapped and pinned; setup only reports
+# their presence. Absent ones make the matching audit stage OPERATOR_REQUIRED
+# (fail-closed), never an install trigger.
+advise "DeepSec workspace (.deepsec pinned, OPERATOR-bootstrapped)" \
+  test -x "$WEEKEND_REPO/.deepsec/node_modules/.bin/deepsec"
+advise "Claude Security plugin (official, OPERATOR-installed)" \
+  bash -c 'claude plugin list --json 2>/dev/null | grep -q claude-security'
 if [[ $fail -ne 0 ]]; then
   echo "Fix the MISSING items above, then re-run."
   echo "  bash 3.2 leaves 34 cloud/tests permanently red on this runner (13 in"
@@ -90,7 +101,7 @@ fi
 # The guard above was written for the clone ("A live cycle owns this clone")
 # and never extended to the shared $WEEKEND_ROOT both loops depend on. R-266.
 for SIBLING_REPO in "$WEEKEND_ROOT/radon" "$WEEKEND_ROOT/radon-testing" \
-  "$WEEKEND_ROOT/radon-ci-performance" "$WEEKEND_ROOT/radon-security"; do
+  "$WEEKEND_ROOT/radon-ci-performance" "$WEEKEND_ROOT/radon-documentation"; do
   if [[ -d "$SIBLING_REPO" ]] \
     && kill -0 "$(cat "$SIBLING_REPO/.weekend-runner.lock/pid" 2>/dev/null)" 2>/dev/null; then
     echo "  a weekend run is in flight in $SIBLING_REPO and shares $WEEKEND_VENV; re-run when it finishes"
@@ -104,46 +115,20 @@ git -C "$WEEKEND_REPO" fetch origin --quiet
 git -C "$WEEKEND_REPO" checkout -f --quiet main
 git -C "$WEEKEND_REPO" reset --hard --quiet origin/main
 touch "$WEEKEND_REPO/.radon-weekend-runner"
-mkdir -p "$WEEKEND_REPO/logs/documentation-nightly"
+# Rail 1: the security marker the wrapper additionally requires. Without
+# it the wrapper refuses, so a stray RADON_WEEKEND_REPO can never run
+# credential-free security work in a sibling loop or operator checkout.
+touch "$WEEKEND_REPO/.radon-security-runner"
+mkdir -p "$WEEKEND_REPO/logs/security-nightly"
 
-# web/.env is gitignored, so a fresh `git clone` can never carry it and the
-# nightly hard-reset would drop it anyway; both wrappers already exclude it
-# from their per-round `git clean`. Without it the Next dev server cannot
-# boot, so the loop cannot do the browser verification CLAUDE.md requires
-# (T-248 filed the resulting permanent local false-red on 2026-08-29).
-#
-# ONLY web/.env. The root .env is deliberately NOT provisioned: it would put
-# IB_FLEX_TOKEN in a second place. web/.env IS read by pytest, not only by
-# Next: 50 scripts/**/*.py producers (grep -rl 'load_dotenv(.*web.*\.env'
-# scripts --include='*.py') call load_dotenv(web/.env) at import, so the
-# clone's TURSO creds land in os.environ under every collected module.
-# scripts/tests/conftest.py::_strip_turso_credentials removes them per test;
-# that fixture, not this file, keeps the pytest gate host-independent (T-317:
-# without it 22 tests red with FlexTokenLocked on a provisioned clone).
-# Re-copied every setup run so a rotated key propagates. Never inline a value.
-provision_env_file() {
-  local rel="$1"
-  local src="$SRC_REPO/$rel"
-  local dst="$WEEKEND_REPO/$rel"
-  if [[ ! -s "$src" ]]; then
-    echo "  skipped $rel (none at $src; the loops run without it)"
-    return 0
-  fi
-  if [[ -s "$dst" && "$dst" -nt "$src" ]]; then
-    echo "  kept $rel (clone copy is newer than $src)"
-    return 0
-  fi
-  mkdir -p "$(dirname "$dst")"
-  install -m 600 "$src" "$dst"
-  echo "  provisioned $rel from $SRC_REPO (0600)"
-}
-if [[ "$SRC_REPO" == "$WEEKEND_REPO" ]]; then
-  echo "  MISSING  env provisioning: run setup from your own checkout, not the runner clone"
-else
-  for env_rel in web/.env; do
-    provision_env_file "$env_rel"
-  done
-fi
+# Rail 5: the security clone receives NO Radon credential. Unlike the other
+# nightly loops, this setup deliberately does NOT provision web/.env (or the
+# root .env, or .env.ib-mode). The security agent runs credential-free — its
+# only allowed secrets are the narrowly scoped model credential launchd/gh
+# already hold, a write-only private-archive credential, and the sanitized
+# dead-man channel — none of which live in the clone. The per-round
+# `git clean` and the launchd env carry nothing broker/deploy/db-scoped.
+echo "  rail 5: web/.env and Radon credentials are NOT provisioned into the security clone"
 
 if [[ ! -f "$WEEKEND_ENV" ]]; then
   cat > "$WEEKEND_ENV" <<'EOF'
@@ -169,18 +154,18 @@ echo "[4/4] dead-man label + launchd jobs"
 # `gh issue create --label` FAILS on a label that does not exist, and the
 # wrapper swallows that failure — so a missing label turns the dead-man
 # channel off silently. Idempotent: an existing label makes this a no-op.
-gh label create documentation-nightly \
-  --description "Nightly documentation loop dead-man" --color 0E8A16 \
+gh label create security-nightly \
+  --description "Nightly security loop dead-man (sanitized status only)" --color B60205 \
   >/dev/null 2>&1 || true
-if gh label list --limit 200 2>/dev/null | grep -q '^documentation-nightly'; then
-  echo "  ok  label documentation-nightly"
+if gh label list --limit 200 2>/dev/null | grep -q '^security-nightly'; then
+  echo "  ok  label security-nightly"
 else
-  echo "  MISSING  label documentation-nightly (dead-man comments will be dropped)"
+  echo "  MISSING  label security-nightly (dead-man comments will be dropped)"
 fi
 mkdir -p "$LAUNCH_AGENTS"
-JOB_PLIST="$LAUNCH_AGENTS/com.radon.documentation-daily.plist"
+JOB_PLIST="$LAUNCH_AGENTS/com.radon.security-daily.plist"
 sed -e "s|__WEEKEND_REPO__|$WEEKEND_REPO|g" -e "s|__HOME__|$HOME|g" \
-  "$WEEKEND_REPO/config/com.radon.documentation-daily.plist" > "$JOB_PLIST"
+  "$WEEKEND_REPO/config/com.radon.security-daily.plist" > "$JOB_PLIST"
 plutil -lint "$JOB_PLIST" >/dev/null
 launchctl unload "$JOB_PLIST" 2>/dev/null || true
 launchctl load "$JOB_PLIST"
@@ -193,14 +178,14 @@ SCHED_MIN="$(plutil -extract StartCalendarInterval.Minute raw -o - "$JOB_PLIST")
 echo
 printf 'Done. Schedule: one cycle daily at %02d:%02d local (audit, then remediate),\n' \
   "$SCHED_HOUR" "$SCHED_MIN"
-echo "in the documentation loop's own clone at $WEEKEND_REPO."
-echo "Dead-man: GitHub issue labeled 'documentation-nightly' gets a comment per"
+echo "in the security loop's own clone at $WEEKEND_REPO."
+echo "Dead-man: GitHub issue labeled 'security-nightly' gets a comment per"
 echo "phase, plus a Pushover when $WEEKEND_ENV carries creds."
 echo "A quiet day means the runner did not fire OR the previous cycle is"
 echo "still running: launchd will not start a second instance of the label."
 echo "Check with: launchctl list | grep radon"
 echo "Smoke test now with:"
-echo "  RADON_WEEKEND_REPO=$WEEKEND_REPO bash $WEEKEND_REPO/scripts/documentation_nightly.sh audit"
+echo "  RADON_WEEKEND_REPO=$WEEKEND_REPO bash $WEEKEND_REPO/scripts/security_nightly.sh audit"
 echo "Upgrading the wrapper in this clone, with no run in flight"
 echo "(check: ls -d $WEEKEND_REPO/.weekend-runner.lock):"
 echo "  git -C $WEEKEND_REPO fetch origin && git -C $WEEKEND_REPO checkout -f main && git -C $WEEKEND_REPO reset --hard origin/main"

--- a/scripts/setup_testing_weekend.sh
+++ b/scripts/setup_testing_weekend.sh
@@ -90,7 +90,7 @@ fi
 # The guard above was written for the clone ("A live cycle owns this clone")
 # and never extended to the shared $WEEKEND_ROOT both loops depend on. R-266.
 for SIBLING_REPO in "$WEEKEND_ROOT/radon" "$WEEKEND_ROOT/radon-ci-performance" \
-  "$WEEKEND_ROOT/radon-documentation"; do
+  "$WEEKEND_ROOT/radon-documentation" "$WEEKEND_ROOT/radon-security"; do
   if [[ -d "$SIBLING_REPO" ]] \
     && kill -0 "$(cat "$SIBLING_REPO/.weekend-runner.lock/pid" 2>/dev/null)" 2>/dev/null; then
     echo "  a weekend run is in flight in $SIBLING_REPO and shares $WEEKEND_VENV; re-run when it finishes"

--- a/scripts/tests/test_ci_performance_loop_contract.py
+++ b/scripts/tests/test_ci_performance_loop_contract.py
@@ -33,7 +33,7 @@ SKILL = REPO / ".claude" / "skills" / "ci-performance" / "SKILL.md"
 CLONE = "radon-ci-performance"
 LABEL = "ci-performance-nightly"
 LOG_DIR = "logs/ci-performance"
-SIBLING_CLONES = ("radon-testing", "radon-documentation")
+SIBLING_CLONES = ("radon-testing", "radon-documentation", "radon-security")
 
 
 def _uncommented(path: Path) -> str:
@@ -173,7 +173,7 @@ class TestSetupProvisionsTheDeadmanLabel:
         assert f'WEEKEND_REPO="$WEEKEND_ROOT/{CLONE}"' in body, body
         assert "com.radon.ci-performance-daily.plist" in body, body
 
-    @pytest.mark.parametrize("sibling", ("radon", "radon-testing", "radon-documentation"))
+    @pytest.mark.parametrize("sibling", ("radon", "radon-testing", "radon-documentation", "radon-security"))
     def test_setup_stands_down_on_every_sibling_lock(self, sibling):
         """All three setups write the SAME `$WEEKEND_ROOT/venv`.
 

--- a/scripts/tests/test_documentation_loop_contract.py
+++ b/scripts/tests/test_documentation_loop_contract.py
@@ -33,7 +33,7 @@ SKILL = REPO / ".claude" / "skills" / "documentation-nightly" / "SKILL.md"
 CLONE = "radon-documentation"
 LABEL = "documentation-nightly"
 LOG_DIR = "logs/documentation-nightly"
-SIBLING_CLONES = ("radon-testing", "radon-ci-performance")
+SIBLING_CLONES = ("radon-testing", "radon-ci-performance", "radon-security")
 
 
 def _uncommented(path: Path) -> str:
@@ -195,7 +195,7 @@ class TestSetupProvisionsTheDeadmanLabel:
         assert "com.radon.documentation-daily.plist" in body, body
 
     @pytest.mark.parametrize(
-        "sibling", ("radon", "radon-testing", "radon-ci-performance")
+        "sibling", ("radon", "radon-testing", "radon-ci-performance", "radon-security")
     )
     def test_setup_stands_down_on_every_sibling_lock(self, sibling):
         """All four setups write the SAME `$WEEKEND_ROOT/venv`.
@@ -217,6 +217,7 @@ class TestSetupProvisionsTheDeadmanLabel:
             "setup_reliability_weekend.sh",
             "setup_testing_weekend.sh",
             "setup_ci_performance.sh",
+            "setup_security_nightly.sh",
         ],
     )
     def test_every_sibling_setup_stands_down_on_this_loops_lock(self, setup_name):

--- a/scripts/tests/test_rel137_weekend_wrapper_survivability.py
+++ b/scripts/tests/test_rel137_weekend_wrapper_survivability.py
@@ -30,11 +30,13 @@ RELIABILITY = REPO / "scripts" / "reliability_weekend.sh"
 TESTING = REPO / "scripts" / "testing_weekend.sh"
 CI_PERFORMANCE = REPO / "scripts" / "ci_performance_nightly.sh"
 DOCUMENTATION = REPO / "scripts" / "documentation_nightly.sh"
+SECURITY = REPO / "scripts" / "security_nightly.sh"
 LOOPS = {
     "reliability": RELIABILITY,
     "testing": TESTING,
     "ci-performance": CI_PERFORMANCE,
     "documentation": DOCUMENTATION,
+    "security": SECURITY,
 }
 BASH = shutil.which("bash") or "/bin/bash"
 
@@ -50,6 +52,8 @@ def _runner_clone(tmp_path: Path, name: str) -> Path:
     repo = tmp_path / f"radon-{name}"
     (repo / "scripts").mkdir(parents=True)
     (repo / ".radon-weekend-runner").write_text("", encoding="utf-8")
+    # the security wrapper additionally requires this marker; inert elsewhere
+    (repo / ".radon-security-runner").write_text("", encoding="utf-8")
     subprocess.run(["git", "init", "-q", str(repo)], check=True)
     return repo
 

--- a/scripts/tests/test_security_loop_contract.py
+++ b/scripts/tests/test_security_loop_contract.py
@@ -1,0 +1,362 @@
+"""The nightly security loop's own identity and isolation contract.
+
+The five nightly loops share one wrapper shape, one runner-lock primitive and
+one `$WEEKEND_ROOT/venv`, and all five fire at 00:00. The security loop is the
+one that must NEVER: run in a sibling clone or the operator checkout, receive a
+Radon credential, or leak a scanner artifact into the public repository. Those
+three properties are enforced by concrete, testable facts asserted here — the
+two-marker gate, the absence of any credential provisioning in its setup, and
+the sanitized dead-man. The shared survivability/dead-man contracts live in
+`test_weekend_loop_deadman.py`, `test_rel137_weekend_wrapper_survivability.py`
+and `test_weekend_wrapper_self_rewrite.py`; this loop is registered in all
+three. The security loop is deliberately NOT registered in
+`test_weekend_runner_env_provisioning.py`: that contract asserts a setup DOES
+provision `web/.env`, which is the exact opposite of rail 5 here.
+"""
+
+from __future__ import annotations
+
+import os
+import plistlib
+import re
+import shutil
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+WRAPPER = REPO / "scripts" / "security_nightly.sh"
+SETUP = REPO / "scripts" / "setup_security_nightly.sh"
+PLIST = REPO / "config" / "com.radon.security-daily.plist"
+SKILL = REPO / ".claude" / "skills" / "security-nightly" / "SKILL.md"
+
+CLONE = "radon-security"
+LABEL = "security-nightly"
+LOG_DIR = "logs/security-nightly"
+SIBLING_CLONES = ("radon", "radon-testing", "radon-ci-performance", "radon-documentation")
+BASH = shutil.which("bash") or "/bin/bash"
+
+
+def _uncommented(path: Path) -> str:
+    return "\n".join(
+        line
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if not line.lstrip().startswith("#")
+    )
+
+
+class TestTheLoopOwnsItsOwnLane:
+    def test_the_wrapper_defaults_to_its_own_clone(self):
+        body = _uncommented(WRAPPER)
+        default = re.search(r'REPO="\$\{RADON_WEEKEND_REPO:-([^}]+)\}"', body).group(1)
+        assert default.endswith(f"/{CLONE}"), (
+            f"the wrapper defaults to {default!r}, not this loop's clone; a "
+            "launchd fire without RADON_WEEKEND_REPO would hard-reset another "
+            "loop's working tree mid-run"
+        )
+
+    # Bare "radon" is a substring of this loop's own "radon-security" clone and
+    # of "$WEEKEND_ROOT/radon-weekend", so the naked-substring check uses only
+    # the distinctly named siblings (as the ci-performance/documentation
+    # contracts do); the reliability clone "$WEEKEND_ROOT/radon" is covered by
+    # the setup sibling-guard test via its exact path form.
+    @pytest.mark.parametrize(
+        "sibling", ("radon-testing", "radon-ci-performance", "radon-documentation")
+    )
+    def test_no_executable_line_names_a_sibling_clone(self, sibling):
+        body = _uncommented(WRAPPER)
+        assert sibling not in body, (
+            f"{sibling} appears in executable wrapper code; only the header "
+            "comment may name a sibling loop's clone"
+        )
+
+    def test_the_deadman_label_and_branch_prefix_are_this_loop(self):
+        body = _uncommented(WRAPPER)
+        assert f'DEADMAN_LABEL="{LABEL}"' in body, body
+        assert 'PR_BRANCH_PREFIX="security/"' in body, (
+            "the wrapper resolves the PR to page about by head-ref prefix; a "
+            "sibling prefix pages this loop's status against that loop's PR"
+        )
+
+    def test_the_wrapper_invokes_this_loops_skill(self):
+        body = _uncommented(WRAPPER)
+        assert "/security-nightly $PHASE" in body, (
+            "the wrapper spawns the agent with another loop's slash command"
+        )
+        assert SKILL.is_file(), f"{SKILL} does not exist, so the run has no prompt"
+
+    def test_the_skill_is_not_gitignored(self):
+        proc = subprocess.run(
+            ["git", "check-ignore", "-q",
+             ".claude/skills/security-nightly/SKILL.md"],
+            cwd=REPO, capture_output=True, timeout=60,
+        )
+        assert proc.returncode != 0, (
+            ".claude/skills/security-nightly/ is gitignored; add the whitelist "
+            "line to .gitignore or the runner clone never gets the skill"
+        )
+
+    def test_the_log_directory_is_this_loops(self):
+        body = _uncommented(WRAPPER)
+        assert f'LOG_DIR="$REPO/{LOG_DIR}"' in body, body
+
+    def test_the_notifier_accepts_this_loop(self):
+        proc = subprocess.run(
+            [sys.executable, str(REPO / "scripts" / "weekend_notify.py"),
+             "--loop", "security", "--phase", "audit", "--status", "OK"],
+            capture_output=True, text=True, timeout=60, env={"PATH": "/usr/bin:/bin"},
+        )
+        assert proc.returncode == 0, (
+            "weekend_notify rejects --loop security, so every phase page is "
+            f"dropped: {proc.stdout}{proc.stderr}"
+        )
+
+
+class TestTheTwoMarkerGate:
+    """Rail 1: only ~/radon-weekend/radon-security carries BOTH markers.
+
+    A sibling loop's clone and the operator checkout have only
+    `.radon-weekend-runner`. The security wrapper must additionally require
+    `.radon-security-runner`, so a stray `RADON_WEEKEND_REPO` cannot run
+    credential-free security work — or scanner egress — in another tree.
+    """
+
+    def test_the_wrapper_requires_the_security_marker_in_source(self):
+        body = _uncommented(WRAPPER)
+        assert ".radon-security-runner" in body, (
+            "the wrapper does not require the security marker, so it would run "
+            "in any clone bearing only .radon-weekend-runner"
+        )
+        # the git clean must preserve it, or the first per-round clean deletes
+        # the marker and the next round refuses.
+        clean = next(ln for ln in body.splitlines() if "git clean" in ln)
+        assert "--exclude=.radon-security-runner" in clean, clean
+
+    def _stub_bin(self, tmp_path: Path) -> tuple[Path, Path]:
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        gh_log = tmp_path / "gh.log"
+        gh = bin_dir / "gh"
+        gh.write_text(
+            "#!/bin/sh\n"
+            f'printf "%s\\n" "$*" >> "{gh_log}"\n'
+            'if [ "$1 $2" = "issue list" ]; then echo 4242; fi\n'
+            "exit 0\n",
+            encoding="utf-8",
+        )
+        gh.chmod(0o755)
+        for name in ("claude", "git", "python3", "timeout"):
+            exe = bin_dir / name
+            if name == "timeout":
+                exe.write_text('#!/bin/sh\nshift $(( $# > 0 ? 1 : 0 ))\nexec "$@"\n', encoding="utf-8")
+            elif name == "claude":
+                exe.write_text("#!/bin/sh\necho 'stub claude must not run here' >&2\nexit 9\n", encoding="utf-8")
+            else:
+                exe.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            exe.chmod(exe.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        return bin_dir, gh_log
+
+    def _clone(self, tmp_path: Path, *, security_marker: bool) -> Path:
+        repo = tmp_path / "clone"
+        (repo / "scripts").mkdir(parents=True)
+        (repo / "logs" / LABEL).mkdir(parents=True)
+        shutil.copy2(WRAPPER, repo / "scripts" / "security_nightly.sh")
+        (repo / "scripts" / "security_nightly.sh").chmod(0o755)
+        (repo / "scripts" / "weekend_notify.py").write_text("# stub\n", encoding="utf-8")
+        (repo / ".radon-weekend-runner").write_text("", encoding="utf-8")
+        if security_marker:
+            (repo / ".radon-security-runner").write_text("", encoding="utf-8")
+        return repo
+
+    def test_a_clone_without_the_security_marker_is_refused(self, tmp_path):
+        bin_dir, gh_log = self._stub_bin(tmp_path)
+        repo = self._clone(tmp_path, security_marker=False)
+        proc = subprocess.run(
+            [BASH, str(repo / "scripts" / "security_nightly.sh"), "audit"],
+            cwd=repo,
+            env={"PATH": f"{bin_dir}:/usr/bin:/bin", "HOME": str(tmp_path / "home"),
+                 "RADON_WEEKEND_REPO": str(repo)},
+            capture_output=True, text=True, timeout=120,
+        )
+        assert proc.returncode == 2, (proc.returncode, proc.stdout, proc.stderr)
+        assert ".radon-security-runner" in proc.stderr or "SECURITY runner" in proc.stderr, proc.stderr
+        calls = gh_log.read_text(encoding="utf-8") if gh_log.exists() else ""
+        assert "issue comment" in calls, f"the refusal must reach the dead-man: {calls!r}"
+
+    def test_a_clone_with_only_the_weekend_marker_of_a_sibling_is_refused(self, tmp_path):
+        # This is precisely the shape of every sibling loop's clone.
+        bin_dir, _gh = self._stub_bin(tmp_path)
+        repo = self._clone(tmp_path, security_marker=False)
+        proc = subprocess.run(
+            [BASH, str(repo / "scripts" / "security_nightly.sh"), "cycle"],
+            cwd=repo,
+            env={"PATH": f"{bin_dir}:/usr/bin:/bin", "HOME": str(tmp_path / "home"),
+                 "RADON_WEEKEND_REPO": str(repo)},
+            capture_output=True, text=True, timeout=120,
+        )
+        assert proc.returncode == 2, (proc.returncode, proc.stderr)
+
+
+class TestTheDeadmanIsSanitized:
+    """Rail 7: Radon is public. The run log holds scanner output and possibly a
+
+    matched secret class, so the wrapper must NEVER post its tail to the public
+    dead-man issue. The sibling loops do (`tail -c 1500 "$RUN_LOG"` into the
+    comment body); the security wrapper must not.
+    """
+
+    def test_the_run_log_tail_is_not_piped_into_the_deadman(self):
+        body = _uncommented(WRAPPER)
+        assert "tail_text" not in body, (
+            "the security wrapper still captures the run-log tail into the "
+            "dead-man comment body; that publishes scanner output to a public "
+            "GitHub issue"
+        )
+        assert 'tail -c 1500 "$RUN_LOG"' not in body, (
+            "the run-log tail is still read into the public report path"
+        )
+
+    def test_the_deadman_still_reports_a_status(self):
+        # Sanitizing the body must not remove the status itself.
+        body = _uncommented(WRAPPER)
+        assert 'report "$status"' in body, body
+
+
+class TestTheSetupIsCredentialFree:
+    """Rail 5: the security clone receives NO Radon credential."""
+
+    def test_setup_does_not_provision_web_env(self):
+        body = _uncommented(SETUP)
+        assert "provision_env_file" not in body, (
+            "the security setup still provisions an env file into the clone; "
+            "rail 5 forbids any Radon credential in the security clone"
+        )
+        assert "for env_rel in web/.env" not in body, body
+        assert "install -m 600" not in body, (
+            "the security setup still installs a credential file into the clone"
+        )
+
+    def test_setup_stamps_both_markers(self):
+        body = _uncommented(SETUP)
+        assert 'touch "$WEEKEND_REPO/.radon-weekend-runner"' in body, body
+        assert 'touch "$WEEKEND_REPO/.radon-security-runner"' in body, (
+            "setup never stamps the security marker, so the wrapper it installs "
+            "will refuse to run"
+        )
+
+    def test_setup_targets_this_loops_clone_and_job(self):
+        body = _uncommented(SETUP)
+        assert f'WEEKEND_REPO="$WEEKEND_ROOT/{CLONE}"' in body, body
+        assert "com.radon.security-daily.plist" in body, body
+
+    def test_setup_creates_the_github_label(self):
+        body = _uncommented(SETUP)
+        assert f"gh label create {LABEL}" in body, (
+            "a missing label makes gh issue create fail and the wrapper "
+            "swallows it, turning the dead-man channel off silently"
+        )
+
+    @pytest.mark.parametrize("sibling", ("radon", "radon-testing", "radon-ci-performance", "radon-documentation"))
+    def test_setup_stands_down_on_every_sibling_lock(self, sibling):
+        body = _uncommented(SETUP)
+        install = body[: body.index("python3.13 -m venv")]
+        assert f'"$WEEKEND_ROOT/{sibling}"' in install, (
+            f"setup re-creates the shared venv without checking {sibling}"
+        )
+
+    @pytest.mark.parametrize(
+        "setup_name",
+        [
+            "setup_reliability_weekend.sh",
+            "setup_testing_weekend.sh",
+            "setup_ci_performance.sh",
+            "setup_documentation_nightly.sh",
+        ],
+    )
+    def test_every_sibling_setup_stands_down_on_this_loops_lock(self, setup_name):
+        body = _uncommented(REPO / "scripts" / setup_name)
+        install = body[: body.index("python3.13 -m venv")]
+        assert f'"$WEEKEND_ROOT/{CLONE}"' in install, (
+            f"{setup_name} re-creates the shared venv without checking {CLONE}"
+        )
+
+
+class TestThePlistFreezesUpdatesAndCarriesNoSecret:
+    def _job(self):
+        resolved = (
+            PLIST.read_text(encoding="utf-8")
+            .replace("__WEEKEND_REPO__", f"/tmp/{CLONE}")
+            .replace("__HOME__", "/tmp/home")
+        )
+        return plistlib.loads(resolved.encode("utf-8"))
+
+    def test_the_plist_parses_and_points_at_this_loop(self):
+        job = self._job()
+        assert job["Label"] == "com.radon.security-daily"
+        program = " ".join(job["ProgramArguments"])
+        assert "scripts/security_nightly.sh" in program, program
+        assert program.rstrip().endswith("cycle"), program
+        assert job["WorkingDirectory"].endswith(f"/{CLONE}")
+        assert job["StandardOutPath"].endswith(f"{LOG_DIR}/launchd-cycle.log")
+
+    def test_the_autoupdater_is_frozen(self):
+        env = self._job()["EnvironmentVariables"]
+        assert env.get("DISABLE_AUTOUPDATER") == "1", (
+            "rail 8: the security plist must freeze Claude Code + plugin updates "
+            "so no scanner/plugin/model upgrade happens unattended"
+        )
+
+    def test_the_plist_carries_no_radon_secret(self):
+        env = self._job()["EnvironmentVariables"]
+        allowed = {"PATH", "RADON_WEEKEND_REPO", "HOME", "DISABLE_AUTOUPDATER"}
+        assert set(env).issubset(allowed), (
+            f"the security plist injects unexpected env keys {set(env) - allowed}; "
+            "rail 5 forbids broker/deploy/db/operator credentials in this job"
+        )
+
+    def test_the_job_fires_daily_at_midnight_and_not_at_load(self):
+        job = self._job()
+        assert job["StartCalendarInterval"] == {"Hour": 0, "Minute": 0}
+        assert job["RunAtLoad"] is False
+
+    def test_the_pre_reset_stands_down_on_a_live_lock(self):
+        program = " ".join(self._job()["ProgramArguments"])
+        assert ".weekend-runner.lock/pid" in program and "kill -0" in program, program
+
+
+class TestTheSkillCarriesTheNonNegotiableRails:
+    @pytest.mark.parametrize(
+        "rail",
+        [
+            ".radon-security-runner",
+            "Never test production or third parties",
+            "Never touch live trading",
+            "Never use production credentials or data",
+            "Never publish a vulnerability",
+            "Never auto-update security tooling",
+            "Never trust a scanner verdict",
+            "Never push `main` or deploy",
+            "Fail closed",
+            "OPERATOR_REQUIRED",
+            "security/<YYYY-MM-DD>",
+            "docs/security-audit-playbook.md",
+            "cloud/.gitleaks.toml",
+        ],
+    )
+    def test_the_rail_is_present(self, rail):
+        text = " ".join(SKILL.read_text(encoding="utf-8").split())
+        assert rail in text, (
+            f"the skill no longer states the rail {rail!r}; the unattended run "
+            "has no other source for it"
+        )
+
+    def test_the_skill_declares_both_phases(self):
+        text = SKILL.read_text(encoding="utf-8")
+        assert "## Audit pipeline" in text and "## Remediation mode" in text
+
+    def test_the_skill_names_both_external_engines(self):
+        text = SKILL.read_text(encoding="utf-8")
+        assert "DeepSec" in text and "Claude Security" in text

--- a/scripts/tests/test_weekend_loop_deadman.py
+++ b/scripts/tests/test_weekend_loop_deadman.py
@@ -48,11 +48,13 @@ RELIABILITY = REPO / "scripts" / "reliability_weekend.sh"
 TESTING = REPO / "scripts" / "testing_weekend.sh"
 CI_PERFORMANCE = REPO / "scripts" / "ci_performance_nightly.sh"
 DOCUMENTATION = REPO / "scripts" / "documentation_nightly.sh"
+SECURITY = REPO / "scripts" / "security_nightly.sh"
 PLISTS = {
     "reliability": REPO / "config" / "com.radon.reliability-daily.plist",
     "testing": REPO / "config" / "com.radon.testing-daily.plist",
     "ci-performance": REPO / "config" / "com.radon.ci-performance-daily.plist",
     "documentation": REPO / "config" / "com.radon.documentation-daily.plist",
+    "security": REPO / "config" / "com.radon.security-daily.plist",
 }
 # Every nightly loop wrapper. A new loop that is not registered here inherits
 # none of the dead-man contract below, which is the whole reason the two
@@ -62,6 +64,7 @@ LOOPS = {
     "testing": TESTING,
     "ci-performance": CI_PERFORMANCE,
     "documentation": DOCUMENTATION,
+    "security": SECURITY,
 }
 
 
@@ -88,6 +91,8 @@ def _fake_runner_clone(tmp_path: Path, name: str) -> Path:
     repo = tmp_path / f"radon-{name}"
     repo.mkdir()
     (repo / ".radon-weekend-runner").write_text("", encoding="utf-8")
+    # the security wrapper additionally requires this marker; inert elsewhere
+    (repo / ".radon-security-runner").write_text("", encoding="utf-8")
     lock = repo / ".weekend-runner.lock"
     lock.mkdir()
     # This process is alive, so acquire_runner_lock cannot reclaim the lock.
@@ -307,6 +312,7 @@ class TestSetupGuardsTheSharedVenv:
         "testing": REPO / "scripts" / "setup_testing_weekend.sh",
         "ci-performance": REPO / "scripts" / "setup_ci_performance.sh",
         "documentation": REPO / "scripts" / "setup_documentation_nightly.sh",
+        "security": REPO / "scripts" / "setup_security_nightly.sh",
     }
 
     def test_the_two_setups_really_do_share_a_venv(self):
@@ -318,7 +324,7 @@ class TestSetupGuardsTheSharedVenv:
             f"precondition changed: {venvs}"
         )
 
-    @pytest.mark.parametrize("name", ["reliability", "testing", "ci-performance", "documentation"])
+    @pytest.mark.parametrize("name", ["reliability", "testing", "ci-performance", "documentation", "security"])
     def test_each_setup_checks_the_sibling_clone_lock(self, name):
         # Comments stripped first: the guard's own comment quotes the
         # `python3.13 -m venv` line it protects, and a naive slice ends there.
@@ -332,7 +338,7 @@ class TestSetupGuardsTheSharedVenv:
             "the other loop's cycle is executing against it"
         )
 
-    @pytest.mark.parametrize("name", ["reliability", "testing", "ci-performance", "documentation"])
+    @pytest.mark.parametrize("name", ["reliability", "testing", "ci-performance", "documentation", "security"])
     def test_each_setup_checks_the_bash_version(self, name):
         """GAP C: `/bin/bash` on this runner is 3.2, and `cloud/tests` needs 4+.
 

--- a/scripts/tests/test_weekend_notify.py
+++ b/scripts/tests/test_weekend_notify.py
@@ -183,7 +183,7 @@ class TestProloguePhaseStillPages:
     test, which reproduced the held-lock refusal end to end.
     """
 
-    LOOPS = ("reliability", "testing", "ci-performance", "documentation")
+    LOOPS = ("reliability", "testing", "ci-performance", "documentation", "security")
 
     @pytest.mark.parametrize("loop", LOOPS)
     def test_the_prologue_page_is_sent(self, loop, monkeypatch):

--- a/scripts/tests/test_weekend_wrapper_self_rewrite.py
+++ b/scripts/tests/test_weekend_wrapper_self_rewrite.py
@@ -60,6 +60,11 @@ LOOPS = {
         "documentation-nightly",
         "com.radon.documentation-daily.plist",
     ),
+    "security": (
+        "security_nightly.sh",
+        "security-nightly",
+        "com.radon.security-daily.plist",
+    ),
 }
 LOOP_IDS = sorted(LOOPS)
 
@@ -94,6 +99,7 @@ def _build(
     wrapper.chmod(wrapper.stat().st_mode | stat.S_IXUSR)
     if marker:
         (clone / ".radon-weekend-runner").touch()
+        (clone / ".radon-security-runner").touch()
     # notify_phase shells `python3 $REPO/scripts/weekend_notify.py`; python3
     # is stubbed, but the file must exist for the call to look real.
     (clone / "scripts" / "weekend_notify.py").write_text("# stub\n", encoding="utf-8")
@@ -540,7 +546,7 @@ class TestTheJobRestoresTheEntryPointBeforeReadingIt:
 
     @pytest.mark.parametrize(
         "setup",
-        ["setup_reliability_weekend.sh", "setup_testing_weekend.sh", "setup_documentation_nightly.sh"],
+        ["setup_reliability_weekend.sh", "setup_testing_weekend.sh", "setup_documentation_nightly.sh", "setup_security_nightly.sh"],
     )
     def test_the_setup_script_states_the_deploy_rule(self, setup: str) -> None:
         src = (REPO / "scripts" / setup).read_text(encoding="utf-8")
@@ -551,7 +557,7 @@ class TestTheJobRestoresTheEntryPointBeforeReadingIt:
 
     @pytest.mark.parametrize(
         "setup",
-        ["setup_reliability_weekend.sh", "setup_testing_weekend.sh", "setup_documentation_nightly.sh"],
+        ["setup_reliability_weekend.sh", "setup_testing_weekend.sh", "setup_documentation_nightly.sh", "setup_security_nightly.sh"],
     )
     def test_the_setup_script_refuses_while_a_run_is_in_flight(self, setup: str) -> None:
         src = (REPO / "scripts" / setup).read_text(encoding="utf-8")

--- a/scripts/weekend_notify.py
+++ b/scripts/weekend_notify.py
@@ -109,7 +109,7 @@ def notify_weekend_phase(
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="weekend_notify")
     parser.add_argument(
-        "--loop", required=True, choices=["reliability", "testing", "ci-performance", "documentation"]
+        "--loop", required=True, choices=["reliability", "testing", "ci-performance", "documentation", "security"]
     )
     # `prologue` is not decorative: every wrapper's report() is reachable with
     # PHASE="prologue" — the marker refusal, the held-lock refusal and the ERR


### PR DESCRIPTION
Adds the fifth 00:00 nightly loop: an unattended security auditor + authorized **local** penetration tester in its own credential-free runner clone `~/radon-weekend/radon-security`, mirroring the family machinery while enforcing the security-specific rails the other loops do not need.

## What
- **Skill** `.claude/skills/security-nightly/SKILL.md`: delta scan since the last audited SHA with pinned deterministic tools + gitleaks secret preflight, then (when operator-bootstrapped) Vercel DeepSec and the official Claude Security plugin as untrusted candidate generators, bounded loopback-only pentests, independent per-candidate current-code verification, and at most one source-actionable root-cause fix with a durable regression. Fail-closed is the default; twelve hard rails (never test prod/third parties, never touch live trading, credential-free, never publish a vuln, never auto-update tooling, never push main).
- **Wrapper** `scripts/security_nightly.sh`: family shape (lock, traps, cap, mid-run self-rewrite survivability) with three divergences — (1) requires a **second** marker `.radon-security-runner` so it runs only in the security clone, (2) the per-round `git clean` preserves it, (3) the dead-man comment is **sanitized** (the run-log tail is never posted to the public repo).
- **Setup** `scripts/setup_security_nightly.sh` + **plist** `config/com.radon.security-daily.plist`: dedicated clone, both markers, `security-nightly` label, 00:00 daily job, `DISABLE_AUTOUPDATER=1`, and **no** `web/.env`/Radon credential in the clone (rail 5). DeepSec + Claude Security are checked, not installed (rail 8, `OPERATOR_REQUIRED`).

## Contract coverage
Registered in `test_weekend_loop_deadman.py`, `test_rel137_weekend_wrapper_survivability.py`, `test_weekend_wrapper_self_rewrite.py`, `test_weekend_notify.py`, `weekend_notify.py` choices; `.radon-security-runner` added to the three shared clone builders. Deliberately **not** in `test_weekend_runner_env_provisioning.py` (it asserts `web/.env` IS provisioned — the opposite of rail 5). New `scripts/tests/test_security_loop_contract.py` functionally proves: a sibling-shaped clone (only `.radon-weekend-runner`) is refused exit 2; setup provisions no credential; the dead-man carries no run-log tail; the plist freezes the autoupdater and carries no secret; sibling venv guards are symmetric across all five setups. `.gitignore` whitelists the new skill.

## Validation
- `465 passed` across the weekend + security + docs contract suites
- `bash -n` on all five setups + wrapper; `plutil -lint` on the plist

## Operator follow-ups (audit stages are OPERATOR_REQUIRED until done)
- Bootstrap + pin the DeepSec `.deepsec` workspace (npm lock + installed checksum).
- Install + pin the official `claude-security` plugin, record approved versions.
- Configure the canonical private archive `radon-cloud:security-archive` and confirm the sanitized dead-man channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tL6SCTsyQuEFAoVwfzj8r