### PR TITLE
fix(ci): repair main after four same-day merges collided semantically

### DIFF
--- a/cloud/.gitleaks.toml
+++ b/cloud/.gitleaks.toml
@@ -61,7 +61,9 @@ commits = [
   "da857b8b19a6e5778bb86bf37465346dca8da89b",
 ]
 
-[allowlist]
+# Global allowlists. The singular legacy `[allowlist]` table cannot coexist
+# with this array, so both entries live here.
+[[allowlists]]
 description = "Generated local artifacts are not source"
 paths = ['''(^|/)__pycache__/|\.pyc$|(^|/)\.venv/''']
 # RADON_DB_NO_REPLICA=1 is the documented replica kill-switch flag (root
@@ -69,3 +71,17 @@ paths = ['''(^|/)__pycache__/|\.pyc$|(^|/)\.venv/''']
 # `RADON_DB_NO_REPLICA=1`" trips generic-api-key (2026-08-16, .pi/AGENTS.md
 # in b2ef3209). The literal is config, never a credential.
 regexes = ['''RADON_DB_NO_REPLICA=1''']
+
+# generic-api-key is a gitleaks DEFAULT rule, so its exception cannot live
+# under a [[rules]] block here. `targetRules` keeps this scoped to that one
+# rule instead of blanket-allowing the commit (gitleaks >= 8.19).
+[[allowlists]]
+description = "Vetted test fixture in an immutable merged commit"
+targetRules = ["generic-api-key"]
+commits = [
+  # 2026-08-31 (#212): the weekend-redactor test spelled a FAKE UW token to
+  # prove the redactor scrubs env values; merged before the scan ran. Never a
+  # valid credential, nothing to rotate. The fixture was rewritten to runtime
+  # construction in the next commit so no later SHA re-trips the rule.
+  "38eeecb91eedb3b90966821bff12d5b240d89708",
+]

--- a/cloud/tests/test_gitleaks_policy.py
+++ b/cloud/tests/test_gitleaks_policy.py
@@ -45,6 +45,21 @@ EXAMPLE_BASELINE_COMMITS = {
 }
 
 
+# generic-api-key is a gitleaks DEFAULT rule, so its exceptions live in a
+# global [[allowlists]] entry scoped with targetRules rather than in a
+# [[rules]] block.
+GENERIC_API_KEY_BASELINE_COMMITS = {
+    # 2026-08-31 (#212): the weekend-redactor test spelled a fake UW token to
+    # prove the redactor scrubs env values; merged before the scan ran. The
+    # fixture was rewritten to runtime construction afterwards.
+    "38eeecb91eedb3b90966821bff12d5b240d89708",
+}
+
+
+def _config() -> dict:
+    return tomllib.loads(GITLEAKS_CONFIG.read_text(encoding="utf-8"))
+
+
 def _config_rules() -> dict[str, dict]:
     config = tomllib.loads(GITLEAKS_CONFIG.read_text(encoding="utf-8"))
     return {rule["id"]: rule for rule in config["rules"]}
@@ -83,6 +98,21 @@ def test_historical_exceptions_are_rule_scoped_and_commit_exact() -> None:
     assert _rule_allowlist_commits(rules["credential-shaped-example"]) == (
         EXAMPLE_BASELINE_COMMITS
     )
+
+
+def test_global_commit_exceptions_are_rule_scoped_and_commit_exact() -> None:
+    config = _config()
+    assert "allowlist" not in config, (
+        "the singular [allowlist] table cannot coexist with [[allowlists]]; "
+        "gitleaks refuses to load the config"
+    )
+    exceptions = [a for a in config["allowlists"] if a.get("commits")]
+    assert len(exceptions) == 1
+    entry = exceptions[0]
+    # Without targetRules a commit exception blanket-allows EVERY rule for
+    # that SHA, including the custom TWS ones.
+    assert entry["targetRules"] == ["generic-api-key"]
+    assert set(entry["commits"]) == GENERIC_API_KEY_BASELINE_COMMITS
 
 
 def test_custom_rules_still_match_new_literals_but_not_empty_placeholders() -> None:

--- a/scripts/api/tests/test_remote_gateway_client.py
+++ b/scripts/api/tests/test_remote_gateway_client.py
@@ -136,12 +136,16 @@ class TestRouteMapping:
         assert resp.status_code == 502
         assert resp.json()["detail"]["returncode"] == 1
 
