### PR TITLE
cash flows: an applied duplicate Activity statement heartbeats ok

### DIFF
--- a/scripts/flex_delivery_ingest.py
+++ b/scripts/flex_delivery_ingest.py
@@ -106,6 +106,13 @@ def ingest_xml(
                 "error": "claim is in_progress from an earlier run; retried once stale",
                 "source_path": source_path,
             }
+        if kind == ACTIVITY:
+            # Its cash flows are already in Turso. The 08:30 re-pull and every
+            # manual re-run land here, so without this the row the lozenge
+            # reads keeps whatever error was written last, over data that is
+            # current. flex-pull's own row still calls a duplicate-only run
+            # stale (R-389); that is a delivery signal, not a cash-flows one.
+            _heartbeat_cash_flow_sync("ok")
         return {
             "ok": True,
             "outcome": "duplicate",

--- a/scripts/tests/test_cash_flows_from_sftp_delivery.py
+++ b/scripts/tests/test_cash_flows_from_sftp_delivery.py
@@ -121,6 +121,39 @@ class TestSftpIngestOwnsTheCashFlowHeartbeat:
         assert kw["error"]["cash_exit"] == cash_flow_sync.EXIT_WRITE_ERROR
         assert "cash_flow_sync" in kw["error"]["message"]
 
+    def test_an_applied_duplicate_activity_statement_heartbeats_ok(
+        self, monkeypatch, heartbeats, activity
+    ):
+        """The 08:30 re-pull and every manual re-run see the same bytes again.
+        Their cash flows are already in Turso, so the row must say the sFTP
+        path is current; otherwise the last error row outlives the data."""
+        monkeypatch.setattr(ingest, "claim_flex_delivery", lambda *_a, **_k: False)
+        monkeypatch.setattr(ingest, "flex_delivery_status", lambda _d: "applied", raising=False)
+
+        xml_text, path = activity
+        result = ingest.ingest_xml(xml_text, source_path=path)
+        assert result["ok"] is True and result["outcome"] == "duplicate"
+
+        cash = [row for row in heartbeats if row[0] == "cash-flow-sync"]
+        assert [state for _, state, _ in cash] == ["ok"]
+
+    def test_an_in_progress_duplicate_does_not_heartbeat(self, monkeypatch, heartbeats, activity):
+        """A fresh lease belongs to a run that may still be half-written (R-436)."""
+        monkeypatch.setattr(ingest, "claim_flex_delivery", lambda *_a, **_k: False)
+        monkeypatch.setattr(ingest, "flex_delivery_status", lambda _d: "in_progress", raising=False)
+
+        xml_text, path = activity
+        assert ingest.ingest_xml(xml_text, source_path=path)["ok"] is False
+        assert [row for row in heartbeats if row[0] == "cash-flow-sync"] == []
+
+    def test_an_applied_duplicate_trades_statement_does_not_heartbeat(self, monkeypatch, heartbeats):
+        monkeypatch.setattr(ingest, "claim_flex_delivery", lambda *_a, **_k: False)
+        monkeypatch.setattr(ingest, "flex_delivery_status", lambda _d: "applied", raising=False)
+
+        trades = (FIXTURES / "flex_trade_confirm_sample.xml").read_text()
+        assert ingest.ingest_xml(trades, source_path="trades.xml")["outcome"] == "duplicate"
+        assert [row for row in heartbeats if row[0] == "cash-flow-sync"] == []
+
     def test_a_trades_statement_does_not_touch_the_cash_flow_row(self, monkeypatch, claims, heartbeats):
         import journal_rehydrate
 


### PR DESCRIPTION
## Why

#251 moved the `cash-flow-sync` heartbeat to the sFTP ingest, but only the NEW-statement path wrote it. Re-running `radon-flex-pull.service` at 20:45 UTC today (to clear the banner from the latest ingest) found all three delivered statements already `applied`, returned `duplicate` for each, and wrote no `cash-flow-sync` row. The stale error from the retired daemon handler stayed on the Orders page.

## Change

- `flex_delivery_ingest.ingest_xml`: an `applied` duplicate whose statement classifies as Activity heartbeats `cash-flow-sync` ok. Its cash flows are already in Turso; that is the normal 08:30 ET retry and every manual re-run.
- `in_progress` duplicates (R-436) and Trade_History duplicates write nothing, pinned by tests.
- flex-pull's own row is untouched: a duplicate-only run is still the R-389 stale-remote error there. That row is the delivery signal; `cash-flow-sync` is the data signal.

## Verification

- `scripts/tests/test_cash_flows_from_sftp_delivery.py` + ingest/sFTP/registration suites: 83 passed.

## After merge

Re-run `radon-flex-pull.service` once; the Activity duplicates write the ok row and the banner clears. flex-pull will report the R-389 stale-remote error until the 07:30 ET delivery, as it does now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMk93W3QuiZUwXEvj1UQPp
