### PR TITLE
fix(order): show two decimals on payoff ratios below 1

### DIFF
--- a/web/lib/order/payoffRatio.ts
+++ b/web/lib/order/payoffRatio.ts
@@ -71,8 +71,20 @@ export function computePayoffRatio(summary: PayoffInput): PayoffRatio | null {
   return { kind: "ratio", ratio, meetsConvexity: ratio >= CONVEXITY_MIN_RATIO };
 }
 
-/** "7.2 : 1" — one decimal, trailing ".0" dropped so 2:1 reads clean. */
+/**
+ * "7.2 : 1" — one decimal, trailing ".0" dropped so 2:1 reads clean.
+ *
+ * Below 1 the left side keeps TWO decimals ("0.73 : 1"): sold call/put
+ * spreads live entirely in that band, and one decimal rounded away the
+ * difference between distinct credit-vs-risk trades (0.73 vs 0.70 both
+ * read "0.7 : 1").
+ */
 export function formatPayoffRatio(ratio: number): string {
+  if (ratio < 1) {
+    const hundredths = Math.round(ratio * 100) / 100;
+    // 0.995..0.999 rounds up to 1.00 — hand it to the >=1 format below.
+    if (hundredths < 1) return `${hundredths.toFixed(2)} : 1`;
+  }
   const rounded = Math.round(ratio * 10) / 10;
   return `${Number.isInteger(rounded) ? rounded : rounded.toFixed(1)} : 1`;
 }

--- a/web/tests/order-payoff-ratio.test.tsx
+++ b/web/tests/order-payoff-ratio.test.tsx
@@ -78,6 +78,19 @@ describe("computePayoffRatio", () => {
     expect(formatPayoffRatio(2)).toBe("2 : 1");
     expect(formatPayoffRatio(12.35)).toBe("12.4 : 1");
   });
+
+  it("keeps two decimals below 1 so credit-spread risk is not rounded away", () => {
+    // Sold call/put spreads live here: 0.73 credit per dollar risked is a
+    // materially different trade from 0.70, and one decimal hid the gap.
+    expect(formatPayoffRatio(0.73)).toBe("0.73 : 1");
+    expect(formatPayoffRatio(0.712)).toBe("0.71 : 1");
+    expect(formatPayoffRatio(0.7)).toBe("0.70 : 1");
+    expect(formatPayoffRatio(0.05)).toBe("0.05 : 1");
+  });
+
+  it("falls back to the >=1 format when a sub-1 ratio rounds up to 1.00", () => {
+    expect(formatPayoffRatio(0.999)).toBe("1 : 1");
+  });
 });
 
 describe("OrderConfirmSummary — leveraged payoff row", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- [x] Red/green TDD (failing test, then fix)
- [x] Staged only the files this change owns (no `git add -A`)
- [x] Owner doc updated, or the commit message has `docs-skip: <reason>` (rule documented in the formatter's own doc comment; no owner doc lists this format)
- [x] Previous `main` deploy finished before this push (branch push only, no deploy triggered)

## Problem

The order-entry payoff/leverage readout rounded every ratio to one decimal. Sold call/put spreads live entirely below 1, where one decimal rounds away real risk-vs-credit differences: a 0.73 : 1 spread and a 0.70 : 1 spread both rendered "0.7 : 1".

## Format rule

Lives in `web/lib/order/payoffRatio.ts` → `formatPayoffRatio()`:

- **ratio < 1** — two decimals on the left side: `0.73 : 1`, `0.71 : 1`, `0.70 : 1`. The right side stays a bare `:1`, never `:1.0`.
- **ratio >= 1** — unchanged: one decimal with trailing `.0` dropped (`2 : 1`, `7.2 : 1`, `12.4 : 1`).
- **0.995–0.999** — rounds up to 1.00 at two decimals, so it falls through to the >=1 format and reads `1 : 1`.

## Coverage

This is the single formatter for the ratio, rendered only by `OrderConfirmSummary` (`data-testid="order-payoff-ratio"`), which every order surface mounts via `OrderRiskGate` (chain ticket, OrderTab open/close, InstrumentDetailModal, IndexOptionOrderForm, ModifyOrderModal, FuturesOrderForm, BookTab stock form, mobile ticket). No other order-placement surface formats this ratio independently — verified by grep for `formatPayoffRatio` / `computePayoffRatio` / `Payoff` renders. One change covers every place Joe sees it while placing an order. No change to the ratio computation itself (`computePayoffRatio` untouched).

## Tests

- New: `formatPayoffRatio(0.73) === "0.73 : 1"`, `0.712 → "0.71 : 1"`, `0.7 → "0.70 : 1"`, `0.05 → "0.05 : 1"`, `0.999 → "1 : 1"` (red before fix, green after).
- Existing >=1 pins unchanged and green: `7.224 → "7.2 : 1"`, `2 → "2 : 1"`, `12.35 → "12.4 : 1"`.
- Full web Vitest suite: 8384 passed, 18 skipped; two files (`rel148-prefill-label-and-leap-age`, `ib-wrappers-db-source`) are cwd-sensitive and pass 11/11 from repo root — pre-existing, unrelated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0de5a3a0-5007-4c3d-9cf8-d0dab1c93814?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0de5a3a0-5007-4c3d-9cf8-d0dab1c93814&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

