### PR TITLE
cash flows: the sFTP ingest owns the cash-flow-sync heartbeat

### DIFF
--- a/scripts/api/server.py
+++ b/scripts/api/server.py
@@ -5570,9 +5570,10 @@ async def cash_flows(
 ):
     """Return cash transactions from the `cash_flows` Turso table.
 
-    Reads-only — populated by `scripts/cash_flow_sync.py` which runs daily
-    via the monitor_daemon `cash_flow_sync` handler. Falls back to
-    `data/cash_flows.json` if the DB read fails.
+    Reads-only — populated by `scripts/cash_flow_sync.py --from-file` on the
+    sFTP-delivered statement (radon-flex-pull.timer, Tue..Sat 07:30 ET, via
+    `flex_delivery_ingest`). Falls back to `data/cash_flows.json` if the DB
+    read fails.
 
     Query params:
       days  - lookback window in days, default 90

--- a/scripts/flex_delivery_ingest.py
+++ b/scripts/flex_delivery_ingest.py
@@ -63,6 +63,12 @@ def mark_flex_delivery_applied(content_sha256: str) -> bool:
 # failure pages on it rather than on a new key: an uncatalogued key is invisible
 # and a scheduled one for a no-cadence signal ages to stale and pages forever.
 HEALTH_SERVICE = "flex-pull"
+# The cash-flows row. The monitor daemon's cash_flow_sync handler wrote it until
+# 2026-09-02 by spawning a no-source SendRequest run that exited
+# EXIT_FLEX_SEND_DISABLED daily. This ingest is the only path that writes
+# `cash_flows`, so it owns the heartbeat the watchdog's daily window and the
+# `/cash-flows` lozenge read.
+CASH_FLOW_HEALTH_SERVICE = "cash-flow-sync"
 
 
 def ingest_xml(
@@ -152,6 +158,20 @@ def _page_release_failure(digest: str, message: str) -> None:
         print(f"[flex-ingest] release-failure page non-fatal: {exc}", file=sys.stderr)
 
 
+def _heartbeat_cash_flow_sync(state: str, error: Dict[str, Any] | None = None) -> None:
+    try:
+        from db import writer  # noqa: PLC0415
+
+        writer.record_service_health(
+            CASH_FLOW_HEALTH_SERVICE,
+            state,
+            finished_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            error=error,
+        )
+    except Exception as exc:  # noqa: BLE001 — best-effort, never masks the ingest result
+        print(f"[flex-ingest] cash-flow-sync heartbeat non-fatal: {exc}", file=sys.stderr)
+
+
 def _apply_classified(kind: str, xml_text: str, digest: str, source_path: str) -> Dict[str, Any]:
     if kind == ACTIVITY:
         import cash_flow_sync
@@ -161,6 +181,14 @@ def _apply_classified(kind: str, xml_text: str, digest: str, source_path: str) -
             raise FlexClassifyError("activity ingest requires a filesystem path")
         cash_code = cash_flow_sync.main(["--from-file", source_path, "--no-file"])
         if cash_code != 0:
+            _heartbeat_cash_flow_sync(
+                "error",
+                {
+                    "message": f"cash_flow_sync --from-file failed (exit {cash_code})",
+                    "cash_exit": cash_code,
+                    "content_sha256": digest,
+                },
+            )
             # `upsert_cash_flow_rows` chunks its writes, so a failure leaves the
             # earlier chunks committed. Building the TWR series over a
             # half-written `cash_flows` and persisting it as authoritative
@@ -178,6 +206,7 @@ def _apply_classified(kind: str, xml_text: str, digest: str, source_path: str) -
                 "error": f"cash_flow_sync failed (exit {cash_code}); TWR not rebuilt",
                 "source_path": source_path,
             }
+        _heartbeat_cash_flow_sync("ok")
         twr = perf_twr_builder.build_and_persist(from_file=source_path, persist=True)
         return {
             "ok": twr.get("status") in ("ok", "stale"),

--- a/scripts/monitor_daemon/CLAUDE.md
+++ b/scripts/monitor_daemon/CLAUDE.md
@@ -8,7 +8,7 @@ Real-time fill / order / journal handlers. Loaded automatically when cwd is unde
 
 `scripts/monitor_daemon/daemon.py:is_market_hours()` gates handlers with `requires_market_hours=True`. Uses `datetime.now(ZoneInfo("America/New_York"))` for EST↔EDT auto via tzdata; fail-open UTC-5 fallback. **Never reintroduce hardcoded offsets.** See `feedback_hardcoded_timezone_offsets.md` for the DST bug that motivated this.
 
-Handlers that run 24/7 (cash-flow-sync, flex-token-check, journal-sync via the rehydrate-style importer) set `requires_market_hours=False`. Real-time fill-monitor / exit-orders / portfolio-sync are gated on.
+Handlers that run 24/7 (flex-token-check, journal-sync via the rehydrate-style importer) set `requires_market_hours=False`. Real-time fill-monitor / exit-orders / portfolio-sync are gated on.
 
 **Post-close grace (opt-in):** `BaseHandler.post_close_grace_minutes` (default 0) lets a market-hours handler keep cycling for a bounded window after the close. The gate answers "was the market open N minutes ago?" via `utils.market_calendar.market_state` (the calendar SoT), so weekends/holidays never gain a window and any calendar error fails closed. Only `journal_sync` opts in (15 min = two more 300s cycles): its per-cycle IB session only covers the current day, so a fill in the session's final seconds was otherwise never journaled (15:59:52 / 15:58:04 incidents). Tests: `scripts/tests/test_monitor_daemon/test_post_close_grace.py`.
 
@@ -42,7 +42,7 @@ Full rule in `web/CLAUDE.md` §Combo / BAG Order Guardrails point 7. Python side
 
 ## Where Other Daemons Live
 
-- `cash_flow_sync` runs once per ET trading day at 08:00 ET (moved from 17:00 ET 2026-08-20: every post-close SendRequest failed Flex 1001 while the same query id succeeded every morning via radon-perf-twr). Reads `IB_FLEX_NAV_QUERY_ID=1442520` (the Activity query "Equity Summary in Base", three sections: NAV in Base, Cash Transactions, Transfers). Don't repurpose for trade pulls.
+- `cash_flow_sync` is NOT registered since 2026-09-02. Cash flows come from the sFTP-delivered Activity statement (`radon-flex-pull.timer` Tue..Sat 07:30 ET -> `flex_delivery_ingest` -> `cash_flow_sync --from-file`), and that ingest writes the `cash-flow-sync` service_health row. The handler's daily no-source run exited `EXIT_FLEX_SEND_DISABLED` and painted "Flex Web Service is file-ingest only" over rows the delivery had already synced. The module stays for its embargo bookkeeping tests (R-104/R-108/R-109); re-registering it means a weekday SendRequest, which is off by policy.
 
   **Only Flex code 1018 is a rate limit** — IBKR publishes one request per second, ten per minute, per token, and no daily or multi-day cooldown anywhere. The breaker ladder is 90s → 5m → 15m → 1h. It was 24h → 48h → 72h → 168h and also fired on **1001** (transient generation failure) and **1019** (*"statement generation in progress"* — the ordinary not-ready response during polling). A statement seconds from ready therefore bought a 24-hour backoff, and a few transient failures walked to a week: that is the 10-day outage from 2026-08-06. 1001/1009 take the soft lane; 1019 on a poll is not an error at all. See `docs/flex-delivery-architecture.md`.
 - `flex_token_check` runs daily, alerts on expiry.

--- a/scripts/monitor_daemon/handlers/cash_flow_sync.py
+++ b/scripts/monitor_daemon/handlers/cash_flow_sync.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python3
 """Cash-flow sync — Monitor daemon handler.
 
