### PR TITLE
weekend loops: pin the model and drop a rung when a quota is exhausted

### DIFF
--- a/scripts/ci_performance_nightly.sh
+++ b/scripts/ci_performance_nightly.sh
@@ -369,6 +369,28 @@ fi
 ROUND_LOG_MARK=0
 MAX_ATTEMPTS=3
 RETRY_PAUSE_SECS=60
+# A subscription quota is per MODEL, so an exhausted one is a reason to drop a
+# rung, not to lose the night. 2026-09-01: `~/.claude/settings.json` carried
+# `model: claude-fable-5[1m]`, these wrappers passed no --model and inherited
+# it, that model's quota was gone, and `claude -p` printed one line and exited
+# 1 in under a second — the security loop's audit AND remediate both died that
+# way at 00:00 while `--model opus` and `--model sonnet` answered normally on
+# the same Max login. Pinning the model also takes the operator's global
+# default off the unattended path: an interactive session changing it must not
+# decide what tonight runs on.
+QUOTA_EXHAUSTED_MARKER="out of usage credits"
+MODEL_LADDER="${RADON_WEEKEND_MODEL_LADDER:-claude-fable-5[1m] claude-opus-5[1m] claude-opus-5 claude-sonnet-5}"
+read -r -a MODEL_RUNGS <<< "$MODEL_LADDER"
+MODEL_INDEX=0
+ALL_MODELS_EXHAUSTED=0
+
+# Scoped to THIS round's slice of the log, like the ceiling detector: RUN_LOG
+# is per phase and every round appends to it, so a whole-file grep would let
+# round 1's exhausted rung drop a model on every later round forever. R-426.
+is_quota_exhausted() {
+  tail -c "+$((ROUND_LOG_MARK + 1))" "$RUN_LOG" 2>/dev/null | grep -qF "$QUOTA_EXHAUSTED_MARKER"
+}
+
 is_transient_network_failure() {
   tail -c 500 "$RUN_LOG" | grep -qE 'API Error|ENOTFOUND|Connection lost|Execution error'
 }
