### PR TITLE
control-plane: read the GitHub main tip over git protocol v1

### DIFF
--- a/cloud/scripts/deploy-root-helper.sh
+++ b/cloud/scripts/deploy-root-helper.sh
@@ -1034,7 +1034,11 @@ resolve_trusted_main_tip() {
       return 76
     }
   fi
-  remote_sha="$(git_bounded ls-remote --refs "$UNIT_REMOTE" refs/heads/main | awk '{print $1}')" || {
+  # Protocol v1: the refs arrive in the info/refs GET. From this host an
+  # unauthenticated v2 ls-refs POST against the public repo answers 401
+  # ("could not read Username"), which failed every deploy at the first real
+  # sync-control-plane run (2026-09-02).
+  remote_sha="$(git_bounded -c protocol.version=1 ls-remote --refs "$UNIT_REMOTE" refs/heads/main | awk '{print $1}')" || {
     echo "could not read the GitHub main tip" >&2
     return 69
   }
@@ -1079,7 +1083,11 @@ resolve_fetched_main_tip() {
       return 76
     }
   fi
-  remote_sha="$(git_bounded ls-remote --refs "$UNIT_REMOTE" refs/heads/main | awk '{print $1}')" || {
+  # Protocol v1: the refs arrive in the info/refs GET. From this host an
+  # unauthenticated v2 ls-refs POST against the public repo answers 401
+  # ("could not read Username"), which failed every deploy at the first real
+  # sync-control-plane run (2026-09-02).
+  remote_sha="$(git_bounded -c protocol.version=1 ls-remote --refs "$UNIT_REMOTE" refs/heads/main | awk '{print $1}')" || {
     echo "could not read the GitHub main tip" >&2
     return 69
   }

--- a/cloud/tests/test_sync_control_plane.py
+++ b/cloud/tests/test_sync_control_plane.py
@@ -199,6 +199,17 @@ class TestContracts:
         assert "github_origin_is_allowed" in tip
         assert 'cat-file -e "${remote_sha}^{commit}"' in tip
 
+    def test_the_tip_is_read_over_git_protocol_v1(self):
+        """2026-09-02: from the VPS, an unauthenticated protocol-v2 `ls-remote`
+        against the public repo got HTTP 401 on the `ls-refs` POST ("could not
+        read Username for 'https://github.com'"), so the first real
+        sync-control-plane run failed every deploy with exit 69. Protocol v1
+        reads the refs from the `info/refs` GET, which answers 200."""
+        helper = ROOT_HELPER.read_text(encoding="utf-8")
+        for fn in ("resolve_fetched_main_tip", "resolve_trusted_main_tip"):
+            body = function_body(helper, fn)
+            assert '-c protocol.version=1 ls-remote --refs "$UNIT_REMOTE" refs/heads/main' in body, fn
+
     def test_verb_has_its_own_deadline_and_never_cancels_radon_jobs(self):
         helper = ROOT_HELPER.read_text(encoding="utf-8")
         assert "readonly ROOT_SYNC_ACTION_TIMEOUT=300" in helper


### PR DESCRIPTION
## Why

The deploy of #247 (`bff97cf9`) failed twice at the new sync-control-plane step with exit 69: `could not read the GitHub main tip`. Reproduced as root on the VPS: an unauthenticated protocol-v2 `git ls-remote https://github.com/joemccann/radon.git` gets 200 on the `info/refs` GET and then **401 on the `ls-refs` POST** ("could not read Username for 'https://github.com'"). The repo is public and the same request works from a laptop; protocol v1 (refs in the GET) returns the tip from the VPS.

Earlier deploys today passed only because the sudo grant for `sync-control-plane` was not installed yet, so the step was a no-op.

## What

- `resolve_trusted_main_tip` and `resolve_fetched_main_tip` run `ls-remote` with `-c protocol.version=1`. Remote pin, sha validation, and the local-store existence check are unchanged.
- Contract test pins the flag in both functions.

## Rollout

The installed helper cannot self-update through the sync it needs. After merge: one root bootstrap from this release's deploy runner (`RADON_BOOTSTRAP_CLOUD_ROOT=<runner>/cloud bash bootstrap-control-plane.sh`), then re-run the deploy job. Deploys self-sync from then on.

## Tests

`cloud/tests/test_sync_control_plane.py`: 29 passed (new test red before the change). Remaining `cloud/tests` failures locally are `flock`-missing on macOS; CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMk93W3QuiZUwXEvj1UQPp
