### PR TITLE
fix(split): Start Gateway hits per-unit start, not stack restart

### DIFF
--- a/web/components/admin/AdminWorkspace.tsx
+++ b/web/components/admin/AdminWorkspace.tsx
@@ -345,8 +345,9 @@ export default function AdminWorkspace() {
   }, [appendLog, fetchHealth, fetchServices]);
 
   // Targeted per-unit stop of the gateway. Leaves it cleanly stopped + stable
-  // (watchdog stands down on a port-down gateway). Start is NOT a per-unit
-  // start — it routes through restartStack so the cascade dependents recover.
+  // (watchdog stands down on a port-down gateway). Start is the matching
+  // per-unit start: on the app host that is the broker mTLS daemon, not
+  // `radon restart` (no operator CLI in the API container).
   const stopGateway = useCallback(async () => {
     const at = new Date().toISOString();
     const unit = "radon-ib-gateway.service";
@@ -373,6 +374,38 @@ export default function AdminWorkspace() {
     } catch (err) {
       const detail = err instanceof Error ? err.message : "gateway stop failed";
       appendLog({ at, action: "service-action", target: `${unit} stop`, ok: false, detail });
+    }
+    void fetchServices();
+    void fetchHealth();
+    return succeeded;
+  }, [appendLog, fetchHealth, fetchServices]);
+
+  const startGateway = useCallback(async () => {
+    const at = new Date().toISOString();
+    const unit = "radon-ib-gateway.service";
+    let succeeded = false;
+    try {
+      const res = await fetch(`/api/admin/services/${unit}/start`, {
+        method: "POST",
+        cache: "no-store",
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        const detail = typeof body.error === "string" ? body.error : `HTTP ${res.status}`;
+        appendLog({ at, action: "service-action", target: `${unit} start`, ok: false, detail });
+      } else {
+        succeeded = true;
+        appendLog({
+          at,
+          action: "service-action",
+          target: `${unit} start`,
+          ok: true,
+          detail: typeof body.detail === "string" ? body.detail.slice(0, 120) : "ok",
+        });
+      }
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : "gateway start failed";
+      appendLog({ at, action: "service-action", target: `${unit} start`, ok: false, detail });
     }
     void fetchServices();
     void fetchHealth();
@@ -480,7 +513,7 @@ export default function AdminWorkspace() {
               servicesSupported={services?.supported ?? false}
               hostRole={services?.host_role ?? health?.host_role}
               onStopGateway={stopGateway}
-              onStartGateway={restartStack}
+              onStartGateway={startGateway}
               // Stopping the gateway cascade-stops radon-api — the very service
               // serving /admin/services + /health — so both polls fail. When the
               // API is unreachable, the last-known unit row reads stale "active";

--- a/web/components/admin/Ib2faControls.tsx
+++ b/web/components/admin/Ib2faControls.tsx
@@ -341,7 +341,7 @@ export default function Ib2faControls({
       <ConfirmDialog
         open={showStopConfirm}
         title="Stop the IB Gateway?"
-        body="This runs systemctl stop on the IB Gateway. It takes IB offline and cascade-stops the API, realtime relay, and monitor. Those will NOT come back on their own. To bring everything back, use Start Gateway (or Restart All Services), which restarts the whole stack in order."
+        body="This stops the IB Gateway. IB data and orders go offline. App services stay up. Start Gateway brings the Gateway back and fires one 2FA push."
         confirmLabel="Stop Gateway"
         destructive
         affectedUnits={gatewayDependents}
@@ -353,7 +353,7 @@ export default function Ib2faControls({
       <ConfirmDialog
         open={showStartConfirm}
         title="Start the IB Gateway?"
-        body="This starts the IB Gateway and brings the API, relay, and monitor back in order. Starting the gateway triggers one IBKR Mobile 2FA push to your phone. Approve it promptly, and approve only ONE push to avoid stacking. This takes about 60 to 90 seconds and the page will briefly lose its connection while FastAPI cycles."
+        body="This starts the IB Gateway. It fires one IBKR Mobile 2FA push. Approve only one. App services stay up."
         confirmLabel="Start Gateway"
         pending={pendingPower}
         onConfirm={runStart}

--- a/web/tests/admin-action-request-assertions.test.tsx
+++ b/web/tests/admin-action-request-assertions.test.tsx
@@ -271,6 +271,50 @@ describe("admin destructive actions reach the wire", () => {
     expect(sent[0].method).toBe("POST");
   });
 
+  it("Start Gateway hits the gateway start path, not stack restart", async () => {
+    const calls: RecordedCall[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        calls.push({ url, method: init?.method ?? "GET", cache: init?.cache });
+        if (url.endsWith("/api/admin/services") && (init?.method ?? "GET") === "GET") {
+          return jsonResponse({
+            ...SERVICES,
+            supported: false,
+            host_role: "app",
+            units: SERVICES.units.map((unit) =>
+              unit.unit === GATEWAY_UNIT
+                ? { ...unit, active_state: "inactive", sub_state: "dead", can_control: true }
+                : unit,
+            ),
+          });
+        }
+        if (init?.method === "POST") {
+          return jsonResponse({ ok: true, detail: "done", returncode: 0 });
+        }
+        return jsonResponse({
+          ...HEALTHY,
+          host_role: "app",
+          ib_gateway: { ...HEALTHY.ib_gateway, port_listening: false, auth_state: "unreachable" },
+        });
+      }),
+    );
+    render(<AdminWorkspace />);
+    await settle();
+
+    expect(screen.getByTestId("gateway-power-button").textContent).toBe("Start Gateway");
+    await click("gateway-power-button");
+    expect(posts(calls)).toHaveLength(0);
+    await click("admin-confirm-action");
+    const sent = posts(calls);
+    expect(sent).toHaveLength(1);
+    expect(sent[0].url).toBe(`/api/admin/services/${GATEWAY_UNIT}/start`);
+    expect(sent[0].method).toBe("POST");
+    expect(sent[0].cache).toBe("no-store");
+    expect(sent.some((c) => c.url === "/api/admin/stack/restart")).toBe(false);
+  });
+
   it("stops a service on the stop path, not the restart path", async () => {
     const calls = await renderWorkspace();
 


### PR DESCRIPTION
## Why

Start Gateway on the operator page POSTed `/api/admin/stack/restart`. That path requires `/usr/local/bin/radon`, which is not in the FastAPI container, so production returned:

`Radon API 400: operator CLI not available at /usr/local/bin/radon`

This was a combined-host leftover. When PartOf cascade-stopped the app with the Gateway, Start had to bring the whole stack back. PartOf is cut. Start is now one Gateway unit. App stays up. One 2FA push.

## What

- `startGateway` POSTs `/api/admin/services/radon-ib-gateway.service/start` (`cache: no-store`)
- Confirm copy: Stop/Start do not cascade-kill or cycle the app
- Wire test: armed Start Gateway hits that URL, not `/api/admin/stack/restart`

FastAPI already proxies that unit through `_control_gateway` -> broker mTLS on `RADON_HOST_ROLE=app`. No helper/CLI on the app host.

## Test

`npx vitest run tests/admin-action-request-assertions.test.tsx` 7 passed
`npx vitest run tests/admin-components.test.tsx` 30 passed

## After merge

Approve the IBKR Mobile 2FA when Start Gateway is used live.