### PR TITLE
security-nightly: auth-derived Claude budget; incomplete phase resumes, never pages OK

### DIFF
--- a/.claude/skills/security-nightly/SKILL.md
+++ b/.claude/skills/security-nightly/SKILL.md
@@ -53,6 +53,49 @@ markers, lesson log — in a mode-`0700` directory OUTSIDE the repository
 dump, secret, or sensitive topology into any tracked file, commit message,
 branch, PR, or the public dead-man issue.
 
+### Completion marker, INCOMPLETE, and resume
+
+The wrapper cannot trust your exit code: `claude -p` exits 0 even when a
+phase was stopped early (2026-08-31, run 20260831T000007 — the remediate
+phase parked a full pytest suite in the background, said "I'll pick up when
+the background run completes", exited 0, and the wrapper paged OK). The
+completion contract is therefore explicit, in both the private run-record and
+the public run log:
+
+1. Every phase runs against a private run directory
+   `~/radon-weekend/.security-nightly-scratch/<run-id>/` whose `run-record.md`
+   records the `run_id`, the phase, the immutable SHAs and range, each
+   pipeline stage's completion as it finishes, and a terminal `status:` line.
+2. **At phase start, look for an incomplete run of the SAME phase**: the
+   newest run directory whose `run-record.md` has no terminal completed
+   status. If one exists, RESUME it — same `run_id`, same recorded immutable
+   `HEAD_SHA`/`LAST_AUDITED_SHA` scope, skip stages the record already marks
+   complete, and finish the in-flight work (a suite still running, a scan cut
+   off, an unarchived finding) — instead of opening a new run id. The
+   wrapper's fresh log stamp and `git reset` do not reset your run identity;
+   the scratch directory outside the clone is the durable state.
+3. A phase is INCOMPLETE — not failed, and never OK — when any of these
+   happened: a provider budget/spend stop, the wall-clock cap or an outer
+   timeout, SIGTERM/kill, work deferred to a background task you did not see
+   finish ("I'll pick up later" IS incomplete now), a test suite still
+   running, a Claude Security scan marked INCOMPLETE, or a stage whose
+   completion marker is missing from the run-record. Record
+   `status: INCOMPLETE` with what remains, do NOT advance any audited SHA,
+   and do NOT print the completion marker — the next fire resumes this run.
+4. Only when the phase truly completed — every applicable stage finished or
+   cleanly recorded `OPERATOR_REQUIRED`/`BLOCKED`, private archival done or
+   explicitly recorded as the blocker, verification gates satisfied — write
+   the terminal status into `run-record.md` and print, as the phase's LAST
+   stdout line, exactly:
+
+   `SECURITY-NIGHTLY PHASE COMPLETE: <phase> run_id=<run-id>`
+
+   The wrapper greps that prefix; without it an exit-0 phase is reported
+   INCOMPLETE and exits non-zero. A clean fail-closed `OPERATOR_REQUIRED`
+   night IS complete and DOES print the marker. Never emit the marker text
+   anywhere else — not in a plan, a quote of this skill, or an interim
+   message.
+
 ## Mission
 
 - Protect operator credentials, brokerage access, live orders, journal
@@ -175,19 +218,24 @@ Before every run:
 4. Create a unique private run directory with mode `0700` outside the public
    repository. Record tool versions, command shapes, timestamps, exit codes,
    immutable SHAs, and sanitized counts. Never record environment values.
-5. Start with an allow-empty environment. Add only `PATH`, locale, temporary
-   directory, `DISABLE_AUTOUPDATER=1`, the approved model credential, and
-   synthetic test variables. Network egress is limited to the exact read-only
+5. Start with an allow-empty environment. Add only `PATH`, `HOME`, `USER`,
+   `LOGNAME`, locale, temporary directory, `DISABLE_AUTOUPDATER=1`, the
+   approved model credential, and synthetic test variables. `HOME`, `USER`,
+   and `LOGNAME` are REQUIRED whenever Claude Code itself runs: macOS
+   Keychain will not unlock the claude.ai subscription session without them
+   (2026-08-31: `env -i` without `USER`/`LOGNAME` produced "Not logged in"
+   on attempt 1). Network egress is limited to the exact read-only
    Git `origin`, pre-approved model endpoint during AI scans, approved
    advisory endpoints during dependency checks, the canonical private archive,
    and the sanitized dead-man endpoint. Package-registry access is allowed
    only during separately authorized bootstrap. If advisory freshness cannot
    be checked within that allowlist, use the last locally cached database and
    mark freshness incomplete.
-6. Apply an outer wall-clock deadline, provider hard-spend ceiling, process
-   group, memory/CPU bounds, and cleanup trap. A timeout is incomplete, not a
-   clean scan. Preserve private resumable state and do not advance the audited
-   SHA.
+6. Apply an outer wall-clock deadline, a provider hard-spend ceiling on the
+   API-key path (a claude.ai subscription session has no dollar cap — the
+   wall clock is its bound), process group, memory/CPU bounds, and cleanup
+   trap. A timeout or spend stop is incomplete, not a clean scan. Preserve
+   private resumable state and do not advance the audited SHA.
 
 ## Ground truth and change selection
 
@@ -337,14 +385,40 @@ Dynamic Workflows, or `auto`-mode permission is unavailable, the stage is
 `OPERATOR_REQUIRED` — never fall back to `bypassPermissions` or an improvised
 scan.
 
-When bootstrapped, require the checked-out `HEAD` to equal `HEAD_SHA` and
-`LAST_AUDITED_SHA` to be its ancestor (the plugin computes `merge-base..HEAD`
-from a base ref; it does not promise arbitrary two-SHA parsing — if ancestry
-fails, run the approved full scan or fail closed), then, with `umask 077`:
+The spend cap is derived AT RUN TIME from how Claude Code is authenticated on
+the runner — never from an operator environment variable and never an
+invented default (operator policy 2026-08-31; a fabricated $25 cap killed the
+2026-08-31 attempt mid-scan). `claude auth status` prints JSON on the runner
+(`loggedIn`, `authMethod`, `subscriptionType`):
+
+- **claude.ai subscription** (`authMethod` `claude.ai` — Max/Pro/Team): pass
+  NO `--max-budget-usd` at all. There is no dollar cap; the outer wall-clock
+  deadline is the bound.
+- **API key** (logged in, any other `authMethod`): pass
+  `--max-budget-usd 50`, exactly.
+- **Logged out or unparseable output**: the stage is `OPERATOR_REQUIRED` —
+  fail closed, never guess a cap and never run uncapped by accident.
+
+Run every `claude` command with `HOME`, `USER`, and `LOGNAME` present
+(trusted-environment rule 5) or the Keychain-held subscription session will
+not unlock. When bootstrapped, require the checked-out `HEAD` to equal
+`HEAD_SHA` and `LAST_AUDITED_SHA` to be its ancestor (the plugin computes
+`merge-base..HEAD` from a base ref; it does not promise arbitrary two-SHA
+parsing — if ancestry fails, run the approved full scan or fail closed),
+then, with `umask 077`:
 
 ```sh
+CLAUDE_AUTH="$(claude auth status 2>/dev/null || true)"
+if ! printf '%s' "$CLAUDE_AUTH" | grep -q '"loggedIn"[[:space:]]*:[[:space:]]*true'; then
+  # OPERATOR_REQUIRED: Claude Code is not authenticated on the runner.
+  exit_stage_operator_required
+fi
+CLAUDE_BUDGET=""
+if ! printf '%s' "$CLAUDE_AUTH" | grep -q '"authMethod"[[:space:]]*:[[:space:]]*"claude\.ai"'; then
+  CLAUDE_BUDGET="--max-budget-usd 50"   # API key; subscription runs uncapped
+fi
 claude --agent claude-security:claude-security --permission-mode auto \
-  --output-format stream-json --verbose --max-budget-usd "$CLAUDE_APPROVED_MAX_USD" \
+  --output-format stream-json --verbose $CLAUDE_BUDGET \
   -p "Scan changes with --base $LAST_AUDITED_SHA --effort medium. I understand it may take a while and use a significant number of tokens. Do not suggest patches or modify tracked files. Write only the standard ignored CLAUDE-SECURITY report." \
   >"$PRIVATE_RUN_DIR/claude-stream.jsonl" 2>"$PRIVATE_RUN_DIR/claude-stderr.log"
 ```
@@ -352,8 +426,8 @@ claude --agent claude-security:claude-security --permission-mode auto \
 For the budgeted monthly refresh, replace the first sentence with a
 whole-repository medium-effort scan. Treat a missing `Workflow` tool,
 unavailable agent/`auto` mode, interactive question, version mismatch,
-incomplete inventory, timeout, or missing revision stamp as an INCOMPLETE scan;
-do not downgrade to a weaker mode. Keep the timestamped `CLAUDE-SECURITY-*/`
+incomplete inventory, timeout, provider budget/spend stop, or missing
+revision stamp as an INCOMPLETE scan; do not downgrade to a weaker mode. Keep the timestamped `CLAUDE-SECURITY-*/`
 Markdown/JSONL/SARIF/revision artifacts private (relocate to the mode-0700 run
 dir), never let model output reach ordinary launchd stdout/stderr, and never
 commit them. The suggestion job is disabled in `audit` mode; in `remediate`
@@ -516,6 +590,11 @@ finding in stdout, public Git, public CI, or a public surface; private
 artifacts copied to the verified canonical `radon-cloud:security-archive`,
 checksum-verified, and removed from the public clone; last-audited SHAs
 advanced only for engines/stages that completed and archived successfully.
+Only after all of that (or a cleanly recorded fail-closed
+`OPERATOR_REQUIRED`) does the phase write its terminal status to the private
+`run-record.md` and print the completion-marker line the wrapper requires; an
+incomplete phase prints nothing, keeps its run-record resumable, and leaves
+every audited SHA where it was.
 
 A completed remediation additionally requires red/green regression evidence,
 all full project suites green or a clearly unrelated pre-existing baseline
@@ -555,7 +634,13 @@ job; send a source tree containing a possible secret to a model; use
 verification into a live curl/port scan/console action; publish a red
 regression that teaches exploitation before the fix is coordinated; advance the
 audited SHA after a timeout/incomplete inventory/failed archive/runtime error;
-generate work merely so the nightly loop appears productive.
+invent a Claude Security spend cap ($25 or any other number) when
+`claude auth status` cannot prove the auth method; print the phase-completion
+marker while work is parked in a background task or a suite is still running
+("I'll pick up when the background run completes" is an INCOMPLETE phase, not
+a completed one); start a fresh run id while a resumable incomplete
+run-record for the same phase exists; generate work merely so the nightly
+loop appears productive.
 
 ## Industry basis
 

--- a/scripts/security_nightly.sh
+++ b/scripts/security_nightly.sh
@@ -182,6 +182,18 @@ log: \`${RUN_LOG##*/}\` on the runner"
 # so that if it is ever cut off anyway the operator is not told it succeeded.
 BG_CEILING_MARKER="Background tasks still running after"
 
+# Operator policy 2026-08-31 (run 20260831T000007): `claude -p` exited 0 with
+# the remediate phase parked mid-flight ("Suite at ~35%; I'll pick up when the
+# background run completes") and text that matched no ceiling marker, so the
+# wrapper paged OK while the private run-record still had a full pytest suite
+# in flight. Exit code 0 alone is therefore NOT completion for this loop: the
+# skill prints this exact prefix as the LAST line of a phase that actually
+# finished (a clean fail-closed OPERATOR_REQUIRED night included), and an
+# exit-0 round without it is INCOMPLETE — reported as such, exited non-zero,
+# audited SHA untouched, so the next fire resumes the same private run in
+# ~/radon-weekend/.security-nightly-scratch/ instead of calling the night OK.
+PHASE_COMPLETE_MARKER="SECURITY-NIGHTLY PHASE COMPLETE:"
+
 phase_status() {
   # rc + run log -> the one status string every dead-man channel carries.
   # `mark` is the size of $run_log before THIS round's invocation. RUN_LOG is
@@ -452,9 +464,21 @@ run_phase() {
   # security archive, out of this wrapper's reach.
   local status
   status="$(phase_status "$RC" "$RUN_LOG" "$ROUND_LOG_MARK")"
+  # OK additionally requires the skill's completion marker in THIS round's
+  # slice (same scoping as the TRUNCATED detector, R-426). Any incomplete
+  # phase — no marker, or ceiling-truncated — must also exit non-zero so
+  # neither the dead-man nor launchd is told an unfinished night succeeded.
+  if [[ "$status" == "OK" ]] && ! tail -c "+$((ROUND_LOG_MARK + 1))" "$RUN_LOG" 2>/dev/null | grep -qF "$PHASE_COMPLETE_MARKER"; then
+    status="INCOMPLETE (exit 0 without the phase-completion marker)"
+    RC=75
+  elif [[ $RC -eq 0 && "$status" == TRUNCATED* ]]; then
+    RC=75
+  fi
   case "$status" in
     OK)
       report "$status" "sanitized: audit/remediate completed; findings (if any) are in the private security run dir and archive, never here" ;;
+    INCOMPLETE*)
+      report "$status" "the agent exited 0 without declaring the phase complete — this phase is INCOMPLETE; the audited SHA was NOT advanced and the next fire resumes the same private run on the runner" ;;
     TRUNCATED*)
       report "$status" "the harness killed unfinished background work and the agent still exited 0 — this phase is INCOMPLETE; the audited SHA was NOT advanced" ;;
     TIMEOUT*)

--- a/scripts/setup_security_nightly.sh
+++ b/scripts/setup_security_nightly.sh
@@ -74,6 +74,13 @@ advise "DeepSec workspace (.deepsec pinned, OPERATOR-bootstrapped)" \
   test -x "$WEEKEND_REPO/.deepsec/node_modules/.bin/deepsec"
 advise "Claude Security plugin (official, OPERATOR-installed)" \
   bash -c 'claude plugin list --json 2>/dev/null | grep -q claude-security'
+# Operator policy 2026-08-31: the Claude Security spend cap is derived at run
+# time from `claude auth status` (claude.ai subscription -> no --max-budget-usd;
+# API key -> --max-budget-usd 50; logged out -> OPERATOR_REQUIRED). No
+# operator budget env var exists any more, so nothing here provisions one;
+# this advisory just shows which budget path the run will take.
+advise "claude authed (subscription: no cap; API key: \$50 cap)" \
+  bash -c 'claude auth status 2>/dev/null | grep -q "\"loggedIn\"[[:space:]]*:[[:space:]]*true"'
 if [[ $fail -ne 0 ]]; then
   echo "Fix the MISSING items above, then re-run."
   echo "  bash 3.2 leaves 34 cloud/tests permanently red on this runner (13 in"

--- a/scripts/tests/test_security_loop_contract.py
+++ b/scripts/tests/test_security_loop_contract.py
@@ -363,3 +363,188 @@ class TestTheSkillCarriesTheNonNegotiableRails:
     def test_the_skill_names_both_external_engines(self):
         text = SKILL.read_text(encoding="utf-8")
         assert "DeepSec" in text and "Claude Security" in text
+
+
+class TestBudgetFollowsClaudeAuthMethod:
+    """Operator policy 2026-08-31: the Claude Security spend cap is derived at
+    run time from `claude auth status` — a claude.ai subscription session runs
+    with NO --max-budget-usd, an API key runs with --max-budget-usd 50, and no
+    surface invents a default when nothing is configured (a fabricated $25 cap
+    killed the 2026-08-31 remediate attempt mid-scan).
+    """
+
+    def test_no_surface_documents_an_operator_budget_env(self):
+        for path in (SKILL, WRAPPER, SETUP, PLIST):
+            assert "CLAUDE_APPROVED_MAX_USD" not in path.read_text(encoding="utf-8"), (
+                f"{path} still tells the operator/agent to source the budget "
+                "from an environment variable; the cap is derived from "
+                "`claude auth status` at run time"
+            )
+
+    def test_the_skill_detects_the_auth_method_at_run_time(self):
+        text = SKILL.read_text(encoding="utf-8")
+        assert "claude auth status" in text, (
+            "the skill no longer derives the spend cap from the runner's "
+            "actual Claude Code authentication"
+        )
+        for key in ("loggedIn", "authMethod", "subscriptionType"):
+            assert key in text, f"the auth-status JSON key {key} is undocumented"
+        assert "OPERATOR_REQUIRED" in text
+
+    def test_the_only_budget_ever_passed_is_the_api_key_50(self):
+        text = SKILL.read_text(encoding="utf-8")
+        assert "--max-budget-usd 50" in text, "the API-key path lost its $50 cap"
+        numeric = set(re.findall(r'--max-budget-usd\s+"?(\d+)', text))
+        assert numeric == {"50"}, (
+            f"--max-budget-usd must be exactly 50 on the API-key path and "
+            f"absent everywhere else: {sorted(numeric)}"
+        )
+        assert not re.search(r'--max-budget-usd\s+"?\$', text), (
+            "a variable-driven budget is back; the cap comes from the auth "
+            "method, never an env var"
+        )
+
+    def test_the_keychain_env_for_the_subscription_session_is_kept(self):
+        text = SKILL.read_text(encoding="utf-8")
+        for var in ("`HOME`", "`USER`", "`LOGNAME`"):
+            assert var in text, (
+                f"the skill no longer keeps {var} for Claude Code invocations; "
+                "macOS Keychain cannot unlock the claude.ai subscription "
+                "session without it (2026-08-31 attempt 1: Not logged in)"
+            )
+
+
+class TestAnIncompletePhaseIsNeverReportedOk:
+    """Operator policy 2026-08-31 (run 20260831T000007): `claude -p` exited 0
+    with the remediate phase parked mid-flight ("Suite at ~35%; I'll pick up
+    when the background run completes"), the text matched no T-239 ceiling
+    marker, and the wrapper paged OK while the private run-record still had a
+    full pytest suite in flight. OK now additionally requires the completion
+    marker the skill prints as a finished phase's last line; without it the
+    status is INCOMPLETE, the wrapper exits non-zero, and the dead-man says
+    the audited SHA was not advanced so the next fire resumes the same
+    private run. Both paths are RUN here, not grepped.
+    """
+
+    def _marker(self) -> str:
+        body = WRAPPER.read_text(encoding="utf-8")
+        match = re.search(r'PHASE_COMPLETE_MARKER="([^"]+)"', body)
+        assert match, (
+            "the wrapper lost PHASE_COMPLETE_MARKER, so OK is keyed on the "
+            "agent's exit code alone again — the 20260831T000007 defect"
+        )
+        return match.group(1)
+
+    def _harness(self, tmp_path: Path, claude_body: str) -> tuple[Path, dict, Path]:
+        clone = tmp_path / "clone"
+        (clone / "scripts").mkdir(parents=True)
+        (clone / "logs" / LABEL).mkdir(parents=True)
+        shutil.copy2(WRAPPER, clone / "scripts" / "security_nightly.sh")
+        (clone / "scripts" / "security_nightly.sh").chmod(0o755)
+        (clone / "scripts" / "weekend_notify.py").write_text("# stub\n", encoding="utf-8")
+        (clone / ".radon-weekend-runner").write_text("", encoding="utf-8")
+        (clone / ".radon-security-runner").write_text("", encoding="utf-8")
+
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        gh_log = tmp_path / "gh.log"
+        stubs = {
+            "gh": (
+                "#!/bin/sh\n"
+                f'printf "%s\\n" "$*" >> "{gh_log}"\n'
+                'if [ "$1 $2" = "issue list" ]; then echo 4242; fi\n'
+                "exit 0\n"
+            ),
+            "git": "#!/bin/sh\nexit 0\n",
+            "python3": "#!/bin/sh\nexit 0\n",
+            "claude": claude_body,
+            # Consume `-k <secs>` and the duration, then run the child, the
+            # same shape the self-rewrite harness uses (the mini has no
+            # /usr/bin/timeout, so the wrapper's calls must go through this).
+            "timeout": (
+                "#!/bin/bash\n"
+                'while [ $# -gt 0 ]; do\n'
+                '  case "$1" in\n'
+                '    -k|--kill-after) shift 2 ;;\n'
+                '    --foreground|--preserve-status) shift ;;\n'
+                '    *) shift; break ;;\n'
+                '  esac\n'
+                'done\n'
+                'exec "$@"\n'
+            ),
+        }
+        for name, body in stubs.items():
+            exe = bin_dir / name
+            exe.write_text(body, encoding="utf-8")
+            exe.chmod(0o755)
+        env = {
+            "PATH": f"{bin_dir}:/usr/bin:/bin",
+            "HOME": str(tmp_path / "home"),
+            "RADON_WEEKEND_REPO": str(clone),
+        }
+        return clone, env, gh_log
+
+    def test_a_phase_that_prints_the_completion_marker_reports_ok(self, tmp_path):
+        marker = self._marker()
+        clone, env, gh_log = self._harness(
+            tmp_path,
+            "#!/bin/sh\n"
+            "echo 'deterministic gates green; OPERATOR_REQUIRED recorded'\n"
+            f"echo '{marker} audit run_id=20260831-audit'\n"
+            "exit 0\n",
+        )
+        proc = subprocess.run(
+            [BASH, str(clone / "scripts" / "security_nightly.sh"), "audit"],
+            cwd=clone, env=env, capture_output=True, text=True, timeout=120,
+        )
+        assert proc.returncode == 0, (proc.returncode, proc.stdout, proc.stderr)
+        calls = gh_log.read_text(encoding="utf-8") if gh_log.exists() else ""
+        assert "**OK**" in calls, calls
+
+    def test_exit_zero_without_the_marker_is_incomplete_and_nonzero(self, tmp_path):
+        # The literal shape of last night's failure: a deferral sentence that
+        # matches neither the ceiling marker nor any error, and exit 0.
+        clone, env, gh_log = self._harness(
+            tmp_path,
+            "#!/bin/sh\n"
+            "echo \"Suite at ~35%; I'll pick up when the background run completes.\"\n"
+            "exit 0\n",
+        )
+        proc = subprocess.run(
+            [BASH, str(clone / "scripts" / "security_nightly.sh"), "audit"],
+            cwd=clone, env=env, capture_output=True, text=True, timeout=120,
+        )
+        assert proc.returncode == 75, (
+            "an incomplete phase must not exit 0 — launchd and the operator "
+            f"were told last night's half-run succeeded: rc={proc.returncode} "
+            f"{proc.stdout} {proc.stderr}"
+        )
+        calls = gh_log.read_text(encoding="utf-8") if gh_log.exists() else ""
+        assert "INCOMPLETE" in calls, calls
+        assert "**OK**" not in calls, calls
+        assert "NOT advanced" in calls, (
+            f"the dead-man must say the audited SHA stayed put: {calls!r}"
+        )
+        assert "resumes the same private run" in calls, calls
+
+    def test_the_skill_prints_the_exact_marker_the_wrapper_greps(self):
+        marker = self._marker()
+        assert marker in SKILL.read_text(encoding="utf-8"), (
+            f"the wrapper greps {marker!r} but the skill never tells the agent "
+            "to print it, so every finished phase would page INCOMPLETE"
+        )
+
+    def test_the_skill_owns_the_resume_contract(self):
+        text = SKILL.read_text(encoding="utf-8")
+        assert "run-record.md" in text, (
+            "the skill no longer names the private run-record that makes an "
+            "interrupted phase resumable"
+        )
+        assert "RESUME" in text or "resume" in text
+        assert ".security-nightly-scratch" in text
+        # The exact conditions the operator listed as INCOMPLETE, not OK.
+        for condition in ("budget", "SIGTERM", "I'll pick up later"):
+            assert condition in text, (
+                f"the skill no longer classifies {condition!r} as an "
+                "INCOMPLETE phase"
+            )

--- a/scripts/tests/test_weekend_wrapper_self_rewrite.py
+++ b/scripts/tests/test_weekend_wrapper_self_rewrite.py
@@ -150,14 +150,24 @@ def _build(
         "exit 0\n" % attack_sh,
     )
 
+    # The security wrapper (operator policy 2026-08-31) keys OK on the skill's
+    # phase-completion marker, not on exit 0 alone, so its stub agent prints
+    # the marker the way a phase that actually finished would. The other
+    # loops' wrappers do not grep for it and the extra line is inert there.
+    complete_line = ""
+    if loop == "security":
+        src = (REPO / "scripts" / script).read_text(encoding="utf-8")
+        marker = re.search(r'PHASE_COMPLETE_MARKER="([^"]+)"', src).group(1)
+        complete_line = f"echo '{marker} stub run_id=stub'\n"
     _executable(
         bin_dir / "claude",
         "#!/bin/bash\n"
         f'echo "claude $*" >> "{agent_log}"\n'
-        'if [ "${STUB_ATTACK_ON:-off}" = "agent" ]; then "%s"; fi\n'
+        f'if [ "${{STUB_ATTACK_ON:-off}}" = "agent" ]; then "{attack_sh}"; fi\n'
         'if [ "${STUB_CLAUDE_SLEEP:-0}" != "0" ]; then sleep "$STUB_CLAUDE_SLEEP"; fi\n'
         "echo 'stub agent output'\n"
-        'exit "${STUB_CLAUDE_RC:-0}"\n' % attack_sh,
+        + complete_line
+        + 'exit "${STUB_CLAUDE_RC:-0}"\n',
     )
 
     # REL-137 gave the real invocation `-k <secs>` so a claude blocked on a

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,34 @@
+# Task: Security nightly — auth-derived Claude budget + incomplete-run resume (2026-08-31)
+
+## Objective
+
+- Claude Security spend cap follows the runner's real auth: claude.ai subscription -> no --max-budget-usd; API key -> --max-budget-usd 50; never an invented default (the fabricated $25 cap killed 20260831 attempt 2).
+- A phase that halts before completing (budget stop, timeout, SIGTERM, "I'll pick up later", suite in flight) is INCOMPLETE — non-zero exit, audited SHA untouched, next launchd fire resumes the same private run_id — never OK (20260831T000007 paged OK on a half-run).
+
+## Dependency graph
+
+- S1 depends_on: [] - Wrapper: PHASE_COMPLETE_MARKER gate; exit-0 without marker -> INCOMPLETE rc=75; TRUNCATED also rc=75
+- S2 depends_on: [] - Skill: run-record/resume contract, auth-derived Stage 4 budget, HOME/USER/LOGNAME kept for Keychain, anti-patterns
+- S3 depends_on: [] - Setup: advisory `claude auth status` check; no operator budget env story
+- S4 depends_on: [S1, S2] - Tests: contract classes (budget policy, incomplete-never-OK run at the wire, marker parity, resume rails); self-rewrite stub prints the security marker
+- S5 depends_on: [S4] - Focused suites green, commit, push, PR
+
+## Checklist
+
+- [x] S1 Wrapper marker gate
+- [x] S2 Skill budget + resume
+- [x] S3 Setup advisory
+- [x] S4 Tests
+- [x] S5 Verified (contract+deadman+launchers 140 passed; self-rewrite+rel137 214 passed; documentation contract 35 passed; bash -n clean)
+
+## Review
+
+- The wrapper stays mechanical: it keys OK on the skill-printed completion marker in the last round's log slice (R-426 scoping) and exits 75 on any incomplete rc-0 phase; run-identity resume lives entirely in the skill against ~/radon-weekend/.security-nightly-scratch/<run-id>/run-record.md, which the per-round git clean cannot reach.
+- No new env knob: budget is derived from `claude auth status` inside Stage 4; logged-out/unparseable fails closed as OPERATOR_REQUIRED.
+- Shared five-loop harnesses untouched except the self-rewrite claude stub, which now prints the marker for the security loop only.
+
+---
+
 # Task: Assistant catalog always tracks live API pins (2026-08-30)
 
 ## Objective


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- [x] Red/green TDD (failing test, then fix)
- [x] Staged only the files this change owns (no `git add -A`)
- [x] Owner doc updated, or the commit message has `docs-skip: <reason>`
- [ ] Previous `main` deploy finished before this push

## What broke (operator policy 2026-08-31, run 20260831T000007)

Two failures in one night on the Mac mini security runner:

1. **Fake budget.** Attempt 1 of the Claude Security stage failed "Not logged in" because the skill's allow-empty environment (`env -i`) dropped `USER`/`LOGNAME`, which macOS Keychain needs to unlock the claude.ai subscription session. Attempt 2 authenticated and then died at a **$25 cap the agent invented** because `CLAUDE_APPROVED_MAX_USD` was unset.
2. **OK on a half-run.** `claude -p` exited 0 with the remediate phase parked mid-flight ("Suite at ~35%; I'll pick up when the background run completes"). That text matches no T-239 ceiling marker, so `phase_status` returned OK and the wrapper paged OK — while `~/radon-weekend/.security-nightly-scratch/20260831-remediate/run-record.md` still had a full pytest suite in flight.

## What changed

### Budget follows the real auth method (`.claude/skills/security-nightly/SKILL.md`, `scripts/setup_security_nightly.sh`)

- Stage 4 derives the cap at run time from `claude auth status` (JSON on the mini: `loggedIn`, `authMethod`, `subscriptionType`):
  - claude.ai subscription (Max/Pro/Team): **no `--max-budget-usd`** — the outer wall clock is the bound;
  - API key: **`--max-budget-usd 50`, exactly**;
  - logged out / unparseable: `OPERATOR_REQUIRED`, fail closed — never a guessed cap.
- The `CLAUDE_APPROVED_MAX_USD` story is deleted from every surface; a new anti-pattern forbids inventing a cap.
- Trusted-environment rule 5 now keeps `HOME`, `USER`, `LOGNAME` for every Claude Code invocation; a provider budget/spend stop is explicitly an INCOMPLETE scan.
- Setup gains an advisory `claude auth status` line so the operator sees which budget path a run will take.

### An incomplete phase is INCOMPLETE, non-zero, and resumed (`scripts/security_nightly.sh`, skill)

- The skill prints `SECURITY-NIGHTLY PHASE COMPLETE: <phase> run_id=<id>` as the **last** stdout line of a phase that truly finished (a clean fail-closed `OPERATOR_REQUIRED` night included), and mirrors the terminal status into the private `run-record.md`.
- The wrapper greps that marker in the last round's log slice (same R-426 scoping as the TRUNCATED detector). Exit 0 without it → status `INCOMPLETE (exit 0 without the phase-completion marker)`, exit code 75, dead-man says the audited SHA was NOT advanced. A TRUNCATED rc-0 round also exits 75 now, so launchd is never told a half-run succeeded.
- The skill opens every phase by looking for an incomplete run-record of the **same phase** in `~/radon-weekend/.security-nightly-scratch/` and resumes that `run_id` — same immutable SHA scope, completed stages skipped, in-flight work finished — instead of starting a fresh stamp. Budget stop, wall-clock cap, SIGTERM, deferral language, a suite still running, a Claude Security INCOMPLETE, or missing completion markers all classify as INCOMPLETE with no audited-SHA advance.

Unchanged: fail-closed on missing bootstrap, sanitized dead-man (status line only, never findings), no production/live-broker/third-party contact, human merge.

## Tests

- New `TestBudgetFollowsClaudeAuthMethod` and `TestAnIncompletePhaseIsNeverReportedOk` in `scripts/tests/test_security_loop_contract.py` — the wrapper paths are RUN at the wire (marker → OK/exit 0; last night's literal deferral text → INCOMPLETE/exit 75/"NOT advanced"), plus marker parity between wrapper and skill and the resume rails. The incomplete case fails against the pre-change wrapper (red) and passes now (green).
- Shared five-loop harness touched in one place only: the self-rewrite stub agent prints the marker for the security loop, since its success paths now model a phase that actually finished.
- Evidence: contract+deadman+launchers `140 passed`; self-rewrite+rel137 `214 passed`; documentation contract `35 passed`; `bash -n` clean on both scripts.

## Deploy note

The live runner clone picks this up via git only (`git -C ~/radon-weekend/radon-security fetch origin && git checkout -f main && git reset --hard origin/main` with no run in flight) after merge; the skill/wrapper pair must move together since the wrapper greps the marker the skill prints.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ad6b86a-7324-431d-be56-bee473e5dccf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ad6b86a-7324-431d-be56-bee473e5dccf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

