### PR TITLE
fix(orders): live EXT close shows Working; Gate 3 does not frame a flatten as adding risk

### DIFF
--- a/scripts/tests/test_ib_place_order_contract_args.py
+++ b/scripts/tests/test_ib_place_order_contract_args.py
@@ -164,3 +164,37 @@ class TestLimitOrderKwargsContract:
 
         kwargs = limit_order_cls.call_args.kwargs
         assert kwargs["tif"] == "DAY", f"tif=DAY not verbatim: {kwargs}"
+
+    def test_stock_close_transmits_extended_eligible(self):
+        """2026-09-01 TQQQ flatten: a closing equity SELL placed for a live
+        extended session must be TRANSMITTED as extended-eligible in one shot
+        (DAY + outsideRth=True on the wire order), not held locally or sent
+        RTH-only. IB then works it in the current pre-market/after-hours
+        window; PreSubmitted from IB on such an order is a working state.
+
+        Quantity sits under the REL-005 notional cap on purpose: the cap is
+        its own control with its own tests, not part of this contract."""
+        client = _make_client(_make_trade(status="PreSubmitted"))
+        params = dict(
+            _BASE_PARAMS,
+            symbol="TQQQ",
+            action="SELL",
+            quantity=1_000,
+            limitPrice=68.80,
+            tif="DAY",
+            outsideRth=True,
+        )
+
+        result, limit_order_cls = _invoke_place_order(params, client)
+
+        assert result["status"] == "ok", f"extended close must transmit: {result}"
+        limit_order_cls.assert_called_once()
+        kwargs = limit_order_cls.call_args.kwargs
+        assert kwargs["action"] == "SELL"
+        assert kwargs["totalQuantity"] == 1_000
+        assert kwargs["lmtPrice"] == 68.80
+        assert kwargs["tif"] == "DAY"
+        assert kwargs["outsideRth"] is True, (
+            f"outsideRth must reach the IB order for an extended-session close: {kwargs}"
+        )
+        client.place_order.assert_called_once()

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,58 @@
+# Task: Orders EXT close QUEUED + Gate 3 blocks reduce (2026-09-02) [WIP]
+
+Live symptom (app.radon.run /orders, ~22:51 ET 2026-09-01): TQQQ Long Stock
+CLOSE, SELL 10,000 LMT 68.80, DAY + EXT, reads QUEUED; modify modal shows the
+Gate 3 critical breach (SMH+SPY+TQQQ 73.0% vs 2.5%) with "before adding
+correlated risk" copy on a flatten.
+
+Root causes (code-verified):
+1. `mapOrderStatus` maps IB `PreSubmitted` to "Queued" unconditionally. IB
+   holds extended-eligible equity orders in `PreSubmitted` while they are live
+   and fillable in the extended session, so the /orders status chip called a
+   working AH order QUEUED for the whole 16:00-20:00 window.
+2. `correlationRiskBanner` derives only from the held book; a working order
+   that CLOSES part of the breached cluster renders the same critical banner
+   and "adding" copy as an add. Gate 3 never actually gated `okToSubmit`, but
+   the surface read as a block on a flatten.
+
+## Dependency graph
+
+- T1 depends_on: [] - this plan
+- T2 depends_on: [] - `isExtendedFillLive(session)` in sessionWindow + tests
+- T3 depends_on: [T2] - `mapOrderStatus` PreSubmitted -> Working when the
+  extended fill window is live + tests
+- T4 depends_on: [T3] - wire into WorkspaceSections single rows + MobileOrderList
+- T5 depends_on: [] - `correlationRiskBanner(report, order)` reduce context:
+  breach cluster containing the reduce ticker suppressed (level "reduce",
+  banner absent); remaining breaches drop the "adding" copy on a close
+- T6 depends_on: [T5] - OrderRiskGate derives `{ticker, reducesExposure}` from
+  the risk input's closeOut and passes it to the banner
+- T7 depends_on: [T5, T6] - ModifyOrderModal test: breached report + stock
+  close -> no critical banner, armed Modify fires the full wire request
+- T8 depends_on: [] - scripts test: SELL stock close + outsideRth + DAY
+  transmits verbatim (LimitOrder kwargs + place_order called once)
+- T9 depends_on: [T4] - e2e orders-session-window: PreSubmitted EXT stock reads
+  WORKING at a frozen 17:30 ET clock, QUEUED at 21:00 ET
+- T10 depends_on: [T2..T9] - focused vitest + pytest, full web gate
+- T11 depends_on: [T10] - commit, push, PR (operator verification notes)
+
+## Checklist
+
+- [x] T2 sessionWindow helper — isExtendedFillLive, 4 unit cases
+- [x] T3 mapOrderStatus — PreSubmitted promotes only when the EXT window is live
+- [x] T4 surfaces wired — WorkspaceSections single rows + MobileOrderList
+- [x] T5 banner reduce context — level "reduce", no "adding" copy on a close
+- [x] T6 OrderRiskGate context — closeOut presence is the reduce signal
+- [x] T7 modal wire test — 5 passed (banner absent, closed gate silent, armed
+      click POSTs /api/orders/modify with exact payload)
+- [x] T8 scripts transmit test — 9 passed (SELL close DAY+outsideRth verbatim)
+- [x] T9 e2e — orders-session-window 3 passed (Working at 17:30 ET, Queued at
+      21:00 ET), modify-order-correlation-risk + mobile-orders-session green
+- [ ] T10 full test gates
+- [ ] T11 PR
+
+---
+
 # Task: Profile overhaul — preferences + secure credentials (2026-08-28) [WIP]
 
 Operator answers (2026-09-01): fold /preferences into profile + promote localStorage

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -48,8 +48,17 @@ Root causes (code-verified):
 - [x] T8 scripts transmit test — 9 passed (SELL close DAY+outsideRth verbatim)
 - [x] T9 e2e — orders-session-window 3 passed (Working at 17:30 ET, Queued at
       21:00 ET), modify-order-correlation-risk + mobile-orders-session green
