### PR TITLE
fix(ci): the docs-ownership gate has been vacuous since 424e66da

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,7 +330,13 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # docs contract (test_docs_contract.py) diffs against DOCS_CONTRACT_BASE.
-          fetch-depth: ${{ matrix.shard == 'scripts-df' && 0 || 1 }}
+          # The branches are QUOTED. GitHub casts the number 0 to false, so the
+          # unquoted `cond && 0 || 1` fell through to the `||` and handed every
+          # shard depth 1 — the base commit was absent, `git diff BASE...HEAD`
+          # failed, _changed_paths swallowed it and the ownership gate passed
+          # for every commit from 424e66da on. A non-empty string is truthy, so
+          # '0' survives the ||. DOC-038.
+          fetch-depth: ${{ matrix.shard == 'scripts-df' && '0' || '1' }}
       - uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
         with:
           python-version: "3.13"

--- a/scripts/tests/test_docs_contract.py
+++ b/scripts/tests/test_docs_contract.py
@@ -639,3 +639,82 @@ class TestRootLedgersAreAppendOnly:
             "history (see TEST_LOG.md, truncated 543 -> 2 lines in 4584e84a "
             "with every gate green)"
         )
+
+
+# --- the workflow has to hand this contract a history it can diff -------------
+#
+# DOC-038. `_changed_paths` diffs `$DOCS_CONTRACT_BASE...HEAD`. In a depth-1
+# clone that base commit is not in the object graph, `git diff` exits non-zero,
+# and the loop `continue`s — so the contract sees ZERO changed paths and passes
+# for every commit. It fails OPEN, silently.
+#
+# ci.yml asked for the full history with
+#     fetch-depth: ${{ matrix.shard == 'scripts-df' && 0 || 1 }}
+# but GitHub casts the NUMBER 0 to false, so the true branch falls through to
+# the `||` and every shard, `scripts-df` included, got depth 1. The ownership
+# gate has been vacuous since 424e66da; two commits in that range violated it
+# and went green.
+
+_WORKFLOW = _ROOT / ".github" / "workflows" / "ci.yml"
+# The shard whose checkout must carry history: it is the one that runs this file.
+_HISTORY_SHARD = "scripts-df"
+_TERNARY = re.compile(
+    r"\$\{\{\s*matrix\.shard\s*==\s*'(?P<shard>[^']+)'\s*"
+    r"&&\s*(?P<yes>\S+)\s*\|\|\s*(?P<no>\S+?)\s*\}\}"
+)
+
+
+def _gha_truthy(token: str) -> bool:
+    """GitHub's documented cast to Boolean.
+
+    ``null``, ``false``, the NUMBER ``0`` and the EMPTY string are false;
+    everything else is true — including the non-empty string ``'0'``, which is
+    why quoting the branches is the fix and not a cosmetic change.
+    """
+    return token not in {"0", "false", "null", "''", '""'}
+
+
+def _resolve_ternary(match: re.Match, *, condition: bool) -> str:
+    yes, no = match.group("yes"), match.group("no")
+    chosen = yes if condition and _gha_truthy(yes) else no
+    return chosen.strip("'\"")
+
+
+class TestTheWorkflowGivesThisContractAHistoryToDiff:
+    def _fetch_depth_expression(self) -> re.Match:
+        text = _WORKFLOW.read_text(encoding="utf-8")
+        line = next(
+            (l for l in text.splitlines() if "fetch-depth:" in l and "matrix.shard" in l),
+            None,
+        )
+        assert line is not None, (
+            "ci.yml no longer varies fetch-depth by shard; if the python job "
+            "now checks out a fixed depth, this contract needs the deep one"
+        )
+        match = _TERNARY.search(line)
+        assert match is not None, f"unrecognised fetch-depth expression: {line.strip()}"
+        assert match.group("shard") == _HISTORY_SHARD, (
+            f"the deep checkout is keyed on {match.group('shard')!r}, but this "
+            f"contract runs in the {_HISTORY_SHARD!r} shard"
+        )
+        return match
+
+    def test_the_shard_that_runs_this_file_checks_out_full_history(self):
+        match = self._fetch_depth_expression()
+        depth = _resolve_ternary(match, condition=True)
+        assert depth == "0", (
+            f"the {_HISTORY_SHARD} shard resolves to fetch-depth {depth!r}, not "
+            "'0'. GitHub casts the number 0 to false, so `cond && 0 || 1` "
+            "always yields 1: the base commit is absent from the clone, every "
+            "`git diff BASE...HEAD` fails, _changed_paths returns nothing, and "
+            "this ownership gate passes for every commit. Quote the branches "
+            "('0' / '1') so the true branch survives the ||."
+        )
+
+    def test_the_other_shards_stay_shallow(self):
+        match = self._fetch_depth_expression()
+        depth = _resolve_ternary(match, condition=False)
+        assert depth == "1", (
+            f"the non-{_HISTORY_SHARD} shards resolve to fetch-depth {depth!r}; "
+            "a full clone on every python shard is a needless CI cost"
+        )


### PR DESCRIPTION
Fixes **DOC-038 (P1)**, filed by the documentation nightly loop (issue #202, audit `983cc8b8`).

## What was broken

`scripts/tests/test_docs_contract.py` diffs `$DOCS_CONTRACT_BASE...HEAD` to find the paths a commit touched, then requires each mapped path's owner doc. In a depth-1 clone the base commit is not in the object graph, so `git diff BASE...HEAD` exits non-zero, `_changed_paths` `continue`s past it, and the contract sees **zero** changed paths and passes. It fails **open**, silently.

`ci.yml` asked for the history it needs:

```yaml
fetch-depth: ${{ matrix.shard == 'scripts-df' && 0 || 1 }}
```

GitHub casts the **number** `0` to false, so the true branch falls through to the `||` and every shard — including `scripts-df`, the one that runs this contract — got depth 1. The gate has enforced nothing since `424e66da`. The documentation loop found two commits in its last audit range that violated the contract and went green.

## The fix

```diff
- fetch-depth: ${{ matrix.shard == 'scripts-df' && 0 || 1 }}
+ fetch-depth: ${{ matrix.shard == 'scripts-df' && '0' || '1' }}
```

A non-empty string is truthy, so the true branch survives the `||`. The same workflow already quotes `'0'` for the `secret-scan` and `changes` jobs, which is why those deep checkouts have always worked — this line was the odd one out.

## Regression

`TestTheWorkflowGivesThisContractAHistoryToDiff` lives beside the contract it protects and resolves the **real expression out of ci.yml** under GitHub's documented cast-to-Boolean rules (null, false, the number `0` and the empty string are false; every other value, including the string `'0'`, is true). It asserts `scripts-df` resolves to `'0'` and that the other shards stay at `'1'` so a full clone is not paid for on every python shard.

A test that merely grepped for `fetch-depth: 0` would have passed against the broken line, which is why the assertion evaluates the ternary instead.

Red before: 1 failed (`resolves to fetch-depth '1', not '0'`). Green after: 26 passed (docs contract), 38 passed (ci gate integrity + deploy concurrency).

## Heads-up

Expect this gate to start failing PRs that change a mapped path without touching its owner doc. That is the gate working. `docs-skip: <reason>` in the commit message remains the documented escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Jw8YYGbZPYZiwsjhoQbHy