### PR TITLE
Fix the six code-actionable alerts in the watchdog daily digest

### DIFF
--- a/docs/equibles-api.md
+++ b/docs/equibles-api.md
@@ -237,6 +237,18 @@ silently with the previous quarter's surviving rows while
 the snapshot carries `holders_persisted` so a consumer can tell when the depth
 rows are behind the summary (R-227).
 
+## A failed weekly cycle carries its own next attempt
+
+`radon-equibles-ats.timer` fires once a week (Tuesday 09:15 UTC). Without a
+retry hint, one failed cycle re-paged the watchdog on every watchdog cycle for
+the seven days until the next attempt — 22 duplicate pages in a single daily
+digest. Every `state='error'` payload from `run()` now carries
+`next_attempt_at`, computed by `_next_scheduled_run()` from the timer
+constants, so the watchdog's embargo suppression covers the dead week. The
+no-series payload also carries `codes`, so a tarpitted or wedged client is
+distinguishable from a genuinely empty venue-share response instead of both
+reading as "no ticker produced a series".
+
 ---
 
 ## Reproducing this document

--- a/scripts/api/server.py
+++ b/scripts/api/server.py
@@ -79,6 +79,7 @@ from api.routes.streaks import router as streaks_router
 
 import app_preferences
 from clients.menthorq_dashboard_client import (
+    MenthorQDashboardAuthEmbargoed,
     MenthorQDashboardAuthError,
     MenthorQDashboardClient,
     MenthorQDashboardPayloadError,
@@ -4869,6 +4870,11 @@ async def options_exposure(symbol: str, frequency: str = "eod"):
     try:
         provider = MenthorQDashboardClient()
         return await asyncio.to_thread(provider.fetch_exposure, symbol, frequency)
+    except MenthorQDashboardAuthEmbargoed as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="Options exposure authentication embargoed after a recent failure",
+        ) from exc
     except MenthorQDashboardAuthError as exc:
         raise HTTPException(
             status_code=503,

--- a/scripts/api/tests/test_options_exposure.py
+++ b/scripts/api/tests/test_options_exposure.py
@@ -13,6 +13,7 @@ if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
 from clients.menthorq_dashboard_client import (  # noqa: E402
+    MenthorQDashboardAuthEmbargoed,
     MenthorQDashboardAuthError,
     MenthorQDashboardPayloadError,
     MenthorQDashboardTimeoutError,
@@ -129,3 +130,23 @@ def test_route_maps_provider_failures_to_sanitized_statuses(
     assert response.json() == {"detail": expected_detail}
     assert "secret" not in response.text.lower()
     assert "private" not in response.text.lower()
+
+
+def test_route_maps_auth_embargo_to_transient_detail(client):
+    def _raise(*_args):
+        raise MenthorQDashboardAuthEmbargoed(
+            "dashboard authentication embargoed after a recent failure"
+        )
+
+    provider = type("Provider", (), {"fetch_exposure": _raise})()
+
+    with patch("scripts.api.server.MenthorQDashboardClient", return_value=provider):
+        response = client.get("/options/exposure/SPX?frequency=eod")
+
+    assert response.status_code == 503
+    detail = response.json()["detail"]
+    assert "embargo" in detail.lower()
+
+    from monitor_daemon.handlers import menthorq_login_probe
+
+    assert menthorq_login_probe._is_auth_failure(503, detail) is False

--- a/scripts/fetch_equibles_ats_venue_share.py
+++ b/scripts/fetch_equibles_ats_venue_share.py
@@ -457,6 +457,10 @@ def payload_has_data(payload: dict[str, Any]) -> bool:
     return bool(payload.get("current"))
 
 
+TIMER_WEEKDAY_UTC = 1         # Tuesday, per cloud/services/radon-equibles-ats.timer
+TIMER_HOUR_UTC = 9
+TIMER_MINUTE_UTC = 15
+
 # A cycle covering less than this fraction of the resolved universe is not a
 # cycle, it is a partial read that happens to have some rows in it.
 MIN_COVERAGE_RATIO = 0.6
@@ -465,6 +469,21 @@ MIN_COVERAGE_RATIO = 0.6
 # override rather than the scheduled watchlist sweep. The all-empty gate still
 # applies at every size.
 MIN_UNIVERSE_FOR_RATIO = 5
+
+
+def _next_scheduled_run(now: datetime) -> str:
+    """The next radon-equibles-ats.timer fire, as the heartbeat's next_attempt_at.
+
+    Weekly cadence: without this, the watchdog re-pages a single failed cycle
+    on every one of its own cycles for the seven days until the next attempt.
+    """
+    stamp = now.astimezone(timezone.utc).replace(
+        hour=TIMER_HOUR_UTC, minute=TIMER_MINUTE_UTC, second=0, microsecond=0
+    )
+    stamp += timedelta(days=(TIMER_WEEKDAY_UTC - stamp.weekday()) % 7)
+    if stamp <= now:
+        stamp += timedelta(days=7)
+    return stamp.isoformat().replace("+00:00", "Z")
 
 
 def has_sufficient_coverage(covered: int, requested: int) -> bool:
@@ -761,6 +780,7 @@ def run(
             scan_time,
             error={
                 "message": f"cycle aborted: {exc}",
+                "next_attempt_at": _next_scheduled_run(now),
                 "requested": len(universe),
                 "covered": len(series_by_ticker),
                 "failed": len(errors),
@@ -781,6 +801,8 @@ def run(
             scan_time,
             error={
                 "message": "no ticker produced a series",
+                "next_attempt_at": _next_scheduled_run(now),
+                "codes": sorted({e["code"] for e in errors if e.get("code")}),
                 "requested": len(universe),
                 "failed": len(errors),
             },
@@ -801,6 +823,7 @@ def run(
                     f"partial cycle: {covered}/{len(universe)} tickers covered, "
                     f"below the {MIN_COVERAGE_RATIO:.0%} floor"
                 ),
+                "next_attempt_at": _next_scheduled_run(now),
                 "requested": len(universe),
                 "covered": covered,
                 "failed": len(errors),
@@ -840,6 +863,7 @@ def run(
                     f"dropped tail: {len(dropped)} ticker(s) deferred by "
                     f"timeout/budget: {', '.join(dropped)}"
                 ),
+                "next_attempt_at": _next_scheduled_run(now),
                 "requested": len(universe),
                 "covered": covered,
                 "failed": len(errors),

--- a/scripts/flex_sftp_pull.py
+++ b/scripts/flex_sftp_pull.py
@@ -38,6 +38,11 @@ DEFAULT_REMOTE_DIR = "outgoing"
 FIRST_DELIVERY_DATE = date(2026, 8, 31)
 FIRST_DELIVERY_ENV = "RADON_FLEX_FIRST_DELIVERY"
 MAX_NIGHTLY_SPAN_DAYS = 5
+# How far behind the last completed session the NEWEST delivered statement may
+# sit before the remote counts as stale. Deliberately NOT MAX_NIGHTLY_SPAN_DAYS,
+# which bounds a statement's own period span — overloading it would let a real
+# IBKR delivery stoppage go unpaged for five days. R-448.
+MAX_DELIVERY_LAG_DAYS = 1
 KEEP_GPG = 3
 # IBKR names a PGP delivery `<acct>.<Query_Name>.<from>.<to>.xml.pgp`. The
 # filter kept only `.gpg`, so three days of files sat in `outgoing` while every
@@ -221,6 +226,26 @@ def nightly_period_ok(xml_text: str) -> bool:
     return (end - start).days <= MAX_NIGHTLY_SPAN_DAYS
 
 
+def statement_period_end(xml_text: str) -> Optional[date]:
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError:
+        return None
+    statement = root.find(".//FlexStatement")
+    if statement is None:
+        return None
+    return _flex_day(statement.get("toDate"))
+
+
+def delivery_is_stale(period_end: Optional[date], now: Optional[datetime] = None) -> bool:
+    from utils.market_calendar import last_completed_session_date
+
+    if period_end is None:
+        return True
+    last_session = date.fromisoformat(last_completed_session_date(now))
+    return (last_session - period_end).days > MAX_DELIVERY_LAG_DAYS
+
+
 def _flex_day(value: Optional[str]) -> Optional[date]:
     if not value or len(value) < 8:
         return None
@@ -381,6 +406,7 @@ def _run(
     _ensure_inbox(inbox)
     failed = False
     ingested = 0
+    newest_period_end: Optional[date] = None
     for name in names:
         dest = inbox / Path(name).name
         try:
@@ -389,6 +415,11 @@ def _run(
             if not nightly_period_ok(xml_text):
                 raise FlexSftpError("period_gate: nightly path rejects 365-day/YTD")
             classify_flex_xml(xml_text)
+            # Every classified file counts here, duplicates included: an
+            # idempotent re-pull of the CURRENT statement is not a stoppage.
+            period_end = statement_period_end(xml_text)
+            if period_end is not None and (newest_period_end is None or period_end > newest_period_end):
+                newest_period_end = period_end
             # `a.xml.pgp` labels as `a.xml`, `trades.gpg` as `trades.xml`.
             plain = dest.with_suffix("")
             if plain.suffix.lower() != ".xml":
@@ -416,7 +447,7 @@ def _run(
     if failed:
         _heartbeat("error", "one or more files rejected")
         return 1
-    if not ingested and not empty_remote_is_expected(now):
+    if not ingested and delivery_is_stale(newest_period_end, now) and not empty_remote_is_expected(now):
         _heartbeat(
             "error",
             "no NEW statement applied; the remote directory is stale "

--- a/scripts/health_probe/probe.py
+++ b/scripts/health_probe/probe.py
@@ -656,6 +656,8 @@ def main() -> int:
     if outcome["write_errors"]:
         sys.stderr.write("[health_probe] probe ledger degraded: %s\n" % "; ".join(outcome["write_errors"]))
     sys.stdout.write(json.dumps({"edge": outcome["edge_row"], "run": outcome["runs_row"]}) + "\n")
+    if any(error.startswith("latest: ") for error in outcome["write_errors"]):
+        return 1
     if outcome["exit_code"] != 0:
         sys.stderr.write("[health_probe] UNHEALTHY (arming the workflow-failure email): %s\n"
                          % outcome["runs_row"]["detail"])

--- a/scripts/ib_reconcile.py
+++ b/scripts/ib_reconcile.py
@@ -461,6 +461,15 @@ def _health_detail(report: dict) -> dict:
         "expired_locally": report.get("expired_locally", [])[:10],
     }
 
+
+def _drift_message(detail: dict) -> str:
+    return (
+        f"position drift vs IB: {detail['new_trades_count']} new trade(s), "
+        f"{detail['quantity_mismatch_count']} quantity mismatch(es), "
+        f"{detail['positions_missing_locally_count']} missing locally, "
+        f"{detail['positions_closed_count']} closed locally"
+    )
+
 def main():
     """Main reconciliation routine."""
     log("Starting IB trade reconciliation...")
@@ -470,7 +479,13 @@ def main():
     client = connect_ib()
     if not client:
         log("Cannot connect to IB Gateway - reconciliation NOT run", "error")
-        _record_health("error", {"reason": "ib_connect_failed"})
+        _record_health(
+            "error",
+            {
+                "reason": "ib_connect_failed",
+                "message": "IB Gateway unreachable - reconciliation not run",
+            },
+        )
         sys.exit(2)
 
     try:
@@ -503,9 +518,12 @@ def main():
 
         # Heartbeat for the watchdog: error when attention is needed so the
         # error bucket pages; ok otherwise.
+        detail = _health_detail(report)
+        if report["needs_attention"]:
+            detail["message"] = _drift_message(detail)
         _record_health(
             "error" if report["needs_attention"] else "ok",
-            _health_detail(report),
+            detail,
         )
 
         # Log summary

--- a/scripts/monitor_daemon/handlers/position_reconcile.py
+++ b/scripts/monitor_daemon/handlers/position_reconcile.py
@@ -96,8 +96,14 @@ class PositionReconcileHandler(BaseHandler):
         report = ib_reconcile.generate_reconciliation_report([], discrepancies)
         detail = ib_reconcile._health_detail(report)
 
+        drift_message = ib_reconcile._drift_message(detail)
         state = "error" if report["needs_attention"] else "ok"
-        self.record_cycle_health(state, error=detail)
+        self.record_cycle_health(
+            state,
+            error={**detail, "message": drift_message}
+            if report["needs_attention"]
+            else None,
+        )
 
         result: dict[str, Any] = {
             "ib_positions": len(ib_positions),
@@ -108,12 +114,8 @@ class PositionReconcileHandler(BaseHandler):
             "expired_locally_count": detail["expired_locally_count"],
         }
         if report["needs_attention"]:
-            result["error"] = (
-                f"position drift vs IB: {detail['quantity_mismatch_count']} quantity "
-                f"mismatch(es), {detail['positions_missing_locally_count']} missing "
-                f"locally, {detail['positions_closed_count']} closed locally"
-            )
-            logger.warning("position-reconcile: %s detail=%s", result["error"], detail)
+            result["error"] = drift_message
+            logger.warning("position-reconcile: %s detail=%s", drift_message, detail)
         else:
             logger.debug(
                 "position-reconcile: in sync (ib=%d local=%d)",

--- a/scripts/tests/test_equibles_ats_venue_share.py
+++ b/scripts/tests/test_equibles_ats_venue_share.py
@@ -6,7 +6,7 @@ that produces them, not as opaque constants.
 """
 import json
 import sqlite3
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -725,3 +725,126 @@ class TestConstructionFailureIsReported:
         with pytest.raises(EquiblesAuthError):
             self.mod.run(tickers=["AAPL"])
         assert self.health == ["error"]
+
+
+class TestNextAttemptAt:
+    """The timer is weekly (Tue 09:15 UTC). Every error heartbeat must say when
+    the next attempt actually lands, or the watchdog re-pages the same weekly
+    writer on every cycle for seven days."""
+
+    @pytest.fixture(autouse=True)
+    def _capture_health(self, tmp_path, monkeypatch):
+        import fetch_equibles_ats_venue_share as mod
+
+        monkeypatch.setattr(mod, "ATS_VENUE_SHARE_JSON", tmp_path / "ats_venue_share.json")
+        self.db_writes = []
+        self.health = []
+        monkeypatch.setattr(
+            mod, "_write_db_cache",
+            lambda payload, scan_time: self.db_writes.append(payload),
+        )
+        monkeypatch.setattr(
+            mod, "_record_health",
+            lambda state, scan_time, error=None: self.health.append(
+                {"state": state, "error": error}
+            ),
+        )
+        self.mod = mod
+
+    def _client(self, tickers, failures=None):
+        weeks = mondays(MIN_HISTORY_WEEKS + 4)
+        off = {t: [off_exchange_row(w) for w in weeks] for t in tickers}
+        short = {t: [r for w in weeks for r in short_volume_week(w)] for t in tickers}
+        return _StubClient(off, short, failures=failures)
+
+    def _expected(self, now):
+        stamp = now.replace(hour=9, minute=15, second=0, microsecond=0)
+        while stamp <= now or stamp.weekday() != 1:
+            stamp += timedelta(days=1)
+        return stamp.isoformat().replace("+00:00", "Z")
+
+    def _errors(self):
+        return [h["error"] for h in self.health if h["state"] == "error"]
+
+    def test_next_scheduled_run_is_the_coming_tuesday_0915_utc(self):
+        anchor = datetime.now(timezone.utc).replace(microsecond=0)
+        tuesday = anchor + timedelta(days=(1 - anchor.weekday()) % 7)
+        for now in (
+            anchor,
+            tuesday.replace(hour=9, minute=0),
+            tuesday.replace(hour=9, minute=30),
+        ):
+            assert self.mod._next_scheduled_run(now) == self._expected(now)
+
+    def test_empty_cycle_error_carries_next_attempt_and_codes(self):
+        from clients.equibles_client import EquiblesNotFoundError
+
+        now = datetime.now(timezone.utc)
+        client = _StubClient(
+            {}, {}, failures={"ZZZZ": EquiblesNotFoundError("nope", 404, "not_found")}
+        )
+        self.mod.run(client=client, tickers=["AAPL", "ZZZZ"], now=now)
+
+        error = self._errors()[0]
+        assert error["message"] == "no ticker produced a series"
+        assert error["next_attempt_at"] == self._expected(now)
+        assert "not_found" in error["codes"]
+
+    def test_wedged_client_empty_cycle_reports_timeout_and_budget_codes(self, monkeypatch):
+        now = datetime.now(timezone.utc)
+
+        def wedged(_client, ticker, _start, _end, timeout_s=0.0):
+            raise TimeoutError(f"{ticker}: fetch exceeded {timeout_s:.0f}s wall-clock")
+
+        monkeypatch.setattr(self.mod, "_fetch_ticker_bounded", wedged)
+        client = _StubClient({}, {})
+        self.mod.run(client=client, tickers=["AAPL", "MSFT", "NVDA"], now=now)
+
+        error = self._errors()[0]
+        assert error["message"] == "no ticker produced a series"
+        assert error["next_attempt_at"] == self._expected(now)
+        assert error["codes"] == ["budget", "timeout"]
+
+    def test_partial_cycle_error_carries_next_attempt(self):
+        from clients.equibles_client import EquiblesNotFoundError
+
+        now = datetime.now(timezone.utc)
+        universe = ["AAPL", "A", "B", "C", "D"]
+        failures = {t: EquiblesNotFoundError("nope") for t in universe[1:]}
+        client = self._client(universe, failures=failures)
+        payload = self.mod.run(client=client, tickers=universe, now=now)
+
+        assert payload["partial"] is True
+        error = self._errors()[0]
+        assert error["message"].startswith("partial cycle:")
+        assert error["next_attempt_at"] == self._expected(now)
+
+    def test_dropped_tail_error_carries_next_attempt(self, monkeypatch):
+        now = datetime.now(timezone.utc)
+        universe = ["AAPL", "MSFT", "NVDA", "AMD", "ZZZZ"]
+        client = self._client(universe)
+        real = self.mod._fetch_ticker_bounded
+
+        def wedge_last(client_, ticker, start_s, end_s, timeout_s=0.0):
+            if ticker == "ZZZZ":
+                raise TimeoutError(f"{ticker}: fetch exceeded {timeout_s:.0f}s wall-clock")
+            return real(client_, ticker, start_s, end_s, timeout_s=timeout_s)
+
+        monkeypatch.setattr(self.mod, "_fetch_ticker_bounded", wedge_last)
+        self.mod.run(client=client, tickers=universe, now=now)
+
+        error = self._errors()[0]
+        assert error["message"].startswith("dropped tail:")
+        assert error["next_attempt_at"] == self._expected(now)
+
+    def test_aborted_cycle_error_carries_next_attempt(self):
+        from clients.equibles_client import EquiblesAuthError
+
+        now = datetime.now(timezone.utc)
+        client = self._client(["AAPL"], failures={"AAPL": EquiblesAuthError("rejected")})
+        with pytest.raises(EquiblesAuthError):
+            self.mod.run(client=client, tickers=["AAPL"], now=now)
+
+        error = self._errors()[0]
+        assert error["message"].startswith("cycle aborted:")
+        assert error["next_attempt_at"] == self._expected(now)

--- a/scripts/tests/test_flex_sftp_pull.py
+++ b/scripts/tests/test_flex_sftp_pull.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
-from datetime import datetime
+from datetime import date, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 from zoneinfo import ZoneInfo
@@ -387,7 +387,8 @@ def test_run_without_ingest_drives_default_ingest(tmp_path, monkeypatch):
     """The production wiring: `run()` with no `ingest=` must reach the writers. T-259.
 
     The re-pull of the same bytes is the R-389 stale-remote case: after the
-    cutover a duplicate-only run is an error, not progress. T-318.
+    cutover a duplicate-only run whose newest statement period is stale is an
+    error, not progress. T-318/R-448.
     """
     import flex_delivery_ingest
     import flex_sftp_pull as pull
@@ -533,3 +534,84 @@ def test_retain_newest_gpg_prunes_pgp_names(tmp_path):
         "U4698258.Trade_History.20260903.20260903.xml.pgp",
         "U4698258.Trade_History.20260904.20260904.xml.pgp",
     ]
+
+
+# --- R-448: an idempotent re-pull of the CURRENT statement is not a stoppage --
+
+_NOW_ET = datetime.now(ZoneInfo("America/New_York")).replace(
+    hour=8, minute=30, second=0, microsecond=0
+)
+
+
+def _statement_xml(period_end: "date") -> bytes:
+    stamp = period_end.strftime("%Y%m%d")
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<FlexQueryResponse queryName="Trade Confirmation" type="TC">'
+        '<FlexStatements count="1">'
+        f'<FlexStatement accountId="U0000000" fromDate="{stamp}" toDate="{stamp}"'
+        ' period="LastBusinessDay" whenGenerated="20260805;073000">'
+        '<Trades>'
+        f'<Trade accountId="U0000000" symbol="NAK" assetCategory="STK" tradeDate="{stamp}"'
+        f' dateTime="{stamp};115321" quantity="-18628" tradePrice="1.585" buySell="SELL"'
+        ' ibCommission="-1.25" tradeID="9998092102" />'
+        '</Trades>'
+        '</FlexStatement>'
+        '</FlexStatements>'
+        '</FlexQueryResponse>'
+    ).encode()
+
+
+def _duplicating_ingest():
+    seen: set[str] = set()
+
+    def ingest(xml_text, source_path=None, **kwargs):
+        outcome = "duplicate" if xml_text in seen else "applied"
+        seen.add(xml_text)
+        return {"ok": True, "outcome": outcome}
+
+    return ingest
+
+
+def _pull_twice(tmp_path, monkeypatch, period_end):
+    import flex_sftp_pull as pull
+
+    heartbeats = []
+    monkeypatch.setattr(
+        pull, "_heartbeat", lambda state, error=None: heartbeats.append((state, error))
+    )
+    config = _ssh_config(tmp_path / "ssh_config")
+    inbox = tmp_path / "inbox"
+    inbox.mkdir()
+    fake = FakeSftp({"trades.gpg": _statement_xml(period_end)})
+    ingest = _duplicating_ingest()
+    codes = [
+        pull.run(
+            config=config,
+            inbox=inbox,
+            runner=fake,
+            decrypt=lambda data, **k: data.decode(),
+            ingest=ingest,
+            now=_NOW_ET,
+        )
+        for _ in range(2)
+    ]
+    return codes, heartbeats
+
+
+def test_duplicate_repull_of_current_statement_is_ok(tmp_path, monkeypatch):
+    from utils.market_calendar import last_completed_session_date
+
+    current = date.fromisoformat(last_completed_session_date(_NOW_ET))
+    codes, heartbeats = _pull_twice(tmp_path, monkeypatch, current)
+
+    assert codes == [0, 0]
+    assert heartbeats[-1][0] == "ok"
+
+
+def test_stale_remote_still_errors(tmp_path, monkeypatch):
+    codes, heartbeats = _pull_twice(tmp_path, monkeypatch, _NOW_ET.date() - timedelta(days=10))
+
+    assert codes[-1] == 1
+    assert heartbeats[-1][0] == "error"
+    assert "stopped delivering" in str(heartbeats[-1][1])

--- a/scripts/tests/test_health_probe.py
+++ b/scripts/tests/test_health_probe.py
@@ -1052,16 +1052,26 @@ class TestRunProbe:
         assert probe.main() == probe.EXIT_UNHEALTHY
         assert history["freshness_ok"] == 0
 
-    def test_main_preserves_healthy_verdict_when_latest_write_fails(self, monkeypatch):
+    def test_ledger_write_failure_exits_nonzero(self, monkeypatch):
         _patch_happy_network(monkeypatch)
 
         def _boom(_row):
             raise turso_http.TursoHttpError("down")
         monkeypatch.setattr(probe, "upsert_external_probe", _boom)
         monkeypatch.setattr(probe, "insert_external_probe_run", lambda row: None)
-        assert probe.main() == 0
+        assert probe.main() == 1
 
-    def test_main_preserves_healthy_verdict_when_history_write_fails(self, monkeypatch):
+    def test_ledger_write_failure_still_emits_stdout_json(self, monkeypatch, capsys):
+        _patch_happy_network(monkeypatch)
+
+        def _boom(_row):
+            raise turso_http.TursoHttpError("down")
+        monkeypatch.setattr(probe, "upsert_external_probe", _boom)
+        monkeypatch.setattr(probe, "insert_external_probe_run", lambda row: None)
+        assert probe.main() == 1
+        assert json.loads(capsys.readouterr().out)["edge"]["ok"] == 1
+
+    def test_history_write_failure_stays_soft(self, monkeypatch):
         _patch_happy_network(monkeypatch)
         monkeypatch.setattr(probe, "upsert_external_probe", lambda row: None)
 
@@ -1070,14 +1080,20 @@ class TestRunProbe:
         monkeypatch.setattr(probe, "insert_external_probe_run", _boom)
         assert probe.main() == 0
 
-    def test_main_preserves_healthy_verdict_on_raw_urllib_timeout(self, monkeypatch):
+    def test_green_run_with_both_writes_landing_exits_zero(self, monkeypatch):
+        _patch_happy_network(monkeypatch)
+        monkeypatch.setattr(probe, "upsert_external_probe", lambda row: None)
+        monkeypatch.setattr(probe, "insert_external_probe_run", lambda row: None)
+        assert probe.main() == 0
+
+    def test_latest_write_raw_urllib_timeout_exits_nonzero(self, monkeypatch):
         _patch_happy_network(monkeypatch)
         monkeypatch.setattr(
             probe, "upsert_external_probe",
             lambda _row: (_ for _ in ()).throw(TimeoutError("SSL read timed out")),
         )
         monkeypatch.setattr(probe, "insert_external_probe_run", lambda row: None)
-        assert probe.main() == 0
+        assert probe.main() == 1
 
 
 # ── dead-man's-switch reader ─────────────────────────────────────────────────

--- a/scripts/tests/test_leap_capacity_shed_retry.py
+++ b/scripts/tests/test_leap_capacity_shed_retry.py
@@ -258,14 +258,21 @@ def test_persistent_capacity_shed_no_duplicate_still_fails(tmp_path: Path) -> No
     port = _free_port()
 
     with _Stub(port, always_status=502, fail_body=SHED_BODY) as stub:
-        result = _run(repo, py, port, shed_wait="3", delay="1")
+        result = _run(repo, py, port, shed_wait="30", delay="10")
 
+    slept = _sleeps(tmp_path)
     assert result.returncode != 0, result.stdout + result.stderr
-    # The ladder is now exact: a 3s budget at a 1s delay buys three waits and
-    # a fourth POST, then gives up. Was `>= 2` because the count was a
-    # function of how fast the box happened to be.
+    # The ladder is exact in retry COUNT: a 30s budget at a 10s delay buys
+    # three waits and a fourth POST, then gives up. The per-step VALUES are
+    # not pinned — the wrapper also charges whole seconds of attempt wall time
+    # against the budget at `date +%s` granularity, so an attempt that
+    # straddles a clock tick clips the final delay. Budgeting 30s against a
+    # 10s step keeps that jitter far below one rung; the old 3s/1s pinning of
+    # [1, 1, 1] made a single straddled tick drop a whole retry.
     assert stub.calls == [PATH] * 4, stub.calls
-    assert _sleeps(tmp_path) == [1, 1, 1], _sleeps(tmp_path)
+    assert len(slept) == 3, slept
+    assert all(d > 0 for d in slept), slept
+    assert sum(slept) <= 30, slept
     assert not marker.exists()
     combined = (result.stdout + result.stderr).lower()
     assert "capacity" in combined or "shed" in combined

--- a/scripts/tests/test_position_reconcile_spine.py
+++ b/scripts/tests/test_position_reconcile_spine.py
@@ -340,6 +340,50 @@ class TestMainExitAndHealth(unittest.TestCase):
         self.assertIn("quantity_mismatch_count", recorded[0][1])
         self.assertEqual(recorded[0][1]["quantity_mismatch_count"], 1)
 
+    def test_ib_unreachable_health_detail_has_message(self):
+        recorded = []
+        with patch.object(ib_reconcile, "connect_ib", return_value=None), patch.object(
+            ib_reconcile, "_record_health", side_effect=lambda s, d: recorded.append((s, d))
+        ):
+            with self.assertRaises(SystemExit):
+                ib_reconcile.main()
+        self.assertIn("unreachable", recorded[0][1]["message"])
+
+    def test_attention_health_detail_has_message(self):
+        client = MagicMock()
+        recorded = []
+        ib_positions = [_ib_opt("AAOI", 5, 10.0, "C", LIVE_EXPIRY_IB)]
+        portfolio = {
+            "positions": [
+                _local_position("AAOI", 3, "LONG", 10.0, "Call", LIVE_EXPIRY_SNAPSHOT)
+            ]
+        }
+        with patch.object(ib_reconcile, "connect_ib", return_value=client), patch.object(
+            ib_reconcile, "load_trade_log", return_value={"trades": []}
+        ), patch.object(
+            ib_reconcile, "load_portfolio_snapshot", return_value=portfolio
+        ), patch.object(
+            ib_reconcile, "fetch_ib_executions", return_value=[]
+        ), patch.object(
+            ib_reconcile, "fetch_ib_positions", return_value=ib_positions
+        ), patch.object(
+            ib_reconcile, "save_reconciliation_report"
+        ), patch.object(
+            ib_reconcile, "_record_health", side_effect=lambda s, d: recorded.append((s, d))
+        ):
+            ib_reconcile.main()
+        self.assertIn("quantity mismatch", recorded[0][1]["message"])
+
+    def test_drift_message_counts_new_trades(self):
+        """needs_attention flips on new_trades alone; the digest line must say so."""
+        detail = {
+            "new_trades_count": 4,
+            "quantity_mismatch_count": 0,
+            "positions_missing_locally_count": 0,
+            "positions_closed_count": 0,
+        }
+        self.assertIn("4 new trade(s)", ib_reconcile._drift_message(detail))
+
 
 class TestPositionReconcileHandler(unittest.TestCase):
     def _make_handler(self, ib_positions, portfolio, connect_ok=True):
@@ -373,6 +417,23 @@ class TestPositionReconcileHandler(unittest.TestCase):
         self.assertEqual(state, "error")
         self.assertEqual(kwargs["error"]["quantity_mismatch_count"], 1)
         client.disconnect.assert_called_once()
+
+    def test_error_health_blob_carries_operator_message(self):
+        handler, _ = self._make_handler(
+            [_ib_opt("AAOI", 5, 10.0, "C", LIVE_EXPIRY_IB)],
+            {"positions": [_local_position("AAOI", 3, "LONG", 10.0, "Call", LIVE_EXPIRY_SNAPSHOT)]},
+        )
+        handler.execute()
+        message = handler.record_cycle_health.call_args[1]["error"]["message"]
+        self.assertIn("quantity mismatch", message)
+
+    def test_clean_run_writes_no_error_blob(self):
+        handler, _ = self._make_handler(
+            [_ib_opt("CRCL", 40, 110.0, "C", LIVE_EXPIRY_IB)],
+            {"positions": [_local_position("CRCL", 40, "LONG", 110.0, "Call", LIVE_EXPIRY_SNAPSHOT)]},
+        )
+        handler.execute()
+        self.assertIsNone(handler.record_cycle_health.call_args[1]["error"])
 
     def test_ok_heartbeat_when_clean(self):
         handler, client = self._make_handler(

--- a/scripts/tests/test_watchdog/test_error_message_extraction.py
+++ b/scripts/tests/test_watchdog/test_error_message_extraction.py
@@ -1,0 +1,64 @@
+"""Error blobs without a `message` key must still render their text.
+
+`drift_audit.py` writes `{"summary": ..., "drift_count": ...}`; the
+watchdog rendered every one of those as `in error state: unknown`, so a
+22-cycle config-drift page named no drifted file.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+_NOW = datetime.now(timezone.utc).replace(microsecond=0)
+
+_DRIFT_BLOB = {
+    "summary": "config drift: fleet-dropin",
+    "drift_count": 1,
+    "drifts": [{"id": "fleet-dropin", "detail": "checksum mismatch"}],
+}
+
+
+def _seed_service_health(db_conn, service: str, state: str, updated_at: datetime, error: dict):
+    db_conn.execute(
+        """
+        INSERT OR REPLACE INTO service_health
+          (service, state, last_attempt_started_at, last_attempt_finished_at,
+           last_error, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (
+            service,
+            state,
+            None,
+            updated_at.isoformat().replace("+00:00", "Z"),
+            json.dumps(error),
+            updated_at.isoformat().replace("+00:00", "Z"),
+        ),
+    )
+    db_conn.commit()
+
+
+class TestErrorMessageExtraction:
+    def test_summary_only_blob_renders_in_check_message(self, db_conn):
+        from watchdog import check
+
+        _seed_service_health(
+            db_conn, "config-drift", "error", _NOW - timedelta(minutes=1), _DRIFT_BLOB
+        )
+        outcome = check.check_service(
+            service="config-drift", kind="error", now=_NOW, market_state="closed"
+        )
+        assert outcome.message == "in error state: config drift: fleet-dropin"
+
+    def test_summary_only_blob_renders_in_grouping_reason(self, db_conn):
+        from watchdog import check, grouping
+
+        _seed_service_health(
+            db_conn, "config-drift", "error", _NOW - timedelta(minutes=1), _DRIFT_BLOB
+        )
+        outcome = check.check_service(
+            service="config-drift", kind="error", now=_NOW, market_state="closed"
+        )
+        reason = grouping._failure_reason(outcome)
+        assert "fleet-dropin" in reason
+        assert "unknown" not in reason

--- a/scripts/tests/test_watchdog/test_external_probe_deadman.py
+++ b/scripts/tests/test_watchdog/test_external_probe_deadman.py
@@ -569,3 +569,27 @@ def test_missing_deploy_markers_never_suppress(tmp_path, monkeypatch) -> None:
 
     assert outcome.fired is True
     assert outcome.severity == "P1"
+
+
+def test_github_witness_prefers_ipv4_before_fetching() -> None:
+    """VPS IPv6 is blackholed to api.github.com; an AAAA-first walk burns the
+    whole bounded timeout and blinds the witness."""
+    from scripts.watchdog import external_probe
+
+    order: list[str] = []
+    response = MagicMock()
+    response.read.return_value = b'{"workflow_runs":[]}'
+
+    def _record_urlopen(*_args, **_kwargs):
+        order.append("fetch")
+        handle = MagicMock()
+        handle.__enter__.return_value = response
+        return handle
+
+    with (
+        patch("utils.ipv4_first.prefer_ipv4", lambda: order.append("prefer_ipv4")),
+        patch.object(external_probe.urllib.request, "urlopen", _record_urlopen),
+    ):
+        external_probe._latest_github_run()
+
+    assert order == ["prefer_ipv4", "fetch"]

--- a/scripts/watchdog/check.py
+++ b/scripts/watchdog/check.py
@@ -224,6 +224,21 @@ def check_service(*, service: str, kind: str, now: datetime, market_state: str) 
     return _check_stale(service=service, health=health, now=now, market_state=market_state)
 
 
+def error_text(blob: Any) -> str:
+    """Operator-facing text from a writer's error blob.
+
+    Writers disagree on the key: `drift_audit` writes `summary`,
+    FastAPI paths write `detail`, reconcile writes `reason`.
+    """
+    if not isinstance(blob, dict):
+        return ""
+    for key in ("message", "summary", "detail", "reason"):
+        value = blob.get(key)
+        if value:
+            return str(value)
+    return ""
+
+
 def _embargo_deadline(err: Any) -> Optional[datetime]:
     """The writer's own next-attempt deadline from its error payload, or None.
 
@@ -262,7 +277,7 @@ def _check_error(*, service: str, health: Optional[dict], now: datetime, market_
         err = json.loads(err_blob) if isinstance(err_blob, str) else err_blob
     except json.JSONDecodeError:
         err = {}
-    err_msg = err.get("message") if isinstance(err, dict) else None
+    err_msg = error_text(err)
     decision = cooldown_mod.record_failure_and_decide(service=service, kind="error", now=now)
     severity = _resolve_severity(service=service, kind="error", market_state=market_state)
     msg = f"in error state: {err_msg or 'unknown'}"

--- a/scripts/watchdog/external_probe.py
+++ b/scripts/watchdog/external_probe.py
@@ -215,6 +215,9 @@ def _sampled_during_deploy_window(sample_time: datetime, now: datetime) -> bool:
 
 def _latest_github_run(timeout: float = FETCH_TIMEOUT_SECONDS) -> dict | None:
     """Independent witness when Turso persistence is stale or unavailable."""
+    from utils.ipv4_first import prefer_ipv4
+
+    prefer_ipv4()
     request = urllib.request.Request(
         GITHUB_RUNS_URL,
         headers={"Accept": "application/vnd.github+json", "User-Agent": "radon-watchdog"},

--- a/scripts/watchdog/grouping.py
+++ b/scripts/watchdog/grouping.py
@@ -56,7 +56,7 @@ from urllib import request as urllib_request
 from . import cooldown as cooldown_mod
 from . import notify
 from . import services as services_mod
-from .check import CheckOutcome
+from .check import CheckOutcome, error_text
 
 
 log = logging.getLogger("watchdog.grouping")
@@ -151,7 +151,7 @@ def _parse_error_text(raw: object) -> str:
     if raw is None:
         return ""
     if isinstance(raw, dict):
-        return str(raw.get("message") or raw.get("detail") or "")
+        return error_text(raw)
     text = str(raw).strip()
     if not text:
         return ""
@@ -161,7 +161,7 @@ def _parse_error_text(raw: object) -> str:
         except (json.JSONDecodeError, TypeError):
             return text
         if isinstance(parsed, dict):
-            return str(parsed.get("message") or parsed.get("detail") or text)
+            return error_text(parsed) or text
     return text
 
 


### PR DESCRIPTION
The daily digest carried 128 alerts across nine services. Triage split them into six code-actionable defects (one commit each, below), seven ops-only conditions the operator must clear by hand, and eight proposals that were rejected as unsafe. Every fix is red/green: a failing test first, then the smallest change that turns it green.

Three of the nine alerts were not defects in the thing they named. They were defects in how the alert was written or how often it repeated.

### Commits

- **`fix(watchdog)`** — `config-drift ×22` rendered as `in error state: unknown`. `drift_audit` writes its blob under `summary`; the reader only looked for `message`. Adds `error_text()` (message > summary > detail > reason) at the render site. The writer keeps its payload shape — `cloud/tests/test_drift_audit.py` pins it, and the reader owns rendering.
- **`fix(reconcile)`** — `position-reconcile` had the same shape of bug on the writer side: a message-less error blob, so real position drift and an unreachable broker host produced byte-identical digest lines. `_drift_message()` is now the single source of the summary, shared by `ib_reconcile.main()` and the handler.
- **`fix(equibles)`** — `equibles-ats-venue-share ×22` is one weekly timer re-paging on every watchdog cycle for seven days. The watchdog's embargo suppression already existed; nothing was feeding it. All four error branches now carry `next_attempt_at`, and the no-series payload carries `codes` so a wedged client stops reading as an empty response.
- **`fix(health-probe)`** — `prober_silent for 141m`, two independent causes. `probe.main()` returned 0 when the `latest` ledger write failed, so a green CI run wrote nothing and looked like scheduler lag. And the GitHub witness that would have disambiguated it fetched without `prefer_ipv4()`, so it timed out on the IPv6 blackhole. Ordering matters: the exit-code fix must land with the witness fix, or a working witness would rewrite the stale verdict and hide the silent-write case.
- **`fix(api)`** — `menthorq-login-probe ×23` claimed a broken credential chain. It was the deliberate post-failure embargo, flattened into the same 503 string the probe classifies as a hard auth failure — so the embargo re-armed the page that caused it. A narrower `except` ahead of the auth branch names it; `_is_auth_failure` already handles `"embargo"`.
- **`fix(flex)`** — `flex-pull ×23` and the latched `radon-flex-pull.service` oneshot are one root cause: the novelty check was per-run, so the 08:30 retry over a delivery the 06:30 run already ingested was indistinguishable from IBKR going dark. Now requires both zero ingested *and* a newest statement period older than the last completed session. `MAX_DELIVERY_LAG_DAYS` is deliberately its own constant — reusing `MAX_NIGHTLY_SPAN_DAYS` (which means statement *period span*) would let a real stoppage go unpaged for five days.

### Not in this PR — operator actions

| Alert | Action |
|---|---|
| `config-drift` | App host: `systemctl start radon-drift-audit.service` (polkit, no `sudo`), read the `DRIFT <id>` lines, re-sync from `cloud/` or allowlist. This PR only makes the ids visible. |
| `fill-monitor ×8` | Broker host: IB Gateway is down on `10.0.0.4:4001`. `docs/ib-gateway-recovery.md`; clear the 2FA push. Self-clears next cycle. No code defect. |
| `flex-token-check ×22` | Provision `data/flex_token_config.json` on the app host at a bind-mounted durable path, `chmod 600`. Gitignored and runtime-mutated — must not be committed. |
| `flex-pull` | Before merge, confirm IBKR is still delivering: `flex_sftp_pull.py --list-only`, read the newest `FlexStatement toDate`. Then `systemctl reset-failed radon-flex-pull.service` to clear the latch. |
| `external-health-probe` | `gh run list --workflow=external-health-probe.yml --limit 12` — ~141m gaps are GitHub scheduler lag; frequent green runs mean silent Turso writes, check `TURSO_AUTH_TOKEN`. |
| `menthorq-login-probe` | After this lands: restart `radon-monitor`, then curl `/options/exposure/SPX?frequency=eod`. A 503 still saying *authentication is unavailable* is a genuine credential failure. |
| `position-reconcile` | Read `service_health` on Turso. Non-zero `quantity_mismatch_count` is real drift needing a snapshot resync. This PR is observability only. |

### Rejected

Widening `reader.STALE_AFTER_SECONDS` (that is how a silent prober goes undetected), raising the watchdog's 2.5s `FETCH_TIMEOUT_SECONDS`, changing `drift_audit`'s payload, any watchdog-side change for equibles, and committing the Flex token config. `fill-monitor` and `flex-token-check` were verified as correct code reporting real host conditions — no safe change exists.

The flex fix as originally specified was also rejected: replacing the `ingested` counter without a hard staleness floor would have turned a genuine IBKR stoppage into a green heartbeat, and this branch is the only remaining missed-delivery detector.

### Verification

`11196 passed, 1 skipped` across `scripts/tests` + `scripts/api/tests` (27m53s), plus `42 passed` on the docs contract after adding the equibles cadence section. Baseline before the branch was green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLh4Xvb7QoE61c8AjPTHVb