### PR TITLE
Public design.md surface for external agents on app.radon.run

### DIFF
--- a/docs/design-evals.md
+++ b/docs/design-evals.md
@@ -1,0 +1,57 @@
+# Design eval scenarios — design.md loop
+
+Seed eval loop for the public agent-design surface, following the Vercel design.md methodology (guidance file + bounded public stylesheet + deterministic checks + frozen scenarios).
+
+**Surface:**
+
+| Piece | URL | Source |
+|---|---|---|
+| Guidance | `https://app.radon.run/design.md` | `web/public/design.md` |
+| Stylesheet | `https://app.radon.run/radon.css` | `web/public/radon.css` |
+| Rendered example | `https://app.radon.run/design-example.html` | `web/public/design-example.html` |
+
+**Deterministic checks:** `web/tests/design-artifact-contract.test.ts` (vocabulary sync, radius cap, no shadows/gradients, token-only color, dual-theme parity, no em dashes).
+
+## How to run a round
+
+1. Give an agent one scenario prompt below plus its mock inputs, with `design.md` loaded. Same prompt, same data, same viewport (1280px) every round. Keep the first attempt, no rerolls.
+2. Screenshot the full page in dark and light (`data-theme="light"`).
+3. Score against the scenario rubric blind against the previous round's output.
+4. Encode each accepted correction in the narrowest place that enforces it: judgment into `web/public/design.md` prose, repeatable mechanics into `web/public/radon.css`, mechanical failures into the contract test. Never hand-tune the generated page.
+
+## Scenario 1 — Flow evaluation brief
+
+**Prompt:** "Build a one-page flow evaluation brief for ticker XMPL from this data: five sessions of dark pool block prints (dates, venues, print counts, notional, VWAP distance, % of ADV), peer off-exchange share for XMPL and three peers, IV rank 22, and a proposed defined-risk call spread with its Kelly fraction. The reader decides whether to enter the trade."
+
+**Rubric:**
+- The supplied figures survive verbatim, each with source and time basis.
+- Executive read in ten seconds: state, headline numbers, decision.
+- The evidence table uses the full available width.
+- Peer values share one scale.
+- Decision presented as signal, structure, sizing math, decision; caveats present but subordinate.
+
+## Scenario 2 — Weekly portfolio review
+
+**Prompt:** "Build a weekly portfolio review from this data: net liq series for the week, per-position P&L table (ticker, structure, entry date, MV, P&L, week change), three exposure concentrations, and two data quality notes. The reader checks health and looks for positions needing action."
+
+**Rubric:**
+- Positions needing action are visually separable without red/green P&L color leakage (signal states only).
+- Numeric columns right-aligned mono; totals reconcile with rows.
+- Data quality notes rendered as `rd-note`/`rd-warn`, not buried and not alarmist.
+
+## Scenario 3 — Incident postmortem
+
+**Prompt:** "Build an incident postmortem page from this data: a timeline of six timestamped events (feed fault, detection, mitigation, recovery), impact metrics (minutes degraded, affected surfaces), root cause, and three follow-up actions. The reader verifies the incident is understood and closed."
+
+**Rubric:**
+- Voice follows the error pattern: system, failure, cause, recovery. No blame language, no drama.
+- Fault color used for the operational fault only; recovery states use the teal family.
+- Follow-ups are concrete and checkable, each with an owner surface.
+
+## Feedback log
+
+Append one line per accepted correction: date, scenario, correction, where it was encoded.
+
+| Date | Scenario | Correction | Encoded in |
+|---|---|---|---|
+| 2026-08-31 | 1 | Baseline round: stylesheet + guidance shipped; dark/light renders verified in headless Chrome | Initial `design.md`, `radon.css`, contract test |

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -169,6 +169,12 @@ export const isPublicRoute = createRouteMatcher([
   // this exemption /robots.txt redirects to /sign-in and the disallow-all
   // policy is never served (Google indexed exactly that redirect URL).
   "/robots.txt",
+  // Public agent design guidance (web/public/design.md) — the whole point is
+  // a stable URL any external agent can load (see docs/design-evals.md). The
+  // matcher's static-file exclusion covers .css/.html companions
+  // (/radon.css, /design-example.html) but not .md, so this one static file
+  // needs an explicit exemption. Serves brand guidance only; no account data.
+  "/design.md",
   ...PUBLIC_SHARE_API_ROUTES,
   ...PUBLIC_WEBHOOK_API_ROUTES,
   "/api/health",

--- a/web/public/design-example.html
+++ b/web/public/design-example.html
@@ -1,0 +1,180 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>XMPL Flow Evaluation — Radon artifact example</title>
+<link rel="stylesheet" href="/radon.css" />
+</head>
+<body>
+<div class="rd-page">
+
+  <header class="rd-masthead">
+    <span class="rd-wordmark">RADON</span>
+    <span class="rd-meta">Flow evaluation</span>
+    <span class="rd-meta">2026-08-28 · 14:32 ET · Sample data</span>
+  </header>
+
+  <h1 class="rd-title">XMPL: dark pool accumulation ahead of guidance</h1>
+  <p class="rd-subtitle">Off-exchange prints absorbed 3.4x average notional over five sessions while lit price held a 1.2% range. Options positioning has not repriced.</p>
+
+  <section class="rd-section">
+    <div class="rd-stats">
+      <div class="rd-stat">
+        <div class="rd-stat-label">Signal state</div>
+        <div class="rd-stat-value"><span class="rd-badge rd-clear">Clear</span></div>
+        <div class="rd-stat-note">Structural candidate</div>
+      </div>
+      <div class="rd-stat">
+        <div class="rd-stat-label">DP notional / 5d</div>
+        <div class="rd-stat-value">$481M</div>
+        <div class="rd-stat-note"><span class="rd-delta-up">+238%</span> vs 20d mean</div>
+      </div>
+      <div class="rd-stat">
+        <div class="rd-stat-label">Lit ratio</div>
+        <div class="rd-stat-value">0.34</div>
+        <div class="rd-stat-note"><span class="rd-delta-down">-0.18</span> vs baseline</div>
+      </div>
+      <div class="rd-stat">
+        <div class="rd-stat-label">IV rank</div>
+        <div class="rd-stat-value">22</div>
+        <div class="rd-stat-note">30d percentile</div>
+      </div>
+    </div>
+  </section>
+
+  <section class="rd-section">
+    <h2 class="rd-label">Off-exchange evidence</h2>
+    <div class="rd-panel">
+      <div class="rd-panel-header">
+        <span class="rd-panel-title">Block prints, five sessions</span>
+        <span class="rd-meta">Source: UW dark pool feed</span>
+      </div>
+      <table class="rd-table">
+        <thead>
+          <tr>
+            <th>Date</th>
+            <th>Venue</th>
+            <th class="rd-num">Prints</th>
+            <th class="rd-num">Notional</th>
+            <th class="rd-num">VWAP dist</th>
+            <th class="rd-num">% of ADV</th>
+            <th>State</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>08-28</td><td>OTC non-ATS</td>
+            <td class="rd-num">61</td><td class="rd-num">$142.1M</td>
+            <td class="rd-num">+0.04%</td><td class="rd-num">18.2%</td>
+            <td><span class="rd-badge rd-strong">Strong</span></td>
+          </tr>
+          <tr>
+            <td>08-27</td><td>ATS block</td>
+            <td class="rd-num">44</td><td class="rd-num">$118.6M</td>
+            <td class="rd-num">-0.02%</td><td class="rd-num">15.1%</td>
+            <td><span class="rd-badge rd-clear">Clear</span></td>
+          </tr>
+          <tr>
+            <td>08-26</td><td>ATS block</td>
+            <td class="rd-num">37</td><td class="rd-num">$96.4M</td>
+            <td class="rd-num">+0.07%</td><td class="rd-num">12.9%</td>
+            <td><span class="rd-badge rd-clear">Clear</span></td>
+          </tr>
+          <tr>
+            <td>08-25</td><td>OTC non-ATS</td>
+            <td class="rd-num">29</td><td class="rd-num">$71.8M</td>
+            <td class="rd-num">+0.11%</td><td class="rd-num">9.6%</td>
+            <td><span class="rd-badge rd-emerging">Emerging</span></td>
+          </tr>
+          <tr>
+            <td>08-24</td><td>ATS block</td>
+            <td class="rd-num">18</td><td class="rd-num">$52.3M</td>
+            <td class="rd-num">-0.05%</td><td class="rd-num">7.0%</td>
+            <td><span class="rd-badge rd-baseline">Baseline</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="rd-section">
+    <div class="rd-grid">
+      <div class="rd-span-6">
+        <div class="rd-panel">
+          <div class="rd-panel-header">
+            <span class="rd-panel-title">Peer 5d off-exchange share</span>
+            <span class="rd-meta">One scale</span>
+          </div>
+          <div class="rd-bar">
+            <span class="rd-bar-label">XMPL</span>
+            <div class="rd-bar-track"><div class="rd-bar-fill" style="width: 66%"></div></div>
+            <span class="rd-bar-value">66%</span>
+          </div>
+          <div class="rd-bar">
+            <span class="rd-bar-label">PEER A</span>
+            <div class="rd-bar-track"><div class="rd-bar-fill rd-neutral" style="width: 41%"></div></div>
+            <span class="rd-bar-value">41%</span>
+          </div>
+          <div class="rd-bar">
+            <span class="rd-bar-label">PEER B</span>
+            <div class="rd-bar-track"><div class="rd-bar-fill rd-neutral" style="width: 38%"></div></div>
+            <span class="rd-bar-value">38%</span>
+          </div>
+          <div class="rd-bar">
+            <span class="rd-bar-label">SECTOR MEDIAN</span>
+            <div class="rd-bar-track"><div class="rd-bar-fill rd-neutral" style="width: 35%"></div></div>
+            <span class="rd-bar-value">35%</span>
+          </div>
+        </div>
+      </div>
+      <div class="rd-span-6">
+        <div class="rd-panel">
+          <div class="rd-panel-header">
+            <span class="rd-panel-title">Vol surface</span>
+            <span class="rd-meta">30d tenor</span>
+          </div>
+          <div class="rd-bar">
+            <span class="rd-bar-label">IV 30D</span>
+            <div class="rd-bar-track"><div class="rd-bar-fill" style="width: 31%"></div></div>
+            <span class="rd-bar-value">31.2</span>
+          </div>
+          <div class="rd-bar">
+            <span class="rd-bar-label">RV 21D</span>
+            <div class="rd-bar-track"><div class="rd-bar-fill rd-neutral" style="width: 27%"></div></div>
+            <span class="rd-bar-value">26.8</span>
+          </div>
+          <div class="rd-bar">
+            <span class="rd-bar-label">SKEW 25D</span>
+            <div class="rd-bar-track"><div class="rd-bar-fill rd-warn" style="width: 12%"></div></div>
+            <span class="rd-bar-value">-1.4</span>
+          </div>
+          <div class="rd-panel-rail">
+            <span class="rd-meta">Surface flat vs 60d history</span>
+            <span class="rd-meta">Call wing unpriced</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="rd-section">
+    <h2 class="rd-label">Decision</h2>
+    <div class="rd-callout">
+      <div class="rd-panel-header">
+        <span class="rd-panel-title">Structure: Nov 21 call spread, defined risk</span>
+        <span class="rd-badge rd-clear">Gates 1-3 pass</span>
+      </div>
+      <p style="margin: 0 0 8px">Accumulation is absorbed and unpriced: five sessions of block prints at 3.4x average notional with the lit tape flat and IV rank at 22. A 60/70 call spread pays 2.8x its debit at the upper strike. Kelly fraction 0.9% of bankroll, inside the 2.5% cap.</p>
+      <p class="rd-note">Probability estimate is model-derived and uncertain. Signal decays if lit price moves more than 3% before entry, or if off-exchange share reverts below 45%.</p>
+    </div>
+  </section>
+
+  <footer class="rd-footer">
+    <span class="rd-meta">Data: IB, Unusual Whales · window 2026-08-24 to 2026-08-28</span>
+    <span class="rd-meta">Radon · reconstructing market structure from noisy signals</span>
+  </footer>
+
+</div>
+</body>
+</html>

--- a/web/public/design.md
+++ b/web/public/design.md
@@ -1,0 +1,198 @@
+# Radon design.md
+
+One file that teaches any agent how to build a page that looks and reads like Radon. Load this URL, link the public stylesheet, and use only the vocabulary documented here.
+
+- Stylesheet: `https://app.radon.run/radon.css`
+- Rendered example: `https://app.radon.run/design-example.html`
+- Monogram asset: `https://app.radon.run/brand/radon-monogram.svg`
+
+Radon is a market-structure reconstruction terminal: it surfaces convex options opportunities from dark pool and OTC flow, vol surfaces, and cross-asset positioning. Every artifact you build represents that instrument. The register is a lab instrument report, not a marketing page and not a SaaS dashboard.
+
+## Scope
+
+Use this file for artifacts produced outside the Radon codebase: trade evaluation briefs, flow reports, portfolio reviews, incident postmortems, proposals, one-off pages. Do not use it to restyle the Radon app itself; the app owns its own component system.
+
+## Reader and task
+
+The reader is an operator deciding whether to act on a reconstruction. Shape every page for two passes:
+
+1. A ten second executive read: what was measured, what state it is in, what the decision is.
+2. A detailed audit: the evidence tables, the comparison scales, the caveats, the data provenance.
+
+Lead with the finding and the decision. Evidence supports the decision; it never buries it. Every figure carries its source and time basis. If a trade decision appears, present it as signal, then structure, then sizing math, then decision, and name any gate that fails.
+
+## Voice
+
+Precise, calm, scientific, unsensational. Prefer nouns and verbs over adjectives.
+
+- Say "Structural event detected", never "Massive trade alert!".
+- Say "Volatility state shifted beyond baseline range", never "This ticker is exploding".
+- Errors read as `[System] + [Failure] + [Cause if known] + [Recovery guidance]`, for example "Flow module unavailable. Upstream feed timed out."
+- No emojis, no exclamation points, no hype words (huge, massive, crazy, insane).
+- No em dashes anywhere in copy. Use a period, a colon, or a comma.
+- State probabilities and uncertainty honestly. Flag model-derived estimates as such.
+- Empty states describe the measurement condition ("No block prints above threshold in this window"), never generic placeholders ("Nothing here yet").
+
+## Color semantics
+
+Color encodes signal clarity, never profit and loss and never decoration.
+
+| State | Meaning | Class |
+|---|---|---|
+| Baseline | No notable structure isolated | `rd-baseline` |
+| Emerging | Weak but non-random candidate | `rd-emerging` |
+| Clear | Strong structural candidate | `rd-clear` |
+| Strong | High-confidence reconstruction | `rd-strong` |
+| Dislocated | Market structure notably out of line | `rd-dislocated` |
+| Extreme | Rare regime, high-convexity event | `rd-extreme` |
+| Warn | Incomplete confidence, data quality concern | `rd-warn` |
+| Fault | Operational failure, not market P&L | `rd-fault` |
+
+The teal family means recovered or clarified structure. Magenta and violet mean tension and dislocation. Amber means incomplete confidence. Red means an operational fault. Use `rd-delta-up` and `rd-delta-down` only for signed numeric changes.
+
+Never introduce your own colors. The stylesheet's tokens are the entire palette. Do not write hex values, `rgb()`, or named colors in artifact markup.
+
+## Observable rules
+
+Each rule is checkable by looking at the rendered page.
+
+1. Panels have hairline borders, matte surfaces, and at most 4px corner radius. No box shadows, no gradients, no glassmorphism.
+2. Evidence tables use the full width available to them. Never squeeze a table to prose width when the page is wider.
+3. All numerals in tables, stat values, and telemetry are set in the mono font with tabular figures. Numeric columns are right-aligned via `rd-num`.
+4. Comparable values sit on a single scale. When peers are compared, use one `rd-bar` group so magnitudes read against each other.
+5. Status and meta text reads like instrument telemetry: mono, uppercase, muted, small.
+6. Hierarchy comes from structure and spacing, not from loud type. One `rd-title` per page.
+7. Every page ends with a `rd-footer` naming data sources and the measurement window.
+8. Dark is the default. For a light artifact set `data-theme="light"` on the `html` element; never hand-tune colors per theme.
+9. Layout snaps to an 8px rhythm. Sections are separated by 32px; the grid gutter is 16px.
+10. The decision or summary lives in one `rd-callout` near the end of the executive read, not scattered across the page.
+
+## Named failure patterns
+
+Recognize these and do not produce them.
+
+- **SaaS gloss**: rounded cards above 4px radius, drop shadows, gradient headers, icon confetti. Radon panels are instruments, not cards.
+- **P&L color leakage**: coloring a signal state green or red because a trade would make or lose money. Color is clarity state only.
+- **Hype copy**: superlatives, exclamation marks, urgency language. The data carries the weight.
+- **Prose-width tables**: an evidence table constrained to text column width with dead space beside it.
+- **Split scales**: peer values plotted on separate axes or separate widgets so they cannot be compared.
+- **Decoration motifs**: background illustrations, emoji bullets, stock imagery. The only permitted ornament is low-opacity structural geometry, and omitting it is always correct.
+- **Orphaned figures**: a number with no source, no time basis, or no unit.
+
+## Page skeleton
+
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Artifact title</title>
+  <link rel="stylesheet" href="https://app.radon.run/radon.css" />
+</head>
+<body>
+<div class="rd-page">
+  <header class="rd-masthead">
+    <span class="rd-wordmark">RADON</span>
+    <span class="rd-meta">Artifact kind</span>
+    <span class="rd-meta">Date, time basis, data status</span>
+  </header>
+  <h1 class="rd-title">Finding stated as a sentence</h1>
+  <p class="rd-subtitle">One or two sentences of concrete, sourced context.</p>
+  <!-- rd-stats strip, then rd-section blocks of evidence, then the rd-callout decision -->
+  <footer class="rd-footer">
+    <span class="rd-meta">Data sources and window</span>
+    <span class="rd-meta">Radon</span>
+  </footer>
+</div>
+</body>
+</html>
+```
+
+## Class vocabulary
+
+This is the complete permitted vocabulary. Do not invent classes and do not write inline styles other than `style="width: N%"` on `rd-bar-fill`.
+
+### Page structure
+
+| Class | Use |
+|---|---|
+| `rd-page` | Root container. Canvas background, max width 1120px. |
+| `rd-section` | Top-level block. Provides the 32px section gap. |
+| `rd-masthead` | Header row: wordmark plus meta fields, hairline bottom border. |
+| `rd-wordmark` | The RADON wordmark with the signal tick. Text content is `RADON`. |
+| `rd-title` | Page title. One per page. |
+| `rd-subtitle` | Supporting sentence under the title. |
+| `rd-footer` | Provenance row at the end of the page. |
+
+### Typography helpers
+
+| Class | Use |
+|---|---|
+| `rd-meta` | Mono uppercase telemetry text: timestamps, sources, sampling notes. |
+| `rd-label` | Uppercase section label above a panel or group. |
+| `rd-note` | Small muted annotation: caveats, model uncertainty, methodology. |
+
+### Layout
+
+| Class | Use |
+|---|---|
+| `rd-grid` | 12-column grid, 16px gutter. |
+| `rd-span-4` `rd-span-6` `rd-span-8` `rd-span-12` | Column spans inside `rd-grid`. Collapse to full width on narrow viewports. |
+
+### Panels
+
+| Class | Use |
+|---|---|
+| `rd-panel` | Instrument panel: panel surface, hairline border, 4px radius, 16px padding. |
+| `rd-panel-header` | Device-label header row inside a panel. |
+| `rd-panel-title` | Panel name inside the header. |
+| `rd-panel-rail` | Metadata rail at the bottom of a panel for sampling and confidence notes. |
+
+### Stat strip
+
+| Class | Use |
+|---|---|
+| `rd-stats` | Responsive strip of stat modules. |
+| `rd-stat` | One stat module. |
+| `rd-stat-label` | Mono uppercase label above the value. |
+| `rd-stat-value` | The metric value. Large, tabular numerals. |
+| `rd-stat-note` | Comparison or context line under the value. |
+
+### Tables
+
+| Class | Use |
+|---|---|
+| `rd-table` | Evidence table. Mono, dense 32px rows, hairline row separators. Give it the full available width. |
+| `rd-num` | Right-aligned numeric cell or header. |
+
+### Badges and deltas
+
+| Class | Use |
+|---|---|
+| `rd-badge` | Capsule state badge. Combine with exactly one state class. |
+| `rd-baseline` `rd-emerging` `rd-clear` `rd-strong` `rd-dislocated` `rd-extreme` `rd-warn` `rd-fault` | Signal state modifiers for `rd-badge`, `rd-callout`, and `rd-bar-fill` (where noted). |
+| `rd-delta-up` `rd-delta-down` | Signed change values. Direction of the number, not sentiment. |
+
+### Comparison bars
+
+| Class | Use |
+|---|---|
+| `rd-bar` | One row: label, track, value. Group rows so peers share one scale. |
+| `rd-bar-label` | Mono row label. |
+| `rd-bar-track` | The full-scale track. |
+| `rd-bar-fill` | The measured fill. Width via inline `style="width: N%"`. Modifiers: `rd-neutral`, `rd-warn`, `rd-dislocated`. |
+| `rd-bar-value` | Right-aligned mono value. |
+| `rd-neutral` | Neutral comparative fill for non-subject rows. |
+
+### Callout
+
+| Class | Use |
+|---|---|
+| `rd-callout` | Decision or summary panel with a 2px signal edge. Modifiers `rd-warn` and `rd-fault` recolor the edge. |
+
+## Publishing as Radon
+
+- The wordmark is the text `RADON` inside `rd-wordmark`; the stylesheet renders the signal tick. Do not recreate the logo, stretch it, or recolor it.
+- If an image mark is required, use the monogram SVG at the asset URL above at 16px to 32px, on canvas or panel backgrounds only.
+- The tagline, when used, is exactly: "Reconstructing market structure from noisy signals."

--- a/web/public/radon.css
+++ b/web/public/radon.css
@@ -1,0 +1,446 @@
+/* ============================================================
+   Radon artifact stylesheet
+   https://app.radon.run/radon.css
+
+   Bounded class vocabulary for agent-generated Radon artifacts
+   (reports, briefs, proposals, one-off pages). Documented in
+   https://app.radon.run/design.md — use only classes documented
+   there. Pinned by web/tests/design-artifact-contract.test.ts.
+
+   Dark is the default theme. Set data-theme="light" on <html>
+   for light artifacts.
+   ============================================================ */
+
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Inter:wght@400;500;600&display=swap");
+
+/* ---- tokens ------------------------------------------------ */
+
+:root {
+  --bg-canvas: #0a0f14;
+  --bg-panel: #0f1519;
+  --bg-panel-raised: #1e252b;
+  --line-grid: #2e3947;
+  --text-primary: #e2e8f0;
+  --text-secondary: #94a3b8;
+  --text-muted: #758192;
+  --signal-core: #05ad98;
+  --signal-strong: #0fcfb5;
+  --signal-deep: #33a090;
+  --warn: #f5a623;
+  --fault: #e85d6c;
+  --dislocation: #e55fb5;
+  --extreme: #9e80f6;
+  --neutral: #94a3b8;
+  --positive: #05ad98;
+  --negative: #e85d6c;
+
+  --font-ui: "Inter", ui-sans-serif, system-ui, sans-serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, monospace;
+}
+
+[data-theme="light"] {
+  --bg-canvas: #ffffff;
+  --bg-panel: #ffffff;
+  --bg-panel-raised: #f1f5f9;
+  --line-grid: #bbbfbf;
+  --text-primary: #000000;
+  --text-secondary: #636363;
+  --text-muted: #878787;
+  --signal-core: #05ad98;
+  --signal-strong: #048a7a;
+  --signal-deep: #037066;
+  --warn: #b45309;
+  --fault: #d4183d;
+  --dislocation: #c026a0;
+  --extreme: #7c3aed;
+  --neutral: #475569;
+  --positive: #048a7a;
+  --negative: #d4183d;
+}
+
+/* ---- page -------------------------------------------------- */
+
+* {
+  box-sizing: border-box;
+}
+
+.rd-page {
+  margin: 0 auto;
+  max-width: 1120px;
+  padding: 48px 32px 64px;
+  background: var(--bg-canvas);
+  color: var(--text-primary);
+  font-family: var(--font-ui);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+body:has(> .rd-page) {
+  margin: 0;
+  background: var(--bg-canvas);
+}
+
+.rd-section {
+  margin-top: 32px;
+}
+
+/* ---- masthead ---------------------------------------------- */
+
+.rd-masthead {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--line-grid);
+}
+
+.rd-masthead .rd-meta {
+  margin-left: auto;
+}
+
+.rd-wordmark {
+  font-weight: 600;
+  font-size: 15px;
+  letter-spacing: 0.01em;
+  color: var(--text-primary);
+}
+
+.rd-wordmark::before {
+  content: "";
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  margin-right: 8px;
+  background: var(--signal-core);
+  border-radius: 2px;
+}
+
+.rd-title {
+  margin: 24px 0 4px;
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  line-height: 1.2;
+}
+
+.rd-subtitle {
+  margin: 0 0 8px;
+  font-size: 14px;
+  font-weight: 400;
+  color: var(--text-secondary);
+}
+
+/* ---- telemetry / labels ------------------------------------ */
+
+.rd-meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 400;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.rd-label {
+  margin: 0 0 12px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+/* ---- grid -------------------------------------------------- */
+
+.rd-grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 16px;
+}
+
+.rd-span-4 {
+  grid-column: span 4;
+}
+
+.rd-span-6 {
+  grid-column: span 6;
+}
+
+.rd-span-8 {
+  grid-column: span 8;
+}
+
+.rd-span-12 {
+  grid-column: span 12;
+}
+
+@media (max-width: 720px) {
+  .rd-span-4,
+  .rd-span-6,
+  .rd-span-8 {
+    grid-column: span 12;
+  }
+}
+
+/* ---- panels ------------------------------------------------ */
+
+.rd-panel {
+  background: var(--bg-panel);
+  border: 1px solid var(--line-grid);
+  border-radius: 4px;
+  padding: 16px;
+}
+
+.rd-panel-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 24px;
+  margin: -4px 0 12px;
+}
+
+.rd-panel-title {
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.rd-panel-header .rd-meta {
+  margin-left: auto;
+}
+
+.rd-panel-rail {
+  display: flex;
+  gap: 16px;
+  margin-top: 12px;
+  padding-top: 8px;
+  border-top: 1px solid var(--line-grid);
+}
+
+/* ---- stat strip -------------------------------------------- */
+
+.rd-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
+}
+
+.rd-stat {
+  background: var(--bg-panel);
+  border: 1px solid var(--line-grid);
+  border-radius: 4px;
+  padding: 12px 16px;
+}
+
+.rd-stat-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.rd-stat-value {
+  margin-top: 4px;
+  font-size: 26px;
+  font-weight: 500;
+  line-height: 1.05;
+  font-variant-numeric: tabular-nums;
+}
+
+.rd-stat-note {
+  margin-top: 4px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.03em;
+  color: var(--text-secondary);
+}
+
+/* ---- tables ------------------------------------------------ */
+
+.rd-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
+.rd-table th {
+  padding: 0 12px;
+  height: 32px;
+  text-align: left;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--line-grid);
+}
+
+.rd-table td {
+  padding: 0 12px;
+  height: 32px;
+  border-bottom: 1px solid color-mix(in srgb, var(--line-grid) 50%, transparent);
+}
+
+.rd-table .rd-num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---- badges ------------------------------------------------ */
+
+.rd-badge {
+  display: inline-block;
+  height: 20px;
+  line-height: 18px;
+  padding: 0 10px;
+  border: 1px solid var(--line-grid);
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.rd-badge.rd-baseline {
+  color: var(--neutral);
+  border-color: color-mix(in srgb, var(--neutral) 40%, transparent);
+}
+
+.rd-badge.rd-emerging {
+  color: var(--signal-deep);
+  border-color: color-mix(in srgb, var(--signal-deep) 40%, transparent);
+}
+
+.rd-badge.rd-clear {
+  color: var(--signal-core);
+  border-color: color-mix(in srgb, var(--signal-core) 40%, transparent);
+}
+
+.rd-badge.rd-strong {
+  color: var(--signal-strong);
+  border-color: color-mix(in srgb, var(--signal-strong) 40%, transparent);
+}
+
+.rd-badge.rd-dislocated {
+  color: var(--dislocation);
+  border-color: color-mix(in srgb, var(--dislocation) 40%, transparent);
+}
+
+.rd-badge.rd-extreme {
+  color: var(--extreme);
+  border-color: color-mix(in srgb, var(--extreme) 40%, transparent);
+}
+
+.rd-badge.rd-warn {
+  color: var(--warn);
+  border-color: color-mix(in srgb, var(--warn) 40%, transparent);
+}
+
+.rd-badge.rd-fault {
+  color: var(--fault);
+  border-color: color-mix(in srgb, var(--fault) 40%, transparent);
+}
+
+/* ---- deltas ------------------------------------------------ */
+
+.rd-delta-up {
+  color: var(--positive);
+  font-variant-numeric: tabular-nums;
+}
+
+.rd-delta-down {
+  color: var(--negative);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---- comparison bars --------------------------------------- */
+
+.rd-bar {
+  display: grid;
+  grid-template-columns: 160px 1fr 88px;
+  align-items: center;
+  gap: 12px;
+  min-height: 28px;
+}
+
+.rd-bar-label {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.01em;
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rd-bar-track {
+  height: 8px;
+  background: color-mix(in srgb, var(--line-grid) 45%, transparent);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.rd-bar-fill {
+  height: 100%;
+  background: var(--signal-core);
+}
+
+.rd-bar-fill.rd-dislocated {
+  background: var(--dislocation);
+}
+
+.rd-bar-fill.rd-warn {
+  background: var(--warn);
+}
+
+.rd-bar-fill.rd-neutral {
+  background: var(--neutral);
+}
+
+.rd-bar-value {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 500;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---- callout (decision panel) ------------------------------ */
+
+.rd-callout {
+  background: var(--bg-panel);
+  border: 1px solid var(--line-grid);
+  border-left: 2px solid var(--signal-core);
+  border-radius: 4px;
+  padding: 16px;
+}
+
+.rd-callout.rd-warn {
+  border-left-color: var(--warn);
+}
+
+.rd-callout.rd-fault {
+  border-left-color: var(--fault);
+}
+
+/* ---- notes and footer -------------------------------------- */
+
+.rd-note {
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+.rd-footer {
+  margin-top: 48px;
+  padding-top: 16px;
+  border-top: 1px solid var(--line-grid);
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}

--- a/web/tests/design-artifact-contract.test.ts
+++ b/web/tests/design-artifact-contract.test.ts
@@ -1,0 +1,119 @@
+/**
+ * design.md / radon.css contract — the deterministic checks behind the public
+ * agent-design surface (https://app.radon.run/design.md).
+ *
+ * Modeled on Vercel's design.md system: judgment lives in design.md prose,
+ * repeatable mechanics live in the stylesheet, and anything mechanical is
+ * checked here so a named failure stays gone once encoded.
+ *
+ * Three surfaces are pinned:
+ *   1. Vocabulary sync — every rd-* class defined in radon.css is documented
+ *      in design.md and vice versa. An undocumented class is invisible to
+ *      agents; a documented ghost class silently renders unstyled.
+ *   2. Brand mechanics in radon.css — radius ≤ 4px (999px capsules exempt),
+ *      no box shadows, no gradients, colors only via the token block.
+ *   3. Copy rules in design.md — no em dashes, and the artifact files it
+ *      points agents at actually exist in web/public/.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const PUBLIC_DIR = join(__dirname, "..", "public");
+const css = readFileSync(join(PUBLIC_DIR, "radon.css"), "utf8");
+const md = readFileSync(join(PUBLIC_DIR, "design.md"), "utf8");
+const example = readFileSync(join(PUBLIC_DIR, "design-example.html"), "utf8");
+
+function classesFrom(text: string, pattern: RegExp): Set<string> {
+  const found = new Set<string>();
+  for (const match of text.matchAll(pattern)) found.add(match[1]);
+  return found;
+}
+
+const cssClasses = classesFrom(css, /\.(rd-[a-z0-9-]+)/g);
+const mdClasses = classesFrom(md, /`(rd-[a-z0-9-]+)`/g);
+
+describe("vocabulary sync — design.md documents exactly the radon.css classes", () => {
+  it("every class defined in radon.css is documented in design.md", () => {
+    const undocumented = [...cssClasses].filter((c) => !mdClasses.has(c)).sort();
+    expect(undocumented).toEqual([]);
+  });
+
+  it("every class documented in design.md exists in radon.css", () => {
+    const ghosts = [...mdClasses].filter((c) => !cssClasses.has(c)).sort();
+    expect(ghosts).toEqual([]);
+  });
+
+  it("the rendered example uses only documented classes", () => {
+    const used = new Set<string>();
+    for (const match of example.matchAll(/class="([^"]+)"/g)) {
+      for (const cls of match[1].split(/\s+/)) {
+        if (cls.startsWith("rd-")) used.add(cls);
+      }
+    }
+    expect(used.size).toBeGreaterThan(10);
+    const unknown = [...used].filter((c) => !cssClasses.has(c)).sort();
+    expect(unknown).toEqual([]);
+  });
+});
+
+describe("brand mechanics — radon.css", () => {
+  it("border-radius never exceeds 4px, except the 999px badge capsule", () => {
+    const radii = [...css.matchAll(/border-radius:\s*([0-9.]+)px/g)].map((m) =>
+      Number(m[1]),
+    );
+    expect(radii.length).toBeGreaterThan(0);
+    for (const r of radii) {
+      expect(r <= 4 || r === 999, `border-radius ${r}px violates the 4px cap`).toBe(
+        true,
+      );
+    }
+  });
+
+  it("declares no box shadows and no gradients", () => {
+    expect(css).not.toMatch(/box-shadow/);
+    expect(css).not.toMatch(/gradient/i);
+    expect(css).not.toMatch(/backdrop-filter/);
+  });
+
+  it("uses color literals only inside the token blocks", () => {
+    // Strip the :root and [data-theme="light"] token blocks, then assert the
+    // remaining rules reference colors exclusively through var()/color-mix.
+    const withoutTokens = css.replace(
+      /(:root|\[data-theme="light"\])\s*\{[^}]*\}/g,
+      "",
+    );
+    expect(withoutTokens).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
+    expect(withoutTokens).not.toMatch(/rgba?\(/);
+  });
+
+  it("defines both themes over the same token set", () => {
+    const block = (selector: string): Set<string> => {
+      const m = css.match(
+        new RegExp(`${selector.replace(/[[\]"]/g, "\\$&")}\\s*\\{([^}]*)\\}`),
+      );
+      expect(m, `missing ${selector} block`).toBeTruthy();
+      return classesFrom(m![1], /(--[a-z-]+):/g);
+    };
+    const dark = block(":root");
+    const light = block('[data-theme="light"]');
+    // Fonts are theme-invariant and live only in :root.
+    const darkColors = [...dark].filter((t) => !t.startsWith("--font")).sort();
+    expect(darkColors).toEqual([...light].sort());
+  });
+});
+
+describe("copy rules — design.md", () => {
+  it("contains no em dashes", () => {
+    expect(md.includes("\u2014")).toBe(false);
+  });
+
+  it("points at artifacts that exist and at the live stylesheet URL", () => {
+    expect(md).toContain("https://app.radon.run/radon.css");
+    expect(md).toContain("https://app.radon.run/design-example.html");
+    expect(md).toContain("https://app.radon.run/brand/radon-monogram.svg");
+    // The example must link the stylesheet by root-relative path so it renders
+    // against the same origin it is served from.
+    expect(example).toContain('href="/radon.css"');
+  });
+});