+NOT REGISTERED since 2026-09-02. Cash flows come from the sFTP-delivered
+statement (radon-flex-pull.timer -> flex_delivery_ingest -> cash_flow_sync
+--from-file), and that ingest writes the `cash-flow-sync` heartbeat. This
+handler's daily no-source run exited EXIT_FLEX_SEND_DISABLED and painted
+"Flex Web Service is file-ingest only" over rows the delivery had already
+synced. The class stays for its embargo bookkeeping contracts
+(R-104/R-108/R-109); registering it again means a weekday SendRequest.
+
 Pulls IB CashTransaction rows (deposits, withdrawals, dividends, interest,
 fees) from the NAV Flex Query and persists to the `cash_flows` Turso
 table once per ET trading day at 08:00 ET (pre-open; see FIRE_HOUR_ET).

--- a/scripts/monitor_daemon/run.py
+++ b/scripts/monitor_daemon/run.py
@@ -33,7 +33,6 @@ from monitor_daemon.handlers import FillMonitorHandler, PresetRebalanceHandler, 
 from monitor_daemon.handlers.flex_token_check import FlexTokenCheck
 from monitor_daemon.handlers.menthorq_session_check import MenthorQSessionCheck
 from monitor_daemon.handlers.menthorq_login_probe import MenthorQLoginProbe
