### PR TITLE
fix(demo): re-enable demo.radon.run signups (22-day provisioning outage)

### DIFF
--- a/docs/demo-environment.md
+++ b/docs/demo-environment.md
@@ -119,3 +119,53 @@ Tests: 55 new Vitest (10 files) + 2 extended perimeter pins + 4 new pytest, all 
 - **Realtime feed entitlement pressure** (decision 5) → monitor IB data-farm capacity; fall back to delayed feed if it pressures prod.
 - **Prod AI-budget burn** (revised 2026-06-27) → demo reuses the prod Anthropic/Cerebras/Exa keys, so a demo quota bug spends the *prod* AI budget. The only guard is the `demo_ai_usage` per-user quota + Upstash tier-D (5/day); add a provider spend cap if abuse appears.
 - **Cost/ops** → second VM + Turso + Upstash + Cloudflare zone. No separate IB paper account needed (TEST_MODE).
+
+---
+
+## Outage 2026-08-13 → 2026-09-03: no new user could get a trial
+
+**Symptom.** Signups completed at Clerk and then every page and `/api/*` call
+returned `403 "Demo access is not active."` with no explanation. The last
+provisioned trial was `2026-08-13T17:30:04Z`; ~60 accounts created after that
+carry empty `publicMetadata`.
+
+**Cause.** Commit `4eaaf5e9` shipped two changes together:
+
+1. A webhook replay ledger — `claimDemoWebhookEvent` INSERTs into
+   `demo_webhook_events` *before* `provisionDemoTrial` runs
+   (`web/app/api/webhooks/clerk/route.ts`). The table was never created in the
+   demo Turso, so every `user.created` delivery threw and provisioned nothing.
+2. A default-deny in `web/lib/demo/demoGate.ts` — any signed-in user with no
+   `demoRole` is refused on the demo deployment. Correct on its own; combined
+   with (1) it turned a silent provisioning failure into a total wall.
+
+**Why the migration never ran.** The demo Turso is a full prod-shaped clone and
+shared ONE `schema_migrations` table with the main series (versions 1..69).
+`demo_migrations/0003` declared version 3, which the main series claimed on
+2026-06-29, so `apply_demo_migrations` read it as already applied and skipped it
+on every run. Every future demo migration numbered ≤ 69 was pre-swallowed the
+same way. This is a different failure from 2026-07-03 ("nobody ran the tool");
+here the tool ran and reported success.
+
+**Fixes.**
+
+| Change | Where |
+|---|---|
+| Demo series gets its own NAME-keyed ledger `demo_schema_migrations`; the shared table is never read or written | `scripts/db/demo_seed.py`, `scripts/db/demo_migrations/*.sql` |
+| `assert_not_prod` also requires the positive `radon-demo` marker | `scripts/db/demo_seed.py` |
+| A missing idempotency STORE degrades to at-least-once provisioning; every other claim failure still throws | `web/lib/demo/webhookLedger.ts` |
+| Provisioning failures page the operator (counts and reason only, never a user id or email) | `web/lib/notify/pushover.ts` |
+| Unprovisioned page requests redirect to a public `/demo-pending` leaf that bounds its own token-refresh retry; `/api/*` keeps the hard 403 | `web/app/demo-pending/`, `web/lib/demo/demoGate.ts`, `web/middleware.ts` |
+| A dead Upstash denies instead of throwing out of middleware as an opaque 500 | `web/lib/demo/rateLimit.ts` |
+| Seed dates anchor to the run date (`RADON_DEMO_SEED_TODAY` overrides) so the demo book never shows expired options | `scripts/db/demo_seed.py` |
+| Marketing CTA deep-links to `/sign-up`; the bare demo origin is a gated route that 404s a signed-out visitor | `site/lib/editorial-content.ts` |
+
+**Stranded users are NOT backfilled.** `clerk.radon.run` is the shared prod
+instance and "created after 2026-08-13 without `demoRole`" is not the set of
+demo signups — OAuth signups never carry the `unsafe_metadata.demo` marker, and
+`updateUserMetadata` replaces rather than merges. Stamping `demoRole` on a real
+prod account puts it behind demo expiry and paper-order routing; stamping the
+operator locks them out of `app.radon.run`. Affected users re-sign-up.
+
+**Set `PUSHOVER_TOKEN` / `PUSHOVER_USER` on the `radon-demo` Vercel project** to
+arm the provisioning alert; it no-ops silently while unset.