-    def test_broker_down_is_502_not_400(self, broker, client):
+    def test_broker_down_is_504_not_400(self, broker, client):
+        # T-347 pinned "not the 400 caller-error bucket"; REL-171 (R-500) then
+        # split the upstream failures: a dead mTLS link is a gateway TIMEOUT,
+        # a malformed broker reply stays a 502.
         httpd = broker()
         httpd.shutdown()
         httpd.server_close()
         resp = client.post(self.ROUTE)
-        assert resp.status_code == 502, resp.text
+        assert resp.status_code == 504, resp.text
+        assert resp.json()["detail"]["returncode"] == services.REMOTE_UNREACHABLE_RC
         assert resp.json()["detail"]["ok"] is False
 
 

--- a/scripts/api/tests/test_streaks_route.py
+++ b/scripts/api/tests/test_streaks_route.py
@@ -109,7 +109,7 @@ def test_short_sources_fall_through_to_yahoo(client):
 
 
 def test_robinhood_outranks_yahoo_when_it_serves_enough_bars(client):
-    from api.routes.streaks import MIN_ACCEPT_BARS
+    from api.routes.streaks import MIN_ACCEPT_BARS, RH_SOURCE
 
     yahoo = MagicMock()
     with patch("api.routes.streaks._read_cached_closes", return_value=None), patch(
@@ -127,7 +127,7 @@ def test_robinhood_outranks_yahoo_when_it_serves_enough_bars(client):
 
     assert resp.status_code == 200
     body = resp.json()
-    assert body["source"] == "robinhood"
+    assert body["source"] == RH_SOURCE  # REL-174 (R-485): the writer vocabulary spelling
     assert body["count"] == MIN_ACCEPT_BARS
     yahoo.assert_not_called()
 

--- a/scripts/tests/test_prologue_page_wire.py
+++ b/scripts/tests/test_prologue_page_wire.py
@@ -49,7 +49,10 @@ def _build(tmp_path: Path, *, marker: bool, lock_held: bool) -> dict:
     (clone / "scripts").mkdir(parents=True)
     if marker:
         (clone / ".radon-weekend-runner").touch()
-        (clone / ".radon-security-runner").touch()
+        # REL-180 (R-504): every wrapper requires its OWN loop marker too, so
+        # this generic clone carries all five.
+        for loop in LOOPS:
+            (clone / f".radon-{loop}-runner").touch()
     if lock_held:
         lock = clone / ".weekend-runner.lock"
         lock.mkdir()

--- a/scripts/tests/test_rel180_loop_launchers.py
+++ b/scripts/tests/test_rel180_loop_launchers.py
@@ -224,15 +224,23 @@ class TestRedactor:
         sys.path.insert(0, str(REPO / "scripts"))
         import weekend_redact
 
+        # Built at runtime: a full `UW_TOKEN='<high-entropy>'` assignment
+        # spelled in the source trips gitleaks' generic-api-key rule over the
+        # full history, and this file is public. Same treatment as the TWS
+        # fixtures in cloud/tests/test_gitleaks_policy.py.
+        fake_token = "tok-" + "1234567890"
         (tmp_path / "web").mkdir()
-        (tmp_path / "web" / ".env").write_text("UW_TOKEN='tok-1234567890'\nSHORT=ab\n")
+        (tmp_path / "web" / ".env").write_text(
+            "UW_" + "TOKEN='" + fake_token + "'\nSHORT=ab\n"
+        )
         values = weekend_redact.env_values(tmp_path)
-        assert "tok-1234567890" in values and "ab" not in values
+        assert fake_token in values and "ab" not in values
         out = weekend_redact.redact(
-            "x tok-1234567890 y CLERK_SECRET_KEY=sk_live_abcdef Authorization: Bearer eyJhbGci.zz TURSO_AUTH_TOKEN: qqq",
+            f"x {fake_token} y CLERK_SECRET_KEY=sk_live_abcdef "
+            "Authorization: Bearer eyJhbGci.zz TURSO_AUTH_TOKEN: qqq",
             values,
         )
-        assert "tok-1234567890" not in out and "sk_live_abcdef" not in out
+        assert fake_token not in out and "sk_live_abcdef" not in out
         assert "eyJhbGci" not in out and "qqq" not in out
         assert out.count("[REDACTED]") >= 4
 

--- a/scripts/tests/test_security_loop_contract.py
+++ b/scripts/tests/test_security_loop_contract.py
@@ -55,6 +55,13 @@ def _uncommented(path: Path) -> str:
     )
 
 
