### PR TITLE
fix(catalysts): sort same-day events chronologically

### DIFF
--- a/web/lib/catalystGroups.ts
+++ b/web/lib/catalystGroups.ts
@@ -40,7 +40,13 @@ function compareCategories(a: CatalystCategory, b: CatalystCategory): number {
 /** Held rows lead their category so exposure survives the collapsed preview. */
 function compareRows(a: CategorizedCatalystRow, b: CategorizedCatalystRow): number {
   if (a.isHeld !== b.isHeld) return a.isHeld ? -1 : 1;
-  return a.days_until - b.days_until;
+  if (a.days_until !== b.days_until) return a.days_until - b.days_until;
+  const aTime = a.event_time ? Date.parse(a.event_time) : NaN;
+  const bTime = b.event_time ? Date.parse(b.event_time) : NaN;
+  if (Number.isFinite(aTime) && Number.isFinite(bTime)) return aTime - bTime;
+  if (Number.isFinite(aTime)) return -1;
+  if (Number.isFinite(bTime)) return 1;
+  return 0;
 }
 
 /**

--- a/web/tests/catalysts-quadrant.test.tsx
+++ b/web/tests/catalysts-quadrant.test.tsx
@@ -72,6 +72,20 @@ describe("CatalystsQuadrant", () => {
     expect(labels).toEqual(["ECONOMIC DATA", "EARNINGS", "FDA"]);
   });
 
+  it("orders same-day rows chronologically by event_time, not insertion order", () => {
+    freeze("2026-08-04T14:00:00Z");
+    payload = snapshot([
+      row({ title: "ISM Services PMI", date: "2026-08-04", event_time: "2026-08-04T14:00:00Z" }),
+      row({ title: "Services PMI", date: "2026-08-04", event_time: "2026-08-04T13:45:00Z" }),
+      row({ title: "Jobless Claims", date: "2026-08-04", event_time: "2026-08-04T12:30:00Z" }),
+    ]);
+    render(<CatalystsQuadrant positionTickers={new Set()} />);
+    const names = Array.from(document.querySelectorAll(".catalyst-group__name")).map(
+      (el) => el.textContent,
+    );
+    expect(names).toEqual(["Jobless Claims", "Services PMI", "ISM Services PMI"]);
+  });
+
   it("opens only the first category and toggles the others on click", () => {
     freeze("2026-08-04T14:00:00Z");
     payload = snapshot([


### PR DESCRIPTION
## Summary
- Upcoming Catalysts sorted only by `days_until` (whole days), so same-day economic prints stayed in insertion order instead of clock order.
- `compareRows` now breaks a same-day tie on `event_time`.

## Test plan
- [x] `npx vitest run tests/catalysts-quadrant.test.tsx` — 10/10 passed, new test pins chronological same-day order.

Not in scope: blank "actual" prints on already-released events are a data-freshness gap in the `fetch_catalysts.py` / FRED-overlay cadence, not a frontend bug — flagging for a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfNpLjqNEADVfjkorf7cNP