### PR TITLE
Four safety interlocks: unit names, order cap, nightly clean, per-loop venvs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,13 @@ jobs:
           else
             ensure_commit "$PUSH_HEAD"
             zero="0000000000000000000000000000000000000000"
-            if [ "$PUSH_BEFORE" = "$zero" ] || ! git cat-file -e "${PUSH_BEFORE}^{commit}" 2>/dev/null; then
+            if [ "$PUSH_BEFORE" = "$zero" ]; then
               log_opts="-n 1 ${PUSH_HEAD}"
             else
+              # A force-push / orphaned `before` used to skip ensure_commit and
+              # fall through to `-n 1 $PUSH_HEAD`, scanning only the tip on the
+              # deploy event. Fetch it; if it is still missing, fail the job.
+              ensure_commit "$PUSH_BEFORE"
               log_opts="${PUSH_BEFORE}..${PUSH_HEAD}"
             fi
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,17 +33,14 @@ jobs:
           # History must be deep enough for merge-base on long PRs and for a
           # committed-then-reverted secret on the branch being scanned. The
           # detect step still limits git log: PRs use merge-base..head, pushes
-          # use HEAD. fetch-depth: 0 also downloads sibling refs; --log-opts
-          # keeps those out of the scan.
+          # use before..HEAD. fetch-depth: 0 also downloads sibling refs;
+          # --log-opts keeps those out of the scan.
           fetch-depth: 0
       # Pinned gitleaks binary (not gitleaks/gitleaks-action@v2): the action
-      # defaults to scanning only the PUSH/PR commit RANGE and short-circuits
-      # to a no-op on some event types, and it nags about an org GITLEAKS_LICENSE.
-      # The bare CLI over the full history is deterministic, license-free, and
-      # is exactly what was verified locally (gitleaks 8.x: the dummy Clerk
-      # publishable key on the `# gitleaks:allow` line is honored; removing that
-      # comment makes the scan FAIL with a generic-api-key finding — proving the
-      # gate has teeth and the allow is load-bearing, not decorative).
+      # short-circuits to a no-op on some event types and nags about an org
+      # GITLEAKS_LICENSE. The CLI is deterministic and license-free. We pass
+      # --log-opts ourselves so a pull_request scans merge-base..PR_HEAD only,
+      # not sibling-branch history that fetch-depth: 0 pulled in.
       - name: Install gitleaks
         run: |
           version="8.30.1"
@@ -61,22 +58,38 @@ jobs:
       # actual secret value out of the public Actions log on a real hit.
       # Default gitleaks git log is --all, so a fetch-depth: 0 clone of every
       # open branch would fail this PR on sibling test fixtures. Scope PRs to
-      # merge-base..head; pushes scan HEAD lineage only.
-      - name: Scan repo history for committed secrets
+      # merge-base..PR_HEAD; pushes use before..HEAD.
+      - name: Scan this event's commits for secrets
         env:
           EVENT_NAME: ${{ github.event_name }}
           PR_BASE: ${{ github.event.pull_request.base.sha }}
           PR_HEAD: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_HEAD: ${{ github.sha }}
         run: |
           set -euo pipefail
+          ensure_commit() {
+            local sha="$1"
+            git cat-file -e "${sha}^{commit}" 2>/dev/null && return 0
+            git fetch --no-tags --prune origin "$sha"
+            git cat-file -e "${sha}^{commit}"
+          }
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            git fetch --no-tags origin "$PR_BASE" "$PR_HEAD"
+            ensure_commit "$PR_BASE"
+            ensure_commit "$PR_HEAD"
             merge_base="$(git merge-base "$PR_BASE" "$PR_HEAD")"
             log_opts="${merge_base}..${PR_HEAD}"
           else
-            log_opts="HEAD"
+            ensure_commit "$PUSH_HEAD"
+            zero="0000000000000000000000000000000000000000"
+            if [ "$PUSH_BEFORE" = "$zero" ] || ! git cat-file -e "${PUSH_BEFORE}^{commit}" 2>/dev/null; then
+              log_opts="-n 1 ${PUSH_HEAD}"
+            else
+              log_opts="${PUSH_BEFORE}..${PUSH_HEAD}"
+            fi
           fi
-          gitleaks detect --source . --config cloud/.gitleaks.toml --redact --no-banner --verbose --log-opts="$log_opts"
+          echo "gitleaks log-opts: ${log_opts}"
+          gitleaks detect --source . --config cloud/.gitleaks.toml --redact --no-banner --verbose --log-opts="${log_opts}"
 
   changes:
     name: Path filter

--- a/cloud/tests/test_deploy_corrections.py
+++ b/cloud/tests/test_deploy_corrections.py
@@ -3288,6 +3288,8 @@ class TestCloudSecretScan:
         assert "git merge-base" in script
         assert "${merge_base}..${PR_HEAD}" in script
         assert 'log_opts="${PUSH_BEFORE}..${PUSH_HEAD}"' in script
+        assert 'ensure_commit "$PUSH_BEFORE"' in script
+        assert '[ "$PUSH_BEFORE" = "$zero" ] || ! git cat-file -e "${PUSH_BEFORE}^{commit}"' not in script
         assert "--log-opts=" in script
 
     def test_root_ci_runs_full_python313_cloud_suite(self) -> None:

--- a/cloud/tests/test_deploy_corrections.py
+++ b/cloud/tests/test_deploy_corrections.py
@@ -3287,6 +3287,7 @@ class TestCloudSecretScan:
         script = scan["run"]
         assert "git merge-base" in script
         assert "${merge_base}..${PR_HEAD}" in script
+        assert 'log_opts="${PUSH_BEFORE}..${PUSH_HEAD}"' in script
         assert "--log-opts=" in script
 
     def test_root_ci_runs_full_python313_cloud_suite(self) -> None:

--- a/cloud/tests/test_gitleaks_policy.py
+++ b/cloud/tests/test_gitleaks_policy.py
@@ -107,8 +107,12 @@ def test_active_root_ci_scopes_pr_gitleaks_to_merge_base_head() -> None:
     assert "git merge-base" in script
     assert "log_opts=" in script
     assert "${merge_base}..${PR_HEAD}" in script
+    assert 'ensure_commit "$PUSH_HEAD"' in script
+    assert 'ensure_commit "$PUSH_BEFORE"' in script
     assert 'log_opts="${PUSH_BEFORE}..${PUSH_HEAD}"' in script
     assert 'log_opts="HEAD"' not in script
+    # A missing non-zero before must fail the job, not scan only the tip.
+    assert '[ "$PUSH_BEFORE" = "$zero" ] || ! git cat-file -e "${PUSH_BEFORE}^{commit}"' not in script
     collapsed = " ".join(script.split())
     expected = (
         "gitleaks detect --source . --config cloud/.gitleaks.toml "

--- a/cloud/tests/test_gitleaks_policy.py
+++ b/cloud/tests/test_gitleaks_policy.py
@@ -99,20 +99,22 @@ def test_active_root_ci_scopes_pr_gitleaks_to_merge_base_head() -> None:
     assert "github.event_name" in str(env.get("EVENT_NAME", ""))
     assert "github.event.pull_request.base.sha" in str(env.get("PR_BASE", ""))
     assert "github.event.pull_request.head.sha" in str(env.get("PR_HEAD", ""))
+    assert "github.event.before" in str(env.get("PUSH_BEFORE", ""))
+    assert "github.sha" in str(env.get("PUSH_HEAD", ""))
 
     script = scan["run"]
     assert 'EVENT_NAME" = "pull_request"' in script
     assert "git merge-base" in script
     assert "log_opts=" in script
     assert "${merge_base}..${PR_HEAD}" in script
+    assert 'log_opts="${PUSH_BEFORE}..${PUSH_HEAD}"' in script
+    assert 'log_opts="HEAD"' not in script
     collapsed = " ".join(script.split())
     expected = (
         "gitleaks detect --source . --config cloud/.gitleaks.toml "
-        '--redact --no-banner --verbose --log-opts="$log_opts"'
+        "--redact --no-banner --verbose --log-opts="
     )
     assert expected in collapsed
-    # Push/main still scans HEAD lineage, never sibling remotes (--all).
-    assert 'log_opts="HEAD"' in script
 
 
 def test_this_branch_has_no_static_tws_credential_assignments() -> None:

--- a/scripts/api/server.py
+++ b/scripts/api/server.py
@@ -2036,18 +2036,28 @@ def _is_app_role_gateway_mutation(request: Request) -> bool:
     Loopback trust would let a compromised Next.js on the public terminator
     restart IBKR without a Clerk operator JWT. Combined/broker keep the
     existing local-helper path.
+
+    The unit name is canonicalized before the comparison: systemd treats
+    ``radon-ib-gateway`` and ``radon-ib-gateway.service`` as the same unit,
+    so matching the caller's spelling would skip this privileged-action gate.
     """
     if admin_services.host_role() != "app":
         return False
     if request.method != "POST":
         return False
-    path = request.url.path
+    path = request.url.path.rstrip("/")
     if path in {"/ib/restart", "/ib/reset-backoff"}:
         return True
-    prefix = "/admin/services/radon-ib-gateway.service/"
-    if path.startswith(prefix) and path.rsplit("/", 1)[-1] in {"start", "stop", "restart"}:
-        return True
-    return False
+    prefix = "/admin/services/"
+    if not path.startswith(prefix):
+        return False
+    rest = path[len(prefix):]
+    if "/" not in rest:
+        return False
+    unit, action = rest.rsplit("/", 1)
+    if action not in {"start", "stop", "restart"}:
+        return False
+    return admin_services.canonicalize_unit_name(unit) == admin_services.GATEWAY_UNIT
 
 
 def _gateway_unit_controllable() -> bool:
@@ -2736,6 +2746,9 @@ def _refuse_if_order_rate_exceeded(order_ref: Optional[str] = None) -> None:
     REL-026: `/orders/replace` reserves its slot BEFORE the destructive cancel
     loop, so passing the same `order_ref` again from the inner `orders_place`
     must not consume a second one — the replace is one placement, not two.
+    The reservation is tagged with `order_ref` only until
+    :func:`_consume_order_rate_reservation` runs after the placement; a
+    later request that repeats a client-supplied ref must claim a new slot.
     """
     from order_limits import max_orders_per_min
 
@@ -2755,6 +2768,21 @@ def _refuse_if_order_rate_exceeded(order_ref: Optional[str] = None) -> None:
             },
         )
     _order_rate_timestamps.append((now, order_ref))
