### PR TITLE
fix(orders): a stock modify is bounded by the SHARE cap, not the contracts cap

### DIFF
--- a/scripts/api/tests/test_modify_snapshot_contract_shape.py
+++ b/scripts/api/tests/test_modify_snapshot_contract_shape.py
@@ -1,0 +1,165 @@
+"""R-431 (P1): `/orders/modify` measured every working order as an OPTION.
+
+`check_modify_limits` read `secType` and `legs` off the TOP level of the
+working order, but the Turso `open_orders` payload
+(`ib_orders.py:fetch_open_orders`) nests them at `contract.secType` and
+`contract.comboLegs`. Every real snapshot row therefore resolved to
+`"option"`, so:
+
+  * a STOCK modify was bounded by the contract cap (`RADON_MAX_ORDER_QTY`,
+    hard max 2500) instead of `RADON_MAX_STOCK_ORDER_QTY` — a 10,000-share
+    resize was refused with "quantity 10000 exceeds the server-side limit of
+    2500 (RADON_MAX_ORDER_QTY)", and raising the contract cap to its ceiling
+    did not unblock it; and
+  * a BAG never reached the combo max-loss branch R-145 added, because
+    `combo_max_loss()` returns None for anything not typed "combo".
+
+The existing R-145 tests passed a hand-built flat shape the snapshot never
+emits, which is why neither hole was caught.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+API_DIR = Path(__file__).resolve().parent.parent
+REPO_ROOT = API_DIR.parent.parent
+for p in (str(REPO_ROOT), str(API_DIR.parent)):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+
+def _stock_order(quantity: float) -> dict:
+    """A working stock order exactly as `fetch_open_orders` serializes it."""
+    return {
+        "orderId": 41,
+        "permId": 991,
+        "orderRef": "radon-abc",
+        "symbol": "SOFI",
+        "contract": {
+            "conId": 1,
+            "symbol": "SOFI",
+            "secType": "STK",
+            "currency": "USD",
+            "multiplier": 1,
+            "strike": 0.0,
+            "right": "",
+            "expiry": None,
+        },
+        "action": "SELL",
+        "orderType": "LMT",
+        "totalQuantity": quantity,
+        "limitPrice": 12.0,
+        "auxPrice": None,
+        "status": "Submitted",
+        "filled": 0.0,
+        "remaining": quantity,
+        "tif": "DAY",
+        "outsideRth": False,
+    }
+
+
+class TestStockModifyUsesTheShareCap:
+    def test_ten_thousand_shares_is_not_refused_by_the_contract_cap(self):
+        from order_limits import check_modify_limits
+
+        violation = check_modify_limits(
+            _stock_order(5_000), new_quantity=10_000, new_price=12.0
+        )
+        assert violation is None, (
+            "a 10,000-share stock modify was refused by the options contract cap"
+        )
+
+    def test_past_the_share_cap_is_still_refused(self):
+        from order_limits import check_modify_limits
+
+        violation = check_modify_limits(
+            _stock_order(5_000), new_quantity=60_000, new_price=1.0
+        )
+        assert violation is not None
+        assert violation["code"] == "ORDER_QTY_LIMIT"
+        assert "RADON_MAX_STOCK_ORDER_QTY" in violation["message"]
+
+    def test_a_stock_modify_still_hits_the_notional_cap(self):
+        from order_limits import check_modify_limits
+
+        violation = check_modify_limits(
+            _stock_order(5_000), new_quantity=10_000, new_price=500.0
+        )
+        assert violation is not None
+        assert violation["code"] == "ORDER_NOTIONAL_LIMIT"
+
+
+class TestSnapshotBagIsMeasuredAsACombo:
+    def test_a_snapshot_bag_reaches_the_max_loss_branch(self):
+        from order_limits import check_modify_limits
+
+        working = {
+            "orderId": 42,
+            "permId": 992,
+            "symbol": "SPY Spread",
+            "contract": {
+                "symbol": "SPY",
+                "secType": "BAG",
+                "comboLegs": [
+                    {"conId": 11, "ratio": 1, "action": "SELL", "right": "P", "strike": 400.0},
+                    {"conId": 12, "ratio": 1, "action": "BUY", "right": "C", "strike": 410.0},
+                ],
+            },
+            "action": "BUY",
+            "orderType": "LMT",
+            "totalQuantity": 1.0,
+            "limitPrice": 1.0,
+        }
+        violation = check_modify_limits(working, new_quantity=500, new_price=1.00)
+        assert violation is not None, (
+            "a snapshot-shaped BAG resized to 500 lots skipped the max-loss branch"
+        )
+        assert violation["code"] in {
+            "ORDER_MAX_LOSS_LIMIT",
+            "ORDER_NOTIONAL_LIMIT",
+            "ORDER_EFFECTIVE_QTY_LIMIT",
+        }
+
+    def test_a_defined_risk_snapshot_bag_resize_still_passes(self):
+        from order_limits import check_modify_limits
+
+        working = {
+            "contract": {
+                "symbol": "SPY",
+                "secType": "BAG",
+                "comboLegs": [
+                    {"conId": 11, "ratio": 1, "action": "SELL", "right": "P", "strike": 195.0},
+                    {"conId": 12, "ratio": 1, "action": "BUY", "right": "P", "strike": 190.0},
+                ],
+            },
+            "action": "BUY",
+            "totalQuantity": 1.0,
+            "limitPrice": 1.0,
+        }
+        assert check_modify_limits(working, new_quantity=500, new_price=1.00) is None
+
+    def test_a_bag_with_unresolvable_legs_keeps_the_contract_cap(self):
+        """`fetch_open_orders` skips legs it cannot qualify, so a strikeless
+        BAG falls back to the bound it CAN compute rather than failing closed
+        on a legitimate resize."""
+        from order_limits import check_modify_limits
+
+        working = {
+            "contract": {
+                "symbol": "SPY",
+                "secType": "BAG",
+                "comboLegs": [
+                    {"conId": 11, "ratio": 1, "action": "SELL"},
+                    {"conId": 12, "ratio": 1, "action": "BUY"},
+                ],
+            },
+            "action": "BUY",
+            "totalQuantity": 1.0,
+            "limitPrice": 1.0,
+        }
+        assert check_modify_limits(working, new_quantity=10, new_price=1.00) is None
+        refused = check_modify_limits(working, new_quantity=5_000, new_price=1.00)
+        assert refused is not None
+        assert refused["code"] == "ORDER_QTY_LIMIT"

--- a/scripts/order_limits.py
+++ b/scripts/order_limits.py
@@ -284,6 +284,62 @@ def check_order_limits(params: dict) -> Optional[dict[str, Any]]:
     return None
 
 
+def _legs_are_priceable(legs: Any) -> bool:
+    """True when `_combo_risk_per_unit` can price every leg.
+
+    `ib_orders.py:fetch_open_orders` skips combo legs it cannot qualify, so a
+    snapshot BAG may carry legs with no strike. `check_order_limits` fails
+    CLOSED on those (ORDER_COMBO_STRIKE), which is right for a placement the
+    caller composed and wrong for a resize of an order IB already holds.
+    """
+    if not isinstance(legs, list) or not 2 <= len(legs) <= _MAX_COMBO_LEGS:
+        return False
+    for leg in legs:
+        if not isinstance(leg, dict):
+            return False
+        if str(leg.get("sec_type") or leg.get("secType") or "").upper() == "STK":
+            continue
+        try:
+            if float(leg.get("strike") or 0) <= 0:
+                return False
+        except (TypeError, ValueError):
+            return False
+    return True
+
+
+def _working_order_shape(working_order: dict) -> tuple[str, Optional[list]]:
+    """(order type, combo legs) of a working order, from either shape.
+
+    R-431: the Turso `open_orders` payload nests the contract —
+    `contract.secType` and `contract.comboLegs` (``ib_orders.py``) — while a
+    caller-composed replacement carries `secType`/`legs` flat. Reading only
+    the flat keys resolved EVERY snapshot row to "option", so a working stock
+    order was bounded by the contracts cap (RADON_MAX_ORDER_QTY, hard max
+    2500): selling 10,000 shares was refused, and raising the contracts cap to
+    its ceiling could not unblock it. A BAG likewise never reached the
+    max-loss branch R-145 added.
+
+    A BAG whose legs cannot be priced stays "option" — the quantity and
+    notional bounds it already had, never a new fail-closed refusal of a
+    legitimate resize (the same trade-off ``ib_order_manage.py`` documents).
+    """
+    contract = working_order.get("contract")
+    contract = contract if isinstance(contract, dict) else {}
+
+    sec_type = str(contract.get("secType") or working_order.get("secType") or "").upper()
+
+    legs = working_order.get("legs")
+    if not isinstance(legs, list):
+        combo_legs = contract.get("comboLegs")
+        legs = combo_legs if isinstance(combo_legs, list) else None
+
+    if sec_type == "BAG" or (legs is not None and len(legs) >= 2):
+        return ("combo" if _legs_are_priceable(legs) else "option"), legs
+    if sec_type == "STK":
+        return "stock", None
+    return "option", None
+
+
 def check_modify_limits(
     working_order: Optional[dict],
     *,
@@ -303,18 +359,15 @@ def check_modify_limits(
 
     An unreadable working order is NOT a bypass: the contract-quantity cap
     still applies, exactly as before.
+
+    R-431: the shape is read through `_working_order_shape`, because the Turso
+    `open_orders` payload nests it one level down and reading the top level
+    typed every real working order as an option.
     """
     if not isinstance(working_order, dict):
         return check_quantity_limit(new_quantity) if new_quantity is not None else None
 
