### PR TITLE
security-nightly: bill the claude.ai subscription, never an Anthropic API key

### DIFF
--- a/.claude/skills/security-nightly/SKILL.md
+++ b/.claude/skills/security-nightly/SKILL.md
@@ -322,6 +322,17 @@ package was `deepsec@2.3.8` while Radon's ignored workspace pinned `2.3.4`, and
 that workspace lacks a pnpm lockfile: until a human reviews and records the npm
 lock and installed-package integrity, DeepSec is `OPERATOR_REQUIRED`.
 
+DeepSec drives Claude through the Claude Agent SDK, and both it and `claude -p`
+prefer an Anthropic API key over the machine's claude.ai login whenever one is
+visible. This loop bills the operator's subscription only. Keep the model route
+at `ai: {mode: "local", provider: "local"}` in `deepsec.config.ts`, never
+provision `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` into `.deepsec/.env*` or
+the launch environment, and treat this stderr line as a FAILED stage, not a
+warning: "claude.ai connectors are disabled because ANTHROPIC_API_KEY or
+another auth source is set and takes precedence over your claude.ai login".
+The wrapper strips the key variables and refuses when a key file is present,
+so a stage that reports API-key auth means the wrapper was bypassed.
+
 When the workspace IS bootstrapped and matches approved private runner state,
 require a clean tree, require `git rev-parse HEAD` to equal `HEAD_SHA`, verify
 the existing lock, installed package checksum, and version WITHOUT network

--- a/scripts/security_nightly.sh
+++ b/scripts/security_nightly.sh
@@ -291,6 +291,31 @@ for credential_file in .env .env.ib-mode web/.env; do
   exit 2
 done
 
+# Rail 5b: model spend rides the operator's claude.ai subscription, never an
+# Anthropic API key. Claude Code and the Claude Agent SDK subprocesses that
+# `deepsec process`/`revalidate` fan out both PREFER a key over the claude.ai
+# login whenever one is visible, and only whisper it on stderr ("claude.ai
+# connectors are disabled because ANTHROPIC_API_KEY or another auth source is
+# set and takes precedence over your claude.ai login"). On 2026-09-01 that put
+# an 83-finding process + revalidate round on metered API billing with nothing
+# in the run record to show for it. Strip the environment first: launchd hands
+# this job no key today, but a hand-run `cycle` from an operator shell inherits
+# the whole environment.
+unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN ANTHROPIC_BASE_URL \
+      CLAUDE_CODE_USE_BEDROCK CLAUDE_CODE_USE_VERTEX AWS_BEARER_TOKEN_BEDROCK
+
+# `unset` cannot reach a key the scanner loads for itself: deepsec reads
+# .deepsec/.env*.local out of its own workspace, which is gitignored and
+# survives every nightly `git clean`. Refuse rather than edit operator state —
+# and never echo the value, only the path the operator has to clear.
+for key_file in .deepsec/.env .deepsec/.env.local .deepsec/.env.*.local .env.local; do
+  [[ -f "$key_file" ]] || continue
+  grep -qE '^[[:space:]]*(export[[:space:]]+)?ANTHROPIC_(API_KEY|AUTH_TOKEN)[[:space:]]*=[[:space:]]*[^[:space:]]' "$key_file" || continue
+  echo "REFUSING: $key_file holds Anthropic API key material; this loop bills the claude.ai subscription only — remove the key line" >&2
+  report "REFUSED" "$key_file holds Anthropic API key material; the scanners would bill metered API usage instead of the claude.ai subscription — remove the key line (rotate the key too, it has been used)" || true
+  exit 2
+done
+
 RUNNER_LOCK="$REPO/.weekend-runner.lock"
 acquire_runner_lock "$RUNNER_LOCK" || {
   echo "REFUSING: another weekend run owns $REPO" >&2

--- a/scripts/tests/test_security_loop_contract.py
+++ b/scripts/tests/test_security_loop_contract.py
@@ -727,3 +727,114 @@ class TestAnIncompletePhaseIsNeverReportedOk:
                 f"the skill no longer classifies {condition!r} as an "
                 "INCOMPLETE phase"
             )