+
+
+def _consume_order_rate_reservation(order_ref: Optional[str] = None) -> None:
+    """Drop the order_ref tag so the same client ref cannot reuse this slot.
+
+    The timestamp stays in the window — the cap still counts the placement.
+    Called after the placement attempt (success or failure) so a repeated
+    client-supplied orderRef is a new claim, not a free pass.
+    """
+    if not order_ref:
+        return
+    for i, (stamp, ref) in enumerate(_order_rate_timestamps):
+        if ref == order_ref:
+            _order_rate_timestamps[i] = (stamp, None)
+            return
 
 
 def _refuse_if_order_limits_violated(params: dict) -> None:
@@ -2808,7 +2836,19 @@ async def orders_place(request: Request):
     # for this ref is recognised instead of double-counted (REL-026).
     if not body.get("orderRef"):
         body["orderRef"] = f"radon-{uuid.uuid4().hex[:20]}"
-    _refuse_if_order_rate_exceeded(body["orderRef"])
+    reserved_ref = body["orderRef"]
+    _refuse_if_order_rate_exceeded(reserved_ref)
+    try:
+        return await _orders_place_after_rate_reservation(body)
+    finally:
+        # Drop the orderRef tag so a later request that repeats a
+        # client-supplied ref claims a new slot. The timestamp stays;
+        # the cap still counts this placement.
+        _consume_order_rate_reservation(reserved_ref)
+
+
+async def _orders_place_after_rate_reservation(body: dict):
+    """Body of /orders/place after the per-minute slot is reserved."""
     if test_mode:
         order_id, perm_id = _next_test_order_ids()
         return {
@@ -2996,8 +3036,18 @@ async def orders_replace(request: Request):
     # destructive. It used to be claimed inside orders_place, which runs after
     # the cancel loop — an exhausted budget left the operator's working orders
     # cancelled and the replacement refused, i.e. the position unhedged.
-    _refuse_if_order_rate_exceeded(replacement["orderRef"])
+    reserved_ref = replacement["orderRef"]
+    _refuse_if_order_rate_exceeded(reserved_ref)
+    try:
+        return await _orders_replace_after_rate_reservation(
+            cancel_orders, replacement,
+        )
+    finally:
+        _consume_order_rate_reservation(reserved_ref)
 
+
+async def _orders_replace_after_rate_reservation(cancel_orders, replacement):
+    """Body of /orders/replace after the per-minute slot is reserved."""
     # Complete every non-transmitting validation before the first cancellation.
     await orders_whatif(_internal_json_request(replacement))
 

--- a/scripts/api/server.py
+++ b/scripts/api/server.py
@@ -2743,20 +2743,19 @@ _order_rate_timestamps: deque = deque()
 def _refuse_if_order_rate_exceeded(order_ref: Optional[str] = None) -> None:
     """Claim one slot in the per-minute placement budget.
 
-    REL-026: `/orders/replace` reserves its slot BEFORE the destructive cancel
-    loop, so passing the same `order_ref` again from the inner `orders_place`
-    must not consume a second one — the replace is one placement, not two.
-    The reservation is tagged with `order_ref` only until
-    :func:`_consume_order_rate_reservation` runs after the placement; a
-    later request that repeats a client-supplied ref must claim a new slot.
+    Every call claims a new slot or 429s. An in-flight `order_ref` does not
+    skip the claim — two overlapping `/orders/place` calls with the same
+    client ref must not share one cap slot.
+
+    `/orders/replace` reserves once, then places through
+    :func:`_orders_place_after_rate_reservation` so the inner placement does
+    not claim a second slot (REL-026).
     """
     from order_limits import max_orders_per_min
 
     now = time.monotonic()
     while _order_rate_timestamps and now - _order_rate_timestamps[0][0] > 60.0:
         _order_rate_timestamps.popleft()
-    if order_ref and any(ref == order_ref for _stamp, ref in _order_rate_timestamps):
-        return
     cap = max_orders_per_min()
     if len(_order_rate_timestamps) >= cap:
         raise HTTPException(
@@ -2832,8 +2831,7 @@ async def orders_place(request: Request):
     body = await request.json()
     _refuse_if_order_limits_violated(body)
     # REL-006: mint the orderRef BEFORE the rate check so it survives a
-    # SIGKILLed subprocess, and so a slot /orders/replace already reserved
-    # for this ref is recognised instead of double-counted (REL-026).
+    # SIGKILLed subprocess.
     if not body.get("orderRef"):
         body["orderRef"] = f"radon-{uuid.uuid4().hex[:20]}"
     reserved_ref = body["orderRef"]
@@ -3065,7 +3063,7 @@ async def _orders_replace_after_rate_reservation(cancel_orders, replacement):
                 "permId": target.get("permId"),
                 "status": (result or {}).get("finalStatus", "cancelled"),
             })
