### PR TITLE
Profile follow-ups: setup latch (REL-192), credential truth (REL-190), prefs merge (REL-204)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -270,6 +270,7 @@ tasks/artifacts/*.png
 docs/security-audit-*.html
 
 # Weekend reliability runner marker (dedicated clone only, never committed)
+/.radon/
 .radon-weekend-runner
 # REL-180 (R-507): per-loop markers and the runner lock live untracked in every
 # loop clone where an agent stages files; a committed lock pid would make all

--- a/scripts/api/routes/credentials.py
+++ b/scripts/api/routes/credentials.py
@@ -47,6 +47,10 @@ logger = logging.getLogger("radon.credentials")
 
 router = APIRouter()
 
+# Names exported from the store into os.environ this process lifetime.
+# Distinguishes live exports from .env-file fallbacks after a delete (R-541).
+_SESSION_EXPORTED: set[str] = set()
+
 UPDATED_BY_MAX_LEN = 64
 
 
@@ -128,6 +132,9 @@ def _service_entry(
     fields = []
     for field in service.fields:
         row = stored.get(field.name)
+        env_present = bool(os.environ.get(field.name))
+        exported_only = row is None and env_present and field.name in _SESSION_EXPORTED
+        env_fallback = row is None and env_present and field.name not in _SESSION_EXPORTED
         fields.append(
             {
                 "name": field.name,
@@ -139,7 +146,8 @@ def _service_entry(
                 "version": row["version"] if row else 0,
                 "updated_at": row["updated_at"] if row else None,
                 "updated_by": row["updated_by"] if row else None,
-                "env_fallback": row is None and bool(os.environ.get(field.name)),
+                "env_fallback": env_fallback,
+                "exported_only": exported_only,
             }
         )
     return {
@@ -239,12 +247,14 @@ async def put_credentials(service_id: str, request: Request):
     if verdict.blocks_save:
         raise HTTPException(
             status_code=422,
-            detail={
-                "code": "CREDENTIAL_REJECTED",
-                "service": service_id,
-                "status": verdict.status,
-                "message": verdict.message,
-            },
+            detail=credential_validators.scrub_validation_message(
+                {
+                    "code": "CREDENTIAL_REJECTED",
+                    "service": service_id,
+                    "status": verdict.status,
+                    "message": verdict.message,
+                }
+            ),
         )
 
     def _save() -> None:
@@ -254,6 +264,7 @@ async def put_credentials(service_id: str, request: Request):
         store.set_secrets(submitted, actor=actor)
         for name, value in submitted.items():
             os.environ[name] = value
+            _SESSION_EXPORTED.add(name)
 
     try:
         await asyncio.to_thread(_save)
@@ -264,7 +275,7 @@ async def put_credentials(service_id: str, request: Request):
     stored = await asyncio.to_thread(_stored_by_name, store)
     return {
         "service": _service_entry(service, stored),
-        "validation": verdict.to_dict(),
+        "validation": credential_validators.scrub_validation_message(verdict.to_dict()),
     }
 
 
@@ -283,7 +294,7 @@ async def validate_credentials(service_id: str, request: Request):
     verdict = await asyncio.to_thread(
         credential_validators.validate, service_id, merged
     )
-    return {"validation": verdict.to_dict()}
+    return {"validation": credential_validators.scrub_validation_message(verdict.to_dict())}
 
 
 @router.delete("/credentials/{service_id}/{name}")
@@ -334,5 +345,6 @@ def bootstrap_exported_names() -> list:
             continue
         if value:
             os.environ[name] = value
+            _SESSION_EXPORTED.add(name)
             exported.append(name)
     return exported

--- a/scripts/api/tests/test_credentials_routes.py
+++ b/scripts/api/tests/test_credentials_routes.py
@@ -125,6 +125,28 @@ class TestList:
         (field,) = uw["fields"]
         assert field["configured"] is False
         assert field["env_fallback"] is True
+        assert field["exported_only"] is False
+
+    def test_exported_only_after_delete(self, client, valid_verdict, monkeypatch):
+        monkeypatch.delenv("UW_TOKEN", raising=False)
+        client.put(
+            "/credentials/unusual_whales",
+            json={"values": {"UW_TOKEN": "uw-live-token"}, "updated_by": "op-1"},
+        )
+        client.delete("/credentials/unusual_whales/UW_TOKEN")
+        import os
+
+        assert os.environ.get("UW_TOKEN") == "uw-live-token"
+        response = client.get("/credentials")
+        uw = next(
+            service
+            for service in response.json()["services"]
+            if service["id"] == "unusual_whales"
+        )
+        (field,) = uw["fields"]
+        assert field["configured"] is False
+        assert field["exported_only"] is True
+        assert field["env_fallback"] is False
 
 
 class TestPut:

--- a/scripts/credential_redaction.py
+++ b/scripts/credential_redaction.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Redact credential-shaped fragments from validator messages (REL-190)."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+_SECRET_SCRUB_PATTERNS = [
+    (re.compile(r"libsql://[^\s'\"]+", re.IGNORECASE), "[redacted-db-url]"),
+    (re.compile(r"https://[a-z0-9.-]+\.turso\.io[^\s'\"]*", re.IGNORECASE), "[redacted-db-url]"),
+    (
+        re.compile(r"(auth[_-]?token|authorization|bearer)(\s*[=:]\s*)\S+", re.IGNORECASE),
+        r"\1\2[redacted]",
+    ),
+    (re.compile(r"eyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]*"), "[redacted-jwt]"),
+    (re.compile(r"\bU\d{6,}\b"), "[redacted-account]"),
+    (re.compile(r"sk-ant-[A-Za-z0-9_-]{6,}"), "[redacted-key]"),
+    (re.compile(r"\bsk_(?:live|test)_[A-Za-z0-9]{6,}\b"), "[redacted-key]"),
+    (re.compile(r"([?&](?:t|token|api[_-]?key)=)[^\s&'\"]+", re.IGNORECASE), r"\1[redacted]"),
+]
+
+
+def scrub_credential_text(value: Any) -> Any:
+    if isinstance(value, str):
+        for pattern, repl in _SECRET_SCRUB_PATTERNS:
+            value = pattern.sub(repl, value)
+        return value
+    if isinstance(value, dict):
+        return {k: scrub_credential_text(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [scrub_credential_text(v) for v in value]
+    return value

--- a/scripts/credential_validators.py
+++ b/scripts/credential_validators.py
@@ -27,8 +27,14 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Dict, Optional
+from urllib.parse import urlparse
 
 import requests
+
+try:
+    import credential_redaction
+except ImportError:  # pragma: no cover
+    from scripts import credential_redaction
 
 try:
     import credentials_registry
@@ -56,7 +62,11 @@ class ValidationResult:
         return self.status == "invalid"
 
     def to_dict(self) -> Dict[str, str]:
-        return {"status": self.status, "message": self.message}
+        return scrub_validation_message({"status": self.status, "message": self.message})
+
+
+def scrub_validation_message(payload: Dict[str, str]) -> Dict[str, str]:
+    return credential_redaction.scrub_credential_text(payload)
 
 
 def _verdict_from_status_code(code: int, vendor: str) -> ValidationResult:
@@ -171,9 +181,26 @@ def _validate_pushover(values: Dict[str, str]) -> ValidationResult:
 
 
 def _validate_turso(values: Dict[str, str]) -> ValidationResult:
-    url = values["TURSO_DB_URL"].strip()
+    raw_url = values["TURSO_DB_URL"].strip()
+    if raw_url.startswith("http://"):
+        return ValidationResult("invalid", "Turso URL must use HTTPS")
+    url = raw_url
     if url.startswith("libsql://"):
         url = "https://" + url[len("libsql://") :]
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or not parsed.netloc:
+        return ValidationResult("invalid", "Turso URL must be a libsql:// or https:// URL")
+    configured = os.environ.get("TURSO_DB_URL", "").strip()
+    if configured:
+        cfg = configured
+        if cfg.startswith("libsql://"):
+            cfg = "https://" + cfg[len("libsql://") :]
+        expected_host = urlparse(cfg).netloc
+        if expected_host and parsed.netloc != expected_host:
+            return ValidationResult(
+                "invalid",
+                "Turso URL host does not match the configured database host",
+            )
     return _post(
         url.rstrip("/") + "/v2/pipeline",
         {"Authorization": f"Bearer {values['TURSO_AUTH_TOKEN']}"},
@@ -203,7 +230,9 @@ def _run_login_subprocess(
         timeout=SLOW_LOGIN_TIMEOUT_S,
     )
     if proc.returncode != 0:
-        detail = (proc.stderr or proc.stdout or "").strip()[-200:]
+        detail = scrub_validation_message(
+            {"message": (proc.stderr or proc.stdout or "").strip()[-200:]}
+        )["message"]
         return ValidationResult(
             "error", f"login check for {service_id} failed to run: {detail}"
         )
@@ -211,7 +240,10 @@ def _run_login_subprocess(
     status = verdict.get("status")
     if status not in _STATUSES:
         raise ValueError(f"login check returned unknown status {status!r}")
-    return ValidationResult(status, str(verdict.get("message", "")))
+    return ValidationResult(
+        status,
+        scrub_validation_message({"message": str(verdict.get("message", ""))})["message"],
+    )
 
 
 def _validate_menthorq(values: Dict[str, str]) -> ValidationResult:

--- a/scripts/credentials_registry.py
+++ b/scripts/credentials_registry.py
@@ -178,7 +178,9 @@ SERVICES: Tuple[CredentialService, ...] = (
         ),
         note=(
             "Never live-validated: a login probe fires a real IBKR Mobile "
-            "2FA push. Verified by the Gateway itself on next start."
+            "2FA push. Saving here does NOT rotate the Gateway password on "
+            "the broker host — that still comes from TWS_PASSWORD_FILE / "
+            "docker secrets until wired separately."
         ),
     ),
     CredentialService(

--- a/scripts/secret_store.py
+++ b/scripts/secret_store.py
@@ -106,6 +106,14 @@ def _sqlite_guarded(fn):
     return wrapper
 
 
+def _ensure_private_file(path: Path) -> None:
+    if not path.is_file():
+        return
+    mode = path.stat().st_mode & 0o777
+    if mode != 0o600:
+        os.chmod(path, 0o600)
+
+
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -151,6 +159,7 @@ class SecretStore:
                     )
                 return key
         if self._key_path.is_file():
+            _ensure_private_file(self._key_path)
             key = self._key_path.read_bytes()
             if len(key) != _KEY_BYTES:
                 raise SecretStoreError(
@@ -230,6 +239,8 @@ class SecretStore:
     def _connect(self) -> sqlite3.Connection:
         existed = self._db_path.is_file()
         self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        if existed:
+            _ensure_private_file(self._db_path)
         conn = sqlite3.connect(self._db_path)
         conn.execute("PRAGMA busy_timeout = 5000")
         conn.executescript(_SCHEMA)

--- a/scripts/tests/test_credential_validators.py
+++ b/scripts/tests/test_credential_validators.py
@@ -249,3 +249,51 @@ class TestSlowLoginValidators:
             "menthorq", {"MENTHORQ_USER": "u", "MENTHORQ_PASS": "p"}
         )
         assert result.status == "error"
+
+
+class TestTursoHostPin:
+    def test_http_url_rejected(self, monkeypatch):
+        monkeypatch.delenv("TURSO_DB_URL", raising=False)
+        result = cv.validate(
+            "turso",
+            {
+                "TURSO_DB_URL": "http://evil.example/db",
+                "TURSO_AUTH_TOKEN": "tok",
+            },
+        )
+        assert result.status == "invalid"
+        assert "HTTPS" in result.message
+
+    def test_host_mismatch_rejected(self, monkeypatch):
+        monkeypatch.setenv(
+            "TURSO_DB_URL", "libsql://radon-joemccann.aws-us-west-2.turso.io"
+        )
+        result = cv.validate(
+            "turso",
+            {
+                "TURSO_DB_URL": "libsql://other-host.aws-us-west-2.turso.io",
+                "TURSO_AUTH_TOKEN": "tok",
+            },
+        )
+        assert result.status == "invalid"
+        assert "host" in result.message.lower()
+
+
+class TestValidatorRedaction:
+    def test_subprocess_stderr_token_redacted(self, monkeypatch):
+        monkeypatch.setattr(
+            cv.subprocess,
+            "run",
+            lambda *a, **k: cv.subprocess.CompletedProcess(
+                args=a[0],
+                returncode=1,
+                stdout="",
+                stderr="login failed token=sk-ant-api03-deadbeef",
+            ),
+        )
+        result = cv.validate(
+            "menthorq", {"MENTHORQ_USER": "u", "MENTHORQ_PASS": "p"}
+        )
+        assert result.status == "error"
+        assert "sk-ant-api03-deadbeef" not in result.message
+        assert "[redacted-key]" in result.message

--- a/scripts/tests/test_secret_store.py
+++ b/scripts/tests/test_secret_store.py
@@ -126,6 +126,18 @@ class TestEncryptionAtRest:
         mode = stat.S_IMODE(os.stat(tmp_path / "secrets.db").st_mode)
         assert mode == 0o600
 
+    def test_existing_loose_permissions_reasserted_0600(self, tmp_path):
+        db = tmp_path / "secrets.db"
+        key = tmp_path / "k.key"
+        first = SecretStore(db_path=db, key_path=key)
+        first.set_secret("UW_TOKEN", UW_SAMPLE, actor="operator")
+        os.chmod(db, 0o644)
+        os.chmod(key, 0o644)
+        second = SecretStore(db_path=db, key_path=key)
+        assert second.get_secret("UW_TOKEN") == UW_SAMPLE
+        assert stat.S_IMODE(os.stat(db).st_mode) == 0o600
+        assert stat.S_IMODE(os.stat(key).st_mode) == 0o600
+
     def test_second_store_instance_reuses_key(self, tmp_path):
         first = SecretStore(
             db_path=tmp_path / "secrets.db", key_path=tmp_path / "k.key"

--- a/web/app/api/profile/route.ts
+++ b/web/app/api/profile/route.ts
@@ -85,6 +85,33 @@ function parseUiPreferences(raw: unknown): Record<string, unknown> | null {
   return null;
 }
 
+function mergeUiPreferencesJson(
+  existing: Record<string, unknown> | null,
+  incoming: Record<string, unknown>,
+): Record<string, unknown> {
+  const base = existing ? { ...existing } : {};
+  if ("theme" in incoming) {
+    base.theme = incoming.theme;
+  }
+  if (incoming.columns && typeof incoming.columns === "object" && !Array.isArray(incoming.columns)) {
+    const mergedColumns: Record<string, unknown> = {
+      ...(typeof base.columns === "object" && base.columns && !Array.isArray(base.columns)
+        ? (base.columns as Record<string, unknown>)
+        : {}),
+    };
+    for (const [tableId, table] of Object.entries(incoming.columns as Record<string, unknown>)) {
+      if (!table || typeof table !== "object" || Array.isArray(table)) continue;
+      const prior =
+        mergedColumns[tableId] && typeof mergedColumns[tableId] === "object"
+          ? (mergedColumns[tableId] as Record<string, unknown>)
+          : {};
+      mergedColumns[tableId] = { ...prior, ...(table as Record<string, unknown>) };
+    }
+    base.columns = mergedColumns;
+  }
+  return base;
+}
+
 async function readProfile(userId: string): Promise<ProfileRow> {
   const result = await dbExecute(
     {
@@ -173,7 +200,12 @@ export async function PUT(req: Request): Promise<Response> {
         requestId,
       );
     }
-    nextUiPreferences = uiResult.value;
+    const existing = await readProfile(userId);
+    const merged = mergeUiPreferencesJson(
+      existing.ui_preferences,
+      JSON.parse(uiResult.value ?? "{}") as Record<string, unknown>,
+    );
+    nextUiPreferences = JSON.stringify(merged);
   }
 
   let nextUsername: string | null = null;

--- a/web/app/api/setup/complete/route.ts
+++ b/web/app/api/setup/complete/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from "next/server";
-import path from "node:path";
 import { radonFetch, RadonApiError } from "@/lib/radonApi";
 import { getRequestId, jsonApiError, setNoStoreResponseHeaders } from "@/lib/apiContracts";
-import { isSetupMode } from "@/lib/setup/setupMode";
-import { verifySetupToken } from "@/lib/setup/setupToken";
+import { isSetupMode, isAuthMisconfigured } from "@/lib/setup/setupMode";
+import { verifySetupToken, consumeSetupToken } from "@/lib/setup/setupToken";
+import { markSetupComplete, resolveRepoRoot } from "@/lib/setup/setupComplete";
 import { writeSetupEnvFiles } from "@/lib/setup/envFiles";
 
 /**
@@ -34,6 +34,17 @@ type ServiceOutcome = {
 
 export async function POST(request: Request): Promise<Response> {
   const requestId = getRequestId();
+  if (isAuthMisconfigured()) {
+    return setNoStoreResponseHeaders(
+      jsonApiError({
+        message: "Setup already completed. Restart the stack to load authentication keys.",
+        status: 403,
+        code: "SETUP_ALREADY_COMPLETE",
+        requestId,
+      }),
+      requestId,
+    );
+  }
   if (!isSetupMode()) {
     return setNoStoreResponseHeaders(
       jsonApiError({ message: "Not found", status: 404, code: "NOT_FOUND", requestId }),
@@ -123,9 +134,23 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   let written: string[] = [];
-  if (Object.keys(collected).length > 0) {
-    written = await writeSetupEnvFiles(collected, path.resolve(process.cwd(), ".."));
+  const repoRoot = resolveRepoRoot(process.cwd());
+  if (!repoRoot) {
+    return setNoStoreResponseHeaders(
+      jsonApiError({
+        message: `Cannot resolve repo root from ${process.cwd()}`,
+        status: 500,
+        code: "SETUP_REPO_ROOT_INVALID",
+        requestId,
+      }),
+      requestId,
+    );
   }
+  if (Object.keys(collected).length > 0) {
+    written = await writeSetupEnvFiles(collected, repoRoot);
+  }
+  await markSetupComplete(repoRoot);
+  consumeSetupToken();
 
   return setNoStoreResponseHeaders(
     NextResponse.json({

--- a/web/app/api/setup/status/route.ts
+++ b/web/app/api/setup/status/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { radonFetch } from "@/lib/radonApi";
 import { getRequestId, jsonApiError, setNoStoreResponseHeaders } from "@/lib/apiContracts";
-import { isSetupMode } from "@/lib/setup/setupMode";
+import { isSetupMode, isAuthMisconfigured } from "@/lib/setup/setupMode";
 import { verifySetupToken } from "@/lib/setup/setupToken";
 
 /**
@@ -18,6 +18,17 @@ export const radonCapability = "internal";
 
 export async function POST(request: Request): Promise<Response> {
   const requestId = getRequestId();
+  if (isAuthMisconfigured()) {
+    return setNoStoreResponseHeaders(
+      jsonApiError({
+        message: "Setup already completed. Restart the stack to load authentication keys.",
+        status: 403,
+        code: "SETUP_ALREADY_COMPLETE",
+        requestId,
+      }),
+      requestId,
+    );
+  }
   if (!isSetupMode()) {
     return setNoStoreResponseHeaders(
       jsonApiError({ message: "Not found", status: 404, code: "NOT_FOUND", requestId }),

--- a/web/app/api/setup/validate/route.ts
+++ b/web/app/api/setup/validate/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { radonFetch, RadonApiError } from "@/lib/radonApi";
 import { getRequestId, jsonApiError, setNoStoreResponseHeaders } from "@/lib/apiContracts";
-import { isSetupMode } from "@/lib/setup/setupMode";
+import { isSetupMode, isAuthMisconfigured } from "@/lib/setup/setupMode";
 import { verifySetupToken } from "@/lib/setup/setupToken";
 
 /**
@@ -21,6 +21,17 @@ export const radonCapability = "internal";
 
 export async function POST(request: Request): Promise<Response> {
   const requestId = getRequestId();
+  if (isAuthMisconfigured()) {
+    return setNoStoreResponseHeaders(
+      jsonApiError({
+        message: "Setup already completed. Restart the stack to load authentication keys.",
+        status: 403,
+        code: "SETUP_ALREADY_COMPLETE",
+        requestId,
+      }),
+      requestId,
+    );
+  }
   if (!isSetupMode()) {
     return setNoStoreResponseHeaders(
       jsonApiError({ message: "Not found", status: 404, code: "NOT_FOUND", requestId }),

--- a/web/app/preferences/page.tsx
+++ b/web/app/preferences/page.tsx
@@ -1,7 +1,7 @@
-import WorkspaceShell from "@/components/WorkspaceShell";
+import { redirect } from "next/navigation";
 
 export const dynamic = "force-dynamic";
 
 export default function PreferencesPage() {
-  return <WorkspaceShell section="preferences" />;
+  redirect("/profile?tab=preferences");
 }

--- a/web/components/profile/CredentialsPanel.tsx
+++ b/web/components/profile/CredentialsPanel.tsx
@@ -45,6 +45,7 @@ function serviceSlug(id: string): string {
 
 function fieldStatus(field: CredentialFieldEntry): string {
   if (field.configured) return `Stored ${field.hint}`;
+  if (field.exported_only) return "Active in this process until restart";
   if (field.env_fallback) return "Using the value from .env";
   return "Not configured";
 }

--- a/web/components/profile/ProfileContent.tsx
+++ b/web/components/profile/ProfileContent.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useMemo, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { useClerk, useUser } from "@clerk/nextjs";
 import { useProfile } from "@/lib/useProfile";
 import { useBookmarks, type Bookmark } from "@/lib/useBookmarks";
@@ -18,6 +19,13 @@ import type { PriceData } from "@/lib/pricesProtocol";
 const USERNAME_PATTERN = /^[A-Za-z0-9_\- ]{1,32}$/;
 
 type ProfileTab = "bookmarks" | "watchlist" | "preferences" | "credentials";
+
+const PROFILE_TABS = new Set<ProfileTab>(["bookmarks", "watchlist", "preferences", "credentials"]);
+
+function initialProfileTab(raw: string | null): ProfileTab {
+  if (raw && PROFILE_TABS.has(raw as ProfileTab)) return raw as ProfileTab;
+  return "bookmarks";
+}
 
 /** Defensive read of a bookmark snapshot. The snapshot is `unknown` per the
  *  Phase 1 contract; news posts shaped like MarketEarPost are the common case. */