+def _phase_complete_marker() -> str:
+    body = WRAPPER.read_text(encoding="utf-8")
+    match = re.search(r'PHASE_COMPLETE_MARKER="([^"]+)"', body)
+    assert match, "the wrapper lost PHASE_COMPLETE_MARKER"
+    return match.group(1)
+
+
 def _clone(tmp_path: Path, *, security_marker: bool) -> Path:
     repo = tmp_path / "clone"
     (repo / "scripts").mkdir(parents=True)
@@ -241,7 +248,7 @@ class TestTheDeadmanIsSanitized:
 
     def _phase_stub_bin(
         self, tmp_path: Path, *, claude_rc: int = 0, timeout_124: bool = False,
-        truncated: bool = False,
+        truncated: bool = False, complete: bool = True,
     ) -> tuple[Path, Path, Path]:
         bin_dir = tmp_path / "bin"
         bin_dir.mkdir()
@@ -267,10 +274,14 @@ class TestTheDeadmanIsSanitized:
             ),
             # The agent: scanner-shaped output into the run log, then the
             # exit the case under test needs.
+            # A phase that ends OK must print the completion marker (R-517);
+            # without it the wrapper downgrades to INCOMPLETE and exits 75.
             "claude": (
                 "#!/bin/sh\n"
                 f"echo 'gitleaks: {self.CANARY} matched in web/lib/secret.ts:12'\n"
                 + ("echo 'Background tasks still running after 600s'\n" if truncated else "")
+                + (f"echo '{_phase_complete_marker()} audit'\n"
+                   if complete and not truncated else "")
                 + f"exit {claude_rc}\n"
             ),
             # `timeout -k <secs> <secs> cmd`: consume the options, then run the
@@ -321,7 +332,10 @@ class TestTheDeadmanIsSanitized:
             ("ok", {"claude_rc": 0}, "**OK**", 0),
             ("failed", {"claude_rc": 7}, "FAILED (exit 7)", 7),
             ("timeout", {"timeout_124": True}, "TIMEOUT", 124),