-    sec_type = str(working_order.get("secType") or "").upper()
-    legs = working_order.get("legs")
-    if sec_type == "BAG" or isinstance(legs, list) and len(legs) >= 2:
-        order_type = "combo"
-    elif sec_type == "STK":
-        order_type = "stock"
-    else:
-        order_type = "option"
+    order_type, legs = _working_order_shape(working_order)
 
     quantity = new_quantity
     if quantity is None:
@@ -329,7 +382,7 @@ def check_modify_limits(
         "limitPrice": price,
         "action": action or working_order.get("action"),
     }
-    if order_type == "combo" and isinstance(legs, list):
+    if order_type == "combo" and legs is not None:
         params["legs"] = legs
     return check_order_limits(params)
 


### PR DESCRIPTION
## Bug

Selling 10,000 shares off a working stock order was refused at the wire:

```json
{"code":"ORDER_QTY_LIMIT","message":"quantity 10000 exceeds the server-side limit of 2500 (RADON_MAX_ORDER_QTY) — refused"}
```

`RADON_MAX_ORDER_QTY` is the **options/combo contracts** cap (hard max 2500). Shares are governed by `RADON_MAX_STOCK_ORDER_QTY` (default 10,000, band 1–50,000), which was never consulted — so raising the contracts cap to its ceiling in Preferences could not unblock the order.