+
+
+class TestTheLoopBillsTheSubscriptionNotTheApiKey:
+    """Rail 5b: model spend rides the operator's claude.ai login, never a key.
+
+    Claude Code and every scanner the agent drives through the Claude Agent
+    SDK (`deepsec process` / `revalidate`) prefer an Anthropic API key over the
+    claude.ai login whenever one is visible in their environment, and say so on
+    stderr: "claude.ai connectors are disabled because ANTHROPIC_API_KEY or
+    another auth source is set and takes precedence over your claude.ai login".
+    On 2026-09-01 that moved an 83-finding process + revalidate round onto
+    metered API billing without a line in any run record. Two halves: the
+    wrapper strips key material from the environment it hands its children, and
+    it refuses outright when a key sits in a file the scanners read themselves.
+    """
+
+    KEY = "sk-ant-api03-CONTRACT-TEST-NOT-A-REAL-KEY"
+    ENV_VARS = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_BASE_URL")
+
+    def _stub_bin(self, tmp_path: Path, env_dump: Path) -> Path:
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        stubs = {
+            "gh": (
+                "#!/bin/sh\n"
+                'if [ "$1 $2" = "issue list" ]; then echo 4242; fi\n'
+                "exit 0\n"
+            ),
+            # The agent records the environment it was actually launched with.
+            "claude": (
+                "#!/bin/sh\n"
+                f"env > '{env_dump}'\n"
+                f"echo '{_phase_complete_marker()} audit'\n"
+                "exit 0\n"
+            ),
+            "timeout": (
+                "#!/bin/bash\n"
+                "while [ $# -gt 0 ]; do\n"
+                '  case "$1" in\n'
+                "    -k|--kill-after) shift 2 ;;\n"
+                "    *) shift; break ;;\n"
+                "  esac\n"
+                "done\n"
+                'exec "$@"\n'
+            ),
+            "git": "#!/bin/sh\nexit 0\n",
+            "python3": "#!/bin/sh\nexit 0\n",
+        }
+        for name, body in stubs.items():
+            exe = bin_dir / name
+            exe.write_text(body, encoding="utf-8")
+            exe.chmod(0o755)
+        return bin_dir
+
+    def _audit(self, tmp_path: Path, *, env_extra=None, deepsec_env=None):
+        env_dump = tmp_path / "agent-env.txt"
+        bin_dir = self._stub_bin(tmp_path, env_dump)
+        repo = _clone(tmp_path, security_marker=True)
+        if deepsec_env is not None:
+            (repo / ".deepsec").mkdir()
+            (repo / ".deepsec" / ".env.local").write_text(deepsec_env, encoding="utf-8")
+        env = {
+            "PATH": f"{bin_dir}:/usr/bin:/bin",
+            "HOME": str(tmp_path / "home"),
+            "RADON_WEEKEND_REPO": str(repo),
+        }
+        env.update(env_extra or {})
+        proc = subprocess.run(
+            [BASH, str(repo / "scripts" / "security_nightly.sh"), "audit"],
+            cwd=repo, env=env, capture_output=True, text=True, timeout=120,
+        )
+        return proc, env_dump
+
+    @pytest.mark.parametrize("var", ENV_VARS)
+    def test_the_agent_child_never_inherits_api_key_material(self, tmp_path, var):
+        proc, env_dump = self._audit(tmp_path, env_extra={var: self.KEY})
+        assert proc.returncode == 0, (proc.returncode, proc.stdout, proc.stderr)
+        dump = env_dump.read_text(encoding="utf-8") if env_dump.exists() else ""
+        assert dump, "the agent stub never ran, so the env it saw proves nothing"
+        assert f"{var}=" not in dump, (
+            f"{var} reached the agent; Claude Code prefers it over the "
+            "claude.ai login, so the whole night bills metered API usage"
+        )
+        assert self.KEY not in dump, dump
+
+    def test_a_key_file_the_scanners_read_themselves_refuses_the_run(self, tmp_path):
+        proc, env_dump = self._audit(
+            tmp_path, deepsec_env=f"ANTHROPIC_API_KEY={self.KEY}\n"
+        )
+        out = proc.stdout + proc.stderr
+        assert proc.returncode == 2, (proc.returncode, out)
+        assert "REFUSING" in out, out
+        assert ".deepsec/.env.local" in out, (
+            "the refusal must name the file the operator has to clear"
+        )
+        assert self.KEY not in out, "the refusal echoed the key it found"
+        assert not env_dump.exists(), "the agent ran anyway after the refusal"
+
+    def test_a_deepsec_env_file_without_key_material_still_runs(self, tmp_path):
+        proc, _env_dump = self._audit(
+            tmp_path,
+            deepsec_env="# ANTHROPIC_API_KEY= (removed 2026-09-01)\nVERCEL_TOKEN=dummy\n",
+        )
+        assert proc.returncode == 0, (proc.returncode, proc.stdout, proc.stderr)
+
+    def test_the_skill_pins_subscription_auth_for_the_scanners(self):
+        text = SKILL.read_text(encoding="utf-8")
+        assert "ANTHROPIC_API_KEY" in text, (
+            "the skill never tells the agent that an API key must not be used "
+            "or provisioned for the scanner stages"
+        )


