### PR TITLE
fix(orders): show realized P&L for stock closes in Executed Orders

### DIFF
--- a/web/components/WorkspaceSections.tsx
+++ b/web/components/WorkspaceSections.tsx
@@ -326,13 +326,16 @@ function resolveOpeningLegBasis(
   };
 }
 
-/** Net cash received by a group's closing option fills in dollars
- *  (SLD positive, BOT negative). Null when any fill is unpriced or sideless. */
+/** Net cash received by a group's closing fills in dollars
+ *  (SLD positive, BOT negative). Options use the ×100 multiplier, stocks ×1.
+ *  Null when any fill is unpriced or sideless. */
 function closedGroupCloseCash(group: PositionFillGroup): number | null {
-  const optFills = group.fills.filter((f) => f.contract.secType === "OPT");
-  if (optFills.length === 0) return null;
+  const priced = group.fills.filter(
+    (f) => f.contract.secType === "OPT" || f.contract.secType === "STK",
+  );
+  if (priced.length === 0) return null;
   let closeCash = 0;
-  for (const fill of optFills) {
+  for (const fill of priced) {
     if (fill.avgPrice == null || !Number.isFinite(fill.avgPrice)) return null;
     const cashSign = fill.side === "SLD" || fill.side === "SELL"
       ? 1
@@ -340,7 +343,8 @@ function closedGroupCloseCash(group: PositionFillGroup): number | null {
         ? -1
         : 0;
     if (cashSign === 0) return null;
-    closeCash += cashSign * fill.avgPrice * Math.abs(fill.quantity) * 100;
+    const multiplier = fill.contract.secType === "OPT" ? 100 : 1;
+    closeCash += cashSign * fill.avgPrice * Math.abs(fill.quantity) * multiplier;
   }
   return closeCash;
 }
@@ -605,10 +609,12 @@ export function groupExecutedOrders(
   };
 
   const isClosingFill = (fill: ExecutedOrder): boolean => {
-    if (fill.contract.secType !== "OPT") return false;
     // Primary signal: IB populated realizedPNL on the commission report.
+    // Applies to every sec type — a stock (or future) SELL-to-close / BUY-to-cover
+    // carries realizedPNL just as an option close does.
     if (fill.realizedPNL != null && Math.abs(fill.realizedPNL) > 0.01) return true;
-    // Fallback: this fill closes against an existing portfolio leg.
+    // Fallback (options only): this fill closes against an existing portfolio leg.
+    if (fill.contract.secType !== "OPT") return false;
     // BOT against a SHORT leg, or SLD against a LONG leg = reduces the position.
     const basis = portfolioLegBasisFor(fill);
     if (!basis) return false;

--- a/web/tests/share-pnl.test.ts
+++ b/web/tests/share-pnl.test.ts
@@ -326,7 +326,7 @@ describe("positionGroupShareData", () => {
     expect(data.pnlPct).toBeNull();
   });
 
-  it("handles stock-only position groups (no OPT fills → pnlPct from P&L identity or null)", () => {
+  it("handles stock-only position groups (pnlPct from the P&L identity with a ×1 multiplier)", () => {
     const group: PositionFillGroup = {
       id: "stock", symbol: "AAPL",
       description: "Closed AAPL Stock",
@@ -341,8 +341,9 @@ describe("positionGroupShareData", () => {
       }],
     };
     const data = positionGroupShareData(group);
-    // No OPT fills means closedGroupOpenCash returns null → pnlPct is null
-    expect(data.pnlPct).toBeNull();
+    // Stock close: closeCash = 252.50 × 100 × 1 = 25250, openCash = 500 − 25250,
+    // pnlPct = 500 / 24750 × 100 ≈ 2.02%.
+    expect(data.pnlPct).toBeCloseTo(2.0202, 3);
     expect(data.pnl).toBe(500);
   });
 

--- a/web/tests/workspace-orders-implied.test.tsx
+++ b/web/tests/workspace-orders-implied.test.tsx
@@ -8,7 +8,7 @@
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen, within } from "@testing-library/react";
-import WorkspaceSections, { groupExecutedOrders } from "../components/WorkspaceSections";
+import WorkspaceSections, { groupExecutedOrders, closedGroupReturnPct } from "../components/WorkspaceSections";
 import { bsCall, bsPut } from "../lib/blackScholes";
 import { yearsToExpiry } from "../lib/impliedValue";
 import type { ExecutedOrder, OrdersData, PriceData } from "../lib/types";
@@ -111,6 +111,22 @@ describe("WorkspaceSections orders — Implied column", () => {
       fill("b", "intent-b", "2026-08-13T14:31:00Z"),
     ]);
     expect(groups).toHaveLength(2);
+  });
+
+  it("classifies a stock SELL carrying realizedPNL as a close and surfaces its P&L", () => {
+    const groups = groupExecutedOrders([
+      {
+        execId: "s1", orderRef: "sell-avgo", symbol: "AVGO", side: "SLD",
+        quantity: 1000, avgPrice: 355, commission: 9.91, realizedPNL: 10650,
+        time: "2026-09-02T20:24:15Z", exchange: "SMART",
+        contract: { conId: 5, symbol: "AVGO", secType: "STK", strike: null, right: null, expiry: null },
+      },
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].isClosing).toBe(true);
+    expect(groups[0].totalPnL).toBeCloseTo(10650, 2);
+    // Return % uses the ×1 stock multiplier: 10650 / (355×1000 − 10650) ≈ 3.09%
+    expect(closedGroupReturnPct(groups[0])).toBeCloseTo(3.093, 2);
   });
 
   it("uses quantity-weighted BAG execution price and rejects incomplete aggregates", () => {


### PR DESCRIPTION
## Bug

Today's Executed Orders rendered stock closes with the **OPEN** pill and a `—` in the Realized P&L column (screenshot: AVGO 1000-share sell, TQQQ 10k round trip). Option closes (WULF) showed P&L correctly.

## Cause

`groupExecutedOrders`' `isClosingFill` returned `false` for any non-OPT fill *before* checking IB's `realizedPNL` signal:

```ts
if (fill.contract.secType !== "OPT") return false;
if (fill.realizedPNL != null && Math.abs(fill.realizedPNL) > 0.01) return true;
```

Stock SELL-to-close / BUY-to-cover fills carry `realizedPNL` on the commission report just like options, but the guard short-circuited it. Every stock close was bucketed as an OPEN group, so `totalPnL` was never computed.

## Fix

- Move the `realizedPNL` primary signal ahead of the OPT-only guard so it applies to every sec type; the portfolio-basis fallback stays options-only.
- `closedGroupCloseCash` now folds STK fills (×1 multiplier vs ×100 for options) so a stock close also surfaces its return %, matching the option-close presentation.

## Tests

- `workspace-orders-implied.test.tsx`: new red→green case — a stock SELL with `realizedPNL` classifies as a close and surfaces P&L + return %.
- `share-pnl.test.ts`: stock-only share-card case updated to assert the P&L-identity return % it now derives (was asserting the old null).
- Full web suite green (one pre-existing, unrelated Anthropic assistant failure fails identically on baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)