### PR TITLE
fix(orders): header WORKING count matches Queued row chips

### DIFF
--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -17,6 +17,18 @@
   KEY_ASSIGN already treats a leading quote as a value, and deepsec
   loads the quoted flag as truthy after unset.
 
+## 2026-09-02 — Overnight TIF is not EXT outsideRth
+
+- IB Overnight is 20:00-03:50 ET, limit (or Adaptive) only, TIF Overnight or
+  Overnight+Day. No GTC. A separate venue from pre-market / after-hours.
+- Radon EXT is `outsideRth` on pre-market + AH (04:00-09:30 and 16:00-20:00
+  ET). DAY+EXT sits Queued through overnight and never routes to Overnight.
+- Do not treat "overnight" as a synonym for EXT. Mapping PreSubmitted to
+  Working is only valid in a live pre-market/AH window.
+- The Orders header WORKING count must use the same mapped status as the
+  row chips. Counting every non-partial open order as Working while every
+  row reads QUEUED is a lie.
+
 ## 2026-09-02 — Snapshot Pushover creds before the agent; comment-only issue writes
 
 - `_notify_curl` read WEEKEND_ROOT/.env at page time. Launchd does not set

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,22 @@
+# Task: Orders header WORKING vs QUEUED rows (2026-09-02) [WIP]
+
+PR 236 comment: Overnight TIF is a separate IB venue from EXT `outsideRth`.
+DAY+EXT sits Queued overnight and never routes Overnight. Separate honesty
+bug: header WORKING 3 while every visible row is QUEUED.
+
+- H1 depends_on: [] - lesson: Overnight != EXT
+- H2 depends_on: [] - summarizeOpenOrders uses mapped row status + session
+- H3 depends_on: [H2] - command-strip Working 0 when all rows Queued
+- H4 depends_on: [H2, H3] - tests + PR
+
+## Checklist
+- [x] H1 lesson
+- [ ] H2 summarizeOpenOrders
+- [ ] H3 command strip
+- [ ] H4 PR
+
+---
+
 # Task: Orders EXT close QUEUED + Gate 3 blocks reduce (2026-09-02) [WIP]
 
 Live symptom (app.radon.run /orders, ~22:51 ET 2026-09-01): TQQQ Long Stock