@@ -410,6 +432,7 @@ run_phase() {
     # never, in the case that matters. `-k` escalates to SIGKILL so a claude
     # blocked on a hung child cannot make the cap advisory. R-384, R-386.
     CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 timeout -k "$KILL_AFTER_SECS" "$remain" claude -p "/ci-performance $PHASE" \
+      --model "${MODEL_RUNGS[$MODEL_INDEX]}" \
       --dangerously-skip-permissions \
       --output-format text >> "$RUN_LOG" 2>&1 &
     ROUND_PID=$!
@@ -423,6 +446,18 @@ run_phase() {
     # The cap is OUR clock, so classify from it rather than from the code, or a
     # round the cap genuinely killed is reported as a crash. R-386.
     if (( RC != 0 && SECONDS - round_start >= remain )); then RC=124; fi
+    # A quota drop is not one of the three transient-network attempts: it
+    # costs no wall clock, and the next rung is a different quota, so it
+    # retries immediately and `attempt` is untouched. Bounded by the ladder.
+    if (( RC != 0 )) && is_quota_exhausted; then
+      if (( MODEL_INDEX + 1 < ${#MODEL_RUNGS[@]} )); then
+        MODEL_INDEX=$((MODEL_INDEX + 1))
+        echo "[ci-performance] ${MODEL_RUNGS[$((MODEL_INDEX - 1))]} is out of usage credits; dropping to ${MODEL_RUNGS[$MODEL_INDEX]}" | tee -a "$RUN_LOG"
+        continue
+      fi
+      ALL_MODELS_EXHAUSTED=1
+      break
+    fi
     [[ $RC -eq 0 || $RC -eq 124 || $attempt -ge $MAX_ATTEMPTS ]] && break
     is_transient_network_failure || break
     echo "[ci-performance] transient network failure (rc=$RC) — attempt $attempt/$MAX_ATTEMPTS, retrying in ${RETRY_PAUSE_SECS}s" | tee -a "$RUN_LOG"
@@ -440,6 +475,11 @@ run_phase() {
   tail_text="$(tail -c 1500 "$RUN_LOG" 2>/dev/null | python3 "$REPO/scripts/weekend_redact.py" --repo "$REPO" 2>/dev/null || true)"
   local status
   status="$(phase_status "$RC" "$RUN_LOG" "$ROUND_LOG_MARK")"
+  # An exhausted ladder is not a generic non-zero exit: the operator needs the
+  # cause and the one place it is fixed, or they re-fire into the same wall.
+  if (( ALL_MODELS_EXHAUSTED )); then
+    status="FAILED (all model quotas exhausted; top up at claude.ai/settings/usage)"
+  fi
   case "$status" in
     OK)
       report "$status" "\`\`\`

--- a/scripts/documentation_nightly.sh
+++ b/scripts/documentation_nightly.sh
@@ -365,6 +365,28 @@ fi
 ROUND_LOG_MARK=0
 MAX_ATTEMPTS=3
 RETRY_PAUSE_SECS=60
+# A subscription quota is per MODEL, so an exhausted one is a reason to drop a
+# rung, not to lose the night. 2026-09-01: `~/.claude/settings.json` carried
+# `model: claude-fable-5[1m]`, these wrappers passed no --model and inherited
+# it, that model's quota was gone, and `claude -p` printed one line and exited
+# 1 in under a second — the security loop's audit AND remediate both died that
+# way at 00:00 while `--model opus` and `--model sonnet` answered normally on
+# the same Max login. Pinning the model also takes the operator's global
+# default off the unattended path: an interactive session changing it must not
+# decide what tonight runs on.
+QUOTA_EXHAUSTED_MARKER="out of usage credits"
+MODEL_LADDER="${RADON_WEEKEND_MODEL_LADDER:-claude-fable-5[1m] claude-opus-5[1m] claude-opus-5 claude-sonnet-5}"
+read -r -a MODEL_RUNGS <<< "$MODEL_LADDER"
+MODEL_INDEX=0
+ALL_MODELS_EXHAUSTED=0
+
+# Scoped to THIS round's slice of the log, like the ceiling detector: RUN_LOG
+# is per phase and every round appends to it, so a whole-file grep would let
+# round 1's exhausted rung drop a model on every later round forever. R-426.
+is_quota_exhausted() {
+  tail -c "+$((ROUND_LOG_MARK + 1))" "$RUN_LOG" 2>/dev/null | grep -qF "$QUOTA_EXHAUSTED_MARKER"
+}
+
 is_transient_network_failure() {
   tail -c 500 "$RUN_LOG" | grep -qE 'API Error|ENOTFOUND|Connection lost|Execution error'
 }
@@ -406,6 +428,7 @@ run_phase() {
     # never, in the case that matters. `-k` escalates to SIGKILL so a claude
     # blocked on a hung child cannot make the cap advisory. R-384, R-386.
     CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 timeout -k "$KILL_AFTER_SECS" "$remain" claude -p "/documentation-nightly $PHASE" \
+      --model "${MODEL_RUNGS[$MODEL_INDEX]}" \
       --dangerously-skip-permissions \
       --output-format text >> "$RUN_LOG" 2>&1 &
     ROUND_PID=$!
@@ -419,6 +442,18 @@ run_phase() {
     # The cap is OUR clock, so classify from it rather than from the code, or a
     # round the cap genuinely killed is reported as a crash. R-386.
     if (( RC != 0 && SECONDS - round_start >= remain )); then RC=124; fi
+    # A quota drop is not one of the three transient-network attempts: it
+    # costs no wall clock, and the next rung is a different quota, so it
+    # retries immediately and `attempt` is untouched. Bounded by the ladder.
+    if (( RC != 0 )) && is_quota_exhausted; then
+      if (( MODEL_INDEX + 1 < ${#MODEL_RUNGS[@]} )); then
+        MODEL_INDEX=$((MODEL_INDEX + 1))
+        echo "[documentation-nightly] ${MODEL_RUNGS[$((MODEL_INDEX - 1))]} is out of usage credits; dropping to ${MODEL_RUNGS[$MODEL_INDEX]}" | tee -a "$RUN_LOG"
+        continue
+      fi
+      ALL_MODELS_EXHAUSTED=1
+      break
+    fi
     [[ $RC -eq 0 || $RC -eq 124 || $attempt -ge $MAX_ATTEMPTS ]] && break
     is_transient_network_failure || break
     echo "[documentation-nightly] transient network failure (rc=$RC) — attempt $attempt/$MAX_ATTEMPTS, retrying in ${RETRY_PAUSE_SECS}s" | tee -a "$RUN_LOG"
@@ -436,6 +471,11 @@ run_phase() {
   tail_text="$(tail -c 1500 "$RUN_LOG" 2>/dev/null | python3 "$REPO/scripts/weekend_redact.py" --repo "$REPO" 2>/dev/null || true)"
   local status
   status="$(phase_status "$RC" "$RUN_LOG" "$ROUND_LOG_MARK")"
+  # An exhausted ladder is not a generic non-zero exit: the operator needs the
+  # cause and the one place it is fixed, or they re-fire into the same wall.
+  if (( ALL_MODELS_EXHAUSTED )); then
+    status="FAILED (all model quotas exhausted; top up at claude.ai/settings/usage)"
+  fi
   case "$status" in
     OK)
       report "$status" "\`\`\`

--- a/scripts/reliability_weekend.sh
+++ b/scripts/reliability_weekend.sh
@@ -362,6 +362,28 @@ ground_truth() {
 #     defer to a future one.
 MAX_ATTEMPTS=3
 RETRY_PAUSE_SECS=60
+# A subscription quota is per MODEL, so an exhausted one is a reason to drop a
+# rung, not to lose the night. 2026-09-01: `~/.claude/settings.json` carried
+# `model: claude-fable-5[1m]`, these wrappers passed no --model and inherited
+# it, that model's quota was gone, and `claude -p` printed one line and exited
+# 1 in under a second — the security loop's audit AND remediate both died that
+# way at 00:00 while `--model opus` and `--model sonnet` answered normally on
+# the same Max login. Pinning the model also takes the operator's global
+# default off the unattended path: an interactive session changing it must not
+# decide what tonight runs on.
+QUOTA_EXHAUSTED_MARKER="out of usage credits"
+MODEL_LADDER="${RADON_WEEKEND_MODEL_LADDER:-claude-fable-5[1m] claude-opus-5[1m] claude-opus-5 claude-sonnet-5}"
+read -r -a MODEL_RUNGS <<< "$MODEL_LADDER"
+MODEL_INDEX=0
+ALL_MODELS_EXHAUSTED=0
+
+# Scoped to THIS round's slice of the log, like the ceiling detector: RUN_LOG
+# is per phase and every round appends to it, so a whole-file grep would let
+# round 1's exhausted rung drop a model on every later round forever. R-426.
+is_quota_exhausted() {
+  tail -c "+$((ROUND_LOG_MARK + 1))" "$RUN_LOG" 2>/dev/null | grep -qF "$QUOTA_EXHAUSTED_MARKER"
+}
+
 is_transient_network_failure() {
   tail -c 500 "$RUN_LOG" | grep -qE 'API Error|ENOTFOUND|Connection lost|Execution error'
 }
@@ -403,6 +425,7 @@ run_round() {
     # never, in the case that matters. `-k` escalates to SIGKILL so a claude
     # blocked on a hung child cannot make the cap advisory. R-384, R-386.
     CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 timeout -k "$KILL_AFTER_SECS" "$remain" claude -p "/reliability-weekend $PHASE" \
+      --model "${MODEL_RUNGS[$MODEL_INDEX]}" \
       --dangerously-skip-permissions \
       --output-format text >> "$RUN_LOG" 2>&1 &
     ROUND_PID=$!
@@ -416,6 +439,18 @@ run_round() {
     # The cap is OUR clock, so classify from it rather than from the code, or a
     # round the cap genuinely killed is reported as a crash. R-386.
     if (( RC != 0 && SECONDS - round_start >= remain )); then RC=124; fi
+    # A quota drop is not one of the three transient-network attempts: it
+    # costs no wall clock, and the next rung is a different quota, so it
+    # retries immediately and `attempt` is untouched. Bounded by the ladder.
+    if (( RC != 0 )) && is_quota_exhausted; then
+      if (( MODEL_INDEX + 1 < ${#MODEL_RUNGS[@]} )); then
+        MODEL_INDEX=$((MODEL_INDEX + 1))
+        echo "[weekend] ${MODEL_RUNGS[$((MODEL_INDEX - 1))]} is out of usage credits; dropping to ${MODEL_RUNGS[$MODEL_INDEX]}" | tee -a "$RUN_LOG"
+        continue
+      fi
+      ALL_MODELS_EXHAUSTED=1
+      break
+    fi
     [[ $RC -eq 0 || $RC -eq 124 || $attempt -ge $MAX_ATTEMPTS ]] && break
     is_transient_network_failure || break
     echo "[weekend] transient network failure (rc=$RC) — attempt $attempt/$MAX_ATTEMPTS, retrying in ${RETRY_PAUSE_SECS}s" | tee -a "$RUN_LOG"
@@ -461,7 +496,7 @@ run_phase() {
     set +e
     run_round
     set -e
-    [[ $RC -ne 0 && $round -lt $MAX_ROUNDS ]] || break
+    [[ $RC -ne 0 && $round -lt $MAX_ROUNDS && $ALL_MODELS_EXHAUSTED -eq 0 ]] || break
     # A daily job must finish inside its own day. launchd will not start a
     # second instance of a running label, so a cycle that overruns silently
     # eats the next fire and the dead-man goes quiet for a full day.
@@ -494,6 +529,11 @@ run_phase() {
   tail_text="$(tail -c 1500 "$RUN_LOG" 2>/dev/null | python3 "$REPO/scripts/weekend_redact.py" --repo "$REPO" 2>/dev/null || true)"
   local status
   status="$(phase_status "$RC" "$RUN_LOG" "$ROUND_LOG_MARK")"
+  # An exhausted ladder is not a generic non-zero exit: the operator needs the
+  # cause and the one place it is fixed, or they re-fire into the same wall.
+  if (( ALL_MODELS_EXHAUSTED )); then
+    status="FAILED (all model quotas exhausted; top up at claude.ai/settings/usage)"
+  fi
   case "$status" in
     OK)
       report "$status" "\`\`\`

--- a/scripts/security_nightly.sh
+++ b/scripts/security_nightly.sh
@@ -417,6 +417,28 @@ fi
 ROUND_LOG_MARK=0
 MAX_ATTEMPTS=3
 RETRY_PAUSE_SECS=60
+# A subscription quota is per MODEL, so an exhausted one is a reason to drop a
+# rung, not to lose the night. 2026-09-01: `~/.claude/settings.json` carried
+# `model: claude-fable-5[1m]`, these wrappers passed no --model and inherited
+# it, that model's quota was gone, and `claude -p` printed one line and exited
+# 1 in under a second — the security loop's audit AND remediate both died that
+# way at 00:00 while `--model opus` and `--model sonnet` answered normally on
+# the same Max login. Pinning the model also takes the operator's global
+# default off the unattended path: an interactive session changing it must not
+# decide what tonight runs on.
+QUOTA_EXHAUSTED_MARKER="out of usage credits"
+MODEL_LADDER="${RADON_WEEKEND_MODEL_LADDER:-claude-fable-5[1m] claude-opus-5[1m] claude-opus-5 claude-sonnet-5}"
+read -r -a MODEL_RUNGS <<< "$MODEL_LADDER"
+MODEL_INDEX=0
+ALL_MODELS_EXHAUSTED=0
+
+# Scoped to THIS round's slice of the log, like the ceiling detector: RUN_LOG
+# is per phase and every round appends to it, so a whole-file grep would let
+# round 1's exhausted rung drop a model on every later round forever. R-426.
+is_quota_exhausted() {
+  tail -c "+$((ROUND_LOG_MARK + 1))" "$RUN_LOG" 2>/dev/null | grep -qF "$QUOTA_EXHAUSTED_MARKER"
+}
+
 is_transient_network_failure() {
   tail -c 500 "$RUN_LOG" | grep -qE 'API Error|ENOTFOUND|Connection lost|Execution error'
 }
@@ -458,6 +480,7 @@ run_phase() {
     # never, in the case that matters. `-k` escalates to SIGKILL so a claude
     # blocked on a hung child cannot make the cap advisory. R-384, R-386.
     CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 timeout -k "$KILL_AFTER_SECS" "$remain" claude -p "/security-nightly $PHASE" \
+      --model "${MODEL_RUNGS[$MODEL_INDEX]}" \
       --dangerously-skip-permissions \
       --output-format text >> "$RUN_LOG" 2>&1 &
     ROUND_PID=$!
@@ -471,6 +494,18 @@ run_phase() {
     # The cap is OUR clock, so classify from it rather than from the code, or a
     # round the cap genuinely killed is reported as a crash. R-386.
     if (( RC != 0 && SECONDS - round_start >= remain )); then RC=124; fi
+    # A quota drop is not one of the three transient-network attempts: it
+    # costs no wall clock, and the next rung is a different quota, so it
+    # retries immediately and `attempt` is untouched. Bounded by the ladder.
+    if (( RC != 0 )) && is_quota_exhausted; then
+      if (( MODEL_INDEX + 1 < ${#MODEL_RUNGS[@]} )); then
+        MODEL_INDEX=$((MODEL_INDEX + 1))
+        echo "[security-nightly] ${MODEL_RUNGS[$((MODEL_INDEX - 1))]} is out of usage credits; dropping to ${MODEL_RUNGS[$MODEL_INDEX]}" | tee -a "$RUN_LOG"
+        continue
+      fi
+      ALL_MODELS_EXHAUSTED=1
+      break
+    fi
     [[ $RC -eq 0 || $RC -eq 124 || $attempt -ge $MAX_ATTEMPTS ]] && break
     is_transient_network_failure || break
     echo "[security-nightly] transient network failure (rc=$RC) — attempt $attempt/$MAX_ATTEMPTS, retrying in ${RETRY_PAUSE_SECS}s" | tee -a "$RUN_LOG"
@@ -489,6 +524,11 @@ run_phase() {
   # security archive, out of this wrapper's reach.
   local status
   status="$(phase_status "$RC" "$RUN_LOG" "$ROUND_LOG_MARK")"
+  # An exhausted ladder is not a generic non-zero exit: the operator needs the
+  # cause and the one place it is fixed, or they re-fire into the same wall.
+  if (( ALL_MODELS_EXHAUSTED )); then
+    status="FAILED (all model quotas exhausted; top up at claude.ai/settings/usage)"
+  fi
   # OK additionally requires the skill's completion marker in THIS round's
   # slice (same scoping as the TRUNCATED detector, R-426). Any incomplete
   # phase — no marker, or ceiling-truncated — must also exit non-zero so

--- a/scripts/testing_weekend.sh
+++ b/scripts/testing_weekend.sh
@@ -386,6 +386,28 @@ fi
 ROUND_LOG_MARK=0
 MAX_ATTEMPTS=3
 RETRY_PAUSE_SECS=60
+# A subscription quota is per MODEL, so an exhausted one is a reason to drop a
+# rung, not to lose the night. 2026-09-01: `~/.claude/settings.json` carried
+# `model: claude-fable-5[1m]`, these wrappers passed no --model and inherited
+# it, that model's quota was gone, and `claude -p` printed one line and exited
+# 1 in under a second — the security loop's audit AND remediate both died that
+# way at 00:00 while `--model opus` and `--model sonnet` answered normally on
+# the same Max login. Pinning the model also takes the operator's global
+# default off the unattended path: an interactive session changing it must not
+# decide what tonight runs on.
+QUOTA_EXHAUSTED_MARKER="out of usage credits"
+MODEL_LADDER="${RADON_WEEKEND_MODEL_LADDER:-claude-fable-5[1m] claude-opus-5[1m] claude-opus-5 claude-sonnet-5}"
+read -r -a MODEL_RUNGS <<< "$MODEL_LADDER"
+MODEL_INDEX=0
+ALL_MODELS_EXHAUSTED=0
+
+# Scoped to THIS round's slice of the log, like the ceiling detector: RUN_LOG
+# is per phase and every round appends to it, so a whole-file grep would let
+# round 1's exhausted rung drop a model on every later round forever. R-426.
+is_quota_exhausted() {
+  tail -c "+$((ROUND_LOG_MARK + 1))" "$RUN_LOG" 2>/dev/null | grep -qF "$QUOTA_EXHAUSTED_MARKER"
+}
+
 is_transient_network_failure() {
   tail -c 500 "$RUN_LOG" | grep -qE 'API Error|ENOTFOUND|Connection lost|Execution error'
 }
@@ -429,6 +451,7 @@ run_phase() {
     # never, in the case that matters. `-k` escalates to SIGKILL so a claude
     # blocked on a hung child cannot make the cap advisory. R-384, R-386.
     CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 timeout -k "$KILL_AFTER_SECS" "$remain" claude -p "/testing-weekend $PHASE" \
+      --model "${MODEL_RUNGS[$MODEL_INDEX]}" \
       --dangerously-skip-permissions \
       --output-format text >> "$RUN_LOG" 2>&1 &
     ROUND_PID=$!
@@ -442,6 +465,18 @@ run_phase() {
     # The cap is OUR clock, so classify from it rather than from the code, or a
     # round the cap genuinely killed is reported as a crash. R-386.
     if (( RC != 0 && SECONDS - round_start >= remain )); then RC=124; fi
+    # A quota drop is not one of the three transient-network attempts: it
+    # costs no wall clock, and the next rung is a different quota, so it
+    # retries immediately and `attempt` is untouched. Bounded by the ladder.
+    if (( RC != 0 )) && is_quota_exhausted; then
+      if (( MODEL_INDEX + 1 < ${#MODEL_RUNGS[@]} )); then
+        MODEL_INDEX=$((MODEL_INDEX + 1))
+        echo "[testing-weekend] ${MODEL_RUNGS[$((MODEL_INDEX - 1))]} is out of usage credits; dropping to ${MODEL_RUNGS[$MODEL_INDEX]}" | tee -a "$RUN_LOG"
+        continue
+      fi
+      ALL_MODELS_EXHAUSTED=1
+      break
+    fi
     [[ $RC -eq 0 || $RC -eq 124 || $attempt -ge $MAX_ATTEMPTS ]] && break
     is_transient_network_failure || break
     echo "[testing-weekend] transient network failure (rc=$RC) — attempt $attempt/$MAX_ATTEMPTS, retrying in ${RETRY_PAUSE_SECS}s" | tee -a "$RUN_LOG"
@@ -459,6 +494,11 @@ run_phase() {
   tail_text="$(tail -c 1500 "$RUN_LOG" 2>/dev/null | python3 "$REPO/scripts/weekend_redact.py" --repo "$REPO" 2>/dev/null || true)"
   local status
   status="$(phase_status "$RC" "$RUN_LOG" "$ROUND_LOG_MARK")"
+  # An exhausted ladder is not a generic non-zero exit: the operator needs the
+  # cause and the one place it is fixed, or they re-fire into the same wall.
+  if (( ALL_MODELS_EXHAUSTED )); then
+    status="FAILED (all model quotas exhausted; top up at claude.ai/settings/usage)"
+  fi
   # Only the rc-0-no-marker arm gains this check; TIMEOUT / FAILED /
   # TRUNCATED keep their precedence. T-379.
   if [[ "$status" == OK ]] && ! phase_committed; then status="$INCOMPLETE_STATUS"; fi

--- a/scripts/tests/test_weekend_loop_deadman.py
+++ b/scripts/tests/test_weekend_loop_deadman.py
@@ -449,6 +449,11 @@ class TestBackgroundWorkIsNotSilentlyKilled:
                 "set -Eeuo pipefail\n"
                 f'PHASE=audit\nremain=30\nRUN_LOG="{run_log}"\n'
                 f'KILL_AFTER_SECS=60\n'
+                # The line also pins the model rung it asks for, so the round's
+                # ladder state has to exist here too — under `set -u` an unset
+                # MODEL_RUNGS kills the command before `claude` is ever reached
+                # and this test would pass no judgement on the ceiling at all.
+                'MODEL_RUNGS=(stub-model)\nMODEL_INDEX=0\n'
                 # Since REL-137 the round is backgrounded so bash can act on a
                 # SIGTERM while it is running; wait for it before reading back.
                 + _claude_invocation_line(LOOPS[name])

--- a/scripts/tests/test_weekend_model_ladder.py
+++ b/scripts/tests/test_weekend_model_ladder.py
@@ -1,0 +1,220 @@
+"""A model quota is per model, so an exhausted quota must drop a rung, not kill the night.
+
+2026-09-01: the operator's global `~/.claude/settings.json` carried
+`model: claude-fable-5[1m]`. The nightly wrappers passed no `--model`, so every
+loop inherited it. That model's subscription quota was exhausted, and `claude
+-p` printed one line and exited 1 in under a second:
+
+    You're out of usage credits. Switch to another model, or manage usage
+    credits at claude.ai/settings/usage?from=cc_cli_limit_message, to continue.
+
+The security loop's audit AND remediate phases both died that way at 00:00,
+paged FAILED twice, and audited nothing — while `claude --model opus` and
+`--model sonnet` answered normally on the same Max login the whole time. A
+global setting any interactive session can change was, in effect, a
+single-point kill switch on all five unattended loops.
+
+Two properties, asserted here for every loop:
+
+- the wrapper PINS the model it asks for rather than inheriting settings.json;
+- when a rung reports an exhausted quota it drops to the next rung and keeps
+  going, walking the whole ladder before it gives up, and a drop does not
+  consume one of the three transient-network attempts.
+
+The stub agent records the `--model` it was handed and fails with the real
+quota line for whichever rungs a test declares exhausted, so these assert the
+sequence of models actually attempted, not the shape of the script.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+BASH = shutil.which("bash") or "/bin/bash"
+
+# Every nightly loop wrapper. A loop missing here keeps the 2026-09-01
+# failure mode.
+LOOPS = {
+    "reliability": REPO / "scripts" / "reliability_weekend.sh",
+    "testing": REPO / "scripts" / "testing_weekend.sh",
+    "ci-performance": REPO / "scripts" / "ci_performance_nightly.sh",
+    "documentation": REPO / "scripts" / "documentation_nightly.sh",
+    "security": REPO / "scripts" / "security_nightly.sh",
+}
+
+# Best first. The top rung is the operator's own default; the next is the same
+# family one tier down, which is what 2026-09-01 needed and never got.
+LADDER = [
+    "claude-fable-5[1m]",
+    "claude-opus-5[1m]",
+    "claude-opus-5",
+    "claude-sonnet-5",
+]
+
+QUOTA_LINE = (
+    "You're out of usage credits. Switch to another model, or manage usage "
+    "credits at claude.ai/settings/usage?from=cc_cli_limit_message, to continue."
+)
+# The security wrapper refuses to call a phase OK without this; harmless noise
+# for the other four.
+COMPLETION = "SECURITY-NIGHTLY PHASE COMPLETE: audit"
+
+MARKERS = (
+    ".radon-weekend-runner",
+    ".radon-security-runner",
+    ".radon-reliability-runner",
+    ".radon-testing-runner",
+    ".radon-ci-performance-runner",
+    ".radon-documentation-runner",
+)
+
+
+def _clone(tmp_path: Path, wrapper: Path) -> Path:
+    repo = tmp_path / "clone"
+    (repo / "scripts").mkdir(parents=True)
+    shutil.copy2(wrapper, repo / "scripts" / wrapper.name)
+    (repo / "scripts" / wrapper.name).chmod(0o755)
+    for helper in ("weekend_notify.py", "weekend_redact.py"):
+        (repo / "scripts" / helper).write_text("# stub\n", encoding="utf-8")
+    for marker in MARKERS:
+        (repo / marker).write_text("", encoding="utf-8")
+    return repo
+
+
+def _stub_bin(tmp_path: Path, models_log: Path, exhausted: Path, gh_log: Path) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    stubs = {
+        "gh": (
+            "#!/bin/sh\n"
+            f'printf "%s\\n" "$*" >> "{gh_log}"\n'
+            'if [ "$1 $2" = "issue list" ]; then echo 4242; fi\n'
+            "exit 0\n"
+        ),
+        # Records the model it was handed, then behaves like a real agent whose
+        # quota for that model is (or is not) gone.
+        "claude": (
+            "#!/bin/bash\n"
+            'model=""\n'
+            "while [ $# -gt 0 ]; do\n"
+            '  if [ "$1" = "--model" ]; then model="$2"; shift 2; continue; fi\n'
+            "  shift\n"
+            "done\n"
+            f'printf "%s\\n" "$model" >> "{models_log}"\n'
+            f'if grep -qxF -- "$model" "{exhausted}"; then\n'
+            f"  echo \"{QUOTA_LINE}\"\n"
+            "  exit 1\n"
+            "fi\n"
+            f'echo "{COMPLETION}"\n'
+            "exit 0\n"
+        ),
+        "timeout": (
+            "#!/bin/bash\n"
+            "while [ $# -gt 0 ]; do\n"
+            '  case "$1" in\n'
+            "    -k|--kill-after) shift 2 ;;\n"
+            "    *) shift; break ;;\n"
+            "  esac\n"
+            "done\n"
+            'exec "$@"\n'
+        ),
+        "git": "#!/bin/sh\nexit 0\n",
+        "python3": "#!/bin/sh\nexit 0\n",
+    }
+    for name, body in stubs.items():
+        exe = bin_dir / name
+        exe.write_text(body, encoding="utf-8")
+        exe.chmod(0o755)
+    return bin_dir
+
+
+def _audit(tmp_path: Path, loop: str, exhausted_models, ladder: str | None = None):
+    wrapper = LOOPS[loop]
+    models_log = tmp_path / "models.txt"
+    gh_log = tmp_path / "gh.log"
+    exhausted = tmp_path / "exhausted.txt"
+    exhausted.write_text("".join(f"{m}\n" for m in exhausted_models), encoding="utf-8")
+    bin_dir = _stub_bin(tmp_path, models_log, exhausted, gh_log)
+    repo = _clone(tmp_path, wrapper)
+    env = {
+        "PATH": f"{bin_dir}:/usr/bin:/bin",
+        "HOME": str(tmp_path / "home"),
+        "RADON_WEEKEND_REPO": str(repo),
+    }
+    if ladder is not None:
+        env["RADON_WEEKEND_MODEL_LADDER"] = ladder
+    proc = subprocess.run(
+        [BASH, str(repo / "scripts" / wrapper.name), "audit"],
+        cwd=repo, env=env, capture_output=True, text=True, timeout=180,
+    )
+    models = (
+        models_log.read_text(encoding="utf-8").splitlines()
+        if models_log.exists() else []
+    )
+    calls = gh_log.read_text(encoding="utf-8") if gh_log.exists() else ""
+    return proc, models, calls
+
+
+@pytest.mark.parametrize("loop", sorted(LOOPS))
+class TestTheLoopPinsItsModel:
+    def test_the_wrapper_passes_an_explicit_model(self, loop):
+        body = LOOPS[loop].read_text(encoding="utf-8")
+        assert "--model" in body, (
+            f"the {loop} loop inherits ~/.claude/settings.json for its model, "
+            "so an interactive session changing the operator's default silently "
+            "decides what the unattended night runs on, and an exhausted quota "
+            "on that default kills the loop outright"
+        )
+
+    def test_the_default_ladder_is_the_agreed_order(self, loop):
+        body = LOOPS[loop].read_text(encoding="utf-8")
+        start = body.index("RADON_WEEKEND_MODEL_LADDER:-")
+        default = body[start + len("RADON_WEEKEND_MODEL_LADDER:-"):body.index("}", start)]
+        assert default.split() == LADDER, (default.split(), LADDER)
+
+
+@pytest.mark.parametrize("loop", sorted(LOOPS))
+class TestAnExhaustedQuotaDropsARung:
+    def test_it_drops_to_opus_1m_when_the_default_model_is_out(self, tmp_path, loop):
+        proc, models, _calls = _audit(tmp_path, loop, [LADDER[0]])
+        assert models[:2] == LADDER[:2], (
+            f"{loop}: expected a drop to {LADDER[1]!r} after {LADDER[0]!r} "
+            f"reported an exhausted quota; models attempted: {models!r}\n"
+            f"{proc.stdout}{proc.stderr}"
+        )
+        assert proc.returncode == 0, (proc.returncode, proc.stdout, proc.stderr)
+
+    def test_it_walks_the_whole_ladder(self, tmp_path, loop):
+        proc, models, _calls = _audit(tmp_path, loop, LADDER[:-1])
+        assert models == LADDER, (models, proc.stdout, proc.stderr)
+        # Four attempts is more than MAX_ATTEMPTS=3: a quota drop is not one of
+        # the three transient-network retries and must not consume one.
+        assert proc.returncode == 0, (proc.returncode, proc.stdout, proc.stderr)
+
+    def test_an_operator_ladder_overrides_the_default(self, tmp_path, loop):
+        proc, models, _calls = _audit(
+            tmp_path, loop, ["stub-a"], ladder="stub-a stub-b"
+        )
+        assert models == ["stub-a", "stub-b"], (models, proc.stdout, proc.stderr)
+        assert proc.returncode == 0, (proc.returncode, proc.stdout, proc.stderr)
+
+    def test_every_rung_exhausted_stops_and_says_so(self, tmp_path, loop):
+        proc, models, calls = _audit(tmp_path, loop, LADDER)
+        assert models == LADDER, (
+            f"{loop}: the ladder must be walked exactly once and then give up; "
+            f"models attempted: {models!r}"
+        )
+        assert proc.returncode != 0, (proc.returncode, proc.stdout, proc.stderr)
+        assert "all model quotas exhausted" in calls, (
+            f"{loop}: the dead-man must name the cause, or the operator sees a "
+            f"bare FAILED and re-fires into the same wall: {calls!r}"
+        )
+        assert "claude.ai/settings/usage" in calls, (
+            f"{loop}: the dead-man must carry the one place this is fixed: {calls!r}"
+        )


### PR DESCRIPTION
## What happened

All five nightly loops passed no `--model`, so every unattended round inherited whatever `~/.claude/settings.json` happened to say. On 2026-09-01 that was `claude-fable-5[1m]`, and that model's subscription quota was gone:

> You're out of usage credits. Switch to another model, or manage usage credits at claude.ai/settings/usage?from=cc_cli_limit_message, to continue.

`claude -p` printed that one line and exited 1 in under a second. The security loop's audit **and** remediate phases both died that way at 00:00, paged FAILED twice and audited nothing — while `claude --model opus` and `claude --model sonnet` answered normally on the same Max login the entire time.

A setting any interactive session on the machine can change was, in effect, a single-point kill switch on every unattended loop, and the only symptom was a bare `FAILED (exit 1)`.

## The fix

A quota is per model, so an exhausted one is a reason to drop a rung, not to lose the night:

```
claude-fable-5[1m] → claude-opus-5[1m] → claude-opus-5 → claude-sonnet-5
```

overridable with `RADON_WEEKEND_MODEL_LADDER`. Applied to all five wrappers (reliability, testing, ci-performance, documentation, security).

- Each wrapper **pins** the rung it asks for, which also takes the operator's global default off the unattended path.
- A round that reports an exhausted quota advances one rung and retries immediately. The drop costs no wall clock and is **not** one of the three transient-network attempts, so a ladder walk cannot be starved by `MAX_ATTEMPTS`.
- The detector reads only **this round's slice** of the run log, like the background-ceiling detector, so round 1's exhausted rung cannot drop a model on every later round forever (R-426).
- When every rung is gone the phase stops after exactly one walk — the reliability loop's continuation rounds are suppressed too, rather than relaunching into the same wall `MAX_ROUNDS` times — and the dead-man carries the cause and the fix instead of a bare FAILED:

```
FAILED (all model quotas exhausted; top up at claude.ai/settings/usage)
```

## Regression

`scripts/tests/test_weekend_model_ladder.py` drives each of the five **real** wrappers end to end with a stub agent that records the `--model` it was handed and fails with the real quota line for whichever rungs the test declares exhausted. It asserts the sequence of models actually attempted, not the shape of the script:

- the drop to `claude-opus-5[1m]` when the default rung is out
- the full four-rung walk (four attempts, more than `MAX_ATTEMPTS=3`)
- an operator ladder override
- an exhausted ladder is walked exactly once, then the loop gives up and says why

`test_weekend_loop_deadman.py`'s ceiling test lifts the invocation line verbatim into a bare `bash -c`, so it now seeds the ladder state the line reads; without it `set -u` killed the command before `claude` was reached and the test would have passed no judgement on the background-wait ceiling at all.

Red before: 30 failed. Green after: `30 passed` for the ladder, `416 passed` across the wrapper contract suites (deadman, survivability, self-rewrite, security contract, report redaction, env provisioning, notify, ladder).

## Verified live

The 2026-09-01 security audit was re-fired on the runner with the top rung forced past the exhausted default: completed `rc=0`, phase-completion marker printed, issue #204 **OK**, archive 1102 objects / 0 differences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Jw8YYGbZPYZiwsjhoQbHy