--- a/scripts/db/demo_migrations/0001_demo_users.sql
+++ b/scripts/db/demo_migrations/0001_demo_users.sql
@@ -24,5 +24,3 @@ CREATE TABLE IF NOT EXISTS demo_users (
 
 CREATE INDEX IF NOT EXISTS idx_demo_users_status     ON demo_users(status);
 CREATE INDEX IF NOT EXISTS idx_demo_users_expires_at ON demo_users(expires_at);
-
-INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (1, datetime('now'));

--- a/scripts/db/demo_migrations/0002_demo_ai_usage.sql
+++ b/scripts/db/demo_migrations/0002_demo_ai_usage.sql
@@ -16,5 +16,3 @@ CREATE TABLE IF NOT EXISTS demo_ai_usage (
   call_count  INTEGER NOT NULL,
   PRIMARY KEY (user_id, endpoint, day_et)
 );
-
-INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (2, datetime('now'));

--- a/scripts/db/demo_migrations/0003_demo_webhook_events.sql
+++ b/scripts/db/demo_migrations/0003_demo_webhook_events.sql
@@ -5,5 +5,3 @@ CREATE TABLE IF NOT EXISTS demo_webhook_events (
   event_type   TEXT NOT NULL,
   processed_at TEXT NOT NULL
 );
-
-INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (3, datetime('now'));

--- a/scripts/db/demo_seed.py
+++ b/scripts/db/demo_seed.py
@@ -33,6 +33,7 @@ import json
 import os
 import re
 import sys
+from datetime import date, timedelta
 from pathlib import Path
 
 _PROJECT_DIR = Path(__file__).resolve().parent.parent.parent
@@ -43,13 +44,73 @@ _DEMO_MIGRATIONS_DIR = Path(__file__).resolve().parent / "demo_migrations"
 # data-loss / leak event, so we refuse outright.
 _PROD_URL_MARKER = "radon-joemccann"
 
-_SEED_SNAPSHOT_TAKEN_AT = "2026-06-17T13:42:11+00:00"
-_SEED_LAST_SYNC = "2026-06-17T13:42:11+00:00"
+# ...and the demo DB is provisioned under this name. Requiring the POSITIVE
+# marker as well means a mistyped / unrelated target is refused rather than
+# silently written: the same ~/radon-cloud/.env on the prod app host holds both
+# credential pairs, so "not prod-marked" alone is too weak a guard.
+_DEMO_URL_MARKER = "radon-demo"
 
-_BOOTSTRAP_SQL = """
-    CREATE TABLE IF NOT EXISTS schema_migrations (
-      version    INTEGER PRIMARY KEY,
-      applied_at TEXT    NOT NULL
+# Seed dates are ANCHORED to the run date, never hardcoded. The first seed
+# baked 2026-06 expiries in, so by September every synthetic option had expired
+# and the demo rendered a dead account. Re-running the seeder now always
+# produces a live-looking book. Override the anchor for deterministic tests.
+_SEED_TODAY_ENV = "RADON_DEMO_SEED_TODAY"
+_SEED_SNAPSHOT_TIME = "T13:42:11+00:00"
+
+
+def _seed_anchor() -> date:
+    override = os.environ.get(_SEED_TODAY_ENV)
+    return date.fromisoformat(override) if override else date.today()
+
+
+def seed_snapshot_taken_at() -> str:
+    return f"{_seed_anchor().isoformat()}{_SEED_SNAPSHOT_TIME}"
+
+
+def _third_friday(year: int, month: int) -> date:
+    first = date(year, month, 1)
+    # weekday(): Monday=0 … Friday=4
+    return first + timedelta(days=(4 - first.weekday()) % 7 + 14)
+
+
+def _expiry_months_out(months: int) -> date:
+    """Third Friday `months` ahead, rolled forward if it has already passed."""
+    anchor = _seed_anchor()
+    year, month = anchor.year, anchor.month + months
+    year, month = year + (month - 1) // 12, (month - 1) % 12 + 1
+    expiry = _third_friday(year, month)
+    while expiry <= anchor:
+        month += 1
+        year, month = year + (month - 1) // 12, (month - 1) % 12 + 1
+        expiry = _third_friday(year, month)
+    return expiry
+
+
+def _expiry_iso(months: int) -> str:
+    return _expiry_months_out(months).isoformat()
+
+
+def _expiry_compact(months: int) -> str:
+    return _expiry_months_out(months).strftime("%Y%m%d")
+
+
+def _days_ago(days: int) -> str:
+    return (_seed_anchor() - timedelta(days=days)).isoformat()
+
+# The demo series gets its OWN, NAME-keyed ledger.
+#
+# The demo Turso DB is a full prod-shaped clone and shares one
+# `schema_migrations` table with the MAIN migration series (versions 1..69).
+# demo_migrations/0003 declared version 3, which the main series had claimed on
+# 2026-06-29, so a version-keyed applier read it as already applied and skipped
+# `demo_webhook_events` forever — every Clerk user.created webhook then threw
+# and demo.radon.run provisioned no trial for 22 days. Keying on the file NAME
+# in a dedicated table makes a version collision with the main series
+# structurally impossible.
+_DEMO_LEDGER_SQL = """
+    CREATE TABLE IF NOT EXISTS demo_schema_migrations (
+      name       TEXT PRIMARY KEY,
+      applied_at TEXT NOT NULL
     )
     """
 
@@ -77,11 +138,17 @@ def _read_demo_env() -> tuple[str, str]:
 
 
 def assert_not_prod(url: str) -> None:
-    """Hard guard — abort if the target URL looks like the prod DB."""
+    """Hard guard — abort unless the target URL is provably the demo DB."""
     if _PROD_URL_MARKER in url:
         raise SystemExit(
             "REFUSING TO SEED: target URL "
             f"({url!r}) contains the production marker {_PROD_URL_MARKER!r}. "
+            "demo_seed.py writes ONLY to the separate demo Turso DB."
+        )
+    if _DEMO_URL_MARKER not in url:
+        raise SystemExit(
+            "REFUSING TO SEED: target URL "
+            f"({url!r}) does not carry the demo marker {_DEMO_URL_MARKER!r}. "
             "demo_seed.py writes ONLY to the separate demo Turso DB."
         )
 
@@ -106,18 +173,28 @@ def _list_demo_migrations() -> list[tuple[int, str, Path]]:
 
 
 def apply_demo_migrations(db) -> None:
-    """Apply pending demo migrations (versioned, idempotent)."""
-    db.execute(_BOOTSTRAP_SQL)
+    """Apply pending demo migrations, keyed by FILE NAME (idempotent).
+
+    Never reads or writes the shared `schema_migrations` table — see
+    _DEMO_LEDGER_SQL for why that ledger cannot be trusted for this series.
+    """
+    db.execute(_DEMO_LEDGER_SQL)
     db.commit()
     applied = {
-        row[0] for row in db.execute("SELECT version FROM schema_migrations").fetchall()
+        row[0]
+        for row in db.execute("SELECT name FROM demo_schema_migrations").fetchall()
     }
-    for version, name, path in _list_demo_migrations():
-        if version in applied:
+    for _version, name, path in _list_demo_migrations():
+        if name in applied:
             continue
         print(f"[demo-seed] applying migration {name}")
         for stmt in _split_statements(path.read_text(encoding="utf-8")):
             db.execute(stmt)
+        db.execute(
+            "INSERT OR REPLACE INTO demo_schema_migrations (name, applied_at) "
+            "VALUES (?, datetime('now'))",
+            (name,),
+        )
         db.commit()
 
 
@@ -179,16 +256,16 @@ def _build_positions() -> list[dict]:
     # SPY/QQQ/TSLA per the Phase-1 brief, plus a SPY bull call spread.
     positions = [
         _single_leg_position(
-            1, "SPY", "Long Call $600.0", "2026-07-17", "LONG", 600.0, "Call",
-            entry_share=8.40, last_share=13.35, contracts=20, entry_date="2026-05-28",
+            1, "SPY", "Long Call $600.0", _expiry_iso(1), "LONG", 600.0, "Call",
+            entry_share=8.40, last_share=13.35, contracts=20, entry_date=_days_ago(20),
         ),
         _single_leg_position(
-            2, "QQQ", "Long Call $520.0", "2026-08-21", "LONG", 520.0, "Call",
-            entry_share=6.10, last_share=9.85, contracts=15, entry_date="2026-06-02",
+            2, "QQQ", "Long Call $520.0", _expiry_iso(2), "LONG", 520.0, "Call",
+            entry_share=6.10, last_share=9.85, contracts=15, entry_date=_days_ago(33),
         ),
         _single_leg_position(
-            3, "TSLA", "Long Call $340.0", "2026-09-18", "LONG", 340.0, "Call",
-            entry_share=11.85, last_share=18.40, contracts=10, entry_date="2026-06-05",
+            3, "TSLA", "Long Call $340.0", _expiry_iso(3), "LONG", 340.0, "Call",
+            entry_share=11.85, last_share=18.40, contracts=10, entry_date=_days_ago(30),
         ),
     ]
 
@@ -204,7 +281,7 @@ def _build_positions() -> list[dict]:
             "structure": "Bull Call Spread $620.0/$650.0",
             "structure_type": "Bull Call Spread",
             "risk_profile": "defined",
-            "expiry": "2026-07-17",
+            "expiry": _expiry_iso(1),
             "contracts": 20,
             "direction": "DEBIT",
             "entry_cost": round(spread_initial, 2),
@@ -214,7 +291,7 @@ def _build_positions() -> list[dict]:
             "kelly_optimal": None,
             "target": None,
             "stop": None,
-            "entry_date": "2026-06-08",
+            "entry_date": _days_ago(9),
         }
     )
     return positions
@@ -245,7 +322,7 @@ def build_portfolio_payload() -> dict:
     return {
         "bankroll": net_liq,
         "peak_value": net_liq,
-        "last_sync": _SEED_LAST_SYNC,
+        "last_sync": seed_snapshot_taken_at(),
         "positions": positions,
         "total_deployed_pct": round(total_initial / net_liq * 100, 2),
         "total_deployed_dollars": round(total_initial, 2),
@@ -266,13 +343,13 @@ def build_journal_rows() -> list[tuple[str, dict, str]]:
     """
     rows = [
         ("demo-spy-call-open", "SPY", "Long Call $600.0", "BUY_OPTION", 600.0,
-         "C", "2026-07-17", 20, 8.40, "2026-05-28"),
+         "C", _expiry_iso(1), 20, 8.40, _days_ago(20)),
         ("demo-qqq-call-open", "QQQ", "Long Call $520.0", "BUY_OPTION", 520.0,
-         "C", "2026-08-21", 15, 6.10, "2026-06-02"),
+         "C", _expiry_iso(2), 15, 6.10, _days_ago(33)),
         ("demo-tsla-call-open", "TSLA", "Long Call $340.0", "BUY_OPTION", 340.0,
-         "C", "2026-09-18", 10, 11.85, "2026-06-05"),
+         "C", _expiry_iso(3), 10, 11.85, _days_ago(30)),
         ("demo-spy-bcs-open", "SPY", "Bull Call Spread $620.0/$650.0", "BUY_COMBO",
-         620.0, "C", "2026-07-17", 20, 11.20, "2026-06-08"),
+         620.0, "C", _expiry_iso(1), 20, 11.20, _days_ago(9)),
     ]
     out: list[tuple[str, dict, str]] = []
     for trade_id, ticker, structure, action, strike, right, expiry, contracts, fill_share, date in rows:
@@ -320,7 +397,7 @@ def build_open_orders() -> list[tuple[int, dict]]:
                 "tif": "DAY",
                 "contract": {
                     "conId": None, "symbol": "TSLA", "secType": "OPT",
-                    "strike": 360.0, "right": "C", "expiry": "20260918",
+                    "strike": 360.0, "right": "C", "expiry": _expiry_compact(3),
                 },
                 "demo": True,
             },
@@ -343,7 +420,7 @@ def build_open_orders() -> list[tuple[int, dict]]:
                 "tif": "GTC",
                 "contract": {
                     "conId": None, "symbol": "QQQ", "secType": "OPT",
-                    "strike": 520.0, "right": "C", "expiry": "20260821",
+                    "strike": 520.0, "right": "C", "expiry": _expiry_compact(2),
                 },
                 "demo": True,
             },
@@ -357,9 +434,12 @@ def seed_synthetic_dataset(db) -> None:
     Fixed primary keys keep this idempotent (overwrite, not duplicate).
     """
     portfolio = build_portfolio_payload()
+    # The snapshot key moves with the anchor, so drop the previous seed rather
+    # than leaving a stale-dated row behind for the "latest snapshot" read.
+    db.execute("DELETE FROM portfolio_snapshots")
     db.execute(
         "INSERT OR REPLACE INTO portfolio_snapshots (taken_at, payload) VALUES (?, ?)",
-        (_SEED_SNAPSHOT_TAKEN_AT, json.dumps(portfolio)),
+        (seed_snapshot_taken_at(), json.dumps(portfolio)),
     )
 
     for trade_id, payload, filled_at in build_journal_rows():

--- a/scripts/tests/test_demo_seed_guard.py
+++ b/scripts/tests/test_demo_seed_guard.py
@@ -106,3 +106,150 @@ def test_market_mirror_retries_transient_turso_502():
     assert "http status 5\\d\\d" in source
     assert "MIRROR_MAX_ATTEMPTS" in source
     assert "source_read" in source
+
+
+# ── demo migration ledger (2026-09-03 demo outage) ───────────────────────
+#
+# The demo Turso DB shares ONE `schema_migrations` table with the MAIN
+# migration series (versions 1..69). demo_migrations/0003 declared version 3,
+# which the main series claimed on 2026-06-29, so the version-keyed applier
+# skipped it forever and `demo_webhook_events` was never created. Every Clerk
+# user.created webhook then threw and no trial was provisioned for 22 days.
+# The demo series gets its own NAME-keyed ledger so a version collision with
+# the main series is structurally impossible.
+
+
+class _LedgerFakeDb:
+    """libsql-shaped fake with a shared, already-populated schema_migrations."""
+
+    def __init__(self, applied_demo_names=(), main_versions=range(1, 70)):
+        self.statements: list[str] = []
+        self.recorded: list[str] = []
+        self._applied_demo_names = list(applied_demo_names)
+        self._main_versions = list(main_versions)
+        self._last_rows: list[tuple] = []
+
+    def execute(self, sql, params=None):
+        self.statements.append(sql.strip())
+        lowered = " ".join(sql.lower().split())
+        if "insert or replace into demo_schema_migrations" in lowered:
+            self.recorded.append(params[0])
+        if "from demo_schema_migrations" in lowered:
+            self._last_rows = [(n,) for n in self._applied_demo_names]
+        elif "from schema_migrations" in lowered:
+            self._last_rows = [(v,) for v in self._main_versions]
+        else:
+            self._last_rows = []
+        return self
+
+    def fetchall(self):
+        return self._last_rows
+
+    def commit(self):
+        pass
+
+
+def test_demo_migrations_apply_despite_main_series_version_collision():
+    db = _LedgerFakeDb()
+    demo_seed.apply_demo_migrations(db)
+    joined = " ".join(db.statements)
+    assert "CREATE TABLE IF NOT EXISTS demo_webhook_events" in joined
+    assert "CREATE TABLE IF NOT EXISTS demo_users" in joined
+    assert "CREATE TABLE IF NOT EXISTS demo_ai_usage" in joined
+
+
+def test_demo_migrations_record_into_their_own_ledger_only():
+    db = _LedgerFakeDb()
+    demo_seed.apply_demo_migrations(db)
+    joined = " ".join(db.statements)
+    assert "demo_schema_migrations" in joined
+    assert db.recorded == [
+        "0001_demo_users.sql",
+        "0002_demo_ai_usage.sql",
+        "0003_demo_webhook_events.sql",
+    ]
+    # The shared main-series ledger is read by nothing and written by nothing.
+    assert "INSERT OR IGNORE INTO schema_migrations" not in joined
+    assert "SELECT version FROM schema_migrations" not in joined
+
+
+def test_demo_migrations_skip_names_already_in_the_demo_ledger():
+    db = _LedgerFakeDb(applied_demo_names=[
+        "0001_demo_users.sql", "0002_demo_ai_usage.sql",
+        "0003_demo_webhook_events.sql",
+    ])
+    demo_seed.apply_demo_migrations(db)
+    joined = " ".join(db.statements)
+    assert "CREATE TABLE IF NOT EXISTS demo_webhook_events" not in joined
+    assert "CREATE TABLE IF NOT EXISTS demo_users" not in joined
+
+
+def test_demo_migration_files_never_touch_the_shared_schema_migrations_table():
+    for _version, name, path in demo_seed._list_demo_migrations():
+        sql = path.read_text(encoding="utf-8")
+        assert "INSERT OR IGNORE INTO schema_migrations" not in sql, (
+            f"{name} writes the shared main-series ledger — that INSERT is a "
+            "silent no-op and misleads any version-keyed applier."
+        )
+
+
+def test_assert_not_prod_requires_the_positive_demo_marker():
+    """A URL that is neither prod-marked nor demo-marked must still be refused."""
+    with pytest.raises(SystemExit) as exc:
+        demo_seed.assert_not_prod("libsql://some-other-db.aws-us-west-2.turso.io")
+    assert "REFUSING TO SEED" in str(exc.value)
+
+
+# ── seed freshness (2026-09-03) ──────────────────────────────────────────
+#
+# The seeded workspace was frozen at 2026-06-17 with hardcoded expiries, so by
+# September every synthetic option had already expired and the demo rendered a
+# dead account. Seed dates are anchored to the run date instead.
+
+
+def _anchored(monkeypatch, iso_day: str):
+    monkeypatch.setenv("RADON_DEMO_SEED_TODAY", iso_day)
+
+
+def test_seeded_positions_never_carry_an_expired_option(monkeypatch):
+    from datetime import date
+
+    for anchor in ("2026-09-03", "2027-03-01", "2028-12-15"):
+        _anchored(monkeypatch, anchor)
+        payload = demo_seed.build_portfolio_payload()
+        today = date.fromisoformat(anchor)
+        for pos in payload["positions"]:
+            expiry = date.fromisoformat(pos["expiry"])
+            assert expiry > today, f"{pos['ticker']} expiry {expiry} <= anchor {today}"
+            assert date.fromisoformat(pos["entry_date"]) < today
+
+
+def test_seeded_open_orders_and_journal_track_the_anchor(monkeypatch):
+    from datetime import date
+
+    _anchored(monkeypatch, "2027-03-01")
+    today = date.fromisoformat("2027-03-01")
+    for _perm_id, order in demo_seed.build_open_orders():
+        expiry = order["contract"]["expiry"]
+        assert len(expiry) == 8, "open_orders use the compact IB YYYYMMDD form"
+        assert date(int(expiry[:4]), int(expiry[4:6]), int(expiry[6:])) > today
+    for _trade_id, payload, filled_at in demo_seed.build_journal_rows():
+        assert date.fromisoformat(payload["expiry"]) > today
+        assert date.fromisoformat(filled_at) < today
+
+
+def test_seed_snapshot_is_taken_at_the_anchor(monkeypatch):
+    _anchored(monkeypatch, "2027-03-01")
+    assert demo_seed.seed_snapshot_taken_at().startswith("2027-03-01T")
+    assert demo_seed.build_portfolio_payload()["last_sync"].startswith("2027-03-01T")
+
+
+def test_reseeding_replaces_the_snapshot_rather_than_accumulating(monkeypatch):
+    _anchored(monkeypatch, "2027-03-01")
+    db = _FakeDb()
+    demo_seed.seed_synthetic_dataset(db)
+    joined = " ".join(db.statements)
+    assert "DELETE FROM portfolio_snapshots" in joined
+    assert joined.index("DELETE FROM portfolio_snapshots") < joined.index(
+        "INSERT OR REPLACE INTO portfolio_snapshots"
+    )

--- a/site/lib/demo-cta.test.ts
+++ b/site/lib/demo-cta.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { DEMO_URL } from "./editorial-content";
+import { DEMO_APP_URL } from "./seo";
+
+/**
+ * Every "try the demo" CTA on radon.run resolves to DEMO_URL. The bare origin
+ * is an authenticated route that 404s a signed-out visitor, so the CTA has to
+ * land on the sign-up entry point instead — the bare origin stays the site's
+ * identity URL for JSON-LD.
+ */
+describe("demo CTA destination", () => {
+  it("points at the public sign-up entry, not the gated root", () => {
+    expect(DEMO_URL).toBe("https://demo.radon.run/sign-up");
+    expect(new URL(DEMO_URL).pathname).not.toBe("/");
+  });
+
+  it("keeps the bare origin as the structured-data identity", () => {
+    expect(DEMO_APP_URL).toBe("https://demo.radon.run");
+  });
+});

--- a/site/lib/editorial-content.ts
+++ b/site/lib/editorial-content.ts
@@ -21,7 +21,9 @@ export const editorialNavLinks: EditorialNavLink[] = [
 
 // The one product destination on the page: the free demo instance
 // (public signups live there; app.radon.run is operator-allowlisted).
-export const DEMO_URL = "https://demo.radon.run";
+// Deep-links to /sign-up deliberately — the demo's root is an authenticated
+// route and 404s a signed-out visitor, so the bare origin is a dead CTA.
+export const DEMO_URL = "https://demo.radon.run/sign-up";
 
 // Data-source reference links (from README.md; UW carries the referral).
 export const IB_URL = "https://www.interactivebrokers.com/";

--- a/web/app/api/webhooks/clerk/route.ts
+++ b/web/app/api/webhooks/clerk/route.ts
@@ -20,6 +20,8 @@ import {
   releaseDemoWebhookEvent,
   type DemoDbClient,
 } from "@/lib/demo/demoUsers";
+import { claimWebhookEventOrDegrade } from "@/lib/demo/webhookLedger";
+import { notifyDemoProvisioningFailure } from "@/lib/notify/pushover";
 import type { DemoPublicMetadata } from "@/lib/demo/demoRole";
 
 export const runtime = "nodejs";
@@ -75,8 +77,19 @@ export async function POST(request: Request): Promise<Response> {
 
   const eventId = request.headers.get("svix-id")!;
   const db = getDemoDb() as unknown as DemoDbClient;
+  let replayGuarded = true;
   try {
-    if (!(await claimDemoWebhookEvent(db, eventId, event.type))) {
+    const claim = await claimWebhookEventOrDegrade({
+      eventId,
+      eventType: event.type,
+      claim: (id, type) => claimDemoWebhookEvent(db, id, type),
+      onDegrade: (reason) => {
+        console.warn(`[demo-webhook] ${reason}`);
+        void notifyDemoProvisioningFailure(reason);
+      },
+    });
+    replayGuarded = claim.replayGuarded;
+    if (!claim.proceed) {
       return ok({ duplicate: true, requestId });
     }
     const result = await provisionDemoTrial(event.data, {
@@ -91,8 +104,11 @@ export async function POST(request: Request): Promise<Response> {
     });
     return ok({ ...result, requestId });
   } catch (error) {
-    await releaseDemoWebhookEvent(db, eventId).catch(() => undefined);
+    if (replayGuarded) {
+      await releaseDemoWebhookEvent(db, eventId).catch(() => undefined);
+    }
     const detail = error instanceof Error ? error.message : "provisioning failed";
+    void notifyDemoProvisioningFailure(detail);
     // 500 so Clerk retries (the provisioning steps are idempotent).
     return ok({ error: "Provisioning failed.", detail, requestId }, 500);
   }

--- a/web/app/demo-pending/DemoPendingRetry.tsx
+++ b/web/app/demo-pending/DemoPendingRetry.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAuth } from "@clerk/nextjs";
+import { useRouter } from "next/navigation";
+
+// A freshly created demo user's trial reaches the session JWT only on token
+// refresh, so the gate can bounce them here for up to a refresh interval even
+// when provisioning worked. Force a fresh token on a BOUNDED schedule and send
+// them on as soon as the claim arrives.
+const MAX_ATTEMPTS = 12;
+const INTERVAL_MS = 5_000;
+
+export default function DemoPendingRetry() {
+  const { getToken, isLoaded } = useAuth();
+  const router = useRouter();
+  const [attempts, setAttempts] = useState(0);
+
+  useEffect(() => {
+    if (!isLoaded) return;
+    if (attempts >= MAX_ATTEMPTS) return;
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      try {
+        await getToken({ skipCache: true });
+      } catch {
+        // A refresh failure is indistinguishable from "not ready"; just retry.
+      }
+      if (cancelled) return;
+      setAttempts((n) => n + 1);
+      router.refresh();
+      router.replace("/portfolio");
+    }, INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [attempts, getToken, isLoaded, router]);
+
+  if (attempts >= MAX_ATTEMPTS) {
+    return (
+      <p className="trial-expired-copy">
+        This is taking longer than expected. Try signing out and back in, or get
+        in touch at{" "}
+        <a href="https://radon.run" className="trial-expired-link">
+          radon.run
+        </a>
+        .
+      </p>
+    );
+  }
+
+  return (
+    <p className="trial-expired-copy" aria-live="polite">
+      Checking access… ({attempts + 1}/{MAX_ATTEMPTS})
+    </p>
+  );
+}

--- a/web/app/demo-pending/page.tsx
+++ b/web/app/demo-pending/page.tsx
@@ -1,0 +1,28 @@
+import DemoPendingRetry from "./DemoPendingRetry";
+
+// Public holding page for a demo signup whose trial has not landed yet
+// (middleware isPublicRoute). The demo gate redirects here instead of the bare
+// 403 that 4eaaf5e9 shipped. Deliberately a bare leaf: no workspace shell, no
+// account data, no Clerk identity echoed — it is reachable unauthenticated on
+// BOTH deployments, so it must render nothing a stranger should not see.
+export const metadata = {
+  title: "Setting up your demo · Radon",
+};
+
+export default function DemoPendingPage() {
+  return (
+    <div className="trial-expired-page">
+      <div className="trial-expired-panel" role="status">
+        <div className="trial-expired-kicker">
+          <span className="trial-expired-dot" aria-hidden />
+          Radon Terminal
+        </div>
+        <h1 className="trial-expired-title">Setting up your demo</h1>
+        <p className="trial-expired-copy">
+          Your account is being provisioned. This usually takes a few seconds.
+        </p>
+        <DemoPendingRetry />
+      </div>
+    </div>
+  );
+}

--- a/web/lib/demo/demoGate.ts
+++ b/web/lib/demo/demoGate.ts
@@ -56,7 +56,9 @@ export async function handleDemoGate(
         requestId,
       }, { status: 403 }));
     }
-    return noStore(new NextResponse("Demo access is not active.", { status: 403 }));
+    return noStore(
+      NextResponse.redirect(new URL("/demo-pending", request.url), 307),
+    );
   }
   if (!ctx) return null;
 

--- a/web/lib/demo/rateLimit.ts
+++ b/web/lib/demo/rateLimit.ts
@@ -49,8 +49,13 @@ function denyUnavailable(tier: DemoRateTier): DemoRateLimitResult {
   return { success: false, limit, remaining: 0, reset: 0 };
 }
 
+type LimiterLike = { limit: (key: string) => Promise<DemoRateLimitResult | {
+  success: boolean; limit: number; remaining: number; reset: number;
+}> };
+
 let _redis: Redis | null | undefined; // undefined = not yet resolved
-const _limiters = new Map<DemoRateTier, Ratelimit>();
+const _limiters = new Map<DemoRateTier, LimiterLike>();
+let _limiterFactory: ((tier: DemoRateTier) => LimiterLike) | null = null;
 
 function getRedis(): Redis | null {
   if (_redis !== undefined) return _redis;
@@ -60,7 +65,8 @@ function getRedis(): Redis | null {
   return _redis;
 }
 
-function getLimiter(tier: DemoRateTier): Ratelimit | null {
+function getLimiter(tier: DemoRateTier): LimiterLike | null {
+  if (_limiterFactory) return _limiterFactory(tier);
   const redis = getRedis();
   if (!redis) return null;
   const existing = _limiters.get(tier);
@@ -90,12 +96,30 @@ export async function demoRateLimit(
       ? denyUnavailable(tier)
       : allowAll(tier);
   }
-  const { success, limit, remaining, reset } = await limiter.limit(userId);
-  return { success, limit, remaining, reset };
+  try {
+    const { success, limit, remaining, reset } = await limiter.limit(userId);
+    return { success, limit, remaining, reset };
+  } catch (error) {
+    // A dead or expired Redis must not throw out of middleware — unhandled,
+    // every demo /api/* call becomes an opaque 500 instead of a 429 the caller
+    // can act on. Deny (same posture as unconfigured), loudly.
+    console.error(
+      `[demo-rate-limit] tier ${tier} unavailable:`,
+      error instanceof Error ? error.message : error,
+    );
+    return denyUnavailable(tier);
+  }
 }
 
 // Test seam — drop memoised redis/limiters so env changes take effect.
 export function __resetRateLimitForTests(): void {
   _redis = undefined;
   _limiters.clear();
+}
+
+// Test seam — inject a limiter without an Upstash connection.
+export function __setLimiterFactoryForTests(
+  factory: ((tier: DemoRateTier) => LimiterLike) | null,
+): void {
+  _limiterFactory = factory;
 }

--- a/web/lib/demo/webhookLedger.ts
+++ b/web/lib/demo/webhookLedger.ts
@@ -1,0 +1,40 @@
+// Clerk webhook replay-ledger claim, with one narrowly-scoped degrade.
+//
+// The ledger (demo_webhook_events) is the idempotency guard added by 4eaaf5e9.
+// It is claimed BEFORE provisioning, so a claim that throws blocks provisioning
+// entirely — which is exactly what happened when the table was missing from the
+// demo Turso: every signup 500'd for 22 days and no trial was ever created.
+//
+// A missing idempotency STORE must not be able to deny service. That one error
+// degrades to at-least-once provisioning (the provisioning steps are already
+// idempotent); every other failure still throws so Clerk retries.
+
+const MISSING_LEDGER = /no such table:\s*demo_webhook_events/i;
+
+export function isMissingWebhookLedgerError(error: unknown): boolean {
+  return error instanceof Error && MISSING_LEDGER.test(error.message);
+}
+
+export type WebhookClaim = {
+  /** Whether to run provisioning for this delivery. */
+  proceed: boolean;
+  /** False when the delivery was provisioned without replay protection. */
+  replayGuarded: boolean;
+};
+
+export async function claimWebhookEventOrDegrade(params: {
+  eventId: string;
+  eventType: string;
+  claim: (eventId: string, eventType: string) => Promise<boolean>;
+  onDegrade?: (reason: string) => void;
+}): Promise<WebhookClaim> {
+  const { eventId, eventType, claim, onDegrade } = params;
+  try {
+    const claimed = await claim(eventId, eventType);
+    return { proceed: claimed, replayGuarded: true };
+  } catch (error) {
+    if (!isMissingWebhookLedgerError(error)) throw error;
+    onDegrade?.("demo_webhook_events is missing — provisioning without replay protection");
+    return { proceed: true, replayGuarded: false };
+  }
+}

--- a/web/lib/notify/pushover.ts
+++ b/web/lib/notify/pushover.ts
@@ -1,0 +1,50 @@
+// Minimal Pushover sender for operator alerts raised from Next.js.
+//
+// No-ops when unconfigured, and never throws: an alert must not be able to fail
+// the request that raised it. Messages carry counts and reasons only — never a
+// user id, email, or any other end-user identifier.
+
+const PUSHOVER_URL = "https://api.pushover.net/1/messages.json";
+
+export async function sendPushover(params: {
+  title: string;
+  message: string;
+  url?: string;
+  urlTitle?: string;
+}): Promise<boolean> {
+  const token = process.env.PUSHOVER_TOKEN;
+  const user = process.env.PUSHOVER_USER;
+  if (!token || !user) return false;
+  try {
+    const body = new URLSearchParams({
+      token,
+      user,
+      title: params.title,
+      message: params.message,
+    });
+    if (params.url) body.set("url", params.url);
+    if (params.urlTitle) body.set("url_title", params.urlTitle);
+    const res = await fetch(PUSHOVER_URL, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body,
+      cache: "no-store",
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Page the operator when a demo signup fails to receive a trial. Silence here
+ * is what let the 2026-08-13 outage run for 22 days.
+ */
+export async function notifyDemoProvisioningFailure(reason: string): Promise<void> {
+  await sendPushover({
+    title: "radon demo provisioning failed",
+    message: `A demo.radon.run signup was not granted a trial: ${reason}`,
+    url: "https://demo.radon.run/sign-up",
+    urlTitle: "demo sign-up",
+  });
+}

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -166,6 +166,10 @@ export const isPublicRoute = createRouteMatcher([
   // Expired-demo landing page — the demo gate redirects signed-in expired
   // trial users here; it must bypass auth or the gate would loop on itself.
   "/trial-expired",
+  // Demo signup whose trial has not reached the session JWT yet — the demo
+  // gate redirects here, so it must bypass auth or the gate loops on itself.
+  // Renders a bare leaf with no shell, no account fetch and no identity.
+  "/demo-pending",
   // Crawler policy (app/robots.ts) — crawlers have no Clerk session; without
   // this exemption /robots.txt redirects to /sign-in and the disallow-all
   // policy is never served (Google indexed exactly that redirect URL).

--- a/web/tests/demo-provisioning-resilience.test.ts
+++ b/web/tests/demo-provisioning-resilience.test.ts
@@ -1,0 +1,178 @@
+/**
+ * 2026-09-03 demo outage regression suite.
+ *
+ * Commit 4eaaf5e9 added a replay ledger whose table was never created in the
+ * demo Turso, so every Clerk user.created webhook threw before provisioning —
+ * and the same commit's default-deny turned that into a bare 403 on every
+ * page. Nothing alerted for 22 days. These tests pin all three halves.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { NextRequest } from "next/server";
+import { handleDemoGate } from "@/lib/demo/demoGate";
+import {
+  isMissingWebhookLedgerError,
+  claimWebhookEventOrDegrade,
+} from "@/lib/demo/webhookLedger";
+import { isPublicRoute } from "@/middleware";
+
+const NOW = Date.parse("2026-09-03T12:00:00-04:00");
+// Resolve against THIS file, never process.cwd() — the workspace runner
+// invokes the suite from web/ or site/ depending on where vitest was started.
+const WEB_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const source = (rel: string) => readFileSync(path.join(WEB_ROOT, rel), "utf8");
+
+describe("webhook replay ledger degrades only on a missing table", () => {
+  it("classifies the exact SQLite missing-table error and nothing else", () => {
+    expect(
+      isMissingWebhookLedgerError(
+        new Error("SQLITE_UNKNOWN: SQLite error: no such table: demo_webhook_events"),
+      ),
+    ).toBe(true);
+    expect(isMissingWebhookLedgerError(new Error("no such table: demo_users"))).toBe(false);
+    expect(isMissingWebhookLedgerError(new Error("UNIQUE constraint failed"))).toBe(false);
+    expect(isMissingWebhookLedgerError(new Error("network timeout"))).toBe(false);
+    expect(isMissingWebhookLedgerError("no such table: demo_webhook_events")).toBe(false);
+  });
+
+  it("claims normally when the ledger exists", async () => {
+    const claim = vi.fn().mockResolvedValue(true);
+    const res = await claimWebhookEventOrDegrade({
+      eventId: "evt_1",
+      eventType: "user.created",
+      claim,
+    });
+    expect(res).toEqual({ proceed: true, replayGuarded: true });
+    expect(claim).toHaveBeenCalledOnce();
+  });
+
+  it("stops on a duplicate delivery", async () => {
+    const res = await claimWebhookEventOrDegrade({
+      eventId: "evt_1",
+      eventType: "user.created",
+      claim: async () => false,
+    });
+    expect(res).toEqual({ proceed: false, replayGuarded: true });
+  });
+
+  it("provisions unguarded rather than blocking when the ledger table is absent", async () => {
+    const onDegrade = vi.fn();
+    const res = await claimWebhookEventOrDegrade({
+      eventId: "evt_1",
+      eventType: "user.created",
+      claim: async () => {
+        throw new Error("SQLITE_UNKNOWN: SQLite error: no such table: demo_webhook_events");
+      },
+      onDegrade,
+    });
+    expect(res).toEqual({ proceed: true, replayGuarded: false });
+    expect(onDegrade).toHaveBeenCalledOnce();
+  });
+
+  it("rethrows every other claim failure so Clerk retries", async () => {
+    await expect(
+      claimWebhookEventOrDegrade({
+        eventId: "evt_1",
+        eventType: "user.created",
+        claim: async () => {
+          throw new Error("network timeout");
+        },
+      }),
+    ).rejects.toThrow("network timeout");
+  });
+
+  it("the route goes through the degrading claim, not the raw one", () => {
+    const route = source("app/api/webhooks/clerk/route.ts");
+    expect(route).toContain("claimWebhookEventOrDegrade");
+    // Replay protection stays claim-FIRST: provisioning must not run before it.
+    expect(route.indexOf("claimWebhookEventOrDegrade")).toBeLessThan(
+      route.indexOf("provisionDemoTrial("),
+    );
+    expect(route).toContain("notifyDemoProvisioningFailure");
+  });
+});
+
+describe("unprovisioned demo users get a pending surface, not a bare 403", () => {
+  it("redirects a page request to /demo-pending", async () => {
+    const res = await handleDemoGate(
+      {
+        userId: "pending",
+        metadata: null,
+        request: new NextRequest("https://demo.radon.run/portfolio"),
+      },
+      { now: NOW, demoDeployment: true },
+    );
+    expect(res?.status).toBe(307);
+    expect(new URL(res!.headers.get("location")!).pathname).toBe("/demo-pending");
+  });
+
+  it("keeps the hard 403 JSON on API paths", async () => {
+    const res = await handleDemoGate(
+      {
+        userId: "pending",
+        metadata: null,
+        request: new NextRequest("https://demo.radon.run/api/portfolio"),
+      },
+      { now: NOW, demoDeployment: true },
+    );
+    expect(res?.status).toBe(403);
+    expect((await res!.json()).code).toBe("DEMO_ACCESS_PENDING");
+  });
+
+  it("never engages off the demo deployment", async () => {
+    const res = await handleDemoGate(
+      {
+        userId: "operator",
+        metadata: null,
+        request: new NextRequest("https://app.radon.run/portfolio"),
+      },
+      { now: NOW },
+    );
+    expect(res).toBeNull();
+  });
+});
+
+describe("/demo-pending perimeter", () => {
+  const req = (url: string) => new NextRequest(url);
+
+  it("is public so the redirect cannot loop on itself", () => {
+    expect(isPublicRoute(req("https://demo.radon.run/demo-pending"))).toBe(true);
+  });
+
+  it("does not widen the perimeter to the workspace root", () => {
+    expect(isPublicRoute(req("https://app.radon.run/"))).toBe(false);
+    expect(isPublicRoute(req("https://app.radon.run/portfolio"))).toBe(false);
+    expect(isPublicRoute(req("https://app.radon.run/api/portfolio"))).toBe(false);
+  });
+
+  it("renders no shell, fetches no account data, echoes no identity", () => {
+    const page = source("app/demo-pending/page.tsx");
+    expect(page).not.toContain("WorkspaceShell");
+    expect(page).not.toContain("fetch(");
+    expect(page).not.toContain("currentUser");
+    expect(page).not.toContain("auth(");
+  });
+
+  it("bounds its own retry loop", () => {
+    const client = source("app/demo-pending/DemoPendingRetry.tsx");
+    expect(client).toContain("MAX_ATTEMPTS");
+    expect(client).toMatch(/attempts?\s*(>=|>)\s*MAX_ATTEMPTS|MAX_ATTEMPTS\s*(<=|<)/);
+    expect(client).not.toContain("email");
+  });
+});
+
+describe("provisioning failures page the operator, without PII", () => {
+  it("sends counts and a reason only — never a user id or email", () => {
+    const notify = source("lib/notify/pushover.ts");
+    expect(notify).toContain("PUSHOVER_TOKEN");
+    expect(notify).toContain("PUSHOVER_USER");
+    // No-ops rather than throwing when unconfigured: alerting must never be
+    // able to fail a webhook that would otherwise have provisioned a trial.
+    expect(notify).toMatch(/if \(!token \|\| !user\)/);
+    const route = source("app/api/webhooks/clerk/route.ts");
+    expect(route).not.toMatch(/notifyDemoProvisioningFailure\([^)]*email/);
+    expect(route).not.toMatch(/notifyDemoProvisioningFailure\([^)]*userId/);
+  });
+});

--- a/web/tests/demo-rate-limit-fail-closed.test.ts
+++ b/web/tests/demo-rate-limit-fail-closed.test.ts
@@ -1,9 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { __resetRateLimitForTests, demoRateLimit } from "@/lib/demo/rateLimit";
+import {
+  __resetRateLimitForTests,
+  __setLimiterFactoryForTests,
+  demoRateLimit,
+} from "@/lib/demo/rateLimit";
 
 afterEach(() => {
   vi.unstubAllEnvs();
+  __setLimiterFactoryForTests(null);
   __resetRateLimitForTests();
 });
 
@@ -21,5 +26,22 @@ describe("durable demo rate limiter configuration", () => {
     vi.stubEnv("NEXT_PUBLIC_RADON_DEMO", "");
     __resetRateLimitForTests();
     expect((await demoRateLimit("B", "user")).success).toBe(true);
+  });
+});
+
+describe("a dead Upstash instance denies, it does not crash the request", () => {
+  it("returns a structured deny instead of throwing out of middleware", async () => {
+    // An expired/deleted Redis makes limiter.limit() reject. Unhandled, that
+    // throws inside web/middleware.ts and every demo /api/* call becomes an
+    // opaque 500 rather than a 429 the client can act on.
+    vi.stubEnv("NEXT_PUBLIC_RADON_DEMO", "1");
+    __setLimiterFactoryForTests(() => ({
+      limit: async () => {
+        throw new Error("Upstash: WRONGPASS invalid or expired token");
+      },
+    }));
+    const result = await demoRateLimit("A", "user_1");
+    expect(result.success).toBe(false);
+    expect(result.remaining).toBe(0);
   });
 });


### PR DESCRIPTION
## What broke

No demo signup has been granted a trial since **2026-08-13T17:30:04Z**. Signups completed at Clerk, then every page and `/api/*` call returned a bare `403 "Demo access is not active."` — no explanation, no path forward. ~60 accounts created since carry empty `publicMetadata`.

Commit `4eaaf5e9` ("remediate DeepSec security report") shipped two changes together:

1. A webhook replay ledger — `claimDemoWebhookEvent` INSERTs into `demo_webhook_events` **before** `provisionDemoTrial` runs (`web/app/api/webhooks/clerk/route.ts:79`). The table was never created in the demo Turso, so every `user.created` delivery threw and provisioned nothing.
2. The `demoGate` default-deny (`web/lib/demo/demoGate.ts:52`). Correct on its own — before it, an unprovisioned user reached the seeded workspace ungated. Combined with (1) it converted a silent provisioning failure into a total wall.

## Why the migration never ran

The demo Turso is a full prod-shaped clone sharing **one** `schema_migrations` table with the main series (versions 1..69). `demo_migrations/0003` declared version 3, claimed by the main series on 2026-06-29, so `apply_demo_migrations` read it as already applied and skipped it on every run — as it would have skipped every future demo migration numbered <= 69.

This is **not** the 2026-07-03 recurrence ("nobody ran the tool"). Here the tool ran and reported success.

## Changes

| Change | Where |
|---|---|
| Demo series gets its own NAME-keyed `demo_schema_migrations` ledger; the shared table is never read or written, and the misleading no-op INSERT is stripped from all three `.sql` files | `scripts/db/demo_seed.py`, `scripts/db/demo_migrations/*.sql` |
| `assert_not_prod` also requires the positive `radon-demo` marker — the same `radon-cloud/.env` holds both credential pairs, so "not prod-marked" is too weak a guard | `scripts/db/demo_seed.py` |
| A missing idempotency **store** degrades to at-least-once provisioning; every other claim failure still throws, keeping the replay guard `4eaaf5e9` added | `web/lib/demo/webhookLedger.ts` |
| Provisioning failures page the operator — counts and reason only, never a user id or email; no-ops while `PUSHOVER_*` is unset | `web/lib/notify/pushover.ts` |
| Unprovisioned **page** requests redirect to a public `/demo-pending` leaf that bounds its own token-refresh retry (a fresh trial reaches the session JWT only on refresh); `/api/*` keeps the hard 403 JSON unchanged | `web/app/demo-pending/`, `web/lib/demo/demoGate.ts`, `web/middleware.ts` |
| A dead/expired Upstash denies instead of throwing out of middleware as an opaque 500 | `web/lib/demo/rateLimit.ts` |
| Seed dates anchor to the run date (`RADON_DEMO_SEED_TODAY` overrides) so the demo book stops showing options that expired in July | `scripts/db/demo_seed.py` |
| Marketing CTA deep-links to `/sign-up`; the bare demo origin is a gated route that 404s a signed-out visitor | `site/lib/editorial-content.ts` |

## Perimeter

`/demo-pending` is added to `isPublicRoute`, which is **not** deployment-scoped — it is public on `app.radon.run` too. It is therefore a bare leaf: no workspace shell, no `fetch`, no `auth()`, no identity echoed. Pinned by test. `"/"` is deliberately **not** made public — `web/app/page.tsx` renders the full workspace shell, and allowlisting it would skip both the demo gate and the `ALLOWED_USER_IDS` operator allowlist.

## Stranded users are not backfilled

`clerk.radon.run` is the shared prod instance. "Created after 2026-08-13 without `demoRole`" is **not** the set of demo signups — OAuth signups never carry the `unsafe_metadata.demo` marker — and `updateUserMetadata` replaces rather than merges. Stamping `demoRole` on a real prod account puts it behind demo expiry and paper-order routing; stamping the operator locks them out of `app.radon.run`. Affected users re-sign-up.

## Verification

- Migration applied live to `radon-demo-joemccann`; demo tables are now `demo_ai_usage, demo_schema_migrations, demo_users, demo_webhook_events` (was: the first and third missing).
- `vitest run` from repo root — **8662 passed, 0 failed** (857 files).
- `pytest scripts/tests` — **10282 passed, 1 skipped, 0 failed**.
- `tsc --noEmit` clean.
- Isolation re-confirmed read-only during diagnosis: demo DB carries zero IBKR account numbers, all account-derived tables empty, demo VM has no tailscale and no reachable IB port on any prod host. The outage failed **closed** — availability, not exposure.

## Operator follow-ups

- Set `PUSHOVER_TOKEN` / `PUSHOVER_USER` on the `radon-demo` Vercel project to arm the alert.
- Re-run `demo_seed.py` against the demo DB after merge to refresh the expired book.
- The demo VM backend is frozen at 2026-07-03 (~543 commits behind the Vercel frontend) — worth a redeploy, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019UVmbs7twgwSmiUd8ECDeE
