### PR TITLE
fix(split): copy radon-ib-gateway-remote in setup-vps, do not enable

### DIFF
--- a/cloud/scripts/setup-vps.sh
+++ b/cloud/scripts/setup-vps.sh
@@ -34,6 +34,7 @@ readonly CADDY_SYNC="${RADON_CADDY_SYNC:-/usr/bin/sync}"
 readonly SERVICE_FILES=(
   radon-ib-gateway.service
   radon-ib-gateway-preheld-restart.service
+  radon-ib-gateway-remote.service
   radon-nextjs.service
   radon-api.service
   radon-relay.service
@@ -633,6 +634,9 @@ enable_services() {
   local base svc
   for svc in "${SERVICE_FILES[@]}"; do
     [[ "$svc" == "radon-ib-gateway-preheld-restart.service" ]] && continue
+    # Broker-only. Combined/app copy the unit but do not enable it. Certs plus
+    # `systemctl enable --now` happen on the broker after the split.
+    [[ "$svc" == "radon-ib-gateway-remote.service" ]] && continue
     if [[ "$svc" == *.timer ]]; then
       timer_units+=("$svc")
     elif [[ -f "${CLOUD_DIR}/services/${svc%.service}.timer" ]]; then


### PR DESCRIPTION
## Why
Main CI `pytest (cloud al)` failed after #205: `setup-vps.sh` did not name `radon-ib-gateway-remote.service`.

## What
Add it to `SERVICE_FILES` so wipe/rebuild copies the unit. Skip `enable` like the preheld adapter. Broker `systemctl enable --now` stays after cert mint.

Local: `77 passed` on the setup/integration pins.