--- a/web/components/WorkspaceSections.tsx
+++ b/web/components/WorkspaceSections.tsx
@@ -3100,8 +3100,8 @@ function OrdersSections({
   }
 
   const canModify = (o: OpenOrder) => o.orderType === "LMT" || o.orderType === "STP LMT";
-  const openOrdersSummary = summarizeOpenOrders(orders.open_orders);
   const now = new Date();
+  const openOrdersSummary = summarizeOpenOrders(orders.open_orders, now);
   const sessionCounts = summarizeSessionWindows(openOrderRows, now);
   const lastSyncLabel = orders.last_sync
     ? formatRelativeTime(orders.last_sync)

--- a/web/lib/orders/orderDisplay.ts
+++ b/web/lib/orders/orderDisplay.ts
@@ -5,6 +5,7 @@
  */
 
 import type { OpenOrder, PortfolioPosition } from "@/lib/types";
+import { classifyOrderSession, isExtendedFillLive } from "@/lib/orders/sessionWindow";
 
 export type OperatorOrderStatus =
   | "Working"
@@ -261,13 +262,19 @@ export function cardToneForIntent(
 
 export function summarizeOpenOrders(
   orders: readonly OpenOrder[],
+  now: Date = new Date(),
 ): OpenOrdersSummary {
   let partialCount = 0;
   let workingCount = 0;
   for (const order of orders) {
-    if (isPartialFill(order)) {
+    const mapped = mapOrderStatus(order.status, {
+      filled: order.filled,
+      remaining: order.remaining,
+      extendedFillLive: isExtendedFillLive(classifyOrderSession(order, now)),
+    });
+    if (mapped.label === "Partial") {
       partialCount += 1;
-    } else {
+    } else if (mapped.label === "Working") {
       workingCount += 1;
     }
   }

--- a/web/tests/orders-command-strip.test.tsx
+++ b/web/tests/orders-command-strip.test.tsx
@@ -185,6 +185,68 @@ describe("orders command strip", () => {
     expect(document.getElementById("orders-historical")).toBeTruthy();
   });
 
+  it("shows Working 0 when every open row is Queued after the extended close", () => {
+    vi.setSystemTime(new Date("2026-08-28T01:00:00.000Z")); // 21:00 ET
+    const orders: OrdersData = {
+      last_sync: new Date("2026-08-28T01:00:00.000Z").toISOString(),
+      open_count: 3,
+      executed_count: 0,
+      executed_orders: [],
+      open_orders: [
+        makeOpenOrder({
+          orderId: 1,
+          permId: 1001,
+          status: "PreSubmitted",
+          tif: "GTC",
+          symbol: "ARM",
+          contract: {
+            conId: 10, symbol: "ARM", secType: "OPT",
+            strike: 260, right: "C", expiry: "2026-09-18",
+          },
+        }),
+        makeOpenOrder({
+          orderId: 2,
+          permId: 1002,
+          status: "PreSubmitted",
+          tif: "GTC",
+          symbol: "SPCX",
+          contract: {
+            conId: 20, symbol: "SPCX", secType: "BAG",
+            strike: null, right: null, expiry: null,
+          },
+        }),
+        makeOpenOrder({
+          orderId: 3,
+          permId: 1003,
+          status: "PreSubmitted",
+          tif: "DAY",
+          outsideRth: true,
+          symbol: "TQQQ",
+          action: "SELL",
+          contract: {
+            conId: 30, symbol: "TQQQ", secType: "STK",
+            strike: null, right: null, expiry: null,
+          },
+        }),
+      ],
+    };
+
+    render(
+      React.createElement(WorkspaceSections, {
+        section: "orders",
+        orders,
+        prices: {},
+        portfolio: null,
+      }),
+    );
+
+    const strip = screen.getByTestId("orders-command-strip");
+    expect(strip.textContent).toMatch(/Working\s*0/);
+    expect(screen.getByTestId("open-order-row-1-1001").textContent).toContain("Queued");
+    expect(screen.getByTestId("open-order-row-2-1002").textContent).toContain("Queued");
+    expect(screen.getByTestId("open-order-row-3-1003").textContent).toContain("Queued");
+  });
+
   it("shows mapped Working status, fill qty, Δ Fill header, and intent OPEN", () => {
     const orders: OrdersData = {
       last_sync: NOW.toISOString(),

--- a/web/tests/orders-display.test.ts
+++ b/web/tests/orders-display.test.ts
@@ -38,6 +38,7 @@ function makeOrder(overrides: Partial<OpenOrder> = {}): OpenOrder {
     remaining: overrides.remaining ?? totalQuantity,
     avgFillPrice: overrides.avgFillPrice ?? null,
     tif: overrides.tif ?? "DAY",
+    outsideRth: overrides.outsideRth,
   };
 }
 
@@ -340,5 +341,67 @@ describe("summarizeOpenOrders", () => {
     expect(summary.openCount).toBe(2);
     expect(summary.partialCount).toBe(1);
     expect(summary.workingCount).toBe(1);
+  });
+
+  // 2026-09-02: after 20:00 ET the table showed three QUEUED chips
+  // (ARM/SPCX NEXT RTH + TQQQ DAY+EXT) while the header said WORKING 3.
+  // Working must match the mapped row status, not "any non-partial open order".
+  const OVERNIGHT_NOW = new Date("2026-08-28T01:00:00.000Z"); // 21:00 ET Thursday
+  const AH_NOW = new Date("2026-08-27T21:30:00.000Z"); // 17:30 ET Thursday
+
+  it("does not count overnight PreSubmitted rows as Working", () => {
+    const summary = summarizeOpenOrders(
+      [
+        makeOrder({
+          status: "PreSubmitted",
+          tif: "GTC",
+          symbol: "ARM",
+          contract: {
+            conId: 1, symbol: "ARM", secType: "OPT",
+            strike: 260, right: "C", expiry: "2026-09-18",
+          },
+        }),
+        makeOrder({
+          permId: 2,
+          status: "PreSubmitted",
+          tif: "GTC",
+          symbol: "SPCX",
+          contract: {
+            conId: 2, symbol: "SPCX", secType: "BAG",
+            strike: null, right: null, expiry: null,
+          },
+        }),
+        makeOrder({
+          permId: 3,
+          status: "PreSubmitted",
+          tif: "DAY",
+          outsideRth: true,
+          symbol: "TQQQ",
+          contract: {
+            conId: 3, symbol: "TQQQ", secType: "STK",
+            strike: null, right: null, expiry: null,
+          },
+        }),
+      ],
+      OVERNIGHT_NOW,
+    );
+    expect(summary.openCount).toBe(3);
+    expect(summary.workingCount).toBe(0);
+    expect(summary.partialCount).toBe(0);
+  });
+
+  it("counts a PreSubmitted EXT stock as Working only while after hours is live", () => {
+    const tqqq = makeOrder({
+      status: "PreSubmitted",
+      tif: "DAY",
+      outsideRth: true,
+      symbol: "TQQQ",
+      contract: {
+        conId: 3, symbol: "TQQQ", secType: "STK",
+        strike: null, right: null, expiry: null,
+      },
+    });
+    expect(summarizeOpenOrders([tqqq], AH_NOW).workingCount).toBe(1);
+    expect(summarizeOpenOrders([tqqq], OVERNIGHT_NOW).workingCount).toBe(0);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- [x] Red/green TDD (failing test, then fix)
- [x] Staged only the files this change owns (no `git add -A`)
- [x] Owner doc updated, or the commit message has `docs-skip: <reason>`
- [x] Previous `main` deploy finished before this push

Follow-up to https://github.com/joemccann/radon/pull/236#issuecomment-5504104233.

## Overnight vs EXT
IB Overnight (20:00-03:50 ET, TIF Overnight / Overnight+Day, no GTC) is a different venue from Radon EXT (`outsideRth` on pre-market + after-hours). DAY+EXT sits Queued through overnight and does not route to Overnight. This PR does not add Overnight TIF.

## Honesty bug
The command-strip WORKING count treated every non-partial open order as Working. After 20:00 ET the table showed three QUEUED chips (ARM/SPCX NEXT RTH, TQQQ DAY+EXT) while the header said WORKING 3.

`summarizeOpenOrders` now uses the same mapped status as the row chips, including the live-AH PreSubmitted promotion from #236.

## How to tell
On /orders after 20:00 ET with only Queued rows: header Working is 0. During 16:00-20:00 ET a PreSubmitted EXT stock still increments Working (chip Working + EXT LIVE).

## Tests
- `web/tests/orders-display.test.ts`: 3 overnight PreSubmitted = Working 0; EXT stock Working only in live AH
- `web/tests/orders-command-strip.test.tsx`: strip Working 0 when every visible row is Queued

Do not merge. No live IB orders.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd8629b8-b10c-4432-8c21-6b215125d9fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd8629b8-b10c-4432-8c21-6b215125d9fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

