### PR TITLE
perf_twr: read flows from a statement in hand before demanding a token

### DIFF
--- a/docs/flex-sftp-setup.md
+++ b/docs/flex-sftp-setup.md
@@ -43,7 +43,7 @@ Keys and env live **outside** `/etc/radon/env` so `TWS_PASSWORD` is not in this 
   known_hosts                         0600  pinned IBKR host key
   env                                 0600  TURSO_* + IB_FLEX_NAV_QUERY_ID + IB_FLEX_QUERY_ID
                                             (no TWS_PASSWORD, no IB_FLEX_TOKEN required)
-/var/lib/radon/flex-inbox/            0700  pulled .gpg files
+/var/lib/radon/flex-inbox/            0700  pulled files (IBKR names them <acct>.<Query_Name>.<from>.<to>.xml.pgp)
 ```
 
 `radon-flex-pull.service` uses `EnvironmentFile=-/var/lib/radon/flex-secrets/env` and `InaccessiblePaths` on `/etc/radon/env`.

--- a/scripts/flex_sftp_pull.py
+++ b/scripts/flex_sftp_pull.py
@@ -39,6 +39,10 @@ FIRST_DELIVERY_DATE = date(2026, 8, 31)
 FIRST_DELIVERY_ENV = "RADON_FLEX_FIRST_DELIVERY"
 MAX_NIGHTLY_SPAN_DAYS = 5
 KEEP_GPG = 3
+# IBKR names a PGP delivery `<acct>.<Query_Name>.<from>.<to>.xml.pgp`. The
+# filter kept only `.gpg`, so three days of files sat in `outgoing` while every
+# run reported an empty directory (2026-09-01 .. 2026-09-02).
+ENCRYPTED_SUFFIXES = (".pgp", ".gpg")
 
 # Directive -> the value it must carry, or None when any value will do.
 # ConnectTimeout / ServerAliveInterval are required because `_sftp`'s own
@@ -143,7 +147,7 @@ def list_remote_gpg(*, config: Path, runner, remote_dir: str = DEFAULT_REMOTE_DI
         # one line. `-1` above asks for one per line; this reads every token
         # regardless, so a server that ignores it still yields every file.
         for token in line.split():
-            if token.lower().endswith(".gpg"):
+            if token.lower().endswith(ENCRYPTED_SUFFIXES):
                 names.append(token.split("/")[-1])
     return names
 
@@ -227,7 +231,10 @@ def _flex_day(value: Optional[str]) -> Optional[date]:
 
 
 def retain_newest_gpg(inbox: Path, keep: int = KEEP_GPG) -> None:
-    files = sorted(inbox.glob("*.gpg"), key=lambda p: p.stat().st_mtime)
+    files = sorted(
+        (p for p in inbox.iterdir() if p.is_file() and p.suffix.lower() in ENCRYPTED_SUFFIXES),
+        key=lambda p: p.stat().st_mtime,
+    )
     for stale in files[:-keep] if keep > 0 else files:
         stale.unlink(missing_ok=True)
 
@@ -382,7 +389,11 @@ def _run(
             if not nightly_period_ok(xml_text):
                 raise FlexSftpError("period_gate: nightly path rejects 365-day/YTD")
             classify_flex_xml(xml_text)
-            result = ingest_fn(xml_text, source_path=str(dest.with_suffix(".xml")))
+            # `a.xml.pgp` labels as `a.xml`, `trades.gpg` as `trades.xml`.
+            plain = dest.with_suffix("")
+            if plain.suffix.lower() != ".xml":
+                plain = plain.with_suffix(".xml")
+            result = ingest_fn(xml_text, source_path=str(plain))
             if not result.get("ok", True):
                 raise FlexSftpError(f"ingest_failed:{result}")
             # `_sftp` issues no `rm` or `rename`, so a delivered file is never

--- a/scripts/perf_twr_builder.py
+++ b/scripts/perf_twr_builder.py
@@ -791,10 +791,16 @@ def resolve_flows(
     """
     token = _os.environ.get("IB_FLEX_TOKEN")
     query_id = _flows_query_id()
-    if not token or not query_id:
+    already_attempted = document is not None and document.query_id == query_id
+    # A statement already in hand (file ingest, or the NAV fetch this run)
+    # carries its own CashTransaction + Transfers; no token is needed to read
+    # it. The sFTP unit runs on an env with no IB_FLEX_TOKEN by design, and
+    # demanding one here made every nightly activity file `flex_not_configured`
+    # -> degraded -> rejected (2026-09-02).
+    in_hand = document is not None and bool(document.xml) and (already_attempted or not allow_fetch)
+    if not in_hand and (not token or not query_id):
         return FlowSet.failed("flex_not_configured"), []
 
-    already_attempted = document is not None and document.query_id == query_id
     if already_attempted and document.xml is None:
         reason = document.error or "nav_fetch_failed"
         print(

--- a/scripts/tests/test_flex_from_file.py
+++ b/scripts/tests/test_flex_from_file.py
@@ -54,6 +54,26 @@ def test_twr_from_file_uses_activity_xml_without_sendrequest(monkeypatch):
     assert payload.get("nav_as_of") or payload.get("period_end")
 
 
+def test_twr_from_file_parses_flows_from_the_file_without_a_token(monkeypatch):
+    """The sFTP unit runs on a stripped env with no IB_FLEX_TOKEN by design
+    (docs/flex-sftp-setup.md). `resolve_flows` demanded a token before looking
+    at the statement already in hand, so every nightly activity file built
+    `flows_status: failed (flex_not_configured)`, degraded, and was rejected
+    (2026-09-02, radon-flex-pull)."""
+    import perf_twr_builder
+
+    monkeypatch.delenv("IB_FLEX_TOKEN", raising=False)
+    monkeypatch.delenv("IB_FLEX_FLOWS_QUERY_ID", raising=False)
+    monkeypatch.delenv("IB_FLEX_NAV_QUERY_ID", raising=False)
+    monkeypatch.setattr(perf_twr_builder, "fetch_flex_xml", lambda *a, **k: (_ for _ in ()).throw(AssertionError("SendRequest")))
+    monkeypatch.setattr(perf_twr_builder, "load_benchmark_closes", lambda *a, **k: {})
+    monkeypatch.setattr(perf_twr_builder, "get_risk_free_rate", lambda **k: (0.0, "test"))
+    payload = perf_twr_builder.build_and_persist(from_file=str(ACTIVITY), persist=False)
+    assert payload.get("nav_source") == "flex_from_file"
+    assert payload.get("flows_status") != "failed", payload.get("warnings")
+    assert not [w for w in payload.get("warnings", []) if w.get("code") == "FLOWS_FETCH_FAILED"]
+
+
 def test_ingest_does_not_import_gdcdyn():
     source = (SCRIPTS / "flex_delivery_ingest.py").read_text()
     assert "gdcdyn" not in source

--- a/scripts/tests/test_flex_sftp_pull.py
+++ b/scripts/tests/test_flex_sftp_pull.py
@@ -459,3 +459,73 @@ def test_retain_newest_gpg_keep_zero_removes_all(tmp_path):
         (inbox / f"{i}.gpg").write_bytes(b"x")
     pull.retain_newest_gpg(inbox, keep=0)
     assert list(inbox.glob("*.gpg")) == []
+
+
+# --- IBKR's real delivery names end in .xml.pgp, not .gpg (2026-09-02) ------
+
+IBKR_LS = (
+    "U4698258.Equity_Summary_in_Base.20260901.20260901.xml.pgp\n"
+    "U4698258.Trade_History.20260901.20260901.xml.pgp\n"
+)
+
+
+def test_list_remote_gpg_accepts_ibkr_pgp_names(tmp_path):
+    """Three days of deliveries sat in `outgoing` while every run reported
+    `empty remote directory after 2026-08-31 delivery start`: IBKR names its
+    PGP files `*.xml.pgp`, and the filter only kept `*.gpg`."""
+    import flex_sftp_pull as pull
+
+    config = _ssh_config(tmp_path / "ssh_config")
+    fake = FakeSftp({}, ls_stdout=IBKR_LS + "notes.txt\n")
+    assert pull.list_remote_gpg(config=config, runner=fake) == [
+        "U4698258.Equity_Summary_in_Base.20260901.20260901.xml.pgp",
+        "U4698258.Trade_History.20260901.20260901.xml.pgp",
+    ]
+
+
+def test_run_ingests_ibkr_pgp_delivery(tmp_path):
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
+
+    import flex_sftp_pull as pull
+
+    config = _ssh_config(tmp_path / "ssh_config")
+    inbox = tmp_path / "inbox"
+    name = "U4698258.Trade_History.20260901.20260901.xml.pgp"
+    fake = FakeSftp({name: TRADES.read_bytes()}, ls_stdout=f"{name}\n")
+    seen: list[str] = []
+
+    def ingest(xml, **k):
+        seen.append(k.get("source_path"))
+        return {"ok": True, "outcome": "applied"}
+
+    rc = pull.run(
+        config=config,
+        inbox=inbox,
+        runner=fake,
+        decrypt=lambda data, **k: data.decode(),
+        ingest=ingest,
+        now=datetime(2026, 9, 2, 7, 30, tzinfo=ZoneInfo("America/New_York")),
+    )
+    assert rc == 0
+    assert (inbox / name).exists()
+    assert seen == [str(inbox / "U4698258.Trade_History.20260901.20260901.xml")]
+
+
+def test_retain_newest_gpg_prunes_pgp_names(tmp_path):
+    import time
+
+    import flex_sftp_pull as pull
+
+    inbox = tmp_path / "inbox"
+    inbox.mkdir()
+    for i in range(5):
+        (inbox / f"U4698258.Trade_History.2026090{i}.2026090{i}.xml.pgp").write_bytes(b"x")
+        time.sleep(0.01)
+    pull.retain_newest_gpg(inbox, keep=3)
+    remaining = sorted(p.name for p in inbox.iterdir())
+    assert remaining == [
+        "U4698258.Trade_History.20260902.20260902.xml.pgp",
+        "U4698258.Trade_History.20260903.20260903.xml.pgp",
+        "U4698258.Trade_History.20260904.20260904.xml.pgp",
+    ]


### PR DESCRIPTION
## Why

After #244 the sFTP unit pulls and decrypts every IBKR delivery, and the three Trade History files applied. Every Equity Summary (activity) file was still rejected: the from-file TWR build reported `flows_status: failed (flex_not_configured)`, floored the payload to `degraded`, and `flex_delivery_ingest` returned `ok: False`, so `radon-flex-pull` still exits 1 and re-pulls the same files every run.

`resolve_flows` required `IB_FLEX_TOKEN` before looking at the statement it was already handed. The sFTP unit's env has no token by design (`docs/flex-sftp-setup.md`: "no IB_FLEX_TOKEN required").

## What

- A statement in hand (file ingest, or the NAV document fetched this run) is parsed for flows without a token. The token gate now applies only where a SendRequest would actually happen; those paths are unchanged.

## Tests

Red/green: `test_twr_from_file_parses_flows_from_the_file_without_a_token`. All perf_twr / flex modules: `194 passed` + `48 passed`.

Live verification after deploy: start `radon-flex-pull.service` on the VPS and confirm the three activity files reach `applied` in `flex_deliveries` and the heartbeat goes `ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMk93W3QuiZUwXEvj1UQPp
