### PR TITLE
flex-pull: accept IBKR's .xml.pgp delivery names

### DIFF
--- a/docs/flex-sftp-setup.md
+++ b/docs/flex-sftp-setup.md
@@ -43,7 +43,7 @@ Keys and env live **outside** `/etc/radon/env` so `TWS_PASSWORD` is not in this 
   known_hosts                         0600  pinned IBKR host key
   env                                 0600  TURSO_* + IB_FLEX_NAV_QUERY_ID + IB_FLEX_QUERY_ID
                                             (no TWS_PASSWORD, no IB_FLEX_TOKEN required)
-/var/lib/radon/flex-inbox/            0700  pulled .gpg files
+/var/lib/radon/flex-inbox/            0700  pulled files (IBKR names them <acct>.<Query_Name>.<from>.<to>.xml.pgp)
 ```
 
 `radon-flex-pull.service` uses `EnvironmentFile=-/var/lib/radon/flex-secrets/env` and `InaccessiblePaths` on `/etc/radon/env`.

--- a/scripts/flex_sftp_pull.py
+++ b/scripts/flex_sftp_pull.py
@@ -39,6 +39,10 @@ FIRST_DELIVERY_DATE = date(2026, 8, 31)
 FIRST_DELIVERY_ENV = "RADON_FLEX_FIRST_DELIVERY"
 MAX_NIGHTLY_SPAN_DAYS = 5
 KEEP_GPG = 3
+# IBKR names a PGP delivery `<acct>.<Query_Name>.<from>.<to>.xml.pgp`. The
+# filter kept only `.gpg`, so three days of files sat in `outgoing` while every
+# run reported an empty directory (2026-09-01 .. 2026-09-02).
+ENCRYPTED_SUFFIXES = (".pgp", ".gpg")
 
 # Directive -> the value it must carry, or None when any value will do.
 # ConnectTimeout / ServerAliveInterval are required because `_sftp`'s own
@@ -143,7 +147,7 @@ def list_remote_gpg(*, config: Path, runner, remote_dir: str = DEFAULT_REMOTE_DI
         # one line. `-1` above asks for one per line; this reads every token
         # regardless, so a server that ignores it still yields every file.
         for token in line.split():
-            if token.lower().endswith(".gpg"):
+            if token.lower().endswith(ENCRYPTED_SUFFIXES):
                 names.append(token.split("/")[-1])
     return names
 
@@ -227,7 +231,10 @@ def _flex_day(value: Optional[str]) -> Optional[date]:
 
 
 def retain_newest_gpg(inbox: Path, keep: int = KEEP_GPG) -> None:
-    files = sorted(inbox.glob("*.gpg"), key=lambda p: p.stat().st_mtime)
+    files = sorted(
+        (p for p in inbox.iterdir() if p.is_file() and p.suffix.lower() in ENCRYPTED_SUFFIXES),
+        key=lambda p: p.stat().st_mtime,
+    )
     for stale in files[:-keep] if keep > 0 else files:
         stale.unlink(missing_ok=True)
 
@@ -382,7 +389,11 @@ def _run(
             if not nightly_period_ok(xml_text):
                 raise FlexSftpError("period_gate: nightly path rejects 365-day/YTD")
             classify_flex_xml(xml_text)
-            result = ingest_fn(xml_text, source_path=str(dest.with_suffix(".xml")))
+            # `a.xml.pgp` labels as `a.xml`, `trades.gpg` as `trades.xml`.
+            plain = dest.with_suffix("")
+            if plain.suffix.lower() != ".xml":
+                plain = plain.with_suffix(".xml")
+            result = ingest_fn(xml_text, source_path=str(plain))
             if not result.get("ok", True):
                 raise FlexSftpError(f"ingest_failed:{result}")
             # `_sftp` issues no `rm` or `rename`, so a delivered file is never

--- a/scripts/tests/test_flex_sftp_pull.py
+++ b/scripts/tests/test_flex_sftp_pull.py
@@ -459,3 +459,73 @@ def test_retain_newest_gpg_keep_zero_removes_all(tmp_path):
         (inbox / f"{i}.gpg").write_bytes(b"x")
     pull.retain_newest_gpg(inbox, keep=0)
     assert list(inbox.glob("*.gpg")) == []
+
+
+# --- IBKR's real delivery names end in .xml.pgp, not .gpg (2026-09-02) ------
+
+IBKR_LS = (
+    "U4698258.Equity_Summary_in_Base.20260901.20260901.xml.pgp\n"
+    "U4698258.Trade_History.20260901.20260901.xml.pgp\n"
+)
+
+
+def test_list_remote_gpg_accepts_ibkr_pgp_names(tmp_path):
+    """Three days of deliveries sat in `outgoing` while every run reported
+    `empty remote directory after 2026-08-31 delivery start`: IBKR names its
+    PGP files `*.xml.pgp`, and the filter only kept `*.gpg`."""
+    import flex_sftp_pull as pull
+
+    config = _ssh_config(tmp_path / "ssh_config")
+    fake = FakeSftp({}, ls_stdout=IBKR_LS + "notes.txt\n")
+    assert pull.list_remote_gpg(config=config, runner=fake) == [
+        "U4698258.Equity_Summary_in_Base.20260901.20260901.xml.pgp",
+        "U4698258.Trade_History.20260901.20260901.xml.pgp",
+    ]
+
+
+def test_run_ingests_ibkr_pgp_delivery(tmp_path):
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
+
+    import flex_sftp_pull as pull
+
+    config = _ssh_config(tmp_path / "ssh_config")
+    inbox = tmp_path / "inbox"
+    name = "U4698258.Trade_History.20260901.20260901.xml.pgp"
+    fake = FakeSftp({name: TRADES.read_bytes()}, ls_stdout=f"{name}\n")
+    seen: list[str] = []
+
+    def ingest(xml, **k):
+        seen.append(k.get("source_path"))
+        return {"ok": True, "outcome": "applied"}
+
+    rc = pull.run(
+        config=config,
+        inbox=inbox,
+        runner=fake,
+        decrypt=lambda data, **k: data.decode(),
+        ingest=ingest,
+        now=datetime(2026, 9, 2, 7, 30, tzinfo=ZoneInfo("America/New_York")),
+    )
+    assert rc == 0
+    assert (inbox / name).exists()
+    assert seen == [str(inbox / "U4698258.Trade_History.20260901.20260901.xml")]
+
+
+def test_retain_newest_gpg_prunes_pgp_names(tmp_path):
+    import time
+
+    import flex_sftp_pull as pull
+
+    inbox = tmp_path / "inbox"
+    inbox.mkdir()
+    for i in range(5):
+        (inbox / f"U4698258.Trade_History.2026090{i}.2026090{i}.xml.pgp").write_bytes(b"x")
+        time.sleep(0.01)
+    pull.retain_newest_gpg(inbox, keep=3)
+    remaining = sorted(p.name for p in inbox.iterdir())
+    assert remaining == [
+        "U4698258.Trade_History.20260902.20260902.xml.pgp",
+        "U4698258.Trade_History.20260903.20260903.xml.pgp",
+        "U4698258.Trade_History.20260904.20260904.xml.pgp",
+    ]


### PR DESCRIPTION
## Why

`radon-flex-pull.service` has exited 1 on every run since 2026-09-01 with heartbeat `empty remote directory after 2026-08-31 delivery start`, while six deliveries (Aug 28, Aug 31, Sep 1; both queries) sat in IBKR's `outgoing`.

IBKR names a PGP delivery `<acct>.<Query_Name>.<from>.<to>.xml.pgp`. `list_remote_gpg` kept only names ending in `.gpg`, so the listing parsed to nothing and the missed-delivery arm fired.

Verified from the VPS before the fix (read-only): TCP 22, pinned host key, publickey auth as the IBKR user, PGP decrypt to the radon-flex key, `period="LastBusinessDay"`, 37 trades in the Sep 1 file. Only the extension filter failed.

## What

- `ENCRYPTED_SUFFIXES = (".pgp", ".gpg")` drives the listing filter and the inbox retention prune (which also globbed `*.gpg`).
- Plaintext label for ingest strips the encrypted suffix (`a.xml.pgp` → `a.xml`, not `a.xml.xml`).
- Setup doc names the real file shape.

## Tests

Red/green with the real IBKR names: listing, full run with ingest label, retention prune. `102 passed` across the flex modules and docs contract.

After deploy, the next timer fire (Thu 07:30 ET) ingests all six files; duplicates are handled by the ingest claim/release path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMk93W3QuiZUwXEvj1UQPp