-        placed = await orders_place(_internal_json_request(replacement))
+        placed = await _orders_place_after_rate_reservation(replacement)
     except HTTPException as exc:
         status = exc.status_code if exc.status_code == 504 else 502
         raise HTTPException(

--- a/scripts/api/services.py
+++ b/scripts/api/services.py
@@ -54,8 +54,26 @@ _SYSTEMCTL_TIMESTAMP_FORMATS = (
 
 # Whitelisted unit-name pattern. Any unit listed by /admin/services or passed
 # to /admin/services/<unit>/<action> must match. This keeps the panel from
-# being a generic systemctl proxy.
+# being a generic systemctl proxy. Compared against the canonical form
+# (missing type suffix → ``.service``), matching systemd.
 _UNIT_PATTERN = re.compile(r"^radon-[a-z0-9-]+(?:\.service|\.timer)?$|^radon-ib-gateway\.service$")
+
+# systemd unit types. A name with none of these suffixes is a .service.
+# Tuple so ``str.endswith`` can take it in one call.
+_UNIT_TYPE_SUFFIXES = (
+    ".service",
+    ".socket",
+    ".target",
+    ".device",
+    ".mount",
+    ".automount",
+    ".swap",
+    ".timer",
+    ".path",
+    ".slice",
+    ".scope",
+    ".snapshot",
+)
 
 # Internal systemd adapter used only by the IB watchdog after it has acquired
 # its exact preheld lease. It must never be listed or controllable through the
@@ -100,12 +118,33 @@ class UnitStatus:
         return asdict(self)
 
 
+def canonicalize_unit_name(unit: str) -> str:
+    """Return systemd's implied unit name for ``unit``.
+
+    ``systemctl`` treats a name without a type suffix as ``.service``, so
+    ``radon-ib-gateway`` and ``radon-ib-gateway.service`` are the same unit.
+    Denylist, broker-restart lease, and the app-role privileged-action gate
+    must compare this form; matching the caller's spelling lets those
+    interlocks be skipped.
+    """
+    if not isinstance(unit, str):
+        return ""
+    name = unit.strip()
+    if not name:
+        return name
+    if name.endswith(_UNIT_TYPE_SUFFIXES):
+        return name
+    return f"{name}.service"
+
+
 def is_valid_unit(unit: str) -> bool:
     """True when ``unit`` is in the allowlist for service control.
 
     Centralised so both the listing endpoint and the action endpoint use the
     same rule. Anything outside this pattern is rejected at the boundary.
+    Canonicalizes first so an unsuffixed denylist name cannot slip through.
     """
+    unit = canonicalize_unit_name(unit)
     return unit not in _INTERNAL_UNITS and bool(_UNIT_PATTERN.match(unit))
 
 
@@ -304,6 +343,7 @@ async def show_unit(unit: str) -> UnitStatus:
     Always returns a value, never raises — a not-found / unreadable unit
     surfaces as ``load_state="not-found"`` so the UI can render the row.
     """
+    unit = canonicalize_unit_name(unit)
     if not is_valid_unit(unit):
         return UnitStatus(unit, "rejected", "unknown", "unknown", "", can_control=False)
 
@@ -631,7 +671,11 @@ async def control_unit(unit: str, action: str) -> ActionResult:
 
     Returns an :class:`ActionResult` whether or not the call succeeded so
     the route handler can shape an HTTP response from a single object.
+    Canonicalizes the unit name before every interlock so systemd aliases
+    (``radon-ib-gateway`` ≡ ``radon-ib-gateway.service``) cannot skip the
+    denylist, the broker restart lease, or the privileged-action gate.
     """
+    unit = canonicalize_unit_name(unit)
     if action not in ALLOWED_ACTIONS:
         return ActionResult(unit, action, False, f"action {action!r} is not allowed", -1)
 

--- a/scripts/api/tests/test_ib_restart_cloud_delegate.py
+++ b/scripts/api/tests/test_ib_restart_cloud_delegate.py
@@ -51,6 +51,9 @@ _GATEWAY_MUTATIONS = [
     ("/ib/restart", "restart"),
     ("/ib/reset-backoff", "reset-lease"),
     ("/admin/services/radon-ib-gateway.service/start", "start"),
+    # systemd alias: missing .service suffix is the same unit. The
+    # privileged-action gate must fire on this spelling too.
+    ("/admin/services/radon-ib-gateway/restart", "restart"),
 ]
 
 
@@ -298,6 +301,8 @@ class TestCloudDelegate:
         for action in ("start", "stop", "restart"):
             unit_action = _req("POST", f"/admin/services/radon-ib-gateway.service/{action}")
             assert server._is_app_role_gateway_mutation(unit_action) is True, action
+            unsuffixed = _req("POST", f"/admin/services/radon-ib-gateway/{action}")
+            assert server._is_app_role_gateway_mutation(unsuffixed) is True, action
         assert server._is_app_role_gateway_mutation(health) is False
         assert server._is_app_role_gateway_mutation(stack) is False
         assert server._is_app_role_gateway_mutation(_req("GET", "/ib/restart")) is False

--- a/scripts/api/tests/test_order_limits_routes.py
+++ b/scripts/api/tests/test_order_limits_routes.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -87,7 +88,7 @@ class TestOrderRateCap:
     def test_repeating_client_order_ref_cannot_reuse_the_cap(
         self, trusted_client, monkeypatch
     ):
-        """A reserved slot is consumed after use, so the same orderRef is a new claim."""
+        """The same client orderRef is a new claim, not a free pass on the cap."""
         client, server = trusted_client
         monkeypatch.setenv("RADON_MAX_ORDERS_PER_MIN", "1")
         monkeypatch.setattr(
@@ -97,6 +98,48 @@ class TestOrderRateCap:
         body = {
             "type": "stock", "symbol": "AAPL", "action": "BUY",
             "quantity": 1, "limitPrice": 200.0, "orderRef": "client-ref-1",
+        }
+        assert client.post("/orders/place", json=body).status_code == 200
+        reused = client.post("/orders/place", json=body)
+        assert reused.status_code == 429
+        assert reused.json()["detail"]["code"] == "ORDER_RATE_LIMIT"
+
+    def test_inflight_same_order_ref_cannot_share_one_cap_slot(
+        self, trusted_client, monkeypatch
+    ):
+        """Two overlapping claims with the same orderRef each take a slot.
+
+        The skip that treated a still-tagged ref as "already reserved" let
+        parallel `/orders/place` calls share one cap slot. Consume never
+        ran between them.
+        """
+        _, server = trusted_client
+        monkeypatch.setenv("RADON_MAX_ORDERS_PER_MIN", "1")
+        server._order_rate_timestamps.clear()
+        try:
+            server._refuse_if_order_rate_exceeded("same-ref")
+            with pytest.raises(HTTPException) as exc:
+                server._refuse_if_order_rate_exceeded("same-ref")
+            assert exc.value.status_code == 429
+            assert exc.value.detail["code"] == "ORDER_RATE_LIMIT"
+        finally:
+            server._order_rate_timestamps.clear()
+
+    def test_place_route_same_order_ref_still_tagged_cannot_reuse_slot(
+        self, trusted_client, monkeypatch
+    ):
+        """Hold the reservation tag (as if consume has not run) and a second
+        `/orders/place` with the same client orderRef must still 429."""
+        client, server = trusted_client
+        monkeypatch.setenv("RADON_MAX_ORDERS_PER_MIN", "1")
+        monkeypatch.setattr(server, "_consume_order_rate_reservation", lambda *a, **k: None)
+        monkeypatch.setattr(
+            server, "_run_ib_script_with_recovery", AsyncMock(return_value=_ok_result())
+        )
+
+        body = {
+            "type": "stock", "symbol": "AAPL", "action": "BUY",
+            "quantity": 1, "limitPrice": 200.0, "orderRef": "in-flight-ref",
         }
         assert client.post("/orders/place", json=body).status_code == 200
         reused = client.post("/orders/place", json=body)

--- a/scripts/api/tests/test_order_limits_routes.py
+++ b/scripts/api/tests/test_order_limits_routes.py
@@ -84,6 +84,25 @@ class TestOrderRateCap:
         assert third.status_code == 429
         assert third.json()["detail"]["code"] == "ORDER_RATE_LIMIT"
 
+    def test_repeating_client_order_ref_cannot_reuse_the_cap(
+        self, trusted_client, monkeypatch
+    ):
+        """A reserved slot is consumed after use, so the same orderRef is a new claim."""
+        client, server = trusted_client
+        monkeypatch.setenv("RADON_MAX_ORDERS_PER_MIN", "1")
+        monkeypatch.setattr(
+            server, "_run_ib_script_with_recovery", AsyncMock(return_value=_ok_result())
+        )
+
+        body = {
+            "type": "stock", "symbol": "AAPL", "action": "BUY",
+            "quantity": 1, "limitPrice": 200.0, "orderRef": "client-ref-1",
+        }
+        assert client.post("/orders/place", json=body).status_code == 200
+        reused = client.post("/orders/place", json=body)
+        assert reused.status_code == 429
+        assert reused.json()["detail"]["code"] == "ORDER_RATE_LIMIT"
+
     def test_refused_orders_do_not_consume_budget(self, trusted_client, monkeypatch):
         """A 422-refused order must not eat the rate budget."""
         client, server = trusted_client

--- a/scripts/api/tests/test_order_replace_state_machine.py
+++ b/scripts/api/tests/test_order_replace_state_machine.py
@@ -56,7 +56,7 @@ def test_replace_preserves_indeterminate_status_and_cancel_audit(trusted_client,
     monkeypatch.setattr(server, "orders_cancel", AsyncMock(return_value={"finalStatus": "Cancelled"}))
     monkeypatch.setattr(
         server,
-        "orders_place",
+        "_orders_place_after_rate_reservation",
         AsyncMock(side_effect=HTTPException(status_code=504, detail={"code": "ORDER_INDETERMINATE"})),
     )
 
@@ -100,7 +100,7 @@ class TestReplaceReservesRateBudgetBeforeCancelling:
         place = AsyncMock(return_value={"status": "ok"})
         monkeypatch.setattr(server, "orders_whatif", AsyncMock(return_value={"status": "ok"}))
         monkeypatch.setattr(server, "orders_cancel", cancel)
-        monkeypatch.setattr(server, "orders_place", place)
+        monkeypatch.setattr(server, "_orders_place_after_rate_reservation", place)
         _exhaust_order_rate_budget(server)
 
         try:
@@ -132,7 +132,7 @@ class TestReplaceReservesRateBudgetBeforeCancelling:
 
         monkeypatch.setattr(server, "orders_whatif", halt_during_whatif)
         monkeypatch.setattr(server, "orders_cancel", cancel)
-        monkeypatch.setattr(server, "orders_place", place)
+        monkeypatch.setattr(server, "_orders_place_after_rate_reservation", place)
         server._order_rate_timestamps.clear()
 
         try:
@@ -149,8 +149,9 @@ class TestReplaceReservesRateBudgetBeforeCancelling:
         place.assert_not_awaited()
 
     def test_replace_consumes_exactly_one_rate_slot(self, trusted_client, monkeypatch):
-        """The reservation must not be double-counted: the inner orders_place
-        is the same placement the pre-flight already reserved for."""
+        """The reservation must not be double-counted: the inner placement
+        goes through `_orders_place_after_rate_reservation`, not the public
+        `/orders/place` route that would claim a second slot."""
         from scripts.api import server
 
         monkeypatch.setattr(server, "orders_whatif", AsyncMock(return_value={"status": "ok"}))
@@ -178,7 +179,11 @@ class TestReplaceReservesRateBudgetBeforeCancelling:
         cancel = AsyncMock(return_value={"finalStatus": "Cancelled"})
         monkeypatch.setattr(server, "orders_whatif", AsyncMock(return_value={"status": "ok"}))
         monkeypatch.setattr(server, "orders_cancel", cancel)
-        monkeypatch.setattr(server, "orders_place", AsyncMock(return_value={"status": "ok", "orderId": 7}))
+        monkeypatch.setattr(
+            server,
+            "_orders_place_after_rate_reservation",
+            AsyncMock(return_value={"status": "ok", "orderId": 7}),
+        )
         server._order_rate_timestamps.clear()
 
         try:

--- a/scripts/api/tests/test_services.py
+++ b/scripts/api/tests/test_services.py
@@ -32,6 +32,8 @@ class TestIsValidUnit:
         "unit",
         [
             "radon-api.service",
+            "radon-api",  # systemd alias: missing suffix is .service
+            "radon-ib-gateway",
             "radon-relay.service",
             "radon-monitor.service",
             "radon-newsfeed.service",
@@ -57,6 +59,7 @@ class TestIsValidUnit:
             "",
             "../radon-api.service",
             "radon-ib-gateway-preheld-restart.service",
+            "radon-ib-gateway-preheld-restart",
         ],
     )
     def test_rejects_non_radon_units(self, unit: str) -> None:
@@ -88,6 +91,40 @@ class TestControlUnitRejection:
         )
         assert result.ok is False
         assert result.returncode == -1
+
+
+class TestCanonicalizeUnitName:
+    """systemd treats a missing type suffix as .service. Interlocks must too."""
+
+    def test_appends_service_when_suffix_missing(self) -> None:
+        assert admin_services.canonicalize_unit_name("radon-ib-gateway") == (
+            "radon-ib-gateway.service"
+        )
+        assert admin_services.canonicalize_unit_name("radon-api") == "radon-api.service"
+
+    def test_keeps_service_and_timer_suffixes(self) -> None:
+        assert admin_services.canonicalize_unit_name("radon-api.service") == (
+            "radon-api.service"
+        )
+        assert admin_services.canonicalize_unit_name("radon-refresh.timer") == (
+            "radon-refresh.timer"
+        )
+
+    def test_strips_surrounding_whitespace(self) -> None:
+        assert admin_services.canonicalize_unit_name("  radon-api  ") == (
+            "radon-api.service"
+        )
+
+    def test_unsuffixed_preheld_is_denied(self) -> None:
+        assert admin_services.is_valid_unit("radon-ib-gateway-preheld-restart") is False
+        assert admin_services.is_valid_unit(
+            "radon-ib-gateway-preheld-restart.service"
+        ) is False
+
+    def test_unsuffixed_gateway_is_still_the_gateway(self) -> None:
+        assert admin_services.canonicalize_unit_name("radon-ib-gateway") == (
+            admin_services.GATEWAY_UNIT
+        )
 
 
 class TestNonSystemdHost:
@@ -405,6 +442,35 @@ class TestControlUnitGatewayPushLock:
         assert helper_log.read_text().splitlines() == [action]
         assert calls == []
         assert not lock_path.exists(), "admin API must not pre-acquire the helper's lease"
+
+    def test_unsuffixed_gateway_name_still_takes_the_lease_path(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """``radon-ib-gateway`` is the same unit as ``.service`` to systemd.
+
+        Comparing the caller's spelling skipped the helper and ran
+        ``systemctl restart``, bypassing the broker restart lease.
+        """
+        helper_log = self._install_helper(tmp_path, monkeypatch)
+        calls: list = []
+        result = self._control("radon-ib-gateway", "restart", calls)
+
+        assert result.ok is True
+        assert result.unit == self.GATEWAY
+        assert helper_log.read_text().splitlines() == ["restart"]
+        assert calls == []
+
+    def test_unsuffixed_preheld_unit_is_rejected_before_systemctl(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        helper_log = self._install_helper(tmp_path, monkeypatch)
+        calls: list = []
+        result = self._control("radon-ib-gateway-preheld-restart", "restart", calls)
+
+        assert result.ok is False
+        assert "unit" in result.detail.lower()
+        assert calls == []
+        assert not helper_log.exists() or helper_log.read_text() == ""
 
     def test_helper_lease_refusal_maps_to_conflict(
         self, tmp_path: Path, monkeypatch

--- a/scripts/ci_performance_nightly.sh
+++ b/scripts/ci_performance_nightly.sh
@@ -39,7 +39,7 @@ set -Eeuo pipefail
 
 # One writer per runner clone. The daily fire, a hand-run smoke test and the
 # setup script all drive the SAME tree, and every entry point runs
-# `git clean -fdq`, so a second run would delete the live agent's uncommitted
+# `git clean -fdxq`, so a second run would delete the live agent's uncommitted
 # work mid-write with both runs reporting success. The plist pre-reset and
 # setup_ci_performance_nightly.sh both stand down on this lock, so it has to exist.
 # mkdir is the atomic primitive here: flock(1) does not exist on macOS.
@@ -51,7 +51,7 @@ acquire_runner_lock() {
       # No pid yet means the winner is between its mkdir and its pid write.
       # That window used to skip the `kill -0` test entirely — the loser read
       # an empty pid, called the lock stale, `rm -rf`d it and took it, and two
-      # cycles then ran `git clean -fdq` in the same clone. Absent evidence is
+      # cycles then ran `git clean -fdxq` in the same clone. Absent evidence is
       # not evidence of staleness. R-411.
       echo "weekend runner lock held (pid not yet published): $dir" >&2
       return 1
@@ -110,7 +110,9 @@ MODE="${1:?usage: ci_performance_nightly.sh audit|remediate|cycle}"
 
 REPO="${RADON_WEEKEND_REPO:-$HOME/radon-weekend/radon-ci-performance}"
 WEEKEND_ROOT="$(dirname "$REPO")"
-VENV="$WEEKEND_ROOT/venv"
+# Per-loop venv. The legacy $WEEKEND_ROOT/venv is not deleted here
+# (operator follow-up after this ships).
+VENV="$WEEKEND_ROOT/venv-ci-performance"
 # Activate the venv so any python3.13 calls inside the agent use it.
 [[ -f "$VENV/bin/activate" ]] && export PATH="$VENV/bin:$PATH"
 DEADMAN_TITLE="Nightly CI performance runner"
@@ -211,7 +213,7 @@ kill_round_group() {
   # process-group leader, so the negative pid reaches claude and anything it
   # left behind. --foreground would signal only timeout's direct child, which
   # is the opposite of what reaping orphaned subagents needs — they would keep
-  # writing into the clone while the next round runs `git clean -fdq`. R-386.
+  # writing into the clone while the next round runs `git clean -fdxq`. R-386.
   kill -TERM -- "-$ROUND_PID" 2>/dev/null || kill -TERM "$ROUND_PID" 2>/dev/null || true
   ROUND_PID=""
 }
@@ -336,7 +338,7 @@ ground_truth() {
   fetch_origin_with_retry
   git checkout -f --quiet main
   git reset --hard --quiet origin/main
-  git clean -fdq --exclude=.radon-weekend-runner --exclude=.radon-ci-performance-runner --exclude=.weekend-runner.lock --exclude=logs/ --exclude=.env --exclude=.env.ib-mode --exclude=web/.env
+  git clean -fdxq --exclude=.radon-weekend-runner --exclude=.radon-ci-performance-runner --exclude=.weekend-runner.lock --exclude=logs/ --exclude=.env --exclude=.env.ib-mode --exclude=web/.env --exclude=node_modules/ --exclude=.next/ --exclude=.deepsec/
 }
 
 # The agent commits per completed task and the skill resumes from the

--- a/scripts/documentation_nightly.sh
+++ b/scripts/documentation_nightly.sh
@@ -35,7 +35,7 @@ set -Eeuo pipefail
 
 # One writer per runner clone. The daily fire, a hand-run smoke test and the
 # setup script all drive the SAME tree, and every entry point runs
-# `git clean -fdq`, so a second run would delete the live agent's uncommitted
+# `git clean -fdxq`, so a second run would delete the live agent's uncommitted
 # work mid-write with both runs reporting success. The plist pre-reset and
 # setup_documentation_nightly.sh both stand down on this lock, so it has to exist.
 # mkdir is the atomic primitive here: flock(1) does not exist on macOS.
@@ -47,7 +47,7 @@ acquire_runner_lock() {
       # No pid yet means the winner is between its mkdir and its pid write.
       # That window used to skip the `kill -0` test entirely — the loser read
       # an empty pid, called the lock stale, `rm -rf`d it and took it, and two
-      # cycles then ran `git clean -fdq` in the same clone. Absent evidence is
+      # cycles then ran `git clean -fdxq` in the same clone. Absent evidence is
       # not evidence of staleness. R-411.
       echo "weekend runner lock held (pid not yet published): $dir" >&2
       return 1
@@ -106,7 +106,9 @@ MODE="${1:?usage: documentation_nightly.sh audit|remediate|cycle}"
 
 REPO="${RADON_WEEKEND_REPO:-$HOME/radon-weekend/radon-documentation}"
 WEEKEND_ROOT="$(dirname "$REPO")"
-VENV="$WEEKEND_ROOT/venv"
+# Per-loop venv. The legacy $WEEKEND_ROOT/venv is not deleted here
+# (operator follow-up after this ships).
+VENV="$WEEKEND_ROOT/venv-documentation"
 # Activate the venv so any python3.13 calls inside the agent use it.
 [[ -f "$VENV/bin/activate" ]] && export PATH="$VENV/bin:$PATH"
 DEADMAN_TITLE="Nightly documentation runner"
@@ -207,7 +209,7 @@ kill_round_group() {
   # process-group leader, so the negative pid reaches claude and anything it
   # left behind. --foreground would signal only timeout's direct child, which
   # is the opposite of what reaping orphaned subagents needs — they would keep
-  # writing into the clone while the next round runs `git clean -fdq`. R-386.
+  # writing into the clone while the next round runs `git clean -fdxq`. R-386.
   kill -TERM -- "-$ROUND_PID" 2>/dev/null || kill -TERM "$ROUND_PID" 2>/dev/null || true
   ROUND_PID=""
 }
@@ -332,7 +334,7 @@ ground_truth() {
   fetch_origin_with_retry
   git checkout -f --quiet main
   git reset --hard --quiet origin/main
-  git clean -fdq --exclude=.radon-weekend-runner --exclude=.radon-documentation-runner --exclude=.weekend-runner.lock --exclude=logs/ --exclude=.env --exclude=.env.ib-mode --exclude=web/.env
+  git clean -fdxq --exclude=.radon-weekend-runner --exclude=.radon-documentation-runner --exclude=.weekend-runner.lock --exclude=logs/ --exclude=.env --exclude=.env.ib-mode --exclude=web/.env --exclude=node_modules/ --exclude=.next/ --exclude=.deepsec/
 }
 
 # The agent commits per completed task and the skill resumes from the

--- a/scripts/reliability_weekend.sh
+++ b/scripts/reliability_weekend.sh
@@ -24,7 +24,7 @@
 set -Eeuo pipefail
 
 # One writer per runner clone. Both weekend plists drive the SAME tree and
-# every entry point (and continuation round) runs `git clean -fdq`, so a
+# every entry point (and continuation round) runs `git clean -fdxq`, so a
 # missed Saturday audit firing on wake near the Sunday slot would delete
 # remediate's uncommitted work mid-write with both runs reporting success.
 # mkdir is the atomic primitive here: flock(1) does not exist on macOS.
@@ -36,7 +36,7 @@ acquire_runner_lock() {
       # No pid yet means the winner is between its mkdir and its pid write.
       # That window used to skip the `kill -0` test entirely — the loser read
       # an empty pid, called the lock stale, `rm -rf`d it and took it, and two
-      # cycles then ran `git clean -fdq` in the same clone. Absent evidence is
+      # cycles then ran `git clean -fdxq` in the same clone. Absent evidence is
       # not evidence of staleness. R-411.
       echo "weekend runner lock held (pid not yet published): $dir" >&2
       return 1
@@ -110,7 +110,9 @@ MODE="${1:?usage: reliability_weekend.sh audit|remediate|cycle}"
 
 REPO="${RADON_WEEKEND_REPO:-$HOME/radon-weekend/radon}"
 WEEKEND_ROOT="$(dirname "$REPO")"
-VENV="$WEEKEND_ROOT/venv"
+# Per-loop venv. The legacy $WEEKEND_ROOT/venv is not deleted here
+# (operator follow-up after this ships).
+VENV="$WEEKEND_ROOT/venv-reliability"
 # Activate the venv so any python3.13 calls inside the agent use it.
 [[ -f "$VENV/bin/activate" ]] && export PATH="$VENV/bin:$PATH"
 DEADMAN_TITLE="Nightly reliability runner"
@@ -211,7 +213,7 @@ kill_round_group() {
   # process-group leader, so the negative pid reaches claude and anything it
   # left behind. --foreground would signal only timeout's direct child, which
   # is the opposite of what reaping orphaned subagents needs — they would keep
-  # writing into the clone while the next round runs `git clean -fdq`. R-386.
+  # writing into the clone while the next round runs `git clean -fdxq`. R-386.
   kill -TERM -- "-$ROUND_PID" 2>/dev/null || kill -TERM "$ROUND_PID" 2>/dev/null || true
   ROUND_PID=""
 }
@@ -339,7 +341,7 @@ reground_for_continuation() {
   rm -f .git/index.lock
   git checkout -f --quiet main \
     && git reset --hard --quiet origin/main \
-    && git clean -fdq --exclude=.radon-weekend-runner --exclude=.radon-reliability-runner --exclude=.weekend-runner.lock --exclude=logs/ --exclude=.env --exclude=.env.ib-mode --exclude=web/.env
+    && git clean -fdxq --exclude=.radon-weekend-runner --exclude=.radon-reliability-runner --exclude=.weekend-runner.lock --exclude=logs/ --exclude=.env --exclude=.env.ib-mode --exclude=web/.env --exclude=node_modules/ --exclude=.next/ --exclude=.deepsec/
 }
 
 ground_truth() {
@@ -347,7 +349,7 @@ ground_truth() {
   fetch_origin_with_retry
   git checkout -f --quiet main
   git reset --hard --quiet origin/main
-  git clean -fdq --exclude=.radon-weekend-runner --exclude=.radon-reliability-runner --exclude=.weekend-runner.lock --exclude=logs/ --exclude=.env --exclude=.env.ib-mode --exclude=web/.env
+  git clean -fdxq --exclude=.radon-weekend-runner --exclude=.radon-reliability-runner --exclude=.weekend-runner.lock --exclude=logs/ --exclude=.env --exclude=.env.ib-mode --exclude=web/.env --exclude=node_modules/ --exclude=.next/ --exclude=.deepsec/
 }
 
 # The agent commits per completed task and the skill resumes from the

--- a/scripts/security_nightly.sh
+++ b/scripts/security_nightly.sh
@@ -45,7 +45,7 @@ set -Eeuo pipefail
 
 # One writer per runner clone. The daily fire, a hand-run smoke test and the
 # setup script all drive the SAME tree, and every entry point runs
-# `git clean -fdq`, so a second run would delete the live agent's uncommitted
+# `git clean -fdxq`, so a second run would delete the live agent's uncommitted
 # work mid-write with both runs reporting success. The plist pre-reset and
 # setup_security_nightly.sh both stand down on this lock, so it has to exist.
 # mkdir is the atomic primitive here: flock(1) does not exist on macOS.
@@ -57,7 +57,7 @@ acquire_runner_lock() {
       # No pid yet means the winner is between its mkdir and its pid write.
       # That window used to skip the `kill -0` test entirely — the loser read
       # an empty pid, called the lock stale, `rm -rf`d it and took it, and two
-      # cycles then ran `git clean -fdq` in the same clone. Absent evidence is
+      # cycles then ran `git clean -fdxq` in the same clone. Absent evidence is
       # not evidence of staleness. R-411.
       echo "weekend runner lock held (pid not yet published): $dir" >&2
       return 1
@@ -116,7 +116,9 @@ MODE="${1:?usage: security_nightly.sh audit|remediate|cycle}"
 
 REPO="${RADON_WEEKEND_REPO:-$HOME/radon-weekend/radon-security}"
 WEEKEND_ROOT="$(dirname "$REPO")"
-VENV="$WEEKEND_ROOT/venv"
+# Per-loop venv. The legacy $WEEKEND_ROOT/venv is not deleted here
+# (operator follow-up after this ships).
+VENV="$WEEKEND_ROOT/venv-security"
 # Activate the venv so any python3.13 calls inside the agent use it.
 [[ -f "$VENV/bin/activate" ]] && export PATH="$VENV/bin:$PATH"
 DEADMAN_TITLE="Nightly security runner"
@@ -229,7 +231,7 @@ kill_round_group() {
   # process-group leader, so the negative pid reaches claude and anything it
   # left behind. --foreground would signal only timeout's direct child, which
   # is the opposite of what reaping orphaned subagents needs — they would keep
-  # writing into the clone while the next round runs `git clean -fdq`. R-386.
+  # writing into the clone while the next round runs `git clean -fdxq`. R-386.
   kill -TERM -- "-$ROUND_PID" 2>/dev/null || kill -TERM "$ROUND_PID" 2>/dev/null || true
   ROUND_PID=""
 }
@@ -384,7 +386,7 @@ ground_truth() {
   fetch_origin_with_retry
   git checkout -f --quiet main
   git reset --hard --quiet origin/main
-  git clean -fdq --exclude=.radon-weekend-runner --exclude=.radon-security-runner --exclude=.weekend-runner.lock --exclude=logs/ --exclude=.env --exclude=.env.ib-mode --exclude=web/.env
+  git clean -fdxq --exclude=.radon-weekend-runner --exclude=.radon-security-runner --exclude=.weekend-runner.lock --exclude=logs/ --exclude=.env --exclude=.env.ib-mode --exclude=web/.env --exclude=node_modules/ --exclude=.next/ --exclude=.deepsec/
 }
 
 # The agent commits per completed task and the skill resumes from the

--- a/scripts/setup_ci_performance.sh
+++ b/scripts/setup_ci_performance.sh
@@ -17,7 +17,9 @@ set -euo pipefail
 
 WEEKEND_ROOT="${RADON_WEEKEND_ROOT:-$HOME/radon-weekend}"
 WEEKEND_REPO="$WEEKEND_ROOT/radon-ci-performance"
-WEEKEND_VENV="$WEEKEND_ROOT/venv"
+# Per-loop venv. The legacy $WEEKEND_ROOT/venv is not deleted here
+# (operator follow-up after this ships).
+WEEKEND_VENV="$WEEKEND_ROOT/venv-ci-performance"
 # Pushover creds for the per-phase page. Lives OUTSIDE the runner clone:
 # every round hard-resets and cleans that clone.
 WEEKEND_ENV="$WEEKEND_ROOT/.env"
@@ -83,18 +85,13 @@ if kill -0 "$(cat "$WEEKEND_REPO/.weekend-runner.lock/pid" 2>/dev/null)" 2>/dev/
   echo "  a weekend run is in flight in $WEEKEND_REPO; re-run when it finishes"
   exit 1
 fi
-# Every SIBLING loop's clone too. WEEKEND_VENV is literally the same path in
-# all three setups, and every wrapper prepends it to the running agent's PATH
-# — so the `python3.13 -m venv` + `pip install` below would mutate the
-# interpreter and site-packages a live sibling agent is executing against,
-# mid-run. The guard above was written for the clone ("A live cycle owns this
-# clone") and never extended to the shared $WEEKEND_ROOT the loops depend
-# on. R-266.
+# Every SIBLING loop's clone too. Each loop now has its own venv; the
+# lock stays so a setup does not race a live sibling. R-266.
 for SIBLING_REPO in "$WEEKEND_ROOT/radon" "$WEEKEND_ROOT/radon-testing" \
   "$WEEKEND_ROOT/radon-documentation" "$WEEKEND_ROOT/radon-security"; do
   if [[ -d "$SIBLING_REPO" ]] \
     && kill -0 "$(cat "$SIBLING_REPO/.weekend-runner.lock/pid" 2>/dev/null)" 2>/dev/null; then
-    echo "  a weekend run is in flight in $SIBLING_REPO and shares $WEEKEND_VENV; re-run when it finishes"
+    echo "  a weekend run is in flight in $SIBLING_REPO; re-run when it finishes"
     exit 1
   fi
 done

--- a/scripts/setup_documentation_nightly.sh
+++ b/scripts/setup_documentation_nightly.sh
@@ -17,7 +17,9 @@ set -euo pipefail
 
 WEEKEND_ROOT="${RADON_WEEKEND_ROOT:-$HOME/radon-weekend}"
 WEEKEND_REPO="$WEEKEND_ROOT/radon-documentation"
-WEEKEND_VENV="$WEEKEND_ROOT/venv"
+# Per-loop venv. The legacy $WEEKEND_ROOT/venv is not deleted here
+# (operator follow-up after this ships).
+WEEKEND_VENV="$WEEKEND_ROOT/venv-documentation"
 # Pushover creds for the per-phase page. Lives OUTSIDE the runner clone:
 # every round hard-resets and cleans that clone.
 WEEKEND_ENV="$WEEKEND_ROOT/.env"
@@ -83,17 +85,13 @@ if kill -0 "$(cat "$WEEKEND_REPO/.weekend-runner.lock/pid" 2>/dev/null)" 2>/dev/
   echo "  a weekend run is in flight in $WEEKEND_REPO; re-run when it finishes"
   exit 1
 fi
-# The SIBLING loop's clone too. WEEKEND_VENV is literally the same path in
-# both setups, and both wrappers prepend it to the running agent's PATH — so
-# the `python3.13 -m venv` + `pip install` below would mutate the interpreter
-# and site-packages a live reliability agent is executing against, mid-run.
-# The guard above was written for the clone ("A live cycle owns this clone")
-# and never extended to the shared $WEEKEND_ROOT both loops depend on. R-266.
+# The SIBLING loop's clone too. Each loop now has its own venv; the
+# lock stays so a setup does not race a live sibling. R-266.
 for SIBLING_REPO in "$WEEKEND_ROOT/radon" "$WEEKEND_ROOT/radon-testing" \
   "$WEEKEND_ROOT/radon-ci-performance" "$WEEKEND_ROOT/radon-security"; do
   if [[ -d "$SIBLING_REPO" ]] \
     && kill -0 "$(cat "$SIBLING_REPO/.weekend-runner.lock/pid" 2>/dev/null)" 2>/dev/null; then
-    echo "  a weekend run is in flight in $SIBLING_REPO and shares $WEEKEND_VENV; re-run when it finishes"
+    echo "  a weekend run is in flight in $SIBLING_REPO; re-run when it finishes"
     exit 1
   fi
 done

--- a/scripts/setup_reliability_weekend.sh
+++ b/scripts/setup_reliability_weekend.sh
@@ -12,7 +12,9 @@ set -euo pipefail
 
 WEEKEND_ROOT="${RADON_WEEKEND_ROOT:-$HOME/radon-weekend}"
 WEEKEND_REPO="$WEEKEND_ROOT/radon"
-WEEKEND_VENV="$WEEKEND_ROOT/venv"
+# Per-loop venv. The legacy $WEEKEND_ROOT/venv is not deleted here
+# (operator follow-up after this ships).
+WEEKEND_VENV="$WEEKEND_ROOT/venv-reliability"
 # Pushover creds for the per-phase page. Lives OUTSIDE the runner clone:
 # every round hard-resets and cleans that clone.
 WEEKEND_ENV="$WEEKEND_ROOT/.env"
@@ -83,17 +85,13 @@ if kill -0 "$(cat "$WEEKEND_REPO/.weekend-runner.lock/pid" 2>/dev/null)" 2>/dev/
   echo "  a weekend run is in flight in $WEEKEND_REPO; re-run when it finishes"
   exit 1
 fi
-# The SIBLING loop's clone too. WEEKEND_VENV is literally the same path in
-# both setups, and both wrappers prepend it to the running agent's PATH — so
-# the `python3.13 -m venv` + `pip install` below would mutate the interpreter
-# and site-packages a live testing agent is executing against, mid-run.
-# The guard above was written for the clone ("A live cycle owns this clone")
-# and never extended to the shared $WEEKEND_ROOT both loops depend on. R-266.
+# The SIBLING loop's clone too. Each loop now has its own venv; the
+# lock stays so a setup does not race a live sibling. R-266.
 for SIBLING_REPO in "$WEEKEND_ROOT/radon-testing" "$WEEKEND_ROOT/radon-ci-performance" \
   "$WEEKEND_ROOT/radon-documentation" "$WEEKEND_ROOT/radon-security"; do
   if [[ -d "$SIBLING_REPO" ]] \
     && kill -0 "$(cat "$SIBLING_REPO/.weekend-runner.lock/pid" 2>/dev/null)" 2>/dev/null; then
-    echo "  a weekend run is in flight in $SIBLING_REPO and shares $WEEKEND_VENV; re-run when it finishes"
+    echo "  a weekend run is in flight in $SIBLING_REPO; re-run when it finishes"
     exit 1
   fi
 done

--- a/scripts/setup_security_nightly.sh
+++ b/scripts/setup_security_nightly.sh
@@ -23,7 +23,9 @@ set -euo pipefail
 
 WEEKEND_ROOT="${RADON_WEEKEND_ROOT:-$HOME/radon-weekend}"
 WEEKEND_REPO="$WEEKEND_ROOT/radon-security"
-WEEKEND_VENV="$WEEKEND_ROOT/venv"
+# Per-loop venv. The legacy $WEEKEND_ROOT/venv is not deleted here
+# (operator follow-up after this ships).
+WEEKEND_VENV="$WEEKEND_ROOT/venv-security"
 # Pushover creds for the per-phase page. Lives OUTSIDE the runner clone:
 # every round hard-resets and cleans that clone.
 WEEKEND_ENV="$WEEKEND_ROOT/.env"
@@ -101,17 +103,13 @@ if kill -0 "$(cat "$WEEKEND_REPO/.weekend-runner.lock/pid" 2>/dev/null)" 2>/dev/
   echo "  a weekend run is in flight in $WEEKEND_REPO; re-run when it finishes"
   exit 1
 fi
-# The SIBLING loop's clone too. WEEKEND_VENV is literally the same path in
-# both setups, and both wrappers prepend it to the running agent's PATH — so
-# the `python3.13 -m venv` + `pip install` below would mutate the interpreter
-# and site-packages a live reliability agent is executing against, mid-run.
-# The guard above was written for the clone ("A live cycle owns this clone")
-# and never extended to the shared $WEEKEND_ROOT both loops depend on. R-266.
+# The SIBLING loop's clone too. Each loop now has its own venv; the
+# lock stays so a setup does not race a live sibling. R-266.
 for SIBLING_REPO in "$WEEKEND_ROOT/radon" "$WEEKEND_ROOT/radon-testing" \
   "$WEEKEND_ROOT/radon-ci-performance" "$WEEKEND_ROOT/radon-documentation"; do
   if [[ -d "$SIBLING_REPO" ]] \
     && kill -0 "$(cat "$SIBLING_REPO/.weekend-runner.lock/pid" 2>/dev/null)" 2>/dev/null; then
-    echo "  a weekend run is in flight in $SIBLING_REPO and shares $WEEKEND_VENV; re-run when it finishes"
+    echo "  a weekend run is in flight in $SIBLING_REPO; re-run when it finishes"
     exit 1
   fi
 done

--- a/scripts/setup_testing_weekend.sh
+++ b/scripts/setup_testing_weekend.sh
@@ -17,7 +17,9 @@ set -euo pipefail
 
 WEEKEND_ROOT="${RADON_WEEKEND_ROOT:-$HOME/radon-weekend}"
 WEEKEND_REPO="$WEEKEND_ROOT/radon-testing"
-WEEKEND_VENV="$WEEKEND_ROOT/venv"
+# Per-loop venv. The legacy $WEEKEND_ROOT/venv is not deleted here
+# (operator follow-up after this ships).
+WEEKEND_VENV="$WEEKEND_ROOT/venv-testing"
 # Pushover creds for the per-phase page. Lives OUTSIDE the runner clone:
 # every round hard-resets and cleans that clone.
 WEEKEND_ENV="$WEEKEND_ROOT/.env"
@@ -83,17 +85,13 @@ if kill -0 "$(cat "$WEEKEND_REPO/.weekend-runner.lock/pid" 2>/dev/null)" 2>/dev/
   echo "  a weekend run is in flight in $WEEKEND_REPO; re-run when it finishes"
   exit 1
 fi
-# The SIBLING loop's clone too. WEEKEND_VENV is literally the same path in
-# both setups, and both wrappers prepend it to the running agent's PATH — so
-# the `python3.13 -m venv` + `pip install` below would mutate the interpreter
-# and site-packages a live reliability agent is executing against, mid-run.
-# The guard above was written for the clone ("A live cycle owns this clone")
-# and never extended to the shared $WEEKEND_ROOT both loops depend on. R-266.
+# The SIBLING loop's clone too. Each loop now has its own venv; the
+# lock stays so a setup does not race a live sibling. R-266.
 for SIBLING_REPO in "$WEEKEND_ROOT/radon" "$WEEKEND_ROOT/radon-ci-performance" \
   "$WEEKEND_ROOT/radon-documentation" "$WEEKEND_ROOT/radon-security"; do
   if [[ -d "$SIBLING_REPO" ]] \
     && kill -0 "$(cat "$SIBLING_REPO/.weekend-runner.lock/pid" 2>/dev/null)" 2>/dev/null; then
-    echo "  a weekend run is in flight in $SIBLING_REPO and shares $WEEKEND_VENV; re-run when it finishes"
+    echo "  a weekend run is in flight in $SIBLING_REPO; re-run when it finishes"
     exit 1
   fi
 done

--- a/scripts/testing_weekend.sh
+++ b/scripts/testing_weekend.sh
@@ -34,7 +34,7 @@ set -Eeuo pipefail
 
 # One writer per runner clone. The daily fire, a hand-run smoke test and the
 # setup script all drive the SAME tree, and every entry point runs
-# `git clean -fdq`, so a second run would delete the live agent's uncommitted
+# `git clean -fdxq`, so a second run would delete the live agent's uncommitted
 # work mid-write with both runs reporting success. The plist pre-reset and
 # setup_testing_weekend.sh both stand down on this lock, so it has to exist.
 # mkdir is the atomic primitive here: flock(1) does not exist on macOS.
@@ -46,7 +46,7 @@ acquire_runner_lock() {
       # No pid yet means the winner is between its mkdir and its pid write.
       # That window used to skip the `kill -0` test entirely — the loser read
       # an empty pid, called the lock stale, `rm -rf`d it and took it, and two
-      # cycles then ran `git clean -fdq` in the same clone. Absent evidence is
+      # cycles then ran `git clean -fdxq` in the same clone. Absent evidence is
       # not evidence of staleness. R-411.
       echo "weekend runner lock held (pid not yet published): $dir" >&2
       return 1
@@ -105,7 +105,9 @@ MODE="${1:?usage: testing_weekend.sh audit|remediate|cycle}"
 
 REPO="${RADON_WEEKEND_REPO:-$HOME/radon-weekend/radon-testing}"
 WEEKEND_ROOT="$(dirname "$REPO")"
-VENV="$WEEKEND_ROOT/venv"
+# Per-loop venv. The legacy $WEEKEND_ROOT/venv is not deleted here
+# (operator follow-up after this ships).
+VENV="$WEEKEND_ROOT/venv-testing"
 # Activate the venv so any python3.13 calls inside the agent use it.
 [[ -f "$VENV/bin/activate" ]] && export PATH="$VENV/bin:$PATH"
 DEADMAN_TITLE="Nightly testing runner"
@@ -228,7 +230,7 @@ kill_round_group() {
   # process-group leader, so the negative pid reaches claude and anything it
   # left behind. --foreground would signal only timeout's direct child, which
   # is the opposite of what reaping orphaned subagents needs — they would keep
-  # writing into the clone while the next round runs `git clean -fdq`. R-386.
+  # writing into the clone while the next round runs `git clean -fdxq`. R-386.
   kill -TERM -- "-$ROUND_PID" 2>/dev/null || kill -TERM "$ROUND_PID" 2>/dev/null || true
   ROUND_PID=""
 }
@@ -353,7 +355,7 @@ ground_truth() {
   fetch_origin_with_retry
   git checkout -f --quiet main
   git reset --hard --quiet origin/main
-  git clean -fdq --exclude=.radon-weekend-runner --exclude=.radon-testing-runner --exclude=.weekend-runner.lock --exclude=logs/ --exclude=.env --exclude=.env.ib-mode --exclude=web/.env
+  git clean -fdxq --exclude=.radon-weekend-runner --exclude=.radon-testing-runner --exclude=.weekend-runner.lock --exclude=logs/ --exclude=.env --exclude=.env.ib-mode --exclude=web/.env --exclude=node_modules/ --exclude=.next/ --exclude=.deepsec/
 }
 
 # The agent commits per completed task and the skill resumes from the

--- a/scripts/tests/test_ci_performance_loop_contract.py
+++ b/scripts/tests/test_ci_performance_loop_contract.py
@@ -1,7 +1,7 @@
 """The nightly CI/deploy performance loop's own identity contract.
 
 The three nightly loops share one wrapper shape, one runner-lock primitive and
-one `$WEEKEND_ROOT/venv`, and all three fire at 00:00. Everything that keeps
+per-loop venvs, and all three fire at 00:00. Everything that keeps
 them from destroying each other is a NAME: the clone directory, the dead-man
 label, the PR branch prefix, the log directory, the launchd label and the
 skill the wrapper invokes. A copy-paste that leaves one of those pointing at a
@@ -178,11 +178,10 @@ class TestSetupProvisionsTheDeadmanLabel:
 
     @pytest.mark.parametrize("sibling", ("radon", "radon-testing", "radon-documentation", "radon-security"))
     def test_setup_stands_down_on_every_sibling_lock(self, sibling):
-        """All three setups write the SAME `$WEEKEND_ROOT/venv`.
+        """Each setup writes its own `$WEEKEND_ROOT/venv-<loop>`.
 
-        Re-creating it re-installs site-packages under whichever sibling agent
-        is mid-run, because every wrapper prepends that venv to the agent's
-        PATH. R-266 fixed this for two loops; a third makes the guard a set.
+        Sibling in-flight locks stay so a setup still stands down on a live
+        sibling clone. R-266.
         """
         body = _uncommented(SETUP)
         install = body[: body.index("python3.13 -m venv")]

--- a/scripts/tests/test_documentation_loop_contract.py
+++ b/scripts/tests/test_documentation_loop_contract.py
@@ -1,7 +1,7 @@
 """The nightly documentation loop's own identity contract.
 
 The four nightly loops share one wrapper shape, one runner-lock primitive and
-one `$WEEKEND_ROOT/venv`, and all four fire at 00:00. Everything that keeps
+per-loop venvs, and all four fire at 00:00. Everything that keeps
 them from destroying each other is a NAME: the clone directory, the dead-man
 label, the PR branch prefix, the log directory, the launchd label and the
 skill the wrapper invokes. A copy-paste that leaves one of those pointing at a
@@ -201,12 +201,10 @@ class TestSetupProvisionsTheDeadmanLabel:
         "sibling", ("radon", "radon-testing", "radon-ci-performance", "radon-security")
     )
     def test_setup_stands_down_on_every_sibling_lock(self, sibling):
-        """All four setups write the SAME `$WEEKEND_ROOT/venv`.
+        """Each setup writes its own `$WEEKEND_ROOT/venv-<loop>`.
 
-        Re-creating it re-installs site-packages under whichever sibling agent
-        is mid-run, because every wrapper prepends that venv to the agent's
-        PATH. R-266 fixed this for two loops; every further loop extends the
-        guard set.
+        Sibling in-flight locks stay so a setup still stands down on a live
+        sibling clone. R-266.
         """
         body = _uncommented(SETUP)
         install = body[: body.index("python3.13 -m venv")]

--- a/scripts/tests/test_security_loop_contract.py
+++ b/scripts/tests/test_security_loop_contract.py
@@ -1,7 +1,7 @@
 """The nightly security loop's own identity and isolation contract.
 
 The five nightly loops share one wrapper shape, one runner-lock primitive and
-one `$WEEKEND_ROOT/venv`, and all five fire at 00:00. The security loop is the
+per-loop venvs, and all five fire at 00:00. The security loop is the
 one that must NEVER: run in a sibling clone or the operator checkout, receive a
 Radon credential, or leak a scanner artifact into the public repository. Those
 three properties are enforced by concrete, testable facts asserted here — the
@@ -385,7 +385,7 @@ class TestTheSetupIsCredentialFree:
         (clone / "config").mkdir()
         (clone / "requirements.txt").write_text("", encoding="utf-8")
         shutil.copy(PLIST, clone / "config" / PLIST.name)
-        venv_bin = root / "venv" / "bin"
+        venv_bin = root / "venv-security" / "bin"
         venv_bin.mkdir(parents=True)
         for tool in ("python", "pip"):
             exe = venv_bin / tool

--- a/scripts/tests/test_weekend_loop_deadman.py
+++ b/scripts/tests/test_weekend_loop_deadman.py
@@ -301,13 +301,12 @@ class TestRotationSparesTheLaunchdSinks:
         assert survivors[0] == "audit-20260827T000008.log", survivors[0]
 
 
-class TestSetupGuardsTheSharedVenv:
-    """R-266: `WEEKEND_VENV` is the same path in both setup scripts.
+class TestSetupGuardsPerLoopVenvs:
+    """Each full-permission loop prepends its own venv to PATH.
 
-    Both wrappers prepend it to the running agent's `PATH`, so running one
-    setup while the other loop's cycle is live re-creates the interpreter and
-    re-installs site-packages under a running agent. The in-flight guard was
-    written for the clone and never extended to the shared root.
+    The five setups previously wrote one `$WEEKEND_ROOT/venv`. The shared
+    path is not deleted here (operator follow-up). Sibling in-flight
+    locks stay so a setup still stands down on a live sibling clone.
     """
 
     SETUPS = {
@@ -317,15 +316,48 @@ class TestSetupGuardsTheSharedVenv:
         "documentation": REPO / "scripts" / "setup_documentation_nightly.sh",
         "security": REPO / "scripts" / "setup_security_nightly.sh",
     }
+    WRAPPERS = {
+        "reliability": REPO / "scripts" / "reliability_weekend.sh",
+        "testing": REPO / "scripts" / "testing_weekend.sh",
+        "ci-performance": REPO / "scripts" / "ci_performance_nightly.sh",
+        "documentation": REPO / "scripts" / "documentation_nightly.sh",
+        "security": REPO / "scripts" / "security_nightly.sh",
+    }
+    VENV_DIR = {
+        "reliability": "$WEEKEND_ROOT/venv-reliability",
+        "testing": "$WEEKEND_ROOT/venv-testing",
+        "ci-performance": "$WEEKEND_ROOT/venv-ci-performance",
+        "documentation": "$WEEKEND_ROOT/venv-documentation",
+        "security": "$WEEKEND_ROOT/venv-security",
+    }
 
-    def test_the_two_setups_really_do_share_a_venv(self):
+    def test_each_setup_writes_a_distinct_venv(self):
         venvs = {
             name: re.search(r'WEEKEND_VENV="([^"]+)"', path.read_text(encoding="utf-8")).group(1)
             for name, path in self.SETUPS.items()
         }
-        assert len(set(venvs.values())) == 1, (
-            f"precondition changed: {venvs}"
-        )
+        assert venvs == self.VENV_DIR, venvs
+        assert len(set(venvs.values())) == len(venvs)
+        assert "$WEEKEND_ROOT/venv" not in venvs.values()
+
+    def test_each_wrapper_prepends_its_own_venv(self):
+        for name, path in self.WRAPPERS.items():
+            body = path.read_text(encoding="utf-8")
+            match = re.search(r'^VENV="([^"]+)"', body, re.M)
+            assert match, f"{name} wrapper lost VENV="
+            assert match.group(1) == self.VENV_DIR[name], (name, match.group(1))
+            assert 'VENV="$WEEKEND_ROOT/venv"' not in body
+
+    def test_no_setup_deletes_the_legacy_shared_venv(self):
+        for name, path in self.SETUPS.items():
+            uncommented = "\n".join(
+                line for line in path.read_text(encoding="utf-8").splitlines()
+                if not line.lstrip().startswith("#")
+            )
+            assert not re.search(r"\brm\b.*\$WEEKEND_ROOT/venv\b", uncommented), (
+                f"{name} setup deletes the legacy shared venv; operator removal "
+                "is a follow-up after this ships"
+            )
 
     @pytest.mark.parametrize("name", ["reliability", "testing", "ci-performance", "documentation", "security"])
     def test_each_setup_checks_the_sibling_clone_lock(self, name):
@@ -337,7 +369,7 @@ class TestSetupGuardsTheSharedVenv:
         )
         install = body[: body.index("python3.13 -m venv")]
         assert "SIBLING_REPO" in install, (
-            f"{name} setup re-creates the shared venv without checking whether "
+            f"{name} setup re-creates the venv without checking whether "
             "the other loop's cycle is executing against it"
         )
 

--- a/scripts/tests/test_weekend_runner_env_provisioning.py
+++ b/scripts/tests/test_weekend_runner_env_provisioning.py
@@ -124,8 +124,14 @@ def _stage(tmp_path: Path, name: str) -> tuple[Path, Path, dict]:
     (clone / "requirements.txt").write_text("", encoding="utf-8")
     shutil.copy(REPO / "config" / PLISTS[name], clone / "config" / PLISTS[name])
 
-    # The venv the toolchain check and the pip lines address.
-    venv_bin = root / "venv" / "bin"
+    # The venv the toolchain check and the pip lines address. Per-loop.
+    venv_name = {
+        "reliability": "venv-reliability",
+        "testing": "venv-testing",
+        "ci-performance": "venv-ci-performance",
+        "documentation": "venv-documentation",
+    }[name]
+    venv_bin = root / venv_name / "bin"
     venv_bin.mkdir(parents=True)
     for tool in ("python", "pip"):
         exe = venv_bin / tool

--- a/scripts/tests/test_weekend_wrapper_self_rewrite.py
+++ b/scripts/tests/test_weekend_wrapper_self_rewrite.py
@@ -541,6 +541,29 @@ class TestTheRunnerLockIsTakenOnce:
             if "git clean" in line and not line.strip().startswith("#"):
                 assert "--exclude=.weekend-runner.lock" in line, line
 
+    @pytest.mark.parametrize("loop", LOOP_IDS)
+    def test_hard_reset_cleans_ignored_agent_files_and_keeps_env_cache(self, loop: str) -> None:
+        """-x drops leftover ignored skills/settings; --exclude keeps env/build-cache."""
+        src = (REPO / "scripts" / LOOPS[loop][0]).read_text(encoding="utf-8")
+        cleans = [
+            line for line in src.splitlines()
+            if "git clean" in line and not line.strip().startswith("#")
+        ]
+        assert cleans, f"{loop} wrapper lost git clean"
+        for line in cleans:
+            assert "git clean -fdxq" in line, line
+            for kept in (
+                "--exclude=.env",
+                "--exclude=.env.ib-mode",
+                "--exclude=web/.env",
+                "--exclude=node_modules/",
+                "--exclude=.next/",
+                "--exclude=.deepsec/",
+                "--exclude=logs/",
+            ):
+                assert kept in line, (loop, kept, line)
+            assert "--exclude=.claude" not in line, line
+
 
 class TestTheJobRestoresTheEntryPointBeforeReadingIt:
     """A wrapper left corrupt on disk dies at the top, before the ground_truth

--- a/web/app/api/admin/services/[unit]/[action]/route.ts
+++ b/web/app/api/admin/services/[unit]/[action]/route.ts
@@ -12,6 +12,32 @@ export const runtime = "nodejs";
 
 const ALLOWED_ACTIONS = new Set(["start", "stop", "restart"]);
 const UNIT_PATTERN = /^radon-[a-z0-9-]+(?:\.service|\.timer)?$|^radon-ib-gateway\.service$/;
+// systemd unit types. A name with none of these suffixes is a .service —
+// matching the FastAPI canonicalize_unit_name helper. Interlock checks
+// (denylist, broker restart lease, privileged-action gate) must see the
+// canonical spelling or they compare against a different string than
+// systemctl does.
+const UNIT_TYPE_SUFFIXES = [
+  ".service",
+  ".socket",
+  ".target",
+  ".device",
+  ".mount",
+  ".automount",
+  ".swap",
+  ".timer",
+  ".path",
+  ".slice",
+  ".scope",
+  ".snapshot",
+] as const;
+
+function canonicalizeUnitName(unit: string): string {
+  const name = unit.trim();
+  if (!name) return name;
+  if (UNIT_TYPE_SUFFIXES.some((suffix) => name.endsWith(suffix))) return name;
+  return `${name}.service`;
+}
 
 export const radonCapability = "admin";
 
@@ -22,7 +48,8 @@ export async function POST(
   const access = await requireRouteAccess(undefined, { operatorOnly: true });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
-  const { unit, action } = await params;
+  const { unit: rawUnit, action } = await params;
+  const unit = canonicalizeUnitName(rawUnit);
 
   if (!UNIT_PATTERN.test(unit)) {
     return setNoStoreResponseHeaders(

--- a/web/tests/api-routes-smoke-admin.test.ts
+++ b/web/tests/api-routes-smoke-admin.test.ts
@@ -182,6 +182,22 @@ describe("POST /api/admin/services/[unit]/[action]", () => {
     );
   });
 
+  it("canonicalizes an unsuffixed unit name before forwarding", async () => {
+    mockRadonFetch.mockResolvedValueOnce({ ok: true, unit: "radon-api.service" });
+    const { POST } = await import(
+      "../app/api/admin/services/[unit]/[action]/route"
+    );
+    const res = await POST(
+      req("http://localhost/api/admin/services/radon-api/restart") as never,
+      { params: Promise.resolve({ unit: "radon-api", action: "restart" }) },
+    );
+    expect(res.status).toBe(200);
+    expect(mockRadonFetch).toHaveBeenCalledWith(
+      "/admin/services/radon-api.service/restart",
+      expect.objectContaining({ method: "POST", token: PRINCIPAL_TOKEN }),
+    );
+  });
+
   it("returns 400 when unit name is disallowed", async () => {
     const { POST } = await import(
       "../app/api/admin/services/[unit]/[action]/route"


### PR DESCRIPTION
## Issue discovered

Admin unit-name checks compared caller spelling while systemd treated two spellings as one unit, so denylist, gateway lease, and the privileged-action gate could be skipped. The per-minute live-order cap could be reused by repeating a client orderRef, including overlapping place calls that shared one in-flight slot. Nightly hard reset left ignored agent files in the clone. All five loops prepended one shared writable venv to PATH.

## What was done to fix it

Canonicalize the unit name (append `.service` when systemd would) before every interlock. Consume the live-order cap after use; overlapping `/orders/place` calls no longer skip on an in-flight orderRef; `/orders/replace` places through `_orders_place_after_rate_reservation` so one replace is one slot. Nightly wrappers `git clean -fdxq` with env/build-cache excludes. Each loop uses `$WEEKEND_ROOT/venv-<loop>`; the shared venv is not deleted.

## Next

Fixed with green deployment