--- a/web/tests/middleware-auth.test.ts
+++ b/web/tests/middleware-auth.test.ts
@@ -82,6 +82,13 @@ describe("isPublicRoute — explicit allowlist", () => {
     expect(isPublicRoute(reqFor("/sign-up/verify"))).toBe(true);
   });
 
+  it("exempts /design.md (public agent design guidance, static file)", () => {
+    expect(isPublicRoute(reqFor("/design.md"))).toBe(true);
+    // Only the exact file — no pattern that could widen to other .md paths.
+    expect(isPublicRoute(reqFor("/design.md/other"))).toBe(false);
+    expect(isPublicRoute(reqFor("/docs/design.md"))).toBe(false);
+  });
+
   it("exempts /api/share/<thing> for OG image renders", () => {
     expect(isPublicRoute(reqFor("/api/share/pnl"))).toBe(true);
     expect(isPublicRoute(reqFor("/api/share/pnl?ticker=AAPL&pnl=420"))).toBe(true);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Vercel's [design.md post](https://vercel.com/blog/how-our-agents-build-on-brand-pages-with-design-md) describes how they get on-brand pages out of agents that run *outside* their codebases: one public guidance URL, a public stylesheet with a bounded documented class vocabulary, and deterministic checks fed by frozen eval scenarios. Radon's brand system (`docs/brand-identity.md`, `brand/`) is repo-internal, so any external agent asked to produce a Radon artifact today invents its own typography, radii, and P&L-colored semantics.

## What ships

Three public URLs on app.radon.run, plus enforcement:

| Piece | URL | Source |
|---|---|---|
| Guidance | `app.radon.run/design.md` | `web/public/design.md` |
| Stylesheet | `app.radon.run/radon.css` | `web/public/radon.css` |
| Rendered example | `app.radon.run/design-example.html` | `web/public/design-example.html` |

**`design.md`** distills the brand into agent-checkable guidance: reader/task framing (operator deciding whether to act on a reconstruction), signal-clarity color semantics (never P&L), voice + error patterns, ten observable rules, named failure patterns (SaaS gloss, P&L color leakage, hype copy, prose-width tables, split scales, decoration motifs, orphaned figures), a page skeleton, and the complete class vocabulary.

**`radon.css`** takes typography/spacing/layout decisions away from the model, per the blog: `rd-*` primitives for instrument panels (hairline border, 4px radius, no shadow), stat strips, mono evidence tables, capsule state badges, single-scale comparison bars, and decision callouts. Tokens come from `brand/radon-design-tokens.json`; dark default with a `data-theme="light"` variant over the identical token set.

**Middleware.** The static-file matcher already bypasses Clerk for `.css`/`.html`, but not `.md`, so `/design.md` gets one explicit `isPublicRoute` entry (guidance only, no account data), pinned in `middleware-auth.test.ts` with negative cases so the exemption cannot widen to other `.md` paths.

**Deterministic checks** (`web/tests/design-artifact-contract.test.ts`): vocabulary sync in both directions between `design.md`, `radon.css`, and the example page; border-radius capped at 4px except 999px capsules; no box-shadow/gradient/backdrop-filter; color literals confined to the token blocks (everything else via `var()`/`color-mix`); dark and light themes define the same token set; no em dashes in the guidance copy.

**Eval loop seed** (`docs/design-evals.md`): three frozen scenarios with rubrics (flow evaluation brief, weekly portfolio review, incident postmortem), the round procedure, and a feedback log routing each accepted correction into prose, stylesheet, or check.

## Not in scope

The Slack design agent, the A/B review harness, and any change to the app's own UI. The app keeps `globals.css`; this is a parallel surface for external agents only.

## Verification

- Full suite: `8389 passed, 0 failed, 18 skipped` (834 files).
- Example artifact rendered in headless Chrome from the shipped stylesheet, both themes:

[Radon artifact example, dark theme](https://cursor.com/agents/bc-01a059d8-935a-777f-8292-8237666a8770/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fradon-artifact-dark.png)
[Radon artifact example, light theme](https://cursor.com/agents/bc-01a059d8-935a-777f-8292-8237666a8770/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fradon-artifact-light.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a059d8-935a-777f-8292-8237666a8770?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a059d8-935a-777f-8292-8237666a8770&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