-- [ ] T10 full test gates
-- [ ] T11 PR
+- [x] T10 full test gates — vitest 7990 passed, 10 skipped (1 unrelated
+      chat-image unhandled-rejection noise); pytest pins 21 passed
+- [x] T11 PR https://github.com/joemccann/radon/pull/236
+
+## Review
+- Status: PreSubmitted + live EXT window -> Working; after 20:00 ET -> Queued + EXT
+- Gate 3: reduce of a breached-cluster ticker renders no banner; add still critical
+- Wire: armed TQQQ close modify POSTs /api/orders/modify; closed gate fires nothing
+- Transmit: SELL stock close DAY + outsideRth=True on LimitOrder kwargs, one place_order
+- ARM/SPCX NEXT RTH left alone
+- Do not merge. Do not place a real IB order.
 
 ---
 

--- a/web/components/CorrelationRiskBanner.tsx
+++ b/web/components/CorrelationRiskBanner.tsx
@@ -3,6 +3,7 @@
 import { ShieldAlert } from "lucide-react";
 import {
   correlationRiskBanner,
+  type CorrelationOrderContext,
   type RiskBudgetReport,
 } from "@/lib/correlationRiskBanner";
 
@@ -18,11 +19,18 @@ import {
 export default function CorrelationRiskBanner({
   report,
   showUnavailable = false,
+  order = null,
 }: {
   report: RiskBudgetReport | null | undefined;
   showUnavailable?: boolean;
+  /** Working-order context: a close/reduce of a breached-cluster ticker
+   *  suppresses that cluster's breach banner (the order IS the trim). */
+  order?: CorrelationOrderContext | null;
 }) {
-  const banner = correlationRiskBanner(report);
+  const banner = correlationRiskBanner(report, order);
+  // A reduce of the breached stack renders no Gate-3 module at all: the
+  // banner exists to stop adds, and this order is the trim it asks for.
+  if (banner?.level === "reduce") return null;
   const measurementUnavailable =
     showUnavailable && (!banner || (banner.level === "none" && banner.insufficientData.length > 0));
   if ((!banner || banner.level === "none") && !measurementUnavailable) return null;

--- a/web/components/ModifyOrderModal.tsx
+++ b/web/components/ModifyOrderModal.tsx
@@ -499,7 +499,7 @@ export default function ModifyOrderModal({ order, loading, prices, portfolio, op
       totalCost: action === "SELL" ? -totalCost : totalCost,
       quote: priceData ? { bid: priceData.bid, ask: priceData.ask } : null,
     };
-  }, [order, editableLegs, newPrice, newQuantity, priceData, portfolio]);
+  }, [order, editableLegs, newPrice, newQuantity, priceData, portfolio, openOrders]);
 
   const riskState = useOrderRisk(riskInput, portfolio);
 

--- a/web/components/WorkspaceSections.tsx
+++ b/web/components/WorkspaceSections.tsx
@@ -74,6 +74,7 @@ import {
 } from "@/lib/orders/orderDisplay";
 import {
   classifyDisplayRowSession,
+  isExtendedFillLive,
   summarizeSessionWindows,
 } from "@/lib/orders/sessionWindow";
 import SessionWindowChip from "./orders/SessionWindowChip";