### PR DESCRIPTION
## What happened

The nightly security loop is supposed to run on the operator's claude.ai Max login. It has not been.

`.deepsec/.env.local` carried a live `ANTHROPIC_API_KEY`, provisioned during the 2026-08-30 DeepSec bootstrap as a "fallback" alongside the intended `--model-auth local` route. Claude Code and every Claude Agent SDK subprocess DeepSec fans out prefer a key over the claude.ai login whenever one is visible, and announce it only on stderr:

> claude.ai connectors are disabled because ANTHROPIC_API_KEY or another auth source is set and takes precedence over your claude.ai login

That line sat unread at the bottom of `deepsec-revalidate.log` for two nights while an 83-finding `deepsec process` plus a 69-finding `revalidate` round billed metered API usage. Nothing in the run record, the dead-man comment, or the audit report said which account paid.

This is separate from the 2026-09-01 cycle failure itself: both phases exited 1 on `You're out of usage credits`, which is subscription usage, not the key.

## The fix — rail 5b

Two halves, because one alone does not hold.

1. **`unset` the key variables in the wrapper prologue.** launchd hands this job no key today (the plist env is `PATH`/`HOME`/`RADON_WEEKEND_REPO`/`DISABLE_AUTOUPDATER`), but a hand-run `security_nightly.sh cycle` from an operator shell inherits the whole environment, and that is how a key reaches `claude -p`. Covers `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`, `CLAUDE_CODE_USE_BEDROCK`, `CLAUDE_CODE_USE_VERTEX`, `AWS_BEARER_TOKEN_BEDROCK`.
2. **REFUSE (exit 2, dead-man `REFUSED`) when key material sits in a file the scanner reads for itself.** `unset` cannot reach `.deepsec/.env*.local`: deepsec loads it out of its own gitignored workspace, which survives every nightly `git clean`. The refusal names the path, never the value, and tells the operator to rotate.

Same shape and same place as the existing rail-5 credential-file refusal, which checked `.env`, `.env.ib-mode` and `web/.env` and had no reason to know about a scanner workspace that did not exist when it was written.

`SKILL.md` Stage 3 now pins `ai: {mode: "local", provider: "local"}` and classifies that stderr line as a FAILED stage rather than a warning.

## Regression

`TestTheLoopBillsTheSubscriptionNotTheApiKey` drives the real wrapper with a stub agent that dumps the environment it was launched with, so the assertion is what the child actually saw, not what the script appears to do.

- three env vars parametrized (key must not reach the agent, and the run still succeeds)
- the refusal: exit 2, names `.deepsec/.env.local`, never echoes the value, agent never runs
- a key-free `.deepsec/.env.local` must still run (no false refusal)
- the skill carries the rail text

Red before: 5 failed. Green after: `test_security_loop_contract.py` 66 passed; deadman + survivability + self-rewrite + report-redaction + env-provisioning 303 passed.

## Operator action

Private runner state (outside this repo) is already applied: the key line is removed from `.deepsec/.env.local`, backed up 0600 to `~/radon-weekend/.security-nightly-scratch/deepsec-env.local.bak-20260901`, and recorded in the private lessons file.

**Rotate that key at console.anthropic.com — it has been used.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Jw8YYGbZPYZiwsjhoQbHy