-from monitor_daemon.handlers.cash_flow_sync import CashFlowSyncHandler
 from monitor_daemon.handlers.evening_execution_sweep import EveningExecutionSweepHandler
 from monitor_daemon.handlers.journal_reconcile import JournalReconcileHandler
 from monitor_daemon.handlers.expiry_sweep import ExpirySweepHandler
@@ -105,7 +104,12 @@ def create_daemon() -> MonitorDaemon:
         ib_port=4001
     ))
 
-    daemon.register(CashFlowSyncHandler())
+    # cash_flow_sync is NOT registered (2026-09-02): cash flows come from the
+    # sFTP-delivered statement (radon-flex-pull.timer -> flex_delivery_ingest
+    # -> cash_flow_sync --from-file), which heartbeats `cash-flow-sync` itself.
+    # The no-source SendRequest run this handler spawned exited
+    # EXIT_FLEX_SEND_DISABLED every morning and painted that skip over the
+    # rows the delivery had already synced.
 
     daemon.register(EveningExecutionSweepHandler(
         ib_port=4001

--- a/scripts/tests/test_cash_flows_from_sftp_delivery.py
+++ b/scripts/tests/test_cash_flows_from_sftp_delivery.py
@@ -1,0 +1,132 @@
+"""Cash flows come from the sFTP-delivered statement, not a daily SendRequest.
+
+`radon-flex-pull.timer` (Tue..Sat 07:30 ET) decrypts IBKR's delivered Activity
+statement and runs `cash_flow_sync --from-file` on it. That is the only path
+that writes `cash_flows`. The monitor daemon's `cash_flow_sync` handler still
+spawned `scripts.cash_flow_sync` with no source every morning at 08:00 ET; the
+CLI exits `EXIT_FLEX_SEND_DISABLED` ("Flex Web Service is file-ingest only"),
+the handler recorded it as a `cash-flow-sync` error, and the Orders page showed
+that banner over rows the sFTP path had already synced hours earlier.
+
+Two invariants:
+
+  1. `create_daemon()` registers no `CashFlowSyncHandler`.
+  2. The sFTP ingest's activity branch heartbeats `cash-flow-sync` itself, so
+     the watchdog's daily window and the `/cash-flows` lozenge follow the path
+     that actually writes the rows.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPTS))
+
+import flex_delivery_ingest as ingest  # noqa: E402
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+ACTIVITY = FIXTURES / "cash_transactions_flex_ytd_detail_sample.xml"
+
+
+class TestDaemonNoLongerRunsCashFlowSync:
+    def test_create_daemon_does_not_register_the_handler(self):
+        tree = ast.parse((SCRIPTS / "monitor_daemon" / "run.py").read_text(encoding="utf-8"))
+        registered = {
+            arg.func.id
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "register"
+            for arg in node.args
+            if isinstance(arg, ast.Call) and isinstance(arg.func, ast.Name)
+        }
+        assert registered, "failed to parse create_daemon() registrations"
+        assert "CashFlowSyncHandler" not in registered
+
+
+@pytest.fixture
+def claims(monkeypatch):
+    monkeypatch.setattr(ingest, "claim_flex_delivery", lambda *_a, **_k: True)
+    monkeypatch.setattr(ingest, "release_flex_delivery", lambda _d: True, raising=False)
+    monkeypatch.setattr(ingest, "flex_delivery_status", lambda _d: None, raising=False)
+    monkeypatch.setattr(ingest, "mark_flex_delivery_applied", lambda _d: True, raising=False)
+
+
+@pytest.fixture
+def heartbeats(monkeypatch):
+    from db import writer
+
+    rows: list[tuple] = []
+    monkeypatch.setattr(
+        writer,
+        "record_service_health",
+        lambda service, state, **kw: rows.append((service, state, kw)),
+    )
+    return rows
+
+
+@pytest.fixture
+def activity(tmp_path):
+    xml_text = ACTIVITY.read_text()
+    path = tmp_path / "activity.xml"
+    path.write_text(xml_text)
+    return xml_text, str(path)
+
+
+class TestSftpIngestOwnsTheCashFlowHeartbeat:
+    def test_a_successful_file_sync_heartbeats_ok(self, monkeypatch, claims, heartbeats, activity):
+        import cash_flow_sync
+        import perf_twr_builder
+
+        monkeypatch.setattr(cash_flow_sync, "main", lambda _argv: 0)
+        monkeypatch.setattr(perf_twr_builder, "build_and_persist", lambda **_k: {"status": "ok"})
+
+        xml_text, path = activity
+        assert ingest.ingest_xml(xml_text, source_path=path)["ok"] is True
+
+        cash = [row for row in heartbeats if row[0] == "cash-flow-sync"]
+        assert len(cash) == 1
+        _, state, kw = cash[0]
+        assert state == "ok"
+        assert kw.get("finished_at")
+        assert kw.get("error") is None
+
+    def test_a_failed_file_sync_heartbeats_error_with_the_exit_code(
+        self, monkeypatch, claims, heartbeats, activity
+    ):
+        import cash_flow_sync
+        import perf_twr_builder
+
+        monkeypatch.setattr(cash_flow_sync, "main", lambda _argv: cash_flow_sync.EXIT_WRITE_ERROR)
+        twr_calls: list[dict] = []
+        monkeypatch.setattr(
+            perf_twr_builder,
+            "build_and_persist",
+            lambda **kwargs: (twr_calls.append(kwargs), {"status": "ok"})[1],
+        )
+
+        xml_text, path = activity
+        assert ingest.ingest_xml(xml_text, source_path=path)["ok"] is False
+        assert twr_calls == []
+
+        cash = [row for row in heartbeats if row[0] == "cash-flow-sync"]
+        assert len(cash) == 1
+        _, state, kw = cash[0]
+        assert state == "error"
+        assert kw["error"]["cash_exit"] == cash_flow_sync.EXIT_WRITE_ERROR
+        assert "cash_flow_sync" in kw["error"]["message"]
+
+    def test_a_trades_statement_does_not_touch_the_cash_flow_row(self, monkeypatch, claims, heartbeats):
+        import journal_rehydrate
+
+        monkeypatch.setattr(
+            journal_rehydrate, "rehydrate", lambda **_k: {"ok": True, "imported": 0, "skipped": 0}
+        )
+        trades = (FIXTURES / "flex_trade_confirm_sample.xml").read_text()
+        assert ingest.ingest_xml(trades, source_path="trades.xml")["ok"] is True
+        assert [row for row in heartbeats if row[0] == "cash-flow-sync"] == []

--- a/scripts/tests/test_service_registration_completeness.py
+++ b/scripts/tests/test_service_registration_completeness.py
@@ -292,7 +292,6 @@ class TestCollectorsAreNotBlind:
             "fill-monitor",
             "journal-sync",
             "flex-token-check",
-            "cash-flow-sync",
             "preset-rebalance",
         }
         missing = expected - names
@@ -301,7 +300,10 @@ class TestCollectorsAreNotBlind:
         # still carries its service_name, but `create_daemon()` does not
         # register it, so it writes no heartbeat and must not be demanded of
         # either catalog. The class-level literal is still discoverable.
+        # `cash-flow-sync` left the same way on 2026-09-02: the sFTP ingest
+        # (flex_delivery_ingest) writes the row directly now.
         assert "exit-orders" not in names
+        assert "cash-flow-sync" not in names
         assert "exit-orders" in _build_handler_service_names(scheduled_only=False)
 
     def test_scan_mirror_collector_sees_mirror_fed_scans(self):
@@ -322,6 +324,7 @@ class TestCollectorsAreNotBlind:
             "credit-spread",
             "catalysts",
             "informed-flow",
+            "cash-flow-sync",
         }
         missing = expected - names
         assert not missing, (

--- a/scripts/tests/test_watchdog/test_check_bucket_daily.py
+++ b/scripts/tests/test_watchdog/test_check_bucket_daily.py
@@ -1,8 +1,9 @@
 """The daily bucket fires regardless of hour.
 
-cash-flow-sync runs once per ET trading day; its open-state window is 25h
-(catches a missed weekday run quickly) and its closed-state window is 4d
-(covers the weekend gap). flex-token-check has a uniform 25h window.
+cash-flow-sync is written by the sFTP ingest Tue..Sat 07:30 ET; its open-state
+window is 3d (a Monday session is ~57h past the Saturday run) and its
+closed-state window is 4d (covers the weekend gap plus a holiday day).
+flex-token-check has a uniform 25h window.
 The watchdog timer fires every hour and we expect the bucket to always run.
 """
 from __future__ import annotations
@@ -48,14 +49,16 @@ class TestDailyBucket:
         report = check.check_bucket(bucket="daily", now=now)
         assert report.ran is True
 
-    def test_daily_fires_when_cash_flow_silent_for_26h(self, db_conn):
+    def test_daily_fires_when_cash_flow_silent_for_3_days(self, db_conn):
         from watchdog import check
 
-        # cash-flow-sync open-state window is 25h. This test runs at 11:00
-        # ET on a Wednesday (market open), so market_state="open" and the
-        # 25h open window applies. Past 26h is stale during market hours.
+        # cash-flow-sync is written by the sFTP ingest (Tue..Sat 07:30 ET),
+        # so its open-state window is 3 days: a Monday session is legitimately
+        # ~57h past the Saturday run. This test runs at 11:00 ET on a
+        # Wednesday (market open), so market_state="open" and the 3-day open
+        # window applies. Past 73h is stale during market hours.
         now = datetime(2026, 5, 13, 15, 0, tzinfo=timezone.utc)
-        _seed(db_conn, "cash-flow-sync", "ok", now - timedelta(hours=26))
+        _seed(db_conn, "cash-flow-sync", "ok", now - timedelta(hours=73))
         _seed(db_conn, "flex-token-check", "ok", now - timedelta(hours=22))
         check.check_bucket(bucket="daily", now=now)
         report = check.check_bucket(bucket="daily", now=now + timedelta(hours=1))

--- a/scripts/watchdog/services.py
+++ b/scripts/watchdog/services.py
@@ -79,10 +79,12 @@ SCHEDULED_SERVICES: dict[str, FreshnessWindow] = {
     "orders-sync":      {"open": 10 * _MIN, "closed": 3 * _DAY, "requires_ib": True},
     "portfolio-sync":   {"open": 10 * _MIN, "closed": 3 * _DAY, "requires_ib": True},
     "journal-sync":     {"open": 10 * _MIN, "closed": 3 * _DAY, "requires_ib": True},
-    # cash-flow-sync fires at 17:00 ET on trading days only; skips weekends
-    # + US holidays. Longest legit gap: Fri 17:00 ET → Mon 17:00 ET ≈ 72h.
-    # Prior 25h closed window tripped every Saturday. Widened to 4 days.
-    "cash-flow-sync":   {"open": 25 * _HOUR, "closed": 4 * _DAY, "requires_ib": False},
+    # cash-flow-sync is written by the sFTP ingest (radon-flex-pull.timer,
+    # Tue..Sat 07:30 ET) when a NEW Activity statement is applied. Longest
+    # legit gap in market hours: Sat 07:30 ET → Mon 16:00 ET ≈ 57h, so the
+    # 25h open window it had as a Mon-Fri daemon handler would trip every
+    # Monday. Closed stays 4 days for the weekend plus one holiday-drift day.
+    "cash-flow-sync":   {"open": 3 * _DAY, "closed": 4 * _DAY, "requires_ib": False},
     # execution-sweep fires at 20:30 ET on trading days only (evening
     # after-hours fill import, REL-012); skips weekends + US holidays.
     # Longest legit gap: Fri 20:30 ET → Mon 20:30 ET ≈ 72h, so closed is

--- a/web/components/CashFlowsSection.tsx
+++ b/web/components/CashFlowsSection.tsx
@@ -48,8 +48,8 @@ function fmtDate(iso: string): string {
 
 // IBKR Flex publishes the CashTransaction section once per day with a
 // ~1-day settlement lag — a withdrawal initiated on day N appears in
-// Flex on the morning of day N+1, and the radon daemon syncs once per
-// ET trading day at 17:00 ET. The lozenge surfaces the last successful
+// Flex on the morning of day N+1, and the sFTP delivery ingest applies it
+// Tue..Sat at 07:30 ET. The lozenge surfaces the last successful
 // sync so an operator who initiated a withdrawal today understands why
 // it hasn't appeared yet. See feedback_flex_cash_transaction_lag.md.
 const SYNC_LOZENGE_EXPLANATION =

--- a/web/lib/serviceHealthWindows.ts
+++ b/web/lib/serviceHealthWindows.ts
@@ -115,14 +115,13 @@ export const SERVICE_FRESHNESS_WINDOWS: Record<string, Window> = {
   // pattern above so the row only fires when the writer should have
   // run inside market hours but didn't.
   "journal-sync": { open: 10 * MIN, extended: 3 * DAY, closed: 3 * DAY, category: "scheduled", requires_ib: true },
-  // ``cash-flow-sync`` fires once per ET trading day at 17:00 ET and
-  // skips weekends + US holidays. The longest legitimate quiet period
-  // is Fri 17:00 ET → Mon 17:00 ET ≈ 72h. The prior 25h uniform
-  // window tripped every Saturday morning. ``closed`` and ``extended``
-  // are widened to 4 days to cover the weekend gap (Fri–Mon) plus one
-  // holiday-drift day; ``open`` stays at 25h to catch a missed weekday
-  // run quickly during trading hours.
-  "cash-flow-sync": { open: 25 * HOUR, extended: 4 * DAY, closed: 4 * DAY, category: "scheduled", requires_ib: false },
+  // ``cash-flow-sync`` is written by the sFTP ingest (radon-flex-pull.timer,
+  // Tue..Sat 07:30 ET) when a NEW Activity statement is applied. The
+  // longest legitimate gap inside market hours is Sat 07:30 ET → Mon
+  // 16:00 ET ≈ 57h, so the 25h ``open`` window it had as a Mon-Fri daemon
+  // handler would trip every Monday. ``closed`` and ``extended`` stay at
+  // 4 days to cover the weekend gap plus one holiday-drift day.
+  "cash-flow-sync": { open: 3 * DAY, extended: 4 * DAY, closed: 4 * DAY, category: "scheduled", requires_ib: false },
   // ``execution-sweep`` fires once per ET trading day at 20:30 ET (the
   // REL-012 evening after-hours fill sweep inside the monitor daemon)
   // and skips weekends + US holidays. The longest legitimate quiet

--- a/web/tests/service-health-windows.test.ts
+++ b/web/tests/service-health-windows.test.ts
@@ -251,14 +251,26 @@ describe("weekend false-positive regression — cash-flow-sync and llm-token-ind
     expect(isStale(service, friFinish, "closed", SUN_EVENING_UTC)).toBe(false);
   });
 
-  it.each([
-    "cash-flow-sync",
-    "llm-token-index",
-  ])("%s: still alerts quickly during market hours when missed", (service) => {
+  it("llm-token-index: still alerts quickly during market hours when missed", () => {
     // 26h ago on a Wednesday market-hours check → stale (open window = 25h).
     const WED_MARKET = Date.parse("2026-05-13T15:00:00Z"); // 11 AM ET Wed
     const twentySixHAgo = new Date(WED_MARKET - 26 * 60 * 60_000).toISOString();
-    expect(isStale(service, twentySixHAgo, "open", WED_MARKET)).toBe(true);
+    expect(isStale("llm-token-index", twentySixHAgo, "open", WED_MARKET)).toBe(true);
+  });
+
+  // cash-flow-sync is written by the sFTP ingest Tue..Sat 07:30 ET since
+  // 2026-09-02, so a Monday session is legitimately ~57h past the Saturday
+  // run: the open window is 3 days, not 25h.
+  it("cash-flow-sync: a Saturday-morning sFTP ingest is not stale on Monday afternoon", () => {
+    const SAT_0730_ET = Date.parse("2026-05-09T11:30:00Z");
+    const MON_1500_ET = Date.parse("2026-05-11T19:00:00Z"); // ~55.5h later
+    expect(isStale("cash-flow-sync", new Date(SAT_0730_ET).toISOString(), "open", MON_1500_ET)).toBe(false);
+  });
+
+  it("cash-flow-sync: still alerts during market hours once 3 days have passed", () => {
+    const WED_MARKET = Date.parse("2026-05-13T15:00:00Z"); // 11 AM ET Wed
+    const seventyThreeHAgo = new Date(WED_MARKET - 73 * 60 * 60_000).toISOString();
+    expect(isStale("cash-flow-sync", seventyThreeHAgo, "open", WED_MARKET)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Symptom

Orders page, Cash Flows panel: red banner "SYNCED 6H AGO · FLEX WEB SERVICE IS FILE-INGEST ONLY. PASS --FROM-FILE OR --SENDREQUEST (SUNDAY RECON, AFTER EMBARGO)., RETRY 08:00 ET TOMORROW" over rows that were already current.

## Cause

Two producers wrote the same `cash-flow-sync` service_health row.

- `radon-flex-pull.timer` (Tue..Sat 07:30 ET) decrypts the sFTP-delivered Activity statement and runs `cash_flow_sync --from-file` on it. This is the only path that writes `cash_flows`, and it is where the "synced 6h ago" came from. It heartbeat `flex-pull` only.
- At 08:00 ET the monitor daemon's `CashFlowSyncHandler` spawned `scripts.cash_flow_sync` with no source. Weekday SendRequest is off by policy, so the CLI exits `EXIT_FLEX_SEND_DISABLED`, and the handler recorded that skip as a `cash-flow-sync` error. `/cash-flows` reads that row for the lozenge.

The cutover review (`docs/flex-sftp-cutover-review.md`, finding 8) already called for the cash-flow handler to be stopped or converted before the sFTP path counted as routine.

## Change

- `create_daemon()` no longer registers `CashFlowSyncHandler`. The class stays for its embargo bookkeeping contracts (R-104/R-108/R-109, ~2300 lines of tests); its header says why it is unregistered.
- `flex_delivery_ingest` heartbeats `cash-flow-sync` from the activity branch: `ok` after `cash_flow_sync --from-file` succeeds, `error` with the exit code when it fails. A trades statement never touches the row.
- Registration-completeness test moves `cash-flow-sync` from the handler collector to the direct `record_service_health` collector (the R-141 `exit-orders` pattern).
- Watchdog + TS `open` window for `cash-flow-sync`: 25h → 3 days. The producer now runs Tue..Sat, so a Monday session is ~57h past the Saturday run and 25h would have paged every Monday. `closed` stays 4 days.

## Not changed

- `flex-pull` keeps its 26h open window. It has the same Tue..Sat cadence and will show the same Monday staleness; that is pre-existing and out of scope here.
- The ok heartbeat fires only when a NEW statement is applied. A duplicate re-pull does not heartbeat, matching R-389 (a stale remote directory must not read as progress).

## Verification

- `scripts/tests/test_cash_flows_from_sftp_delivery.py`: red before (3 failed), green after.
- pytest over test_watchdog, test_monitor_daemon, the flex ingest/sftp suites, cash_flow_sync CLI, embargo durability, registration completeness: 910 passed.
- vitest service-health-windows, service-health-banner, admin-components, cash-flows-sync-lozenge, panel-freshness-honesty: 5 files passed.

After deploy, the banner clears on the next sFTP ingest (Tue..Sat 07:30 ET) when it writes the first `ok` row. Until then the stale error row stays; `_load_cash_flow_sync_status` reads whatever is there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMk93W3QuiZUwXEvj1UQPp
