### PR TITLE
Fix credential field overlap on profile Credentials tab

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -20844,6 +20844,72 @@ body[data-mobile="true"] .alerts-rule__channel {
   margin: 0;
 }
 
+/* ── Service rows (profile Credentials tab, setup wizard) ──
+   One row per vendor service with N fields stacked below the header.
+   Fields never share a grid cell, so multi-field services (MenthorQ,
+   IB Flex) cannot paint on top of each other. */
+.preferences-row--service {
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-areas:
+    "head"
+    "description"
+    "fields"
+    "actions"
+    "error";
+}
+
+.credentials-fields {
+  grid-area: fields;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 4px;
+  min-width: 0;
+}
+
+.credentials-field {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 300px);
+  gap: 2px 16px;
+  align-items: start;
+  min-width: 0;
+}
+
+.credentials-field__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  cursor: pointer;
+}
+
+.credentials-field__title {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 4px 8px;
+  min-width: 0;
+}
+
+.credentials-field__inputrow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.credentials-field__input {
+  flex: 1 1 auto;
+  min-width: 0;
+  width: auto;
+  text-align: left;
+}
+
+.preferences-row__key {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
 .preferences-badge {
   font-size: 11px;
   font-family: var(--font-mono);
@@ -20899,6 +20965,25 @@ body[data-mobile="true"] .alerts-rule__channel {
   .preferences-row__input {
     width: 100%;
     text-align: left;
+  }
+
+  .credentials-field {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 6px;
+  }
+
+  .credentials-field__input {
+    width: 100%;
+  }
+
+  .credentials-field__inputrow .order-input,
+  .credentials-field__inputrow .admin-btn {
+    min-height: 44px;
+  }
+
+  .preferences-row--service .admin-actions-row .admin-btn {
+    min-height: 44px;
+    width: 100%;
   }
 }
 

--- a/web/components/profile/CredentialsPanel.tsx
+++ b/web/components/profile/CredentialsPanel.tsx
@@ -213,7 +213,7 @@ export default function CredentialsPanel() {
             const slug = serviceSlug(service.id);
             return (
               <div
-                className="preferences-row"
+                className="preferences-row preferences-row--service"
                 data-testid={`credential-service-${slug}`}
                 key={service.id}
               >
@@ -232,52 +232,56 @@ export default function CredentialsPanel() {
                   <p className="preferences-row__description">{service.note}</p>
                 ) : null}
 
-                {service.fields.map((field) => (
-                  <div className="preferences-row__control" key={field.name}>
-                    <label className="preferences-row__meta" htmlFor={`cred-${field.name}`}>
-                      <span className="preferences-row__head">
-                        <span className="preferences-row__label">{field.label}</span>
-                        <code className="preferences-row__key">{field.name}</code>
-                      </span>
-                      <span className="preferences-row__metaline" data-testid={`credential-status-${field.name}`}>
-                        {fieldStatus(field)}
-                      </span>
-                    </label>
-                    <input
-                      id={`cred-${field.name}`}
-                      className="order-input preferences-row__input"
-                      type={field.secret ? "password" : "text"}
-                      autoComplete="off"
-                      spellCheck={false}
-                      placeholder={
-                        field.configured
-                          ? `Replace ${field.hint}`
-                          : field.placeholder || "Paste value"
-                      }
-                      value={drafts[field.name] ?? ""}
-                      disabled={busy}
-                      onChange={(e) =>
-                        setDrafts((current) => ({
-                          ...current,
-                          [field.name]: e.target.value,
-                        }))
-                      }
-                    />
-                    {field.configured ? (
-                      <button
-                        type="button"
-                        className="admin-btn admin-btn-ghost"
-                        data-testid={`credential-clear-${field.name}`}
-                        disabled={busy}
-                        onClick={() => {
-                          void clearField(service, field);
-                        }}
-                      >
-                        Clear
-                      </button>
-                    ) : null}
-                  </div>
-                ))}
+                <div className="credentials-fields">
+                  {service.fields.map((field) => (
+                    <div className="credentials-field" key={field.name}>
+                      <label className="credentials-field__meta" htmlFor={`cred-${field.name}`}>
+                        <span className="credentials-field__title">
+                          <span className="preferences-row__label">{field.label}</span>
+                          <code className="preferences-row__key">{field.name}</code>
+                        </span>
+                        <span className="preferences-row__meta" data-testid={`credential-status-${field.name}`}>
+                          {fieldStatus(field)}
+                        </span>
+                      </label>
+                      <div className="credentials-field__inputrow">
+                        <input
+                          id={`cred-${field.name}`}
+                          className="order-input preferences-row__input credentials-field__input"
+                          type={field.secret ? "password" : "text"}
+                          autoComplete="off"
+                          spellCheck={false}
+                          placeholder={
+                            field.configured
+                              ? `Replace ${field.hint}`
+                              : field.placeholder || "Paste value"
+                          }
+                          value={drafts[field.name] ?? ""}
+                          disabled={busy}
+                          onChange={(e) =>
+                            setDrafts((current) => ({
+                              ...current,
+                              [field.name]: e.target.value,
+                            }))
+                          }
+                        />
+                        {field.configured ? (
+                          <button
+                            type="button"
+                            className="admin-btn admin-btn-ghost"
+                            data-testid={`credential-clear-${field.name}`}
+                            disabled={busy}
+                            onClick={() => {
+                              void clearField(service, field);
+                            }}
+                          >
+                            Clear
+                          </button>
+                        ) : null}
+                      </div>
+                    </div>
+                  ))}
+                </div>
 
                 <div className="admin-actions-row">
                   <button

--- a/web/components/setup/SetupWizard.tsx
+++ b/web/components/setup/SetupWizard.tsx
@@ -284,7 +284,7 @@ export default function SetupWizard() {
               const verdict = verdicts[service.id];
               const hasValues = Object.keys(valuesFor(service)).length > 0;
               return (
-                <div className="preferences-row" data-testid={`setup-service-${service.id}`} key={service.id}>
+                <div className="preferences-row preferences-row--service" data-testid={`setup-service-${service.id}`} key={service.id}>
                   <div className="preferences-row__head">
                     <span className="preferences-row__label">
                       {service.label}
@@ -297,29 +297,33 @@ export default function SetupWizard() {
                   {service.note ? (
                     <p className="preferences-row__description">{service.note}</p>
                   ) : null}
-                  {service.fields.map((field) => (
-                    <div className="preferences-row__control" key={field.name}>
-                      <label className="preferences-row__meta" htmlFor={`setup-${field.name}`}>
-                        <span className="preferences-row__head">
-                          <span className="preferences-row__label">{field.label}</span>
-                          <code className="preferences-row__key">{field.name}</code>
-                        </span>
-                      </label>
-                      <input
-                        id={`setup-${field.name}`}
-                        className="order-input preferences-row__input"
-                        type={field.secret ? "password" : "text"}
-                        autoComplete="off"
-                        spellCheck={false}
-                        placeholder={field.placeholder || "Paste value"}
-                        value={drafts[field.name] ?? ""}
-                        disabled={busy || completing}
-                        onChange={(e) =>
-                          setDrafts((current) => ({ ...current, [field.name]: e.target.value }))
-                        }
-                      />
-                    </div>
-                  ))}
+                  <div className="credentials-fields">
+                    {service.fields.map((field) => (
+                      <div className="credentials-field" key={field.name}>
+                        <label className="credentials-field__meta" htmlFor={`setup-${field.name}`}>
+                          <span className="credentials-field__title">
+                            <span className="preferences-row__label">{field.label}</span>
+                            <code className="preferences-row__key">{field.name}</code>
+                          </span>
+                        </label>
+                        <div className="credentials-field__inputrow">
+                          <input
+                            id={`setup-${field.name}`}
+                            className="order-input preferences-row__input credentials-field__input"
+                            type={field.secret ? "password" : "text"}
+                            autoComplete="off"
+                            spellCheck={false}
+                            placeholder={field.placeholder || "Paste value"}
+                            value={drafts[field.name] ?? ""}
+                            disabled={busy || completing}
+                            onChange={(e) =>
+                              setDrafts((current) => ({ ...current, [field.name]: e.target.value }))
+                            }
+                          />
+                        </div>
+                      </div>
+                    ))}
+                  </div>
                   {service.validator ? (
                     <div className="admin-actions-row">
                       <button


### PR DESCRIPTION
Every field block reused the single 'control' grid cell of
.preferences-row, so multi-field services (MenthorQ, IB Flex) painted
their labels and inputs on top of each other. Service rows now use a
dedicated single-column layout with one grid row per field: label left,
input right on desktop, stacked with 44px targets on mobile. Same fix
applied to the setup wizard, which shared the markup pattern.

Verified: credentials + preferences Vitest 33/33 green, tsc clean,
eslint clean. Production build was not used as a gate: 'next build'
panics in Turbopack on @xyflow CSS identically on the clean tree.
