### PR TITLE
fix(orders): align combo marks with portfolio pricing

### DIFF
--- a/web/components/WorkspaceSections.tsx
+++ b/web/components/WorkspaceSections.tsx
@@ -54,12 +54,15 @@ import { useTableFilter } from "@/lib/useTableFilter";
 import TableSearch from "./TableSearch";
 import SortTh from "./SortTh";
 import { usePriceDirection } from "@/lib/usePriceDirection";
-import { fmtPrice, fmtUsd, legPriceKey } from "@/lib/positionUtils";
+import { fmtPrice, fmtPriceOrCalculated, fmtUsd, legPriceKey, resolveRealtimePrice } from "@/lib/positionUtils";
 import {
   buildOpenOrderDisplayRows,
   type OpenOrderDisplayRow,
   buildExecutedGroupDescription,
   resolveOpenOrderComboPrice,
+  resolveOpenOrderComboPriceData,
+  resolveSignedComboPrice,
+  type ResolvedOpenOrderPrice,
   findPortfolioLegDirection,
 } from "@/lib/openOrderCombos";
 import {
@@ -2637,37 +2640,136 @@ function orderPriceKey(contract: OpenOrder["contract"]): string | null {
   return contract.symbol;
 }
 
+function normalizedOptionRight(right: string | null | undefined): "C" | "P" | null {
+  if (right === "C" || right === "CALL") return "C";
+  if (right === "P" || right === "PUT") return "P";
+  return null;
+}
+
+function portfolioLegMatchesComboLeg(
+  position: PortfolioPosition,
+  leg: PortfolioPosition["legs"][number],
+  comboLeg: NonNullable<OpenOrder["contract"]["comboLegs"]>[number],
+): boolean {
+  if (comboLeg.conId > 0 && leg.con_id != null && leg.con_id > 0) {
+    return comboLeg.conId === leg.con_id;
+  }
+  const comboRight = normalizedOptionRight(comboLeg.right);
+  const comboExpiry = comboLeg.expiry?.replace(/-/g, "") ?? "";
+  if (!comboRight || comboLeg.strike == null || comboExpiry.length !== 8) return false;
+  const legRight = leg.type === "Call" ? "C" : leg.type === "Put" ? "P" : null;
+  const legExpiry = (leg.expiry ?? position.expiry).replace(/-/g, "");
+  return legRight === comboRight && leg.strike === comboLeg.strike && legExpiry === comboExpiry;
+}
+
+function matchingPortfolioLeg(
+  position: PortfolioPosition,
+  comboLeg: NonNullable<OpenOrder["contract"]["comboLegs"]>[number],
+) {
+  return position.legs.find((leg) => portfolioLegMatchesComboLeg(position, leg, comboLeg)) ?? null;
+}
+
+function positionMatchesComboLegs(
+  position: PortfolioPosition,
+  comboLegs: NonNullable<OpenOrder["contract"]["comboLegs"]>,
+): boolean {
+  if (
+    position.legs.length !== comboLegs.length
+    || !Number.isFinite(position.contracts)
+    || position.contracts === 0
+  ) {
+    return false;
+  }
+
+  const unmatchedLegs = [...position.legs];
+  return comboLegs.every((comboLeg) => {
+    const direction = comboLeg.action === "BUY" ? "LONG" : comboLeg.action === "SELL" ? "SHORT" : null;
+    if (!direction || !Number.isFinite(comboLeg.ratio) || comboLeg.ratio <= 0) return false;
+    const index = unmatchedLegs.findIndex((leg) => {
+      if (leg.direction !== direction) return false;
+      const ratio = Math.abs(leg.contracts / position.contracts);
+      if (Math.abs(ratio - comboLeg.ratio) > Number.EPSILON) return false;
+      return portfolioLegMatchesComboLeg(position, leg, comboLeg);
+    });
+    if (index < 0) return false;
+    unmatchedLegs.splice(index, 1);
+    return true;
+  });
+}
+
+function matchingBagPosition(
+  order: OpenOrder,
+  portfolio: PortfolioData | null | undefined,
+): PortfolioPosition | null {
+  if (!portfolio) return null;
+  const candidates = portfolio.positions.filter(
+    (position) => position.ticker.toUpperCase() === order.contract.symbol.toUpperCase() && position.legs.length > 1,
+  );
+  const comboLegs = order.contract.comboLegs;
+  if (!comboLegs?.length) return candidates.length === 1 ? candidates[0] : null;
+  const matches = candidates.filter((position) => positionMatchesComboLegs(position, comboLegs));
+  return matches.length === 1 ? matches[0] : null;
+}
+
 /**
  * Resolve the "last price" for an order.
  * For STK/OPT: use the WS price directly.
- * For BAG (spread): find the matching portfolio position and compute
- * the net mid from each leg's WS bid/ask (long leg mid − short leg mid).
+ * For BAG (spread): resolve each structural leg with the same stale-last /
+ * calculated-mid policy as the portfolio, then aggregate one signed BAG unit.
  */
-function resolveOrderLastPrice(
+function resolveOrderLastPriceData(
   order: OpenOrder,
   prices: Record<string, PriceData> | undefined,
   portfolio: PortfolioData | null | undefined,
-): number | null {
-  if (!prices) return null;
+): ResolvedOpenOrderPrice {
+  if (!prices) return { price: null, isCalculated: false };
   const pk = orderPriceKey(order.contract);
-  if (pk) return prices[pk]?.last ?? null;
-
-  // BAG: compute net mid from portfolio legs
-  if (order.contract.secType !== "BAG" || !portfolio) return null;
-  const pos = portfolio.positions.find((p) => p.ticker === order.contract.symbol && p.legs.length > 1);
-  if (!pos) return null;
-
-  let netMid = 0;
-  for (const leg of pos.legs) {
-    const key = legPriceKey(pos.ticker, pos.expiry, leg);
-    if (!key) return null;
-    const lp = prices[key];
-    if (!lp || lp.bid == null || lp.ask == null) return null;
-    const mid = (lp.bid + lp.ask) / 2;
-    const sign = leg.direction === "LONG" ? 1 : -1;
-    netMid += sign * mid;
+  if (pk) {
+    const priceData = prices[pk];
+    if (order.contract.secType === "OPT") return resolveRealtimePrice(priceData);
+    return {
+      price: priceData?.last ?? null,
+      isCalculated: Boolean(priceData?.lastIsCalculated),
+    };
   }
-  return Math.round(netMid * 100) / 100;
+
+  if (order.contract.secType !== "BAG") return { price: null, isCalculated: false };
+  const position = matchingBagPosition(order, portfolio);
+
+  const comboLegs = order.contract.comboLegs;
+  if (comboLegs?.length) {
+    const resolved = resolveSignedComboPrice(comboLegs.map((comboLeg) => {
+      const right = normalizedOptionRight(comboLeg.right);
+      const expiry = comboLeg.expiry?.replace(/-/g, "") ?? "";
+      const symbol = (comboLeg.symbol || order.contract.symbol).toUpperCase();
+      const key = right && comboLeg.strike != null && expiry.length === 8
+        ? optionKey({ symbol, expiry, strike: comboLeg.strike, right })
+        : null;
+      const fallbackLeg = position ? matchingPortfolioLeg(position, comboLeg) : null;
+      return {
+        action: comboLeg.action,
+        ratio: comboLeg.ratio,
+        priceData: key ? prices[key] : null,
+        fallbackPrice: fallbackLeg?.market_price,
+        fallbackIsCalculated: fallbackLeg?.market_price_is_calculated,
+      };
+    }));
+    if (resolved.price != null) return resolved;
+  }
+
+  if (!position || !Number.isFinite(position.contracts) || position.contracts === 0) {
+    return { price: null, isCalculated: false };
+  }
+  return resolveSignedComboPrice(position.legs.map((leg) => {
+    const key = legPriceKey(position.ticker, position.expiry, leg);
+    return {
+      action: leg.direction === "LONG" ? "BUY" : "SELL",
+      ratio: Math.abs(leg.contracts / position.contracts),
+      priceData: key ? prices[key] : null,
+      fallbackPrice: leg.market_price,
+      fallbackIsCalculated: leg.market_price_is_calculated,
+    };
+  }));
 }
 
 function makeOpenOrderExtract(
@@ -2687,7 +2789,7 @@ function makeOpenOrderExtract(
       case "lastPrice":
         return item.kind === "combo"
           ? resolveOpenOrderComboPrice(item.orders, prices)
-          : resolveOrderLastPrice(item.order, prices, portfolio);
+          : resolveOrderLastPriceData(item.order, prices, portfolio).price;
       case "deltaFill": {
         if (item.kind === "combo") {
           const last = resolveOpenOrderComboPrice(item.orders, prices);
@@ -2701,7 +2803,7 @@ function makeOpenOrderExtract(
         return distanceToFill({
           action: item.order.action,
           limitPrice: item.order.limitPrice,
-          lastPrice: resolveOrderLastPrice(item.order, prices, portfolio),
+          lastPrice: resolveOrderLastPriceData(item.order, prices, portfolio).price,
         })?.delta ?? null;
       }
       case "implied":
@@ -2723,11 +2825,11 @@ function makeOpenOrderExtract(
 }
 
 /** Wrapper so usePriceDirection can be called per-order row (hooks can't go in map callbacks). */
-function OrderPriceCell({ price }: { price: number | null }) {
+function OrderPriceCell({ price, isCalculated = false }: ResolvedOpenOrderPrice) {
   const { direction, flashDirection } = usePriceDirection(price);
   return (
     <td className={`right last-price-cell ${flashDirection ? `last-price-${flashDirection}` : ""}`}>
-      {price != null ? fmtPrice(price) : "—"}
+      {price != null ? fmtPriceOrCalculated(price, isCalculated) : "—"}
       {direction === "up" && <ArrowUp size={11} className="price-trend-icon price-trend-up" aria-label="price up" />}
       {direction === "down" && <ArrowDown size={11} className="price-trend-icon price-trend-down" aria-label="price down" />}
     </td>
@@ -3341,7 +3443,8 @@ function OrdersSections({
                     const comboQtyLabel = partialLeg
                       ? formatFillQuantity(partialLeg)
                       : String(o.totalQuantity);
-                    const comboLast = resolveOpenOrderComboPrice(o.orders, prices);
+                    const comboPrice = resolveOpenOrderComboPriceData(o.orders, prices);
+                    const comboLast = comboPrice.price;
                     const comboDistance = distanceToFill({
                       action: o.orders[0]?.action ?? "BUY",
                       limitPrice: o.limitPrice,
@@ -3400,7 +3503,7 @@ function OrdersSections({
                           </td>
                         )}
                         {orderColumns.lastPrice && (
-                          <OrderPriceCell price={comboLast} />
+                          <OrderPriceCell {...comboPrice} />
                         )}
                         {orderColumns.deltaFill && (
                           <td className="right">
@@ -3469,7 +3572,8 @@ function OrdersSections({
                   const isPendingCancel = pendingCancels.has(o.order.permId);
                   const isPendingModify = pendingModifies.has(o.order.permId);
                   const isPending = isPendingCancel || isPendingModify;
-                  const singleLast = resolveOrderLastPrice(o.order, prices, portfolio);
+                  const singlePrice = resolveOrderLastPriceData(o.order, prices, portfolio);
+                  const singleLast = singlePrice.price;
                   const singleDistance = distanceToFill({
                     action: o.order.action,
                     limitPrice: o.order.limitPrice,
@@ -3540,7 +3644,7 @@ function OrdersSections({
                         </td>
                       )}
                       {orderColumns.lastPrice && (
-                        <OrderPriceCell price={singleLast} />
+                        <OrderPriceCell {...singlePrice} />
                       )}
                       {orderColumns.deltaFill && (
                         <td className="right">

--- a/web/e2e/open-order-combo.spec.ts
+++ b/web/e2e/open-order-combo.spec.ts
@@ -84,6 +84,93 @@ const ORDERS_RISK_REVERSAL = {
   executed_count: 0,
 };
 
+const SMH_PORTFOLIO = {
+  ...PORTFOLIO_MOCK,
+  position_count: 1,
+  defined_risk_count: 1,
+  positions: [
+    {
+      id: 18,
+      ticker: "SMH",
+      structure: "Bull Put Spread $545.0/$550.0",
+      structure_type: "Bull Put Spread",
+      risk_profile: "defined",
+      expiry: "2026-09-18",
+      contracts: 150,
+      direction: "COMBO",
+      entry_cost: -34_200,
+      max_risk: 40_800,
+      market_value: -25_950,
+      legs: [
+        {
+          con_id: 545,
+          direction: "LONG",
+          contracts: 150,
+          type: "Put",
+          strike: 545,
+          entry_cost: 187_050,
+          avg_cost: 1_247,
+          market_price: 9.6,
+          market_value: 144_000,
+        },
+        {
+          con_id: 550,
+          direction: "SHORT",
+          contracts: 150,
+          type: "Put",
+          strike: 550,
+          entry_cost: 221_250,
+          avg_cost: 1_475,
+          market_price: 11.33,
+          market_price_is_calculated: true,
+          market_value: 169_950,
+        },
+      ],
+      ib_daily_pnl: 289,
+      kelly_optimal: null,
+      target: null,
+      stop: null,
+      entry_date: "2026-08-01",
+    },
+  ],
+};
+
+const SMH_BAG_ORDER = {
+  last_sync: new Date().toISOString(),
+  open_orders: [
+    {
+      orderId: 71,
+      permId: 7101,
+      symbol: "SMH Spread",
+      contract: {
+        conId: 0,
+        symbol: "SMH",
+        secType: "BAG",
+        strike: null,
+        right: null,
+        expiry: null,
+        comboLegs: [
+          { conId: 545, ratio: 1, action: "BUY", symbol: "SMH", strike: 545, right: "P", expiry: "2026-09-18" },
+          { conId: 550, ratio: 1, action: "SELL", symbol: "SMH", strike: 550, right: "P", expiry: "2026-09-18" },
+        ],
+      },
+      action: "SELL",
+      orderType: "LMT",
+      totalQuantity: 150,
+      limitPrice: -1.95,
+      auxPrice: null,
+      status: "Submitted",
+      filled: 0,
+      remaining: 150,
+      avgFillPrice: null,
+      tif: "GTC",
+    },
+  ],
+  executed_orders: [],
+  open_count: 1,
+  executed_count: 0,
+};
+
 async function stubApis(page: import("@playwright/test").Page) {
   await page.unrouteAll({ behavior: "ignoreErrors" });
 
@@ -142,6 +229,38 @@ async function stubApis(page: import("@playwright/test").Page) {
   await page.route("**/api/prices", (route) => route.abort());
 }
 
+async function stubSmhApis(page: import("@playwright/test").Page) {
+  await page.unrouteAll({ behavior: "ignoreErrors" });
+  await page.route("**/api/portfolio**", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(SMH_PORTFOLIO) }),
+  );
+  await page.route("**/api/orders", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(SMH_BAG_ORDER) }),
+  );
+  await page.route("**/api/blotter", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        as_of: new Date().toISOString(),
+        summary: { closed_trades: 0, open_trades: 0, total_commissions: 0, realized_pnl: 0 },
+        closed_trades: [],
+        open_trades: [],
+      }),
+    }),
+  );
+  await page.route("**/api/ib-status", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ connected: true }) }),
+  );
+  await page.route("**/api/regime", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ score: 15, cri: { score: 15 } }) }),
+  );
+  await page.route("**/api/risk-free-rate", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ rate: 0.05, source: "FRED:DFF", stale: false }) }),
+  );
+  await page.route("**/api/prices**", (route) => route.abort());
+}
+
 test.describe("Orders open-order combo rendering", () => {
   test("combines short put and long call as a risk reversal row and opens combo modify", async ({ page }) => {
     await stubApis(page);
@@ -168,5 +287,34 @@ test.describe("Orders open-order combo rendering", () => {
     await expect(modal.locator("#modify-quantity-input")).toHaveValue("10");
     await expect(modal.locator("#modify-leg-0-strike")).toHaveValue("150");
     await expect(modal.locator("#modify-leg-1-strike")).toHaveValue("165");
+  });
+
+  test("uses the same calculated combo mark on Orders and Portfolio", async ({ page }, testInfo) => {
+    await stubSmhApis(page);
+
+    await page.goto("/orders");
+
+    const orderRow = page.getByTestId("open-order-row-71-7101");
+    await expect(orderRow).toBeVisible({ timeout: 10_000 });
+    await expect(orderRow).toContainText("$-1.95");
+    const orderLast = orderRow.locator("td.last-price-cell");
+    await expect(orderLast).toHaveText("C$-1.73");
+    const orderLastText = await orderLast.textContent();
+
+    const ordersShot = testInfo.outputPath("smh-orders-price.png");
+    await page.getByTestId("open-orders-table").screenshot({ path: ordersShot });
+    await testInfo.attach("SMH Orders combo price", { path: ordersShot, contentType: "image/png" });
+
+    await page.goto("/portfolio");
+
+    const positionRow = page.locator("table.position-table-sticky tbody tr").filter({ hasText: "SMH" }).first();
+    await expect(positionRow).toBeVisible({ timeout: 10_000 });
+    const positionLast = positionRow.locator("td.last-price-cell").last();
+    await expect(positionLast).toHaveText("C$-1.73");
+    expect(await positionLast.textContent()).toBe(orderLastText);
+
+    const portfolioShot = testInfo.outputPath("smh-portfolio-price.png");
+    await page.locator("table.position-table-sticky").first().screenshot({ path: portfolioShot });
+    await testInfo.attach("SMH Portfolio combo price", { path: portfolioShot, contentType: "image/png" });
   });
 });

--- a/web/lib/openOrderCombos.ts
+++ b/web/lib/openOrderCombos.ts
@@ -2,6 +2,7 @@ import type { ExecutedOrder, OpenOrder, PortfolioPosition } from "./types";
 import { detectStructure, type OrderLeg } from "./optionsChainUtils";
 import type { PriceData } from "./pricesProtocol";
 import { optionKey } from "./pricesProtocol";
+import { resolveRealtimePrice } from "./positionUtils";
 
 type NormalizedAction = "BUY" | "SELL";
 type NormalizedRight = "C" | "P";
@@ -39,6 +40,57 @@ export type OpenOrderComboRow = {
 };
 
 export type OpenOrderDisplayRow = OpenOrderSingleRow | OpenOrderComboRow;
+
+export type ResolvedOpenOrderPrice = {
+  price: number | null;
+  isCalculated: boolean;
+};
+
+export type SignedComboPriceLeg = {
+  action: string;
+  ratio: number;
+  priceData?: PriceData | null;
+  fallbackPrice?: number | null;
+  fallbackIsCalculated?: boolean;
+};
+
+const UNAVAILABLE_ORDER_PRICE: ResolvedOpenOrderPrice = {
+  price: null,
+  isCalculated: false,
+};
+
+/**
+ * Resolve one signed combo mark from leg quotes using the same stale-last and
+ * midpoint policy as portfolio positions. The action is structural: BUY adds
+ * the leg and SELL subtracts it, independent of the BAG envelope action.
+ */
+export function resolveSignedComboPrice(
+  legs: readonly SignedComboPriceLeg[],
+): ResolvedOpenOrderPrice {
+  if (legs.length === 0) return UNAVAILABLE_ORDER_PRICE;
+
+  let price = 0;
+  let isCalculated = false;
+  for (const leg of legs) {
+    if ((leg.action !== "BUY" && leg.action !== "SELL") || !Number.isFinite(leg.ratio) || leg.ratio <= 0) {
+      return UNAVAILABLE_ORDER_PRICE;
+    }
+    const resolved = resolveRealtimePrice(
+      leg.priceData,
+      leg.fallbackPrice,
+      leg.fallbackIsCalculated,
+    );
+    if (resolved.price == null) return UNAVAILABLE_ORDER_PRICE;
+    price += (leg.action === "BUY" ? 1 : -1) * leg.ratio * resolved.price;
+    isCalculated = isCalculated || resolved.isCalculated;
+  }
+
+  if (!Number.isFinite(price)) return UNAVAILABLE_ORDER_PRICE;
+  return {
+    price: Math.round(price * 100) / 100,
+    isCalculated,
+  };
+}
 
 export type OpenOrderRowSortKey =
   | "symbol"
@@ -469,40 +521,44 @@ function buildComboStructureAndSummary(
   return { structure, summary: `${structure} (${parts.join(" / ")})` };
 }
 
-export function resolveOpenOrderComboPrice(orders: OpenOrder[], prices?: Record<string, PriceData>): number | null {
-  if (!prices) return null;
-  if (orders.length === 0) return null;
+export function resolveOpenOrderComboPriceData(
+  orders: OpenOrder[],
+  prices?: Record<string, PriceData>,
+): ResolvedOpenOrderPrice {
+  if (!prices || orders.length === 0) return UNAVAILABLE_ORDER_PRICE;
 
   const nonZeroLegSizes = orders.map((order) => Math.abs(order.totalQuantity)).filter((q) => q > 0);
-  if (nonZeroLegSizes.length === 0) return null;
+  if (nonZeroLegSizes.length === 0) return UNAVAILABLE_ORDER_PRICE;
   const baseQuantity = Math.min(...nonZeroLegSizes);
 
-  let netLast = 0;
+  const legs: SignedComboPriceLeg[] = [];
 
   for (const order of orders) {
-    if (order.contract.secType !== "OPT") return null;
-    if (order.contract.strike == null || order.contract.right == null || !order.contract.expiry) return null;
+    if (order.contract.secType !== "OPT") return UNAVAILABLE_ORDER_PRICE;
+    if (order.contract.strike == null || order.contract.right == null || !order.contract.expiry) {
+      return UNAVAILABLE_ORDER_PRICE;
+    }
 
     const right = normalizeRight(order.contract.right);
     const expiry = normalizeExpiry(order.contract.expiry);
-    if (!right || !expiry) return null;
+    if (!right || !expiry) return UNAVAILABLE_ORDER_PRICE;
 
     const symbol = order.contract.symbol.toUpperCase();
     const key = optionKey({ symbol, expiry: expiry.replace(/-/g, ""), strike: order.contract.strike, right });
-    const pd = prices[key];
-    if (!pd) return null;
-
-    const quote = pd.last ?? (pd.bid == null || pd.ask == null ? null : (pd.bid + pd.ask) / 2);
-    if (quote == null) return null;
-
-    const sign = order.action === "BUY" ? 1 : -1;
     const quantityScale = Math.abs(order.totalQuantity) / baseQuantity;
-    if (!Number.isFinite(quantityScale) || quantityScale <= 0) return null;
-    netLast += sign * quote * quantityScale;
+    if (!Number.isFinite(quantityScale) || quantityScale <= 0) return UNAVAILABLE_ORDER_PRICE;
+    legs.push({
+      action: order.action,
+      ratio: quantityScale,
+      priceData: prices[key],
+    });
   }
 
-  if (!Number.isFinite(netLast)) return null;
-  return Math.round(netLast * 100) / 100;
+  return resolveSignedComboPrice(legs);
+}
+
+export function resolveOpenOrderComboPrice(orders: OpenOrder[], prices?: Record<string, PriceData>): number | null {
+  return resolveOpenOrderComboPriceData(orders, prices).price;
 }
 
 export function buildOpenOrderDisplayRows(

--- a/web/lib/sectionTooltips.ts
+++ b/web/lib/sectionTooltips.ts
@@ -75,7 +75,8 @@ export const SECTION_TOOLTIPS: Record<string, string> = {
     "RTH vs EXT chips show whether a working order can fill after 16:00 ET. " +
     "Options and option combos stay RTH-only even with FILL OUTSIDE RTH. " +
     "Stocks and ETFs fill after RTH only when that flag is on. Futures can fill outside equity RTH. " +
-    "Last Price shows the current market mid for the contract. Orders can be modified " +
+    "Last Price uses a reliable last trade, or a calculated mark prefixed C. Calculated marks normally use the bid/ask midpoint when the last is stale or unavailable. " +
+    "Combo marks are the signed sum of those resolved leg prices. Orders can be modified " +
     "(price/quantity) or cancelled directly. Status reflects IB order state " +
     "(PreSubmitted, Submitted, Filled, Cancelled).",
 

--- a/web/tests/open-order-combos.test.ts
+++ b/web/tests/open-order-combos.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { ExecutedOrder, OpenOrder, PortfolioPosition } from "../lib/types";
-import { buildExecutedGroupDescription, buildOpenOrderDisplayRows, resolveOpenOrderComboPrice } from "../lib/openOrderCombos";
+import {
+  buildExecutedGroupDescription,
+  buildOpenOrderDisplayRows,
+  resolveOpenOrderComboPrice,
+  resolveOpenOrderComboPriceData,
+} from "../lib/openOrderCombos";
 import type { PriceData } from "../lib/pricesProtocol";
 
 function makeOrder(overrides: Partial<OpenOrder> & { symbol?: string; right?: string; strike?: number; expiry?: string } = {}): OpenOrder {
@@ -266,6 +271,30 @@ describe("buildOpenOrderDisplayRows", () => {
 });
 
 describe("resolveOpenOrderComboPrice", () => {
+  it("uses the portfolio stale-last policy and carries calculated provenance", () => {
+    const longPut = makeOrder({ orderId: 1, action: "BUY", right: "P", strike: 145, totalQuantity: 150 });
+    const shortPut = makeOrder({ orderId: 2, action: "SELL", right: "P", strike: 150, totalQuantity: 150 });
+    const prices: Record<string, PriceData> = {
+      AAPL_20260417_145_P: makePrice({
+        symbol: "AAPL_20260417_145_P",
+        last: 9.6,
+        bid: 9.16,
+        ask: 9.6,
+      }),
+      AAPL_20260417_150_P: makePrice({
+        symbol: "AAPL_20260417_150_P",
+        last: 11.2,
+        bid: 11.3,
+        ask: 11.36,
+      }),
+    };
+
+    expect(resolveOpenOrderComboPriceData([longPut, shortPut], prices)).toEqual({
+      price: -1.73,
+      isCalculated: true,
+    });
+  });
+
   it("computes signed net quote from option legs", () => {
     const shortPut = makeOrder({ orderId: 1, action: "SELL", right: "P", strike: 150, totalQuantity: 10 });
     const longCall = makeOrder({ orderId: 2, action: "BUY", right: "C", strike: 165, totalQuantity: 10 });

--- a/web/tests/workspace-orders-implied.test.tsx
+++ b/web/tests/workspace-orders-implied.test.tsx
@@ -11,7 +11,7 @@ import { cleanup, render, screen, within } from "@testing-library/react";
 import WorkspaceSections, { groupExecutedOrders, closedGroupReturnPct } from "../components/WorkspaceSections";
 import { bsCall, bsPut } from "../lib/blackScholes";
 import { yearsToExpiry } from "../lib/impliedValue";
-import type { ExecutedOrder, OrdersData, PriceData } from "../lib/types";
+import type { ExecutedOrder, OrdersData, PortfolioData, PriceData } from "../lib/types";
 
 // Lighten the render: stub out interactive children that pull contexts we don't care about.
 vi.mock("../components/TickerLink", () => ({
@@ -100,6 +100,142 @@ function enableAllImpliedOrderColumns() {
 }
 
 describe("WorkspaceSections orders — Implied column", () => {
+  it("uses the portfolio pricing definition for a BAG last price", () => {
+    const matchingPosition: PortfolioData["positions"][number] = {
+      id: 1,
+      ticker: "SMH",
+      structure: "Bull Put Spread $545.0/$550.0",
+      structure_type: "Bull Put Spread",
+      risk_profile: "defined",
+      expiry: "2026-09-18",
+      contracts: 150,
+      direction: "COMBO",
+      entry_cost: -34_200,
+      max_risk: 40_800,
+      market_value: -25_950,
+      legs: [
+        {
+          con_id: 545,
+          direction: "LONG",
+          contracts: 150,
+          type: "Put",
+          strike: 545,
+          entry_cost: 187_050,
+          avg_cost: 1_247,
+          market_price: 9.6,
+          market_value: 144_000,
+        },
+        {
+          con_id: 550,
+          direction: "SHORT",
+          contracts: 150,
+          type: "Put",
+          strike: 550,
+          entry_cost: 221_250,
+          avg_cost: 1_475,
+          market_price: 11.33,
+          market_price_is_calculated: true,
+          market_value: 169_950,
+        },
+      ],
+      ib_daily_pnl: 289,
+      kelly_optimal: null,
+      target: null,
+      stop: null,
+      entry_date: "2026-08-01",
+    };
+    const supersetDecoy: PortfolioData["positions"][number] = {
+      ...matchingPosition,
+      id: 2,
+      structure: "Three-leg SMH position",
+      legs: [
+        { ...matchingPosition.legs[0], market_price: 8 },
+        { ...matchingPosition.legs[1], market_price: 12 },
+        {
+          con_id: 600,
+          direction: "LONG",
+          contracts: 150,
+          type: "Call",
+          strike: 600,
+          entry_cost: 15_000,
+          avg_cost: 100,
+          market_price: 1,
+          market_value: 15_000,
+        },
+      ],
+    };
+    const portfolio: PortfolioData = {
+      bankroll: 100_000,
+      peak_value: 100_000,
+      last_sync: NOW.toISOString(),
+      total_deployed_pct: 0,
+      total_deployed_dollars: 0,
+      remaining_capacity_pct: 100,
+      position_count: 2,
+      defined_risk_count: 2,
+      undefined_risk_count: 0,
+      avg_kelly_optimal: null,
+      positions: [supersetDecoy, matchingPosition],
+    };
+    const orders: OrdersData = {
+      last_sync: NOW.toISOString(),
+      open_count: 1,
+      executed_count: 0,
+      executed_orders: [],
+      open_orders: [
+        {
+          orderId: 71,
+          permId: 7101,
+          symbol: "SMH Spread",
+          contract: {
+            conId: 0,
+            symbol: "SMH",
+            secType: "BAG",
+            strike: null,
+            right: null,
+            expiry: null,
+            comboLegs: [
+              { conId: 545, ratio: 1, action: "BUY", symbol: "SMH", strike: 545, right: "P", expiry: "2026-09-18" },
+              { conId: 550, ratio: 1, action: "SELL", symbol: "SMH", strike: 550, right: "P", expiry: "2026-09-18" },
+            ],
+          },
+          action: "SELL",
+          orderType: "LMT",
+          totalQuantity: 150,
+          limitPrice: -1.95,
+          auxPrice: null,
+          status: "Submitted",
+          filled: 0,
+          remaining: 150,
+          avgFillPrice: null,
+          tif: "GTC",
+        },
+      ],
+    };
+    const prices: Record<string, PriceData> = {
+      SMH_20260918_545_P: pd({
+        symbol: "SMH_20260918_545_P",
+        last: 9.6,
+        bid: 9.16,
+        ask: 9.6,
+      }),
+    };
+
+    render(
+      React.createElement(WorkspaceSections, {
+        section: "orders",
+        orders,
+        prices,
+        portfolio,
+      }),
+    );
+
+    const table = screen.getByTestId("open-orders-table");
+    const row = within(table).getByText("SMH").closest("tr");
+    expect(row?.textContent).toContain("C$-1.73");
+    expect(row?.textContent).toContain("-0.22");
+  });
+
   it("groups executions by durable order identity instead of calendar minute", () => {
     const fill = (execId: string, orderRef: string, time: string): ExecutedOrder => ({
       execId, orderRef, symbol: "SPY", side: "BOT", quantity: 1, avgPrice: 2,


### PR DESCRIPTION
## Problem

Open Orders always summed option-leg bid/ask midpoints, while Portfolio retained reliable last trades and calculated a midpoint only when a last was stale or unavailable. The same SMH bull put spread therefore showed `$-1.95` on Orders and `C$-1.73` on Portfolio.

## Changes

- Route single-option, grouped-option, and BAG order marks through the canonical realtime price resolver.
- Preserve calculated-price provenance with the existing `C` prefix.
- Keep structural leg signs and ratios independent of the BAG envelope action.
- Require a unique, exact one-to-one portfolio structure match before using synced fallback marks.
- Clarify the Open Orders price definition.
- Add Vitest and Playwright regressions for the SMH case and fallback matching.

## Verification

- Full Vitest: 805 files, 8,169 tests passed.
- Focused Vitest: 5 files, 68 tests passed.
- Playwright: 2 tests passed; Orders and Portfolio screenshots both show `C$-1.73`.
- TypeScript: passed.
- ESLint: 0 errors, 0 warnings.
- Secret scan and commit hooks: passed.
