### PR TITLE
perf_twr: the fresher NAV series wins between disk cache and Turso

### DIFF
--- a/scripts/perf_twr_builder.py
+++ b/scripts/perf_twr_builder.py
@@ -504,7 +504,7 @@ def _fetch_nav_document() -> Optional[FlexDocument]:
 def get_nav_snapshots(*, sendrequest: bool = False) -> NavResolution:
     """Resolve NAV. Live Flex only when ``sendrequest`` is true.
 
-    Default is disk then Turso. Page-driven and weekday jobs must not
+    Default is the fresher of disk and Turso. Page-driven and weekday jobs must not
     SendRequest. A saved statement uses ``build_and_persist(from_file=...)``.
     """
     document: Optional[FlexDocument] = None
@@ -519,10 +519,16 @@ def get_nav_snapshots(*, sendrequest: bool = False) -> NavResolution:
             _cache_nav_to_disk(entries)
             return NavResolution(entries, "flex_live", tuple(gap_dates), document)
 
+    # Fresher series wins; a tie stays on disk. "Disk then Turso" served the
+    # 08-21 disk cache for 18 days after the sFTP ingest had mirrored NAV
+    # through 09-01 into Turso, because nothing SendRequests any more and the
+    # cache only ages out at 30 days (2026-09-02).
     disk = load_nav_from_disk()
+    turso = load_nav_from_turso()
+    if disk and turso and max(turso) > max(disk):
+        return NavResolution(turso, "turso", (), document)
     if disk:
         return NavResolution(disk, "disk_cache", (), document)
-    turso = load_nav_from_turso()
     if turso:
         return NavResolution(turso, "turso", (), document)
     return NavResolution({}, "none", (), document)

--- a/tests/test_perf_twr_flows.py
+++ b/tests/test_perf_twr_flows.py
@@ -376,6 +376,53 @@ def test_76c_the_thirty_day_boundary(tmp_path, monkeypatch):
     assert load_nav_from_disk() is None
 
 
+def _nav_map(newest: date, count: int = 5) -> dict[str, float]:
+    return {
+        (newest - timedelta(days=count - 1 - i)).isoformat(): 100_000.0 + i
+        for i in range(count)
+    }
+
+
+def test_76d_a_fresher_turso_mirror_beats_a_within_budget_disk_cache(monkeypatch):
+    """Live defect 2026-09-02: the sFTP ingest mirrored NAV through 09-01 into
+    Turso, but the daily builder served the 08-21 disk cache for another 18
+    days because "disk then Turso" never compared dates."""
+    disk = _nav_map(date.today() - timedelta(days=12))
+    turso = _nav_map(date.today() - timedelta(days=1), count=20)
+    monkeypatch.setattr(builder, "load_nav_from_disk", lambda: disk)
+    monkeypatch.setattr(builder, "load_nav_from_turso", lambda: turso)
+
+    resolution = builder.get_nav_snapshots(sendrequest=False)
+    assert resolution.source == "turso"
+    assert max(resolution.by_date) == max(turso)
+
+
+def test_76e_a_fresher_disk_cache_still_wins_and_ties_stay_on_disk(monkeypatch):
+    disk = _nav_map(date.today() - timedelta(days=1))
+    turso = _nav_map(date.today() - timedelta(days=4), count=20)
+    monkeypatch.setattr(builder, "load_nav_from_disk", lambda: disk)
+    monkeypatch.setattr(builder, "load_nav_from_turso", lambda: turso)
+    assert builder.get_nav_snapshots(sendrequest=False).source == "disk_cache"
+
+    monkeypatch.setattr(builder, "load_nav_from_turso", lambda: _nav_map(date.today() - timedelta(days=1), count=20))
+    assert builder.get_nav_snapshots(sendrequest=False).source == "disk_cache"
+
+
+def test_76f_turso_alone_and_disk_alone_still_resolve(monkeypatch):
+    only = _nav_map(date.today() - timedelta(days=1))
+    monkeypatch.setattr(builder, "load_nav_from_disk", lambda: None)
+    monkeypatch.setattr(builder, "load_nav_from_turso", lambda: only)
+    assert builder.get_nav_snapshots(sendrequest=False).source == "turso"
+
+    monkeypatch.setattr(builder, "load_nav_from_disk", lambda: only)
+    monkeypatch.setattr(builder, "load_nav_from_turso", lambda: None)
+    assert builder.get_nav_snapshots(sendrequest=False).source == "disk_cache"
+
+    monkeypatch.setattr(builder, "load_nav_from_disk", lambda: None)
+    monkeypatch.setattr(builder, "load_nav_from_turso", lambda: None)
+    assert builder.get_nav_snapshots(sendrequest=False).source == "none"
+
+
 @pytest.mark.parametrize(
     "nav_source,sessions_behind,expected_status,expected_codes",
     [


### PR DESCRIPTION
## Why

After #244 and #245 the sFTP ingest mirrors NAV nightly into Turso `nav_snapshots` (now through 2026-09-01). The daily `radon-perf-twr.timer` still published the 2026-08-21 series: `get_nav_snapshots` resolves "disk then Turso", and the disk cache (`data/nav_history_ib.json`, last written by a live Flex fetch on 08-23) stays inside its 30-day age budget until 09-20. Nothing SendRequests any more, so the disk cache can no longer refresh itself.

## What

- Between disk and Turso the newer series (max report date) wins. Tie stays on disk. Disk-only, Turso-only, and the 30-day refusal of an old cache are unchanged.

## Tests

Red/green: `test_76d/76e/76f` in `tests/test_perf_twr_flows.py`. All perf_twr / flex modules plus docs contract: `284 passed`.

Live verification after deploy: `systemctl start radon-perf-twr.service` and confirm `status=... source=turso` with `as_of=2026-09-01`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMk93W3QuiZUwXEvj1UQPp
