### PR TITLE
Add Cloud Agent dev environment (bun + Python 3.13)

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,15 @@
+{
+  "name": "Radon",
+  "install": "bash .cursor/install.sh",
+  "terminals": [
+    {
+      "name": "next",
+      "command": "export PATH=\"$HOME/.local/bin:$HOME/.bun/bin:$PATH\" && cd web && bun run dev:next"
+    },
+    {
+      "name": "fastapi",
+      "command": "export PATH=\"$HOME/.local/bin:$HOME/.bun/bin:$PATH\" && source .venv/bin/activate && RADON_API_TEST_MODE=1 python -m uvicorn scripts.api.server:app --host 127.0.0.1 --port 8321"
+    }
+  ],
+  "ports": [3000, 8321]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Cloud Agent install — idempotent bootstrap for the Radon dev environment.
+#
+# Layers:
+#   1. Toolchains not in the base image: bun (root + web/) and Python 3.13 (uv).
+#   2. JS deps (bun) for the repo root and the Next.js terminal in web/.
+#   3. Python deps into a project venv (.venv) via uv pip.
+#   4. Dev-safe env files, if absent, so Next.js boots into first-run setup mode
+#      and FastAPI runs in test mode without live broker credentials.
+#
+# Runtime services are launched by the `terminals` in .cursor/environment.json,
+# never here. No process started by this script is expected to outlive it.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+export PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH"
+
+echo "== [1/4] toolchains =="
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "installing bun..."
+  curl -fsSL https://bun.sh/install | bash
+fi
+export PATH="$HOME/.bun/bin:$PATH"
+bun --version
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "installing uv..."
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+export PATH="$HOME/.local/bin:$PATH"
+
+# Python 3.13 — the project pins it (3.14 breaks ib_insync/eventkit). uv fetches
+# a standalone build and we expose it on PATH as `python3.13`, which scripts call
+# directly.
+uv python install 3.13
+ln -sf "$(uv python find 3.13)" "$HOME/.local/bin/python3.13"
+python3.13 --version
+
+echo "== [2/4] JS deps (bun) =="
+bun install
+( cd web && bun install )
+
+echo "== [3/4] Python deps (uv venv + uv pip) =="
+if [ ! -d .venv ]; then
+  uv venv --python 3.13 .venv
+fi
+VIRTUAL_ENV="$REPO_ROOT/.venv" uv pip install -r requirements.txt
+
+echo "== [4/4] dev env files =="
+# Root .env — python-dotenv for FastAPI/scripts. Placeholders only.
+if [ ! -f .env ]; then
+  cp .env.example .env
+  echo "created .env from .env.example"
+fi
+# web/.env — Next.js. Blank the Clerk placeholders so the app boots into
+# first-run setup mode (ClerkProvider refuses an invalid key). A real deploy
+# fills these in and setup mode switches off automatically.
+if [ ! -f web/.env ]; then
+  cp web/.env.example web/.env
+  sed -i 's/^NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=.*/NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=/' web/.env
+  sed -i 's/^CLERK_SECRET_KEY=.*/CLERK_SECRET_KEY=/' web/.env
+  echo "created web/.env from web/.env.example (Clerk keys blanked for setup mode)"
+fi
+
+echo "== install complete =="


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a committed Cloud Agent environment so the repo boots end-to-end without manual toolchain setup.

- `.cursor/environment.json` — `install` bootstrap plus two `terminals` (Next.js `:3000`, FastAPI `:8321`) and exposed `ports`.
- `.cursor/install.sh` — idempotent bootstrap: installs `bun` and Python 3.13 (via `uv`), runs `bun install` (root + `web/`), creates a `.venv` and `uv pip install -r requirements.txt`, and seeds dev-safe `.env` files.

## Why

The base image ships Node 22 but not `bun` (root + `web/` package manager per `DEVELOPMENT.md`) or `python3.13` (pinned; 3.14 breaks `ib_insync`/`eventkit`). Without live Clerk/IB/UW credentials the app is designed to degrade:

- Next.js boots into **first-run setup mode** when Clerk keys are absent (`web/lib/setup/setupMode.ts`), so the install blanks the Clerk placeholders that would otherwise make `ClerkProvider` throw.
- FastAPI runs under `RADON_API_TEST_MODE=1`, which disables IB Gateway/pool startup (no Docker/broker needed).

## Validation

- `install.sh` runs clean twice (idempotent).
- Next.js `:3000` — `/` → 307 → `/setup` (200), title `Radon Terminal`, first-run wizard renders.
- FastAPI `:8321` — `/health` → 200 `{"status":"ok","test_mode":true,...}`.

Setup wizard, served by the running Next.js dev server:

![Radon first-run setup wizard rendered at localhost:3000/setup](https://cursor.com/artifacts/c/art-18bd1389-42c7-4060-9bd7-00cda3c238a8)

Full terminal (portfolio/orders/scanners) still requires real Clerk + Interactive Brokers + Unusual Whales credentials, added later as environment secrets.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-816f163e-3c45-40ab-b486-30ca4b91add5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-816f163e-3c45-40ab-b486-30ca4b91add5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

