### PR TITLE
fix(split): app FastAPI can control Gateway without host systemctl

### DIFF
--- a/cloud/scripts/radon-app-runtime.sh
+++ b/cloud/scripts/radon-app-runtime.sh
@@ -359,6 +359,16 @@ cmd_run() {
     -v "${MEDIA_DIR}:${MEDIA_DIR_IN_CONTAINER}" \
     -v "${LEASE_DIR}:/var/lib/radon/ib-lease"
 
+  # App-role Gateway control: mTLS client pair lives on the host at
+  # /etc/radon/ib-remote. Mount that directory only, never /etc/radon
+  # (TWS secrets, Turso tokens). Read-only. Missing dir is combined/broker.
+  if [[ "$unit" == "radon-api.service" ]]; then
+    local ib_remote_certs="${RADON_IB_REMOTE_CERT_DIR:-/etc/radon/ib-remote}"
+    if [[ -d "$ib_remote_certs" ]]; then
+      set -- "$@" -v "${ib_remote_certs}:${ib_remote_certs}:ro"
+    fi
+  fi
+
   if [[ -n "${NOTIFY_SOCKET:-}" && "${NOTIFY_SOCKET}" == /* ]]; then
     start_notify_proxy "$unit" "$NOTIFY_SOCKET" || exit $?
     set -- "$@" --env "NOTIFY_SOCKET=${NOTIFY_PROXY_SOCKET}" --env WATCHDOG_USEC \

--- a/cloud/tests/test_app_runtime.py
+++ b/cloud/tests/test_app_runtime.py
@@ -518,6 +518,45 @@ def test_run_binds_only_the_narrow_state_subdirectories(tmp_path: Path) -> None:
     assert ":/var/lib/radon/ib-lease" in log
 
 
+def test_run_api_mounts_ib_remote_certs_readonly_when_present(tmp_path: Path) -> None:
+    certs = tmp_path / "ib-remote"
+    certs.mkdir()
+    result = _run(
+        tmp_path,
+        ["run", "radon-api.service"],
+        extra_env={"RADON_IB_REMOTE_CERT_DIR": str(certs)},
+    )
+    assert result.returncode == 0, result.stderr
+    log = result.docker_log.read_text(encoding="utf-8")  # type: ignore[attr-defined]
+    assert f"{certs}:{certs}:ro" in log
+    assert f"{certs.parent}:" not in log.replace(f"{certs}:", "")
+
+
+def test_run_api_skips_ib_remote_certs_mount_when_absent(tmp_path: Path) -> None:
+    missing = tmp_path / "no-ib-remote"
+    result = _run(
+        tmp_path,
+        ["run", "radon-api.service"],
+        extra_env={"RADON_IB_REMOTE_CERT_DIR": str(missing)},
+    )
+    assert result.returncode == 0, result.stderr
+    log = result.docker_log.read_text(encoding="utf-8")  # type: ignore[attr-defined]
+    assert "ib-remote" not in log
+
+
+def test_run_newsfeed_does_not_mount_ib_remote_certs(tmp_path: Path) -> None:
+    certs = tmp_path / "ib-remote"
+    certs.mkdir()
+    result = _run(
+        tmp_path,
+        ["run", "radon-newsfeed.service"],
+        extra_env={"RADON_IB_REMOTE_CERT_DIR": str(certs)},
+    )
+    assert result.returncode == 0, result.stderr
+    log = result.docker_log.read_text(encoding="utf-8")  # type: ignore[attr-defined]
+    assert "ib-remote" not in log
+
+
 def test_run_newsfeed_mounts_host_playwright_browsers(tmp_path: Path) -> None:
     """Page 3e952746: container newsfeed crash-looped because Playwright
     looked up chromium_headless_shell-1217 under the image ENV

--- a/scripts/api/services.py
+++ b/scripts/api/services.py
@@ -304,6 +304,29 @@ async def show_unit(unit: str) -> UnitStatus:
     if not is_valid_unit(unit):
         return UnitStatus(unit, "rejected", "unknown", "unknown", "", can_control=False)
 
+    # App FastAPI runs in a container with no systemctl. Gateway status still
+    # comes from the broker daemon over mTLS.
+    if unit == GATEWAY_UNIT and host_role() == "app":
+        status = UnitStatus(
+            unit,
+            load_state="remote",
+            active_state="unknown",
+            sub_state="unknown",
+            description="IB Gateway on broker",
+            can_control=False,
+        )
+        if not is_remote_gateway_configured():
+            return status
+        remote = await remote_gateway_action("status")
+        status.can_control = True
+        if remote.ok and "running" in remote.detail:
+            status.active_state = "active"
+            status.sub_state = "running"
+        elif "stopped" in remote.detail:
+            status.active_state = "inactive"
+            status.sub_state = "dead"
+        return status
+
     if not is_systemd_available():
         return UnitStatus(
             unit,
@@ -344,23 +367,6 @@ async def show_unit(unit: str) -> UnitStatus:
         uptime_secs=_derive_uptime_secs(parsed),
     )
     if unit != GATEWAY_UNIT:
-        return status
-
-    if host_role() == "app":
-        if not is_remote_gateway_configured():
-            status.can_control = False
-            return status
-        remote = await remote_gateway_action("status")
-        status.can_control = True
-        if remote.ok and "running" in remote.detail:
-            status.active_state = "active"
-            status.sub_state = "running"
-        elif "stopped" in remote.detail:
-            status.active_state = "inactive"
-            status.sub_state = "dead"
-        else:
-            status.active_state = "unknown"
-            status.sub_state = "unknown"
         return status
 
     # A Type=oneshot/RemainAfterExit wrapper can stay active (exited) after

--- a/scripts/api/tests/test_services.py
+++ b/scripts/api/tests/test_services.py
@@ -105,6 +105,29 @@ class TestNonSystemdHost:
         assert status.load_state == "unsupported"
         assert status.can_control is False
 
+    def test_app_gateway_status_does_not_need_systemctl(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("RADON_HOST_ROLE", "app")
+        ca = tmp_path / "ca.pem"
+        cert = tmp_path / "client.pem"
+        key = tmp_path / "client.key"
+        for path in (ca, cert, key):
+            path.write_text("x")
+        monkeypatch.setenv("RADON_IB_REMOTE_URL", "https://10.0.0.4:8340")
+        monkeypatch.setenv("RADON_IB_REMOTE_CA", str(ca))
+        monkeypatch.setenv("RADON_IB_REMOTE_CLIENT_CERT", str(cert))
+        monkeypatch.setenv("RADON_IB_REMOTE_CLIENT_KEY", str(key))
+        remote = admin_services.ActionResult(
+            "radon-ib-gateway.service", "status", True, "running", 0,
+        )
+        async def fake_remote(_action: str):
+            return remote
+        with patch.object(admin_services, "is_systemd_available", return_value=False), \
+             patch.object(admin_services, "remote_gateway_action", side_effect=fake_remote):
+            status = asyncio.run(admin_services.show_unit("radon-ib-gateway.service"))
+        assert status.can_control is True
+        assert status.active_state == "active"
+        assert status.sub_state == "running"
+
     def test_control_unit_refuses_without_systemctl(self) -> None:
         with patch.object(admin_services, "is_systemd_available", return_value=False):
             result = asyncio.run(

--- a/web/components/admin/Ib2faControls.tsx
+++ b/web/components/admin/Ib2faControls.tsx
@@ -112,7 +112,7 @@ export default function Ib2faControls({
   // Start triggers a fresh 2FA login, so gate it on the same push lock as
   // Force 2FA to keep two pushes from racing (feedback_2fa_push_stacking).
   const startBlockedByPush = isForcePushDisabled({ pushLock, pending: false });
-  const powerDisabledReason = !servicesSupported
+  const powerDisabledReason = !servicesSupported && !remoteGateway
     ? "Read-only: this browser is not on the Hetzner VPS."
     : powerState === "unknown"
       ? "Gateway state is unknown while the control plane is unreachable."

--- a/web/tests/admin-action-request-assertions.test.tsx
+++ b/web/tests/admin-action-request-assertions.test.tsx
@@ -247,7 +247,7 @@ describe("admin destructive actions reach the wire", () => {
         const url = typeof input === "string" ? input : input.toString();
         calls.push({ url, method: init?.method ?? "GET", cache: init?.cache });
         if (url.endsWith("/api/admin/services") && (init?.method ?? "GET") === "GET") {
-          return jsonResponse({ ...SERVICES, host_role: "app" });
+          return jsonResponse({ ...SERVICES, supported: false, host_role: "app" });
         }
         if (init?.method === "POST") {
           return jsonResponse({ ok: true, detail: "done", returncode: 0, restarted: true });


### PR DESCRIPTION
## Why
Broker daemon is live on `10.0.0.4:8340`. App mTLS healthz/status work. `/admin/services` still returned `can_control: false` because FastAPI runs in a container with no `systemctl`, and the client certs were not mounted.

## What
- `show_unit` for the Gateway on `RADON_HOST_ROLE=app` uses the broker daemon even when systemd is absent.
- `Ib2faControls` treats remote `can_control` as enough for Force 2FA / Stop / Start when `supported` is false.
- `radon-app-runtime` bind-mounts `/etc/radon/ib-remote:ro` into `radon-api` only.

## Live
Broker daemon active, mTLS from `10.0.0.2` ok, public `:8340` timed out, IB `authenticated`.