## Cause

`check_modify_limits` read `secType` and `legs` off the **top level** of the working order:

```python
sec_type = str(working_order.get("secType") or "").upper()
legs = working_order.get("legs")
```

The Turso `open_orders` payload that `_find_working_order` hands it nests them one level down — `contract.secType` and `contract.comboLegs` (`scripts/ib_orders.py:fetch_open_orders`). Every real snapshot row therefore resolved to `sec_type == ""` and fell through to the `else` branch, `"option"`. Two consequences:

- a **stock** modify was measured against the contracts cap (the reported bug); and
- a **BAG** never reached the combo max-loss branch R-145 added, because `combo_max_loss()` returns `None` for anything not typed `"combo"` — the exact hole R-145 was written to close.

The R-145 tests passed a hand-built flat shape (`{"secType": "BAG", "legs": [...]}`) that the snapshot never emits, which is why neither hole was caught.

## Fix

`_working_order_shape()` resolves the type and legs from the nested contract first, falling back to the flat keys a caller-composed replacement payload carries.

A BAG whose legs cannot be priced stays `"option"`: `fetch_open_orders` skips combo legs it cannot qualify, and `check_order_limits` fails **closed** on a strikeless combo leg (`ORDER_COMBO_STRIKE`). That is right for a placement the caller composed and wrong for a resize of an order IB already holds — the same bound-it-can-compute trade-off `ib_order_manage.py` documents at the transport funnel. So the fix adds no new refusal class.

No cap changes: the share cap still refuses past 50,000, the notional cap still applies, and an unreadable working order still falls back to the contract-quantity cap.

## Tests

New `scripts/api/tests/test_modify_snapshot_contract_shape.py`, built on the real `fetch_open_orders` payload shape. Red before the fix, green after:

| Test | Before |
|---|---|
| 10,000-share stock modify allowed | ❌ refused with `RADON_MAX_ORDER_QTY` |
| 60,000-share stock modify refused citing `RADON_MAX_STOCK_ORDER_QTY` | ❌ cited the wrong key |
| stock modify still hits `ORDER_NOTIONAL_LIMIT` | ❌ hit the qty cap first |
| snapshot BAG reaches the max-loss branch | ❌ skipped entirely |
| defined-risk snapshot BAG resize still passes | ✅ |
| strikeless BAG keeps the contract cap, no fail-closed refusal | ✅ |

`110 passed` across `test_modify_snapshot_contract_shape.py`, `test_modify_full_limits_and_pool_lock.py`, `test_order_limits.py`, `test_app_preferences.py`, `test_order_limits_routes.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fvem6SFywB3Qf6w9RaSMWr