-            ("truncated", {"truncated": True}, "TRUNCATED", 0),
+            # R-517: an incomplete phase exits 75, so neither the dead-man nor
+            # launchd is told an unfinished night succeeded.
+            ("truncated", {"truncated": True}, "TRUNCATED", 75),
+            ("incomplete", {"complete": False}, "INCOMPLETE", 75),
         ],
     )
     def test_no_run_log_content_reaches_the_public_deadman(

--- a/scripts/tests/test_weekend_loop_deadman.py
+++ b/scripts/tests/test_weekend_loop_deadman.py
@@ -530,6 +530,8 @@ def _committing_clone(tmp_path: Path, git: str) -> Path:
     repo = tmp_path / "radon-testing"
     (repo / "scripts").mkdir(parents=True)
     (repo / ".radon-weekend-runner").write_text("", encoding="utf-8")
+    # REL-180 (R-504): the testing wrapper requires its own loop marker too.
+    (repo / ".radon-testing-runner").write_text("", encoding="utf-8")
     subprocess.run([git, "init", "-q", str(repo)], check=True, env=_GIT_ENV)
     at = [git, "-C", str(repo)]
     subprocess.run([*at, "symbolic-ref", "HEAD", "refs/heads/main"], check=True, env=_GIT_ENV)

--- a/scripts/weekend_notify.py
+++ b/scripts/weekend_notify.py
@@ -40,8 +40,13 @@ def _load_env_file(path: Optional[str]) -> Optional[str]:
         from dotenv import dotenv_values
     except ImportError:
         return "python-dotenv is not importable (is the venv on PATH?)"
-    for key, value in dotenv_values(env_path, interpolate=False).items():
-        if key and value is not None and key not in os.environ:
+    values = dotenv_values(env_path, interpolate=False)
+    # T-351 (rail 5): import ONLY the Pushover keys. Every wrapper passes the
+    # shared `$WEEKEND_ROOT/.env`, which on the runner also carries
+    # IB_FLEX_TOKEN / TURSO_AUTH_TOKEN / CLERK_*.
+    for key in ENV_FILE_KEYS:
+        value = values.get(key)
+        if value is not None and key not in os.environ:
             os.environ[key] = value
     return None
 


### PR DESCRIPTION
Run [33410378860](https://github.com/joemccann/radon/actions/runs/33410378860) on `4584e84a` is red in four jobs: `Secret scan (gitleaks)`, `pytest (scripts-npsz)`, `pytest (rest-api)`, `pytest (scripts-rs)`. 11 test failures plus one gitleaks finding.

Every one is a merge collision. PRs #212 (reliability), #213 (testing) and #214 (security) all landed within a few hours, none of them touched the same *line* as another, so git merged all three clean — while three behavioural contracts changed under tests written against the old ones. Neither branch's CI could have caught it; only the merge result is red.

## What changed

| # | Collision | Resolution |
|---|---|---|
| 1 | REL-174 (R-485, #212) collapsed the Robinhood source spelling to `"rh"`; T-349 (#213) asserted `"robinhood"` | Route is right — the test reads `RH_SOURCE` now so the two cannot drift again |
| 2 | T-347 (#213) moved unreachable-broker off 400 onto 502; REL-171 (R-500, #212) then split it into 504 unreachable / 502 bad-reply | T-347's intent (not 400) preserved; test pins 504 and the `REMOTE_UNREACHABLE_RC` sentinel |
| 3 | REL-180 (R-504, #212) made every wrapper require its own `.radon-<loop>-runner`; two harnesses in #213 stage only the shared marker | Both harnesses stage the loop markers; the wrappers were refusing with exit 2 before reaching the behaviour under test |
| 4 | R-517 (#214) made `OK` require `PHASE_COMPLETE_MARKER` and every incomplete phase exit 75; T-350's (#213) stub `claude` exits 0 without it | Stub prints the marker for the OK case, TRUNCATED expects 75, and a fifth case now covers the INCOMPLETE downgrade itself |
| 5 | **Real defect.** T-351 (#213) restricted `weekend_notify --env-file` to the Pushover keys; R-508 (#212) rewrote the same function. The merge kept R-508's body and T-351's `ENV_FILE_KEYS` constant — and dropped the filter that used it | Filter restored on top of R-508's reason-returning shape |
| 6 | gitleaks full-history scan trips `generic-api-key` on the weekend-redactor test's fake UW token, committed in `38eeecb9` (#212) | Fixture rewritten to runtime construction; `38eeecb9` gets a commit-exact, rule-scoped exception |

### On #5

This is the one that is not a stale expectation. Rail 5 of the security loop is that its child process never receives a Radon credential. Between the merge and this commit, every wrapper was handing the notifier the whole shared `~/radon-weekend/.env` — `IB_FLEX_TOKEN`, `TURSO_AUTH_TOKEN`, `CLERK_*`. The test that caught it is the one T-351 shipped; it was red from the moment the two PRs met.

### On #6

The value was never a valid credential and there is nothing to rotate, but the commit is immutable on protected `main`, so history-scan needs an exception. Both halves match the precedent already in this config for the TWS fixtures: rewrite the fixture so no later SHA re-trips the rule, *and* allowlist the one commit.

`generic-api-key` is a gitleaks default rule, so the exception cannot live under `[[rules]]`. It is a global `[[allowlists]]` entry with `targetRules = ["generic-api-key"]` rather than a blanket commit allow. gitleaks 8.30.1 refuses a config carrying both the legacy singular `[allowlist]` table and `[[allowlists]]`, so the existing artifact/regex entry moves into the array unchanged. `test_gitleaks_policy.py` pins the new entry commit-exact and asserts `targetRules` is present, so a future widening to a blanket commit allow fails CI.

## Verification

Local, at the failing SHA, with the CI dependency set:

- `scripts/tests` + `scripts/api/tests`: **9332 passed, 1 skipped, 0 failed** (was 11 failed)
- `cloud/tests`: 35 failed, 1508 passed — the documented darwin baseline, unchanged by this commit
- gitleaks 8.30.1 (pinned to the CI checksum), full history: **2612 commits scanned, no leaks found** (was `leaks found: 1`)

Every failure was reproduced locally before it was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nVvKvpEXYszv9coXt8a5i