@@ -87,7 +95,8 @@ function sourceDomain(source: string | null): string {
 export default function ProfileContent({ prices }: { prices?: Record<string, PriceData> }) {
   const { isMobile, hasMounted } = useViewport();
   const compact = hasMounted && isMobile;
-  const [tab, setTab] = useState<ProfileTab>("bookmarks");
+  const searchParams = useSearchParams();
+  const [tab, setTab] = useState<ProfileTab>(() => initialProfileTab(searchParams.get("tab")));
 
   const { profile, saveProfile } = useProfile();
   const { user } = useUser();

--- a/web/components/setup/SetupWizard.tsx
+++ b/web/components/setup/SetupWizard.tsx
@@ -45,7 +45,7 @@ async function postJson<T>(url: string, body: unknown): Promise<T> {
     cache: "no-store",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
-    signal: AbortSignal.timeout(110_000),
+    signal: AbortSignal.timeout(220_000),
   });
   const json = (await res.json().catch(() => null)) as
     | (T & { error?: string })

--- a/web/instrumentation.ts
+++ b/web/instrumentation.ts
@@ -2,9 +2,15 @@
 // Used to keep the Turso connection pool warm so uncached DB reads/writes stay
 // on the ~12ms warm path instead of paying the ~60-80ms cold TLS handshake.
 export async function register() {
+  if (process.env.NEXT_RUNTIME !== "nodejs") return;
+  try {
+    const { syncSetupCompleteFromMarker } = await import("@/lib/setup/setupComplete");
+    await syncSetupCompleteFromMarker();
+  } catch (err) {
+    console.warn("[instrumentation] setup-complete sync failed:", err);
+  }
   // Only the long-lived Node.js production server has a process + undici pool
   // worth warming. Skip Edge runtime, the build, dev, and CI.
-  if (process.env.NEXT_RUNTIME !== "nodejs") return;
   if (process.env.NODE_ENV !== "production") return;
   try {
     const { startDbKeepAlive } = await import("@/lib/dbKeepAlive");

--- a/web/lib/credentials.ts
+++ b/web/lib/credentials.ts
@@ -20,6 +20,7 @@ export type CredentialFieldEntry = {
   updated_at: string | null;
   updated_by: string | null;
   env_fallback: boolean;
+  exported_only: boolean;
 };
 
 export type CredentialServiceEntry = {

--- a/web/lib/setup/setupComplete.ts
+++ b/web/lib/setup/setupComplete.ts
@@ -10,14 +10,10 @@ import { existsSync } from "node:fs";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 
-export const SETUP_COMPLETE_ENV = "RADON_SETUP_COMPLETE";
-export const SETUP_MARKER_REL = ".radon/setup-complete";
+import { SETUP_COMPLETE_ENV } from "@/lib/setup/setupCompleteFlag";
 
-export function isSetupCompleteFlagSet(
-  flag: string | undefined = process.env[SETUP_COMPLETE_ENV],
-): boolean {
-  return flag === "1";
-}
+export { SETUP_COMPLETE_ENV } from "@/lib/setup/setupCompleteFlag";
+export const SETUP_MARKER_REL = ".radon/setup-complete";
 
 export function isValidRepoRoot(root: string): boolean {
   return (

--- a/web/lib/setup/setupComplete.ts
+++ b/web/lib/setup/setupComplete.ts
@@ -1,0 +1,63 @@
+/**
+ * First-run setup completion latch (REL-192).
+ *
+ * A marker file under the repo root records that the wizard finished. Edge
+ * middleware cannot read the filesystem, so `instrumentation.ts` and the
+ * complete route mirror the marker into `RADON_SETUP_COMPLETE=1`.
+ */
+
+import { existsSync } from "node:fs";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+export const SETUP_COMPLETE_ENV = "RADON_SETUP_COMPLETE";
+export const SETUP_MARKER_REL = ".radon/setup-complete";
+
+export function isSetupCompleteFlagSet(
+  flag: string | undefined = process.env[SETUP_COMPLETE_ENV],
+): boolean {
+  return flag === "1";
+}
+
+export function isValidRepoRoot(root: string): boolean {
+  return (
+    existsSync(path.join(root, "package.json"))
+    && existsSync(path.join(root, "web", "package.json"))
+  );
+}
+
+/** Resolve monorepo root from the Next.js app dir (`web/`). */
+export function resolveRepoRoot(cwd: string = process.cwd()): string | null {
+  const candidate = path.resolve(cwd, "..");
+  return isValidRepoRoot(candidate) ? candidate : null;
+}
+
+export function setupMarkerPath(repoRoot: string): string {
+  return path.join(repoRoot, SETUP_MARKER_REL);
+}
+
+export async function markSetupComplete(repoRoot: string): Promise<string> {
+  if (!isValidRepoRoot(repoRoot)) {
+    throw new Error(`invalid repo root: ${repoRoot}`);
+  }
+  const marker = setupMarkerPath(repoRoot);
+  await fs.mkdir(path.dirname(marker), { recursive: true });
+  await fs.writeFile(marker, `${new Date().toISOString()}\n`, { mode: 0o600 });
+  process.env[SETUP_COMPLETE_ENV] = "1";
+  return marker;
+}
+
+/** Node boot: promote an on-disk marker into the env flag the Edge gate reads. */
+export async function syncSetupCompleteFromMarker(
+  cwd: string = process.cwd(),
+): Promise<boolean> {
+  const root = resolveRepoRoot(cwd);
+  if (!root) return false;
+  try {
+    await fs.access(setupMarkerPath(root));
+    process.env[SETUP_COMPLETE_ENV] = "1";
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/web/lib/setup/setupCompleteFlag.ts
+++ b/web/lib/setup/setupCompleteFlag.ts
@@ -1,0 +1,14 @@
+/**
+ * Edge-safe setup completion flag (REL-192).
+ *
+ * Middleware reads only `RADON_SETUP_COMPLETE=1`; marker-file sync lives in
+ * `setupComplete.ts` (Node-only).
+ */
+
+export const SETUP_COMPLETE_ENV = "RADON_SETUP_COMPLETE";
+
+export function isSetupCompleteFlagSet(
+  flag: string | undefined = process.env[SETUP_COMPLETE_ENV],
+): boolean {
+  return flag === "1";
+}

--- a/web/lib/setup/setupMode.ts
+++ b/web/lib/setup/setupMode.ts
@@ -10,7 +10,7 @@
  * Edge-safe: pure env reads, no node:* (the middleware imports this).
  */
 
-import { isSetupCompleteFlagSet } from "@/lib/setup/setupComplete";
+import { isSetupCompleteFlagSet } from "@/lib/setup/setupCompleteFlag";
 
 function clerkKeysAbsent(
   publishableKey: string | undefined = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,

--- a/web/lib/setup/setupMode.ts
+++ b/web/lib/setup/setupMode.ts
@@ -1,21 +1,46 @@
 /**
- * First-run setup mode — active only when NO Clerk keys are configured.
+ * First-run setup mode — active only on an unconfigured clone that has NOT
+ * finished the wizard yet.
  *
- * A fresh clone has no auth to protect anything with, and nothing worth
- * protecting yet: setup mode locks the whole app down to /setup (plus its
- * API), where the wizard collects bootstrap + vendor credentials guarded by
- * a one-shot console token. The moment Clerk keys exist (the restart after
- * the wizard writes them), this returns false everywhere and the setup
- * surface hard-refuses with 404.
+ * After the wizard completes, a repo-root marker is written and mirrored into
+ * `RADON_SETUP_COMPLETE=1` (Edge-safe). A configured host that loses its
+ * Clerk env on a running process must NOT re-open /setup — that is the
+ * separate auth-misconfigured gate.
  *
  * Edge-safe: pure env reads, no node:* (the middleware imports this).
  */
 
-export function isSetupMode(
+import { isSetupCompleteFlagSet } from "@/lib/setup/setupComplete";
+
+function clerkKeysAbsent(
   publishableKey: string | undefined = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
   secretKey: string | undefined = process.env.CLERK_SECRET_KEY,
 ): boolean {
   return !(publishableKey || "").trim() && !(secretKey || "").trim();
+}
+
+export function isSetupComplete(
+  setupCompleteFlag: string | undefined = process.env.RADON_SETUP_COMPLETE,
+): boolean {
+  return isSetupCompleteFlagSet(setupCompleteFlag);
+}
+
+export function isSetupMode(
+  publishableKey: string | undefined = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+  secretKey: string | undefined = process.env.CLERK_SECRET_KEY,
+  setupCompleteFlag: string | undefined = process.env.RADON_SETUP_COMPLETE,
+): boolean {
+  if (isSetupComplete(setupCompleteFlag)) return false;
+  return clerkKeysAbsent(publishableKey, secretKey);
+}
+
+/** Wizard finished but Clerk keys are not loaded in this process yet. */
+export function isAuthMisconfigured(
+  publishableKey: string | undefined = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+  secretKey: string | undefined = process.env.CLERK_SECRET_KEY,
+  setupCompleteFlag: string | undefined = process.env.RADON_SETUP_COMPLETE,
+): boolean {
+  return isSetupComplete(setupCompleteFlag) && clerkKeysAbsent(publishableKey, secretKey);
 }
 
 export const SETUP_PAGE_PATH = "/setup";

--- a/web/lib/setup/setupToken.ts
+++ b/web/lib/setup/setupToken.ts
@@ -12,6 +12,7 @@
 import { randomBytes, timingSafeEqual } from "node:crypto";
 
 let generated: string | null = null;
+let consumed = false;
 
 export function getSetupToken(): string {
   const fromEnv = (process.env.RADON_SETUP_TOKEN || "").trim();
@@ -33,6 +34,7 @@ export function getSetupToken(): string {
 }
 
 export function verifySetupToken(provided: unknown): boolean {
+  if (consumed) return false;
   if (typeof provided !== "string" || !provided.trim()) return false;
   const expected = Buffer.from(getSetupToken(), "utf8");
   const candidate = Buffer.from(provided.trim(), "utf8");
@@ -40,7 +42,13 @@ export function verifySetupToken(provided: unknown): boolean {
   return timingSafeEqual(expected, candidate);
 }
 
+/** One-shot: invalidate the token after a successful wizard completion. */
+export function consumeSetupToken(): void {
+  consumed = true;
+}
+
 /** Test-only: reset the generated token between cases. */
 export function __resetSetupTokenForTests(): void {
   generated = null;
+  consumed = false;
 }

--- a/web/lib/uiPreferences.ts
+++ b/web/lib/uiPreferences.ts
@@ -49,19 +49,41 @@ function sanitize(raw: unknown): UiPreferences {
   return prefs;
 }
 
+export function mergeUiPreferences(
+  local: UiPreferences | null,
+  server: UiPreferences,
+): UiPreferences {
+  if (!local) return server;
+  const merged: UiPreferences = { ...local };
+  if (local.theme === undefined && server.theme !== undefined) {
+    merged.theme = server.theme;
+  }
+  if (server.columns) {
+    const columns = { ...(local.columns ?? {}) };
+    for (const [tableId, table] of Object.entries(server.columns)) {
+      columns[tableId] = { ...(columns[tableId] ?? {}), ...table };
+    }
+    merged.columns = columns;
+  }
+  return merged;
+}
+
 export function hydrateUiPreferences(): Promise<UiPreferences> {
   if (cache) return Promise.resolve(cache);
   if (!hydratePromise) {
     hydratePromise = fetch("/api/profile", { cache: "no-store" })
       .then(async (res) => {
-        if (!res.ok) return {};
+        if (!res.ok) throw new Error(`profile hydrate ${res.status}`);
         const json = (await res.json()) as { ui_preferences?: unknown };
         return sanitize(json.ui_preferences);
       })
-      .catch(() => ({}))
       .then((prefs) => {
-        cache = cache ?? prefs;
-        return cache;
+        cache = mergeUiPreferences(cache, prefs);
+        return cache ?? {};
+      })
+      .catch(() => {
+        hydratePromise = null;
+        return cache ?? {};
       });
   }
   return hydratePromise;
@@ -109,4 +131,9 @@ export function __resetUiPreferencesForTests(): void {
   hydratePromise = null;
   if (flushTimer) clearTimeout(flushTimer);
   flushTimer = null;
+}
+
+/** Test-only: seed the in-memory cache without a network round-trip. */
+export function __seedUiPreferencesForTests(prefs: UiPreferences): void {
+  cache = prefs;
 }

--- a/web/lib/useColumnVisibility.ts
+++ b/web/lib/useColumnVisibility.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { hydrateUiPreferences, saveUiColumns } from "@/lib/uiPreferences";
 
 /**
@@ -29,6 +29,7 @@ export function useColumnVisibility<K extends string>(
 ): ColumnVisibility<K> {
   const storageKey = `${STORAGE_PREFIX}${tableId}`;
   const alwaysOnSet = new Set<K>(alwaysOn);
+  const userEditedRef = useRef(false);
 
   const [visible, setVisible] = useState<Record<K, boolean>>(() => ({ ...defaults }));
   const [hydrated, setHydrated] = useState(false);
@@ -86,16 +87,16 @@ export function useColumnVisibility<K extends string>(
     }
   }, [hydrated, storageKey, visible]);
 
+  useEffect(() => {
+    if (!hydrated || !userEditedRef.current) return;
+    saveUiColumns(tableId, visible);
+  }, [hydrated, tableId, visible]);
+
   const toggle = useCallback(
     (key: K) => {
       if (alwaysOnSet.has(key)) return;
-      setVisible((prev) => {
-        const next = { ...prev, [key]: !prev[key] };
-        // Server sync happens ONLY on a user action, never on hydration —
-        // pushing hydrated defaults would clobber another device's choice.
-        saveUiColumns(tableId, next);
-        return next;
-      });
+      userEditedRef.current = true;
+      setVisible((prev) => ({ ...prev, [key]: !prev[key] }));
     },
     // alwaysOnSet is derived from the same `alwaysOn` array — referentially stable per render.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -103,10 +104,10 @@ export function useColumnVisibility<K extends string>(
   );
 
   const reset = useCallback(() => {
+    userEditedRef.current = true;
     const reset: Record<K, boolean> = { ...defaults };
     for (const key of alwaysOnSet) reset[key] = true;
     setVisible(reset);
-    saveUiColumns(tableId, reset);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -14,7 +14,7 @@ import {
 } from "@/lib/publicShareRoutes";
 import { handleDemoGate } from "@/lib/demo/demoGate";
 import type { DemoPublicMetadata } from "@/lib/demo/demoRole";
-import { isSetupMode, isSetupPath, SETUP_PAGE_PATH } from "@/lib/setup/setupMode";
+import { isSetupMode, isSetupPath, isAuthMisconfigured, SETUP_PAGE_PATH } from "@/lib/setup/setupMode";
 
 // ── Enforced Content-Security-Policy (per-request nonce) ────────────────────
 //
@@ -427,6 +427,29 @@ export function handleSetupModeGate(request: NextRequest): NextResponse | null {
   return NextResponse.redirect(new URL(SETUP_PAGE_PATH, request.url));
 }
 
+/** Setup finished but Clerk keys are not loaded in this process — restart. */
+export function handleAuthMisconfiguredGate(request: NextRequest): NextResponse | null {
+  if (!isAuthMisconfigured()) return null;
+  const pathname = request.nextUrl.pathname;
+  const requestId = getRequestId();
+  const message =
+    "Radon setup is complete but authentication keys are not loaded. Restart the stack.";
+  if (isApiPath(pathname)) {
+    const response = jsonApiError({
+      message,
+      status: 503,
+      code: "AUTH_MISCONFIGURED",
+      requestId,
+    });
+    return setNoStoreResponseHeaders(response, requestId);
+  }
+  const response = new NextResponse(message, {
+    status: 503,
+    headers: { "content-type": "text/plain; charset=utf-8" },
+  });
+  return setNoStoreResponseHeaders(response, requestId);
+}
+
 export default async function middleware(
   request: NextRequest,
   event: NextFetchEvent,
@@ -435,6 +458,9 @@ export default async function middleware(
   // clerkMiddleware cannot run at all, and there is nothing to protect yet.
   const setupGate = handleSetupModeGate(request);
   if (setupGate) return setupGate;
+
+  const misconfiguredGate = handleAuthMisconfiguredGate(request);
+  if (misconfiguredGate) return misconfiguredGate;
 
   // Probe routes are bearer-gated EVERYWHERE — before the local-dev bypass —
   // so the gate behaves identically in dev, tests, and production.

--- a/web/tests/setup-first-run.test.tsx
+++ b/web/tests/setup-first-run.test.tsx
@@ -19,6 +19,7 @@ import { upsertEnvContent, writeSetupEnvFiles } from "../lib/setup/envFiles";
 const CLERK_ENV_KEYS = [
   "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
   "CLERK_SECRET_KEY",
+  "RADON_SETUP_COMPLETE",
 ] as const;
 
 let savedEnv: Record<string, string | undefined> = {};
@@ -44,11 +45,15 @@ afterEach(async () => {
 });
 
 describe("setup mode detection", () => {
-  it("active only when BOTH Clerk keys are absent", () => {
+  it("active only when BOTH Clerk keys are absent and setup is not complete", async () => {
+    const { isSetupMode, isAuthMisconfigured } = await import("../lib/setup/setupMode");
     expect(isSetupMode(undefined, undefined)).toBe(true);
     expect(isSetupMode("", "  ")).toBe(true);
     expect(isSetupMode("pk_live_x", undefined)).toBe(false);
     expect(isSetupMode(undefined, "sk_live_x")).toBe(false);
+    process.env.RADON_SETUP_COMPLETE = "1";
+    expect(isSetupMode()).toBe(false);
+    expect(isAuthMisconfigured()).toBe(true);
   });
 
   it("setup paths are the page and its API only", () => {
@@ -171,6 +176,9 @@ describe("setup API routes", () => {
     process.env.RADON_SETUP_TOKEN = "tok-1";
     const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "radon-setup-"));
     await fs.mkdir(path.join(tmp, "web"));
+    await fs.writeFile(path.join(tmp, "package.json"), "{}");
+    await fs.writeFile(path.join(tmp, "web", "package.json"), "{}");
+    const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(path.join(tmp, "web"));
     const puts: Array<{ path: string; body: unknown }> = [];
     vi.doMock("@/lib/radonApi", () => ({
       radonFetch: vi.fn(async (apiPath: string, init?: { body?: string }) => {
@@ -183,10 +191,6 @@ describe("setup API routes", () => {
       },
       radonErrorDetailText: () => "",
     }));
-    vi.doMock("node:path", async (importOriginal) => {
-      const actual = (await importOriginal()) as typeof path;
-      return { ...actual, default: { ...actual, resolve: () => tmp } };
-    });
     const route = await import("../app/api/setup/complete/route");
     const res = await route.POST(
       new Request("http://x/api/setup/complete", {
@@ -211,8 +215,8 @@ describe("setup API routes", () => {
     expect(body.written.length).toBeGreaterThan(0);
     const root = await fs.readFile(path.join(tmp, ".env"), "utf8");
     expect(root).toContain("UW_TOKEN='uw-1'");
+    cwdSpy.mockRestore();
     vi.doUnmock("@/lib/radonApi");
-    vi.doUnmock("node:path");
   });
 });
 
@@ -329,5 +333,73 @@ describe("setup wizard wire contract", () => {
       services: { clerk: { CLERK_SECRET_KEY: "sk_live_new" } },
     });
     expect(document.body.innerHTML).not.toContain("sk_live_new");
+  });
+});
+
+describe("setup completion latch (REL-192)", () => {
+  it("setup complete + blank Clerk yields auth-misconfigured, not /setup", async () => {
+    process.env.RADON_SETUP_COMPLETE = "1";
+    const { handleSetupModeGate, handleAuthMisconfiguredGate } = await import("../middleware");
+    expect(handleSetupModeGate(new NextRequest("http://localhost/orders"))).toBeNull();
+    const api = handleAuthMisconfiguredGate(
+      new NextRequest("http://localhost/api/portfolio"),
+    );
+    expect(api?.status).toBe(503);
+    const page = handleAuthMisconfiguredGate(new NextRequest("http://localhost/orders"));
+    expect(page?.status).toBe(503);
+  });
+
+  it("consumed setup token rejects replay", async () => {
+    process.env.RADON_SETUP_TOKEN = "tok-1";
+    const { verifySetupToken, consumeSetupToken } = await import("../lib/setup/setupToken");
+    expect(verifySetupToken("tok-1")).toBe(true);
+    consumeSetupToken();
+    expect(verifySetupToken("tok-1")).toBe(false);
+  });
+
+  it("complete writes marker, consumes token, and rejects invalid repo root", async () => {
+    process.env.RADON_SETUP_TOKEN = "tok-1";
+    vi.doMock("@/lib/radonApi", () => ({
+      radonFetch: vi.fn(async () => ({ validation: { status: "valid", message: "" } })),
+      RadonApiError: class RadonApiError extends Error {
+        status = 500;
+        detail: unknown = null;
+      },
+      radonErrorDetailText: () => "",
+    }));
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "radon-setup-latch-"));
+    await fs.mkdir(path.join(tmp, "web"));
+    await fs.writeFile(path.join(tmp, "package.json"), "{}");
+    await fs.writeFile(path.join(tmp, "web", "package.json"), "{}");
+    const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(path.join(tmp, "web"));
+    const route = await import("../app/api/setup/complete/route");
+    const res = await route.POST(
+      new Request("http://x/api/setup/complete", {
+        method: "POST",
+        body: JSON.stringify({
+          token: "tok-1",
+          services: { clerk: { CLERK_SECRET_KEY: "sk_live_1" } },
+        }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    await fs.access(path.join(tmp, ".radon", "setup-complete"));
+    const { verifySetupToken } = await import("../lib/setup/setupToken");
+    expect(verifySetupToken("tok-1")).toBe(false);
+    cwdSpy.mockRestore();
+    vi.doUnmock("@/lib/radonApi");
+  });
+
+  it("setup API returns 403 when auth is misconfigured", async () => {
+    process.env.RADON_SETUP_COMPLETE = "1";
+    process.env.RADON_SETUP_TOKEN = "tok-1";
+    const route = await import("../app/api/setup/complete/route");
+    const res = await route.POST(
+      new Request("http://x/api/setup/complete", {
+        method: "POST",
+        body: JSON.stringify({ token: "tok-1", services: { clerk: { CLERK_SECRET_KEY: "x" } } }),
+      }),
+    );
+    expect(res.status).toBe(403);
   });
 });

--- a/web/tests/ui-preferences-sync.test.tsx
+++ b/web/tests/ui-preferences-sync.test.tsx
@@ -96,6 +96,32 @@ describe("profile route ui_preferences", () => {
     expect(body.ui_preferences).toEqual({ theme: "dark" });
   });
 
+  it("PUT ui_preferences merges per top-level key instead of replacing", async () => {
+    const route = await import("../app/api/profile/route");
+    await route.PUT(
+      new Request("http://x/api/profile", {
+        method: "PUT",
+        body: JSON.stringify({
+          ui_preferences: {
+            theme: "dark",
+            columns: { orders: { qty: false, status: true } },
+          },
+        }),
+      }),
+    );
+    await route.PUT(
+      new Request("http://x/api/profile", {
+        method: "PUT",
+        body: JSON.stringify({ ui_preferences: { theme: "light" } }),
+      }),
+    );
+    const body = await jsonOf(await route.GET());
+    expect(body.ui_preferences).toEqual({
+      theme: "light",
+      columns: { orders: { qty: false, status: true } },
+    });
+  });
+
   it("rejects unknown preference keys and bad theme values", async () => {
     const route = await import("../app/api/profile/route");
     const unknown = await route.PUT(
@@ -169,6 +195,62 @@ describe("uiPreferences client module", () => {
         columns: { "orders-open": { qty: false, status: true } },
       },
     });
+  });
+
+  it("mergeUiPreferences keeps local theme and adopts server columns", async () => {
+    const mod = await import("../lib/uiPreferences");
+    expect(
+      mod.mergeUiPreferences(
+        { theme: "dark" },
+        { theme: "light", columns: { orders: { qty: false } } },
+      ),
+    ).toEqual({
+      theme: "dark",
+      columns: { orders: { qty: false } },
+    });
+  });
+
+  it("theme toggle before hydrate settles still flushes server columns", async () => {
+    vi.useFakeTimers();
+    const calls = stubFetch({
+      ui_preferences: { theme: "light", columns: { orders: { qty: false } } },
+    });
+    const mod = await import("../lib/uiPreferences");
+    mod.__resetUiPreferencesForTests();
+    const pending = mod.hydrateUiPreferences();
+    mod.saveUiTheme("dark");
+    await pending;
+    await vi.advanceTimersByTimeAsync(1000);
+    const puts = calls.filter((c) => c.method === "PUT");
+    expect(puts).toHaveLength(1);
+    expect(puts[0].body).toEqual({
+      ui_preferences: { theme: "dark", columns: { orders: { qty: false } } },
+    });
+  });
+
+  it("failed hydrate does not poison cache with an empty object", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("", { status: 503 })),
+    );
+    const mod = await import("../lib/uiPreferences");
+    mod.__resetUiPreferencesForTests();
+    const prefs = await mod.hydrateUiPreferences();
+    expect(prefs).toEqual({});
+    mod.__seedUiPreferencesForTests({ theme: "dark" });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(JSON.stringify({ ui_preferences: { theme: "light" } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+    mod.__resetUiPreferencesForTests();
+    mod.__seedUiPreferencesForTests({ theme: "dark" });
+    const retry = await mod.hydrateUiPreferences();
+    expect(retry.theme).toBe("dark");
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the three reliability backlog items left after PR #125 merged.

### REL-192 — setup latch shut (P1)

- Writes `.radon/setup-complete` on wizard completion; `instrumentation.ts` mirrors it to `RADON_SETUP_COMPLETE=1` for Edge middleware.
- One-shot setup token (`consumeSetupToken()` on successful complete).
- Validated `resolveRepoRoot()` (package.json + web/package.json probe); invalid cwd → 500, no writes.
- New `AUTH_MISCONFIGURED` gate: completed setup + blank Clerk env → 503 (not a re-open of `/setup`); setup APIs return 403.
- Wizard client timeout raised to 220s.

### REL-190 — credential surface truth (P2)

- `exported_only` vs `env_fallback` on reads after delete (live env export vs `.env` provenance).
- Validator stderr/JWT/token redaction via `scripts/credential_redaction.py`.
- Turso validator rejects `http://` and host mismatches vs configured `TURSO_DB_URL`.
- IB gateway registry note: saving here does not rotate the broker password.
- Secret store re-asserts 0600 on open for existing db/key files.

### REL-204 — ui_preferences merge (P2)

- Server PUT merges per top-level key (theme + per-table columns).
- Client hydrate merges server into local cache (local theme wins); failed hydrate does not poison cache.
- Column visibility saves moved out of the `setVisible` updater.

### Cleanup

- `/preferences` redirects to `/profile?tab=preferences`.
- `/.radon/` gitignored (setup marker).

## Verification

- vitest: `setup-first-run` 15/15, `ui-preferences-sync` 11/11, `credentials-panel-request-assertions` 8/8
- pytest: credentials routes + validators + secret store 72/72

## Out of scope (unchanged deferrals)

- systemd unit reload on credential save
- IB Flex sFTP key upload UI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a045b2-2f4a-7b2c-90d7-97eed92aca53?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a045b2-2f4a-7b2c-90d7-97eed92aca53&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

