### PR TITLE
Fix app-role drift audit false positives

### DIFF
--- a/cloud/scripts/drift_audit.py
+++ b/cloud/scripts/drift_audit.py
@@ -549,6 +549,11 @@ ROLE_SKIPPED_UNITS: dict[str, frozenset[str]] = {
         }
     ),
 }
+# Gateway runtime surfaces are absent by design on app-role hosts. Keep them
+# visible as role-skipped notes without weakening broker/combined audits.
+ROLE_SKIPPED_GATEWAY_SURFACES: dict[str, frozenset[str]] = {
+    "app": frozenset({"ib-gateway-control", "compose"}),
+}
 
 
 def resolve_host_role(environ=None) -> str:
@@ -694,12 +699,21 @@ def _check_repo_dirty(drifts: list[dict]) -> None:
 def gather() -> tuple[list[dict], dict[str, str], list[str]]:
     raw_drifts: list[dict] = []
     known_untracked: list[str] = []
+    role_skipped = ROLE_SKIPPED_GATEWAY_SURFACES.get(
+        resolve_host_role(), frozenset()
+    )
 
     for live, repo_rel, label in FILE_PAIRS:
+        if label in role_skipped:
+            known_untracked.append(f"role-skipped:{label}")
+            continue
         drift = _compare_file_pair(live, repo_rel, label)
         if drift:
             raw_drifts.append(drift)
-    _check_compose(raw_drifts)
+    if "compose" in role_skipped:
+        known_untracked.append("role-skipped:compose")
+    else:
+        _check_compose(raw_drifts)
     _check_units(raw_drifts, known_untracked)
     _check_sudoers(raw_drifts, known_untracked)
     _check_env_invariants(raw_drifts)

--- a/cloud/tests/test_drift_audit.py
+++ b/cloud/tests/test_drift_audit.py
@@ -397,6 +397,79 @@ def test_gateway_control_helper_is_drift_audited():
     ) in da.FILE_PAIRS
 
 
+class TestRoleSkippedGatewayPlane:
+    def _gather(self, monkeypatch, role):
+        checked_files = []
+        compose_checks = []
+
+        def compare_file_pair(_live, _repo, label):
+            checked_files.append(label)
+            if label == "ib-gateway-control":
+                return {
+                    "id": "live-missing:ib-gateway-control",
+                    "detail": "/usr/local/bin/radon-ib-gateway-control",
+                }
+            return None
+
+        def check_compose(drifts):
+            compose_checks.append(True)
+            drifts.append(
+                {"id": "compose:unresolvable", "detail": "no such container"}
+            )
+
+        monkeypatch.setattr(da, "resolve_host_role", lambda environ=None: role)
+        monkeypatch.setattr(da, "_compare_file_pair", compare_file_pair)
+        monkeypatch.setattr(da, "_check_compose", check_compose)
+        monkeypatch.setattr(da, "_check_units", lambda drifts, known: None)
+        monkeypatch.setattr(da, "_check_sudoers", lambda drifts, known: None)
+        monkeypatch.setattr(da, "_check_env_invariants", lambda drifts: None)
+        monkeypatch.setattr(da, "_read_repo", lambda relative: "")
+        result = da.gather()
+        return result, checked_files, compose_checks
+
+    def test_app_role_marks_gateway_file_and_compose_as_role_skipped(
+        self, monkeypatch
+    ):
+        (drifts, allowed, known), checked_files, compose_checks = self._gather(
+            monkeypatch, "app"
+        )
+
+        assert drifts == []
+        assert allowed == {}
+        assert checked_files.count("ib-gateway-control") == 0
+        assert compose_checks == []
+        assert known == [
+            "role-skipped:ib-gateway-control",
+            "role-skipped:compose",
+        ]
+
+    def test_broker_role_still_checks_gateway_file_and_compose(self, monkeypatch):
+        (drifts, _allowed, known), checked_files, compose_checks = self._gather(
+            monkeypatch, "broker"
+        )
+
+        assert [drift["id"] for drift in drifts] == [
+            "live-missing:ib-gateway-control",
+            "compose:unresolvable",
+        ]
+        assert checked_files.count("ib-gateway-control") == 1
+        assert compose_checks == [True]
+        assert known == []
+
+    def test_combined_role_still_checks_gateway_file_and_compose(self, monkeypatch):
+        (drifts, _allowed, known), checked_files, compose_checks = self._gather(
+            monkeypatch, "combined"
+        )
+
+        assert [drift["id"] for drift in drifts] == [
+            "live-missing:ib-gateway-control",
+            "compose:unresolvable",
+        ]
+        assert checked_files.count("ib-gateway-control") == 1
+        assert compose_checks == [True]
+        assert known == []
+
+
 class TestSummary:
     def test_error_summary_is_compact_and_capped(self):
         drifts = [


### PR DESCRIPTION
## Summary
- Treat the Gateway control helper and Gateway compose runtime as role-skipped notes on RADON_HOST_ROLE=app.
- Preserve both audits unchanged for broker and combined hosts.
- Add regression coverage for all three host roles.

## Cause
The drift audit learned role-aware systemd unit absence in REL-169, but its Gateway file and compose checks remained single-host assumptions. Split app hosts intentionally own neither surface, so clean app hosts emitted live-missing:ib-gateway-control and compose:unresolvable.

## Verification
- Red: app-role regression failed with both production drift IDs before the fix.
- Green: cloud/tests/test_drift_audit.py, 48 passed.
- Cloud suite: 1666 passed, 7 skipped; 5 local Caddy dependency failures are unrelated.
- Full Python suite: 11544 passed, 1 skipped; 2 load-timeout flakes passed 2/2 immediately in isolation.
- python3.13 -m py_compile passed for both changed files.
- git diff --check passed.
- Ruff was unavailable in the local Python environment.