### PR TITLE
Remove HELD badge from option position header

### DIFF
--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,19 @@
+# Task: Remove mobile cockpit HELD chip (FM-RADON-HELD) [WIP]
+
+Captain: the teal HELD badge between the SMH OPTION header and the
+structure card wastes a row. Drop it. Keep FLAT, LIVE, STOCK/OPTION.
+
+- H1 depends_on: [] - failing mobile header test
+- H2 depends_on: [H1] - omit HELD chip when a position is held
+- H3 depends_on: [H2] - focused vitest + e2e spec update
+
+## Checklist
+- [x] H1 failing test
+- [x] H2 remove chip
+- [ ] H3 tests green
+
+---
+
 # Task: Orders header WORKING vs QUEUED rows (2026-09-02) [WIP]
 
 PR 236 comment: Overnight TIF is a separate IB venue from EXT `outsideRth`.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -10,7 +10,13 @@ structure card wastes a row. Drop it. Keep FLAT, LIVE, STOCK/OPTION.
 ## Checklist
 - [x] H1 failing test
 - [x] H2 remove chip
-- [ ] H3 tests green
+- [x] H3 tests green — 8508 passed, 18 skipped
+
+## Review
+- Mobile header omits HELD when a position is held; FLAT stays
+- STOCK/OPTION switcher and LIVE dot unchanged
+- Desktop structure chip unchanged
+- No PR per ticket
 
 ---
 

--- a/web/components/ticker-detail/CockpitHeader.tsx
+++ b/web/components/ticker-detail/CockpitHeader.tsx
@@ -89,12 +89,10 @@ export default function CockpitHeader({
   }, [ticker, toggleWatch]);
 
   if (mobile) {
-    // Mobile: condensed strip — ticker + last + day chg + live dot + position chip.
-    // Spread is dropped to keep the single row thumb-readable; position chip links
-    // to the p-deck where the full summary lives. The chip stays a compact
-    // HELD/FLAT token: the full structure string is owned by the position
-    // summary directly below — repeating it here wrapped the header onto a
-    // second cluttered row (2026-08-04).
+    // Mobile: condensed strip — ticker + last + day chg + live dot.
+    // Spread is dropped to keep the single row thumb-readable. The structure
+    // card sits directly below a held option, so a HELD chip here is a wasted
+    // wrap row (FM-RADON-HELD). FLAT stays when there is no position.
     return (
       <div className="cockpit-head ckh--mobile">
         <span className="ckh-sym mono">{ticker}</span>
@@ -136,14 +134,16 @@ export default function CockpitHeader({
             {Math.abs(deltaPct).toFixed(2)}%
           </span>
         )}
-        <button
-          type="button"
-          className={`ckh-poschip tap-target ${position ? "held" : ""}`}
-          aria-label={position ? `Position: ${position.structure}` : "No position"}
-          onClick={() => onDeckChange("p")}
-        >
-          {position ? "HELD" : "FLAT"}
-        </button>
+        {!position && (
+          <button
+            type="button"
+            className="ckh-poschip tap-target"
+            aria-label="No position"
+            onClick={() => onDeckChange("p")}
+          >
+            FLAT
+          </button>
+        )}
       </div>
     );
   }

--- a/web/e2e/mobile-cockpit-book-layout.spec.ts
+++ b/web/e2e/mobile-cockpit-book-layout.spec.ts
@@ -10,8 +10,8 @@ import { expect, test, type Page } from "@playwright/test";
  *    than the viewport (right-edge clipping).
  * 3. `.book-window-head` (nowrap + overflow hidden) clipped SPRD and the tape
  *    toggle clean off a 393px screen.
- * 4. The header position chip repeated the FULL structure string that the
- *    position summary right below it already shows.
+ * 4. The header HELD chip sat on its own wrap row above the structure card.
+ *    Summary owns the held cue; the header chip is gone when a position is held.
  */
 
 const now = new Date().toISOString();
@@ -222,10 +222,9 @@ test("a credit combo's AVG ENTRY reads negative, not positive (2026-08-07)", asy
   expect(avgEntry ?? "").not.toMatch(/(?<![-])\$0\.12/);
 });
 
-test("the structure string renders once — summary owns it, the header chip stays compact", async ({ page }) => {
+test("the structure string renders once — summary owns it, the header has no HELD chip", async ({ page }) => {
   await openCockpit(page);
   await expect(page.locator(".ckp-pos-summary")).toContainText(STRUCTURE);
-  const chip = page.locator(".ckh-poschip");
-  await expect(chip).toBeVisible();
-  await expect(chip).not.toContainText("Risk Reversal");
+  await expect(page.locator(".ckh-poschip")).toHaveCount(0);
+  await expect(page.locator(".cockpit-head")).not.toContainText("HELD");
 });

--- a/web/tests/cockpit-header-mobile-switcher.test.tsx
+++ b/web/tests/cockpit-header-mobile-switcher.test.tsx
@@ -62,3 +62,21 @@ describe("CockpitHeader mobile — STOCK|OPTION switcher", () => {
     expect(onInstrumentViewChange).toHaveBeenCalledWith("underlying");
   });
 });
+
+describe("CockpitHeader mobile — no HELD chip on a held option", () => {
+  it("omits the HELD badge when a position is held", () => {
+    const { container } = renderHeader({
+      position: { structure: "Bull Put Spread $545.0/$550.0" },
+      live: true,
+    });
+    expect(container.querySelector(".ckh-poschip")).toBeNull();
+    expect(container.textContent ?? "").not.toMatch(/\bHELD\b/);
+    expect(container.querySelector(".ckh-instr")).not.toBeNull();
+    expect(container.querySelector(".ckh-live")).not.toBeNull();
+  });
+
+  it("keeps the FLAT chip when there is no position", () => {
+    const { container } = renderHeader({ position: null });
+    expect(container.querySelector(".ckh-poschip")?.textContent?.trim()).toBe("FLAT");
+  });
+});


### PR DESCRIPTION
## Summary
- Drop the teal HELD chip from the mobile cockpit option header (`CockpitHeader.tsx`) so the structure card sits closer to the ticker.
- FLAT, LIVE, and STOCK/OPTION stay. Desktop structure chip unchanged.

## Test plan
- [ ] Option position screen no longer shows HELD
- [ ] FLAT / LIVE / STOCK-OPTION still render
- [ ] CI green