@@ -3460,6 +3461,7 @@ function OrdersSections({
                     remaining: o.order.remaining,
                     isPendingCancel,
                     isPendingModify,
+                    extendedFillLive: isExtendedFillLive(session),
                   });
                   const intent = resolveOrderIntent(o.order, portfolio?.positions);
                   const singleRowClass = [

--- a/web/components/mobile/MobileOrderList.tsx
+++ b/web/components/mobile/MobileOrderList.tsx
@@ -13,7 +13,11 @@ import {
   type OrderIntent,
   type OrderStatusTone,
 } from "@/lib/orders/orderDisplay";
-import { classifyDisplayRowSession } from "@/lib/orders/sessionWindow";
+import {
+  classifyDisplayRowSession,
+  isExtendedFillLive,
+  type OrderSession,
+} from "@/lib/orders/sessionWindow";
 import SessionWindowChip from "../orders/SessionWindowChip";
 import Card from "./Card";
 import BottomSheet from "./BottomSheet";
@@ -92,6 +96,7 @@ function statusInfo(
     remaining?: number;
     isPendingCancel: boolean;
     isPendingModify: boolean;
+    session?: OrderSession;
   },
 ): { label: string; tone: OrderStatusTone } {
   if (opts.isPendingCancel) return { label: "Cancelling...", tone: "pending" };
@@ -99,6 +104,7 @@ function statusInfo(
   const mapped = mapOrderStatus(raw, {
     filled: opts.filled,
     remaining: opts.remaining,
+    extendedFillLive: opts.session ? isExtendedFillLive(opts.session) : false,
   });
   return { label: mapped.label, tone: mapped.tone };
 }
@@ -110,6 +116,7 @@ function statusLabel(
     remaining?: number;
     isPendingCancel: boolean;
     isPendingModify: boolean;
+    session?: OrderSession;
   },
 ): string {
   return statusInfo(raw, opts).label;
@@ -140,6 +147,7 @@ function StatusChip({ label, tone }: { label: string; tone: OrderStatusTone }) {
 function rowSummary(
   row: OpenOrderDisplayRow,
   pending: { cancel: boolean; modify: boolean },
+  session?: OrderSession,
 ): {
   title: string;
   subtitle: string;
@@ -155,6 +163,7 @@ function rowSummary(
       remaining: first?.remaining,
       isPendingCancel: pending.cancel,
       isPendingModify: pending.modify,
+      session,
     });
     return {
       title: `${row.symbol} · ${row.structure}`,
@@ -171,6 +180,7 @@ function rowSummary(
     remaining: o.remaining,
     isPendingCancel: pending.cancel,
     isPendingModify: pending.modify,
+    session,
   });
   return {
     title: `${o.contract.symbol} · ${o.action}`,
@@ -257,6 +267,7 @@ function OrderSheetSummary({
       remaining: first?.remaining,
       isPendingCancel: pending.cancel,
       isPendingModify: pending.modify,
+      session,
     });
     return (
       <div className="mobile-order-sheet-summary" data-testid="mobile-order-sheet-summary">
@@ -301,6 +312,7 @@ function OrderSheetSummary({
     remaining: o.remaining,
     isPendingCancel: pending.cancel,
     isPendingModify: pending.modify,
+    session,
   });
   return (
     <div className="mobile-order-sheet-summary" data-testid="mobile-order-sheet-summary">
@@ -434,11 +446,11 @@ export default function MobileOrderList({
       <div className="mobile-card-list" data-testid="mobile-order-list">
         {sortRows(rows, sortKey).map((row) => {
           const pending = pendingFor(row, cancels, modifies);
-          const summary = rowSummary(row, pending);
+          const session = classifyDisplayRowSession(row);
+          const summary = rowSummary(row, pending, session);
           const action = rowAction(row);
           const intent = rowIntent(row, portfolioPositions);
           const tone = rowCardTone(intent, action, row.kind === "combo");
-          const session = classifyDisplayRowSession(row);
           const id = row.kind === "combo" ? row.id : `single-${row.order.permId}`;
 
           return (

--- a/web/e2e/orders-session-window.spec.ts
+++ b/web/e2e/orders-session-window.spec.ts
@@ -145,4 +145,66 @@ test.describe("/orders session window", () => {
     await expect(strip.getByTestId("open-orders-rth-count")).toHaveCount(0);
     await expect(strip.getByTestId("open-orders-ext-count")).toHaveCount(0);
   });
+
+  // 2026-09-01 TQQQ flatten: IB reports PreSubmitted for extended-eligible
+  // equity orders that ARE live in the extended session; the table called
+  // them QUEUED for the whole after-hours window. While the extended window
+  // is live the status must read Working (chip EXT LIVE); once the session
+  // closes, Queued is the honest label and the EXT chip names the eligibility.
+  const EXTENDED_NOW = new Date("2026-08-27T21:30:00.000Z"); // 17:30 ET Thursday
+  const CLOSED_NOW = new Date("2026-08-28T01:00:00.000Z"); // 21:00 ET Thursday
+
+  function tqqqPreSubmittedClose() {
+    return {
+      last_sync: EXTENDED_NOW.toISOString(),
+      open_count: 1,
+      executed_count: 0,
+      executed_orders: [],
+      open_orders: [
+        makeOpenOrder({
+          orderId: 3,
+          permId: 1003,
+          action: "SELL",
+          tif: "DAY",
+          outsideRth: true,
+          status: "PreSubmitted",
+          symbol: "TQQQ",
+          limitPrice: 68.8,
+          contract: {
+            conId: 30,
+            symbol: "TQQQ",
+            secType: "STK",
+            strike: null,
+            right: null,
+            expiry: null,
+          },
+        }),
+      ],
+    };
+  }
+
+  test("a PreSubmitted EXT stock close reads Working while after hours is live", async ({ page }) => {
+    await page.clock.install({ time: EXTENDED_NOW });
+    await stubOrdersPage(page, tqqqPreSubmittedClose());
+
+    await page.goto("/orders");
+
+    const row = page.getByTestId("open-order-row-3-1003");
+    await expect(row).toBeVisible();
+    await expect(row).toContainText("Working");
+    await expect(row).not.toContainText("Queued");
+    await expect(row.getByTestId("order-session-chip")).toHaveText("EXT LIVE");
+  });
+
+  test("the same order reads Queued once the extended session has closed", async ({ page }) => {
+    await page.clock.install({ time: CLOSED_NOW });
+    await stubOrdersPage(page, tqqqPreSubmittedClose());
+
+    await page.goto("/orders");
+
+    const row = page.getByTestId("open-order-row-3-1003");
+    await expect(row).toBeVisible();
+    await expect(row).toContainText("Queued");
+    await expect(row.getByTestId("order-session-chip")).toHaveText("EXT");
+  });
 });

--- a/web/lib/correlationRiskBanner.ts
+++ b/web/lib/correlationRiskBanner.ts
@@ -28,7 +28,24 @@ export type RiskBudgetReport = {
   book_budget: number;
 };
 
-export type CorrelationBannerLevel = "none" | "info" | "unmeasured" | "critical";
+export type CorrelationBannerLevel =
+  | "none"
+  | "info"
+  | "unmeasured"
+  | "critical"
+  | "reduce";
+
+/**
+ * What the WORKING ORDER under review does to the book. Gate 3 guards against
+ * ADDING to a concentrated bet; a close that reduces a breached cluster is the
+ * trim the gate asks for, so the breach must not present as a block on it.
+ */
+export type CorrelationOrderContext = {
+  ticker: string;
+  /** True when the order closes or reduces held exposure in `ticker`
+   *  (the chokepoint's close-out branch). */
+  reducesExposure: boolean;
+};
 
 export type CorrelationClusterRow = {
   tickers: string[];
@@ -67,25 +84,61 @@ function toClusterRow(cluster: RiskBudgetCluster): CorrelationClusterRow {
 
 export function correlationRiskBanner(
   report: RiskBudgetReport | null | undefined,
+  order?: CorrelationOrderContext | null,
 ): CorrelationRiskBanner | null {
   if (!report) return null;
 
-  const breachedClusters = report.breaches.map(toClusterRow);
   const insufficientData = report.insufficient_data ?? [];
+
+  // A working order that reduces a ticker inside a breached cluster IS the
+  // trim Gate 3 asks for. Its cluster must not present as a block on the
+  // reduce; clusters the order does not touch stay critical.
+  const orderTicker = order?.ticker?.toUpperCase() ?? null;
+  const isReduce = order?.reducesExposure === true && orderTicker != null;
+  const reducedBreaches = isReduce
+    ? report.breaches.filter((cluster) =>
+        cluster.tickers.some((t) => t.toUpperCase() === orderTicker),
+      )
+    : [];
+  const activeBreaches = report.breaches.filter(
+    (cluster) => !reducedBreaches.includes(cluster),
+  );
+  const breachedClusters = activeBreaches.map(toClusterRow);
 
   if (breachedClusters.length > 0) {
     const names = breachedClusters
       .map((c) => c.tickers.join("+"))
       .join(", ");
+    // Never tell the operator they are "adding" risk when the working order
+    // is a close/reduce (2026-09-01 TQQQ flatten misread).
+    const guidance = isReduce
+      ? "This working order is a close and does not add to it. The cluster stays over budget until trimmed or hedged."
+      : "Trim or hedge before adding correlated risk.";
     return {
       gate: 3,
       level: "critical",
       headline: `Gate 3: correlated exposure over budget (${names})`,
       detail:
-        "Highly-correlated positions stack into a single concentrated bet. " +
-        "Trim or hedge before adding correlated risk.",
+        `Highly-correlated positions stack into a single concentrated bet. ${guidance}`,
       clusterCount: report.clusters.length,
       breachedClusters,
+      insufficientData,
+    };
+  }
+
+  if (reducedBreaches.length > 0) {
+    const names = reducedBreaches
+      .map((cluster) => cluster.tickers.join("+"))
+      .join(", ");
+    return {
+      gate: 3,
+      level: "reduce",
+      headline: `Gate 3: this order reduces the ${names} stack`,
+      detail:
+        "The working order closes exposure inside the breached cluster. " +
+        "Reducing is the action Gate 3 asks for; it is not blocked.",
+      clusterCount: report.clusters.length,
+      breachedClusters: [],
       insufficientData,
     };
   }

--- a/web/lib/order/risk/OrderRiskGate.tsx
+++ b/web/lib/order/risk/OrderRiskGate.tsx
@@ -27,6 +27,7 @@ import { useShortAvailability } from "../hooks/useShortAvailability";
 import { useWhatIfMargin } from "./useWhatIfMargin";
 import { mergeWhatIfMargin } from "./mergeWhatIfMargin";
 import CorrelationRiskBanner from "@/components/CorrelationRiskBanner";
+import type { CorrelationOrderContext } from "@/lib/correlationRiskBanner";
 
 // Phase-2 IB what-if margin. Ships OFF: the backend (endpoint + script branch)
 // is inert until this flag is set, after live verification on an authenticated
@@ -164,6 +165,7 @@ export function OrderRiskGate({
       <CorrelationRiskBanner
         report={state.correlationReport}
         showUnavailable={state.coverageStatus === "resolved"}
+        order={resolveCorrelationOrderContext(input)}
       />
       {showLocateChip && (
         <LocateFeeChip status={locateStatus} data={locateData} />
@@ -199,6 +201,23 @@ export function resolveLocateChipEnabled(
   // and the projected order still carries an uncovered/naked obligation.
   if (portfolio == null || state?.coverageStatus !== "resolved") return false;
   return state.summary.undefinedRiskReason != null;
+}
+
+/**
+ * Working-order context for the Gate-3 correlation banner. Both input
+ * variants mark a close/reduce of held exposure with `closeOut` (the
+ * chokepoint's close-out branch), so its presence is the reduce signal:
+ * a breached cluster containing this ticker must not present as a block
+ * on the order that trims it.
+ */
+export function resolveCorrelationOrderContext(
+  input: OrderRiskInput | null,
+): CorrelationOrderContext | null {
+  if (input == null || !input.ticker) return null;
+  return {
+    ticker: input.ticker,
+    reducesExposure: (input as { closeOut?: unknown }).closeOut != null,
+  };
 }
 
 function inputHasSellLeg(input: OrderRiskInput): boolean {

--- a/web/lib/orders/orderDisplay.ts
+++ b/web/lib/orders/orderDisplay.ts
@@ -72,6 +72,17 @@ export function mapOrderStatus(
     remaining?: number;
     isPendingCancel?: boolean;
     isPendingModify?: boolean;
+    /**
+     * True when the order's extended fill window is live right now
+     * (`isExtendedFillLive` from sessionWindow). IB reports `PreSubmitted`
+     * for extended-eligible equity orders that ARE live and fillable in the
+     * current pre-market / after-hours session; labelling those Queued told
+     * the operator a marketable TQQQ close was not working during AH
+     * (2026-09-01). Only IB-acknowledged `PreSubmitted` promotes to Working;
+     * `PendingSubmit` / `ApiPending` have no IB acknowledgement and stay
+     * Queued regardless.
+     */
+    extendedFillLive?: boolean;
   },
 ): MappedOrderStatus {
   const status = (raw ?? "").trim();
@@ -91,6 +102,9 @@ export function mapOrderStatus(
   const lower = status.toLowerCase();
 
   if (lower === "presubmitted" || lower === "pendingsubmit" || lower === "apipending") {
+    if (lower === "presubmitted" && opts?.extendedFillLive === true) {
+      return { label: "Working", raw: status, tone: "working" };
+    }
     return { label: "Queued", raw: status, tone: "working" };
   }
   if (

--- a/web/lib/orders/sessionWindow.ts
+++ b/web/lib/orders/sessionWindow.ts
@@ -185,6 +185,20 @@ export function classifyDisplayRowSession(
   return classifyOrderSession(row.order, now);
 }
 
+/**
+ * True when the order's EXTENDED fill window is live RIGHT NOW: the order is
+ * extended-eligible and the market is currently in an extended session
+ * (pre-market or after hours). IB holds extended-eligible equity orders in
+ * `PreSubmitted` while they are live and fillable in that session, so the
+ * status mapper needs this to label them Working instead of Queued.
+ */
+export function isExtendedFillLive(session: OrderSession): boolean {
+  return (
+    session.eligibility === "extended"
+    && session.marketState === MarketState.EXTENDED
+  );
+}
+
 export type SessionWindowCounts = {
   rth: number;
   ext: number;

--- a/web/tests/correlation-risk-banner.test.ts
+++ b/web/tests/correlation-risk-banner.test.ts
@@ -101,3 +101,83 @@ describe("correlationRiskBanner", () => {
     expect(banner!.breachedClusters[0].budgetPctLabel).toBe("2.5%");
   });
 });
+
+// 2026-09-01 TQQQ flatten: a working order that CLOSES part of the breached
+// SMH+SPY+TQQQ stack rendered the same critical breach with "before adding
+// correlated risk" copy as an add. Gate 3 is a guard against ADDING to a
+// concentrated bet; an order that reduces the cluster must not read as
+// blocked, and the copy must never call a close an add.
+describe("correlationRiskBanner with a working-order context", () => {
+  const STACK_CLUSTER = {
+    tickers: ["SMH", "SPY", "TQQQ"],
+    aggregate_exposure: 0.73,
+    budget: 0.025,
+    breached: true,
+    max_pair_corr: 0.92,
+    per_ticker_exposure: { SMH: 0.3, SPY: 0.23, TQQQ: 0.2 },
+  };
+
+  it("suppresses the breach when the order reduces a ticker in the cluster", () => {
+    const banner = correlationRiskBanner(
+      report({ clusters: [STACK_CLUSTER], breaches: [STACK_CLUSTER] }),
+      { ticker: "TQQQ", reducesExposure: true },
+    );
+    expect(banner!.level).toBe("reduce");
+    expect(banner!.breachedClusters).toHaveLength(0);
+    expect(banner!.headline).toContain("reduces");
+    expect(banner!.detail).not.toMatch(/adding/i);
+    expect(banner!.headline).not.toContain("\u2014");
+    expect(banner!.detail).not.toContain("\u2014");
+  });
+
+  it("matches the reduce ticker case-insensitively", () => {
+    const banner = correlationRiskBanner(
+      report({ clusters: [STACK_CLUSTER], breaches: [STACK_CLUSTER] }),
+      { ticker: "tqqq", reducesExposure: true },
+    );
+    expect(banner!.level).toBe("reduce");
+  });
+
+  it("keeps the critical breach when the same order is an add", () => {
+    const banner = correlationRiskBanner(
+      report({ clusters: [STACK_CLUSTER], breaches: [STACK_CLUSTER] }),
+      { ticker: "TQQQ", reducesExposure: false },
+    );
+    expect(banner!.level).toBe("critical");
+    expect(banner!.detail).toMatch(/adding/);
+  });
+
+  it("keeps unrelated breaches critical but never calls a close an add", () => {
+    const banner = correlationRiskBanner(
+      report({
+        clusters: [STACK_CLUSTER, BREACH_CLUSTER],
+        breaches: [STACK_CLUSTER, BREACH_CLUSTER],
+      }),
+      { ticker: "TQQQ", reducesExposure: true },
+    );
+    // AAA+BBB is untouched by the TQQQ close: still a real breach.
+    expect(banner!.level).toBe("critical");
+    expect(banner!.breachedClusters).toHaveLength(1);
+    expect(banner!.breachedClusters[0].tickers).toEqual(["AAA", "BBB"]);
+    expect(banner!.detail).not.toMatch(/adding/i);
+    expect(banner!.detail).not.toContain("\u2014");
+  });
+
+  it("a reduce on a ticker outside every cluster keeps the breach without add copy", () => {
+    const banner = correlationRiskBanner(
+      report({ clusters: [STACK_CLUSTER], breaches: [STACK_CLUSTER] }),
+      { ticker: "GLD", reducesExposure: true },
+    );
+    expect(banner!.level).toBe("critical");
+    expect(banner!.breachedClusters).toHaveLength(1);
+    expect(banner!.detail).not.toMatch(/adding/i);
+  });
+
+  it("no order context leaves every existing verdict unchanged", () => {
+    const banner = correlationRiskBanner(
+      report({ clusters: [STACK_CLUSTER], breaches: [STACK_CLUSTER] }),
+    );
+    expect(banner!.level).toBe("critical");
+    expect(banner!.detail).toMatch(/adding/);
+  });
+});

--- a/web/tests/modify-order-gate3-close.test.tsx
+++ b/web/tests/modify-order-gate3-close.test.tsx
@@ -1,0 +1,270 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Gate 3 vs a working equity CLOSE inside ModifyOrderModal (2026-09-01 TQQQ).
+ *
+ * Live symptom: TQQQ Long Stock CLOSE, SELL 10,000 @ 68.80, with the book
+ * carrying a breached SMH+SPY+TQQQ cluster (73.0% vs 2.5%, corr 0.92). The
+ * modify modal rendered the critical Gate 3 breach with "before adding
+ * correlated risk" copy on an order that REDUCES that stack, and read as a
+ * block on the flatten.
+ *
+ * Contracts pinned here:
+ *  1. A stock close that reduces a breached-cluster ticker renders NO Gate 3
+ *     banner ("Gate 3 banner absent on reduce").
+ *  2. Gate 3 never disables modify on a reduce: the armed Modify Order click
+ *     reaches the wire — full URL, method, exact payload — through the REAL
+ *     OrderActionsProvider (the component that owns the fetch), and nothing
+ *     fires while the gate is still closed (no field changed).
+ *  3. An ADD on the same ticker keeps the critical breach banner and its
+ *     trim-or-hedge copy.
+ */
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { OpenOrder, PortfolioData, PortfolioPosition } from "@/lib/types";
+import type { RiskBudgetReport } from "@/lib/correlationRiskBanner";
+import type { ModifyOrderRequest } from "@/lib/orderModify";
+import ModifyOrderModal from "@/components/ModifyOrderModal";
+import { OrderActionsProvider, useOrderActions } from "@/lib/OrderActionsContext";
+
+vi.mock("@/lib/useRiskFreeRate", () => ({
+  useRiskFreeRate: () => 0,
+}));
+
+vi.mock("@/components/Modal", () => ({
+  default: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? React.createElement("div", { className: "mock-modal" }, children) : null,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+const BREACHED_STACK: RiskBudgetReport = {
+  clusters: [
+    {
+      tickers: ["SMH", "SPY", "TQQQ"],
+      aggregate_exposure: 0.73,
+      budget: 0.025,
+      breached: true,
+      max_pair_corr: 0.92,
+      per_ticker_exposure: { SMH: 0.3, SPY: 0.23, TQQQ: 0.2 },
+    },
+  ],
+  breaches: [
+    {
+      tickers: ["SMH", "SPY", "TQQQ"],
+      aggregate_exposure: 0.73,
+      budget: 0.025,
+      breached: true,
+      max_pair_corr: 0.92,
+      per_ticker_exposure: { SMH: 0.3, SPY: 0.23, TQQQ: 0.2 },
+    },
+  ],
+  aggregate_exposure: 0.73,
+  insufficient_data: [],
+  corr_threshold: 0.7,
+  book_budget: 0.025,
+};
+
+function tqqqSellOrder(): OpenOrder {
+  return {
+    orderId: 41,
+    permId: 653640001,
+    symbol: "TQQQ",
+    contract: {
+      conId: 320227,
+      symbol: "TQQQ",
+      secType: "STK",
+      strike: null,
+      right: null,
+      expiry: null,
+    },
+    action: "SELL",
+    orderType: "LMT",
+    totalQuantity: 10_000,
+    limitPrice: 68.8,
+    auxPrice: null,
+    status: "PreSubmitted",
+    filled: 0,
+    remaining: 10_000,
+    avgFillPrice: null,
+    tif: "DAY",
+    outsideRth: true,
+  };
+}
+
+function portfolio(withTqqqStock: boolean): PortfolioData {
+  const positions: PortfolioPosition[] = withTqqqStock
+    ? [{
+        id: 7,
+        ticker: "TQQQ",
+        structure: "Long Stock (10,000 shares)",
+        structure_type: "Stock",
+        risk_profile: "Defined",
+        expiry: "",
+        contracts: 10_000,
+        direction: "LONG",
+        entry_cost: 660_000,
+        max_risk: null,
+        market_value: null,
+        legs: [{
+          direction: "LONG",
+          contracts: 10_000,
+          type: "Stock",
+          strike: null,
+          entry_cost: 660_000,
+          avg_cost: 66,
+          market_price: null,
+          market_value: null,
+        }],
+        kelly_optimal: null,
+        target: null,
+        stop: null,
+        entry_date: "2026-08-14",
+      }]
+    : [];
+
+  return {
+    bankroll: 1_500_000,
+    peak_value: 1_500_000,
+    last_sync: "2026-09-01T23:30:00.000Z",
+    positions,
+    total_deployed_pct: 0,
+    total_deployed_dollars: 0,
+    remaining_capacity_pct: 100,
+    position_count: positions.length,
+    defined_risk_count: positions.length,
+    undefined_risk_count: 0,
+    avg_kelly_optimal: null,
+    risk_budget: BREACHED_STACK,
+    account_summary: {
+      net_liquidation: 1_500_000,
+      daily_pnl: 0,
+      unrealized_pnl: 0,
+      realized_pnl: 0,
+      settled_cash: 300_000,
+      maintenance_margin: 0,
+      excess_liquidity: 300_000,
+      buying_power: 600_000,
+      available_funds: 300_000,
+      dividends: 0,
+    },
+  };
+}
+
+type RecordedCall = { url: string; method: string; body: unknown };
+
+function recordFetch(): RecordedCall[] {
+  const calls: RecordedCall[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const body = typeof init?.body === "string" ? JSON.parse(init.body) : init?.body;
+      calls.push({ url, method: init?.method ?? "GET", body });
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }),
+  );
+  return calls;
+}
+
+/** Mirrors the /orders page wiring: onConfirm routes through the REAL
+ *  requestModify, the component that owns the /api/orders/modify fetch. */
+function Harness({ order, book }: { order: OpenOrder; book: PortfolioData }) {
+  const { requestModify } = useOrderActions();
+  return (
+    <ModifyOrderModal
+      order={order}
+      loading={false}
+      portfolio={book}
+      onConfirm={(request: ModifyOrderRequest) => {
+        void requestModify(order, request);
+      }}
+      onClose={() => {}}
+    />
+  );
+}
+
+function renderModal(order: OpenOrder, book: PortfolioData): RecordedCall[] {
+  const calls = recordFetch();
+  render(
+    <OrderActionsProvider>
+      <Harness order={order} book={book} />
+    </OrderActionsProvider>,
+  );
+  return calls;
+}
+
+describe("Gate 3 on a stock close that reduces the breached stack", () => {
+  it("renders no Gate 3 banner on the reduce", () => {
+    renderModal(tqqqSellOrder(), portfolio(true));
+    expect(screen.queryByTestId("correlation-risk-banner")).toBeNull();
+  });
+
+  it("does not fire the wire while the gate is closed (nothing changed)", async () => {
+    const calls = renderModal(tqqqSellOrder(), portfolio(true));
+    const modify = screen.getByRole("button", { name: /Modify Order/i }) as HTMLButtonElement;
+    expect(modify.disabled).toBe(true);
+    fireEvent.click(modify);
+    await Promise.resolve();
+    expect(calls).toHaveLength(0);
+  });
+
+  it("armed modify on the reduce reaches the wire with the exact payload", async () => {
+    const calls = renderModal(tqqqSellOrder(), portfolio(true));
+
+    fireEvent.change(screen.getByLabelText(/New Limit Price/i), { target: { value: "68.50" } });
+
+    const modify = screen.getByRole("button", { name: /Modify Order/i }) as HTMLButtonElement;
+    expect(modify.disabled).toBe(false);
+    fireEvent.click(modify);
+    await vi.waitFor(() => expect(calls).toHaveLength(1));
+
+    expect(calls[0].url).toBe("/api/orders/modify");
+    expect(calls[0].method).toBe("POST");
+    expect(calls[0].body).toEqual({
+      orderId: 41,
+      permId: 653640001,
+      newPrice: 68.5,
+    });
+  });
+
+  it("an outsideRth-only change on the reduce also reaches the wire", async () => {
+    const calls = renderModal(tqqqSellOrder(), portfolio(true));
+
+    fireEvent.click(screen.getByLabelText(/FILL OUTSIDE RTH/i));
+
+    const modify = screen.getByRole("button", { name: /Modify Order/i }) as HTMLButtonElement;
+    expect(modify.disabled).toBe(false);
+    fireEvent.click(modify);
+    await vi.waitFor(() => expect(calls).toHaveLength(1));
+
+    expect(calls[0].url).toBe("/api/orders/modify");
+    expect(calls[0].method).toBe("POST");
+    expect(calls[0].body).toEqual({
+      orderId: 41,
+      permId: 653640001,
+      outsideRth: false,
+    });
+  });
+});
+
+describe("Gate 3 on the same ticker as an ADD", () => {
+  it("keeps the critical breach banner with the trim-or-hedge copy", () => {
+    // No held TQQQ stock: a SELL 10,000 is an opening short, not a close.
+    renderModal(tqqqSellOrder(), portfolio(false));
+
+    const banner = screen.getByTestId("correlation-risk-banner");
+    expect(banner.getAttribute("data-level")).toBe("critical");
+    expect(banner.textContent).toContain("SMH+SPY+TQQQ");
+    expect(banner.textContent).toMatch(/adding correlated risk/);
+    expect(banner.textContent).not.toContain("\u2014");
+  });
+});

--- a/web/tests/order-session-window.test.ts
+++ b/web/tests/order-session-window.test.ts
@@ -6,6 +6,7 @@ import { MarketState } from "../lib/useMarketHours";
 import {
   classifyDisplayRowSession,
   classifyOrderSession,
+  isExtendedFillLive,
 } from "../lib/orders/sessionWindow";
 
 const OPEN_NOW = new Date("2026-07-09T15:00:00.000Z"); // 11:00 ET Thursday, RTH
@@ -258,6 +259,26 @@ describe("classifyOrderSession labels when the cash session is closed", () => {
     expect(session.eligibility).toBe("extended");
     expect(session.label).toBe("EXT");
     expect(session.tone).toBe("extended");
+  });
+});
+
+describe("isExtendedFillLive", () => {
+  const extStock = () => makeOrder({ tif: "DAY", outsideRth: true, symbol: "TQQQ" });
+
+  it("is true for an extended-eligible stock during a live extended session", () => {
+    expect(isExtendedFillLive(classifyOrderSession(extStock(), EXTENDED_NOW))).toBe(true);
+  });
+
+  it("is false for the same order once the extended session has closed", () => {
+    expect(isExtendedFillLive(classifyOrderSession(extStock(), CLOSED_NOW))).toBe(false);
+  });
+
+  it("is false during RTH (the regular session is the fill window, not EXT)", () => {
+    expect(isExtendedFillLive(classifyOrderSession(extStock(), OPEN_NOW))).toBe(false);
+  });
+
+  it("is false for an rth-only option even during extended hours", () => {
+    expect(isExtendedFillLive(classifyOrderSession(opt({ tif: "GTC" }), EXTENDED_NOW))).toBe(false);
   });
 });
 

--- a/web/tests/orders-display.test.ts
+++ b/web/tests/orders-display.test.ts
@@ -167,6 +167,37 @@ describe("mapOrderStatus", () => {
     expect(mapOrderStatus("Cancelled").label).toBe("Cancelled");
     expect(mapOrderStatus("ApiCancelled").label).toBe("Cancelled");
   });
+
+  // IB holds extended-eligible equity orders in `PreSubmitted` while they are
+  // live and fillable in the extended session. Calling that QUEUED told the
+  // operator a marketable TQQQ close was not working during after hours
+  // (2026-09-01). When the order's extended fill window is live, PreSubmitted
+  // is Working; outside any live session, Queued stays the honest label.
+  it("maps PreSubmitted to Working while the order's extended fill window is live", () => {
+    const mapped = mapOrderStatus("PreSubmitted", { extendedFillLive: true });
+    expect(mapped.label).toBe("Working");
+    expect(mapped.tone).toBe("working");
+    expect(mapped.raw).toBe("PreSubmitted");
+  });
+
+  it("keeps PreSubmitted as Queued when no extended fill window is live", () => {
+    expect(mapOrderStatus("PreSubmitted", { extendedFillLive: false }).label).toBe("Queued");
+    expect(mapOrderStatus("PreSubmitted").label).toBe("Queued");
+  });
+
+  it("never promotes unacknowledged statuses, even in a live extended window", () => {
+    expect(mapOrderStatus("PendingSubmit", { extendedFillLive: true }).label).toBe("Queued");
+    expect(mapOrderStatus("ApiPending", { extendedFillLive: true }).label).toBe("Queued");
+  });
+
+  it("partial fill still outranks the live extended window", () => {
+    const mapped = mapOrderStatus("PreSubmitted", {
+      extendedFillLive: true,
+      filled: 2,
+      remaining: 3,
+    });
+    expect(mapped.label).toBe("Partial");
+  });
 });
 
 describe("distanceToFill", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- [x] Red/green TDD (failing test, then fix)
- [x] Staged only the files this change owns (no `git add -A`)
- [x] Owner doc updated, or the commit message has `docs-skip: <reason>`
- [x] Previous `main` deploy finished before this push

## Symptom
On app.radon.run /orders around 2026-09-01 19:51 PT (22:51 ET), a TQQQ Long Stock CLOSE (SELL 10,000 LMT 68.80, DAY + EXT) stayed **QUEUED** instead of Working at IB. The modify modal showed Gate 3 CORRELATION RISK BUDGET (SMH+SPY+TQQQ 73.0% vs 2.5%, corr 0.92) with copy that said trim before **adding** correlated risk. This order reduces that stack.

US equity after hours is 4-8pm ET. At 10:51pm ET there is no AH session, so it cannot fill until pre-market even if IB has it. The software bugs were: (1) IB `PreSubmitted` always mapped to Queued, including during a live extended session; (2) Gate 3 scored the held book only and used "adding" copy on a flatten.

## Cause
IB holds extended-eligible equity orders in `PreSubmitted` while they are live and fillable in the current pre-market / after-hours window. `mapOrderStatus` labelled every `PreSubmitted` Queued, so a marketable DAY+EXT stock close read as locally queued during 16:00-20:00 ET.

The Gate 3 banner read `portfolio.risk_budget` with no working-order context. A close of TQQQ inside the breached SMH+SPY+TQQQ cluster rendered the same critical breach and "before adding correlated risk" copy as an add. Gate 3 never gated `okToSubmit` (coverage + finite figures still do); the surface read as a block because of that copy and the red banner on a flatten.

## Fix
- `isExtendedFillLive(session)` is true only for an extended-eligible order during a live extended session.
- `mapOrderStatus("PreSubmitted", { extendedFillLive: true })` is **Working**. `PendingSubmit` / `ApiPending` stay Queued (no IB acknowledgement). After 20:00 ET the same order honestly reads Queued + EXT.
- `correlationRiskBanner(report, { ticker, reducesExposure })` drops breached clusters the order reduces (`level: "reduce"`, banner absent). Remaining unrelated breaches stay critical but never say "adding" on a close.
- `OrderRiskGate` passes `{ ticker, reducesExposure: closeOut != null }` into the banner.
- ARM/SPCX NEXT RTH GTC option/combo rows are unchanged (rth-only).

No live IB place/cancel/modify. Transmit contract is mocked (`LimitOrder` kwargs + one `place_order` call).

## How to tell on app.radon.run (next 4-8pm ET window)
This cloud VM cannot exercise a live extended session. During the next after-hours window, on a closing EXT equity order that IB has accepted:

1. Open Orders row: status chip **Working** (not Queued). Session chip **EXT LIVE**. Intent pill **CLOSE**. TIF **DAY**.
2. After 20:00 ET the same resting order may read **Queued** + **EXT**. That is honest: no session is open. ARM/SPCX option rows stay **QUEUED** + **NEXT RTH**.
3. Modify modal on that close: **FILL OUTSIDE RTH** checked. Gate 3 banner **absent** (the flatten is the trim). **MODIFY ORDER** arms when quantity, limit, or the EXT flag changes; it stays disabled when nothing changed (existing rule).
4. An add on the same ticker still shows the critical Gate 3 banner and "before adding correlated risk".

## Tests
- Vitest full gate: 7990 passed, 10 skipped (1 unrelated chat-image unhandled-rejection)
- Pytest pins: 21 passed (`test_ib_place_order_contract_args`, `test_ib_orders_outside_rth`, `test_portfolio_risk_gate3_measurability`)
- Playwright: `orders-session-window` 3 passed; `modify-order-correlation-risk` + `mobile-orders-session` green
- `web/tests/modify-order-gate3-close.test.tsx`: banner absent on TQQQ close; armed click POSTs `/api/orders/modify` with the exact payload

## Out of scope
Hosted-MCP files, `/regime/ma-ratio`, mobile portfolio cards. Do not merge. Do not place a real IB order.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd8629b8-b10c-4432-8c21-6b215125d9fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd8629b8-b10c-4432-8c21-6b215125d9fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

