### PR TITLE
fix(web): stop order-book SHARES and MARKET from colliding

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -8501,19 +8501,17 @@ body[data-mobile="true"] .orders-command-strip__jump:active {
 .cockpit--mobile .book-row .book-mkt {
   font-size: 12px;
 }
-/* Tighter side columns on a phone: the desktop 52px-mkt / 70px-px pairs plus
-   12px pads need 382px of montage — 17px more than a 393px viewport leaves,
-   which grew an inner horizontal scrollbar and amputated the ask side. */
+/* Phone montage: market flexes, size hugs the price, gap keeps SHARES off MARKET. */
 .cockpit--mobile .book-side.bid .book-colhead,
 .cockpit--mobile .book-side.bid .book-row {
-  grid-template-columns: 44px minmax(0, 1fr) 58px;
+  grid-template-columns: minmax(0, 1fr) minmax(36px, auto) 58px;
   column-gap: 6px;
   padding-left: 8px;
   padding-right: 8px;
 }
 .cockpit--mobile .book-side.ask .book-colhead,
 .cockpit--mobile .book-side.ask .book-row {
-  grid-template-columns: 58px minmax(0, 1fr) 44px;
+  grid-template-columns: 58px minmax(36px, auto) minmax(0, 1fr);
   column-gap: 6px;
   padding-left: 8px;
   padding-right: 8px;
@@ -9824,14 +9822,29 @@ tr {
   border-bottom: 1px solid var(--line-grid);
   background: var(--bg-panel-raised);
 }
+.book-colhead > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .book-colhead .r { text-align: right; }
 .book-colhead .c { text-align: center; }
 
-/* two-sided montage (stock / option) */
+/* two-sided montage (stock / option)
+   Market is the flexible column (minmax 0 so long MPIDs ellipsis). Size hugs
+   the price: bid size right-aligned, ask size left-aligned. column-gap keeps
+   SHARES and MARKET from colliding on names like DRCTEDARK. */
 .book-sides { display: grid; grid-template-columns: 1fr 1fr; }
 .book-side.bid { border-right: 1px solid var(--line-grid); }
-.book-side.bid .book-colhead, .book-side.bid .book-row { grid-template-columns: 52px 1fr 70px; }
-.book-side.ask .book-colhead, .book-side.ask .book-row { grid-template-columns: 70px 1fr 52px; }
+.book-side.bid .book-colhead, .book-side.bid .book-row {
+  grid-template-columns: minmax(0, 1.15fr) minmax(44px, auto) 70px;
+  column-gap: 8px;
+}
+.book-side.ask .book-colhead, .book-side.ask .book-row {
+  grid-template-columns: 70px minmax(44px, auto) minmax(0, 1.15fr);
+  column-gap: 8px;
+}
 .book-row {
   display: grid;
   align-items: center;
@@ -9843,8 +9856,18 @@ tr {
   position: relative;
 }
 .book-row .book-mkt { color: var(--text-secondary); font-size: 11px; }
-.book-row .book-shares { color: var(--text-secondary); font-variant-numeric: tabular-nums; text-align: right; }
-.book-row .book-px { font-weight: 600; font-variant-numeric: tabular-nums; }
+.book-row .book-shares {
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  min-width: 0;
+}
+.book-side.ask .book-row .book-shares { text-align: left; }
+.book-row .book-px {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  min-width: 0;
+}
 .book-side.bid .book-row .book-px { text-align: right; color: var(--signal-core-text); }
 .book-side.ask .book-row .book-px { text-align: left; color: var(--fault); }
 .book-side.ask .book-row .book-mkt { text-align: right; }
@@ -9930,10 +9953,16 @@ tr {
   align-items: center;
   gap: 5px;
   min-width: 0;
+  overflow: hidden;
   white-space: nowrap;
 }
 .book-side.ask .book-row .book-mkt { justify-content: flex-end; }
-.book-venue-lead { overflow: hidden; text-overflow: ellipsis; }
+.book-venue-lead {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+  flex: 1 1 auto;
+}
 .book-venue-more {
   flex: 0 0 auto;
   padding: 1px 4px;

--- a/web/components/ticker-detail/DepthMontage.tsx
+++ b/web/components/ticker-detail/DepthMontage.tsx
@@ -19,7 +19,7 @@ function venueCell(venues: string, side: "bid" | "ask", isCombo: boolean) {
   const pairs = isCombo ? venues.split(" | ") : [venues];
   const overflow = pairs.length - 1;
   return (
-    <span className="book-mkt" key="m" title={overflow > 0 ? venues : undefined}>
+    <span className="book-mkt" key="m" title={venues}>
       {side === "ask" && overflow > 0 && <span className="book-venue-more">+{overflow}</span>}
       <span className="book-venue-lead">{pairs[0]}</span>
       {side === "bid" && overflow > 0 && <span className="book-venue-more">+{overflow}</span>}
@@ -126,7 +126,7 @@ export function DepthMontage({ book, onPriceClick }: { book: DepthBook; onPriceC
         <div className="book-side ask">
           <div className="book-colhead">
             <span>Ask</span>
-            <span className="r">{isOption ? "Size" : "Shares"}</span>
+            <span>{isOption ? "Size" : "Shares"}</span>
             <span className="r">{isOption ? "Exchange" : isCombo ? "Leg venues" : "Market"}</span>
           </div>
           {asks.map((level, i) => row(level, "ask", i))}

--- a/web/e2e/book-montage-spacing.spec.ts
+++ b/web/e2e/book-montage-spacing.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * Desktop stock montage: ask SHARES and MARKET must not collide on a long MPID.
+ * Repro (2026-09-04): AAOI inside ask rendered "195DRCTED...".
+ *
+ * Layout-only: load the ticker cockpit so globals.css is the production sheet,
+ * then inject a 360px two-sided montage (cockpit book column with tape). A
+ * live depth socket is not required for the spacing contract.
+ */
+
+const now = new Date().toISOString();
+
+async function stubApis(page: Page) {
+  await page.unrouteAll({ behavior: "ignoreErrors" });
+  const json = (body: unknown) => (r: { fulfill: (o: object) => Promise<void> }) =>
+    r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+  await page.route("**/api/portfolio", json({
+    bankroll: 100_000, peak_value: 100_000, last_sync: now, total_deployed_pct: 0,
+    total_deployed_dollars: 0, remaining_capacity_pct: 100, position_count: 0,
+    defined_risk_count: 0, undefined_risk_count: 0, avg_kelly_optimal: null,
+    exposure: {}, violations: [], positions: [],
+  }));
+  await page.route("**/api/orders", json({ last_sync: now, open_orders: [], executed_orders: [] }));
+  await page.route("**/api/regime", json({ score: 15, level: "LOW" }));
+  await page.route("**/api/ib-status", json({ connected: true }));
+  await page.route("**/api/blotter", json({ as_of: now, summary: { realized_pnl: 0 }, closed_trades: [], open_trades: [] }));
+  await page.route("**/api/cash-flows**", json({ rows: [], summary: {} }));
+  await page.route("**/api/flex-token", json({ ok: true, days_until_expiry: 14 }));
+  await page.route("**/api/ticker/**", json({}));
+}
+
+test("ask shares and a long MPID stay in separate cells with a gap", async ({ page }) => {
+  await stubApis(page);
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto("/AAOI");
+  await expect(page.locator(".book-window")).toBeVisible();
+
+  const markup = `
+    <div class="book-side bid">
+      <div class="book-colhead">
+        <span>Market</span>
+        <span class="r">Shares</span>
+        <span class="r">Bid</span>
+      </div>
+      <div class="book-row">
+        <span class="book-mkt"><span class="book-venue-lead">NSDQ</span></span>
+        <span class="book-shares">230</span>
+        <span class="book-px">105.00</span>
+      </div>
+      <div class="book-row">
+        <span class="book-mkt"><span class="book-venue-lead">DRCTEDARK</span></span>
+        <span class="book-shares">127</span>
+        <span class="book-px">104.97</span>
+      </div>
+    </div>
+    <div class="book-side ask">
+      <div class="book-colhead">
+        <span>Ask</span>
+        <span>Shares</span>
+        <span class="r">Market</span>
+      </div>
+      <div class="book-row">
+        <span class="book-px">105.24</span>
+        <span class="book-shares">195</span>
+        <span class="book-mkt"><span class="book-venue-lead">DRCTEDARK</span></span>
+      </div>
+      <div class="book-row">
+        <span class="book-px">105.25</span>
+        <span class="book-shares">105</span>
+        <span class="book-mkt"><span class="book-venue-lead">IEXG</span></span>
+      </div>
+    </div>
+  `;
+
+  async function paint(width: number) {
+    await page.evaluate(({ html, w }) => {
+      const win = document.querySelector(".book-window");
+      if (!win) throw new Error("book-window missing");
+      win.innerHTML = `<div class="book-sides" style="width:${w}px">${html}</div>`;
+    }, { html: markup, w: width });
+  }
+
+  async function askGap(): Promise<number> {
+    const row = page.locator(".book-side.ask .book-row").first();
+    await expect(row).toBeVisible();
+    await expect(row.locator(".book-shares")).toHaveText("195");
+    await expect(row.locator(".book-mkt")).toContainText("DRCTEDARK");
+    return row.evaluate((el) => {
+      const size = el.querySelector(".book-shares")!.getBoundingClientRect();
+      const mkt = el.querySelector(".book-mkt")!.getBoundingClientRect();
+      return mkt.left - size.right;
+    });
+  }
+
+  // Tape-hidden desktop book column (~520px montage).
+  await paint(520);
+  expect(await askGap()).toBeGreaterThanOrEqual(6);
+  await page.locator(".book-sides").screenshot({ path: "/tmp/book-montage-spacing.png" });
+
+  // Tight montage (tape visible on a 1280px cockpit): still no overlap.
+  await paint(360);
+  expect(await askGap()).toBeGreaterThanOrEqual(6);
+});

--- a/web/e2e/ci-curation-ledger.txt
+++ b/web/e2e/ci-curation-ledger.txt
@@ -32,6 +32,7 @@ account-day-move-ib-daily-pnl.spec.ts
 admin-panel.spec.ts
 admin-visual-snapshot.spec.ts
 book-depth-client-nav.spec.ts
+book-montage-spacing.spec.ts
 bpi-tab.spec.ts
 cash-flows-section.spec.ts
 cash-flows-withdrawal-may8.spec.ts

--- a/web/tests/book-montage-spacing.test.ts
+++ b/web/tests/book-montage-spacing.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Stock/option two-sided montage: SHARES and MARKET must not collide.
+ *
+ * AAOI repro (2026-09-04): ask inside was "195DRCTED..." because desktop
+ * columns were `70px 1fr 52px` with no gap and ask size right-aligned into
+ * a 52px venue cell. Combo/mobile already used column-gap; desktop stock
+ * did not.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const css = readFileSync(resolve(__dirname, "../app/globals.css"), "utf8");
+
+function stockMontageBlock(): string {
+  const start = css.indexOf("/* two-sided montage (stock / option)");
+  const end = css.indexOf("/* option per-exchange BBO montage");
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+  return css.slice(start, end);
+}
+
+function ruleBody(block: string, selector: string): string {
+  const idx = block.indexOf(selector);
+  expect(idx, `missing ${selector}`).toBeGreaterThan(-1);
+  const open = block.indexOf("{", idx);
+  const close = block.indexOf("}", open);
+  expect(open).toBeGreaterThan(-1);
+  expect(close).toBeGreaterThan(open);
+  return block.slice(open, close + 1);
+}
+
+describe("desktop stock/option montage spacing", () => {
+  it("puts a column gap between market, size, and price on both sides", () => {
+    const block = stockMontageBlock();
+    const bid = ruleBody(block, ".book-side.bid .book-colhead, .book-side.bid .book-row");
+    const ask = ruleBody(block, ".book-side.ask .book-colhead, .book-side.ask .book-row");
+    expect(bid).toMatch(/column-gap:\s*8px/);
+    expect(ask).toMatch(/column-gap:\s*8px/);
+  });
+
+  it("lets the market column shrink (minmax 0) so long MPIDs ellipsis instead of overflowing into size", () => {
+    const block = stockMontageBlock();
+    const bid = ruleBody(block, ".book-side.bid .book-colhead, .book-side.bid .book-row");
+    const ask = ruleBody(block, ".book-side.ask .book-colhead, .book-side.ask .book-row");
+    expect(bid).toMatch(/minmax\(0,/);
+    expect(ask).toMatch(/minmax\(0,/);
+    expect(bid).not.toMatch(/52px 1fr 70px/);
+    expect(ask).not.toMatch(/70px 1fr 52px/);
+  });
+
+  it("left-aligns ask size so shares sit next to the ask price, not the venue", () => {
+    const block = stockMontageBlock();
+    expect(block).toMatch(/\.book-side\.ask \.book-row \.book-shares[^}]*text-align:\s*left/);
+  });
+
+  it("clips venue labels with ellipsis instead of letting them paint into the size column", () => {
+    expect(css).toMatch(/\.book-row \.book-mkt[^}]*overflow:\s*hidden/);
+    expect(css).toMatch(/\.book-venue-lead[^}]*min-width:\s*0/);
+  });
+
+  it("clips colhead labels so MARKET and SHARES cannot concatenate", () => {
+    expect(css).toMatch(/\.book-colhead > span[^}]*overflow:\s*hidden/);
+    expect(css).toMatch(/\.book-colhead > span[^}]*text-overflow:\s*ellipsis/);
+  });
+});

--- a/web/tests/depth-book-render.test.tsx
+++ b/web/tests/depth-book-render.test.tsx
@@ -369,6 +369,27 @@ describe("Time & Sales tape wiring", () => {
   });
 });
 
+describe("Ask-side SHARES header sits toward the price, not the venue", () => {
+  it("does not right-align the ask size header into MARKET", () => {
+    const book: DepthBook = {
+      ...STOCK_BOOK,
+      ask: [
+        { price: 105.24, size: 195, marketMaker: "DRCTEDARK", exchange: "SMART" },
+        { price: 105.25, size: 105, marketMaker: "IEXG", exchange: "SMART" },
+      ],
+    };
+    const { container } = renderBook(book, "stock");
+    const askHead = [...container.querySelectorAll(".book-side.ask .book-colhead > span")];
+    expect(askHead.map((el) => el.textContent)).toEqual(["Ask", "Shares", "Market"]);
+    expect(askHead[1].classList.contains("r")).toBe(false);
+    expect(askHead[2].classList.contains("r")).toBe(true);
+
+    const askRow = container.querySelector(".book-side.ask .book-row")!;
+    expect(askRow.querySelector(".book-shares")?.textContent).toBe("195");
+    expect(askRow.querySelector(".book-mkt")?.textContent).toBe("DRCTEDARK");
+  });
+});
+
 describe("Brand tokens only — no raw hex / tailwind color utilities", () => {
   it("emits no raw hex colors or green-500/red-500 in the rendered markup", () => {
     const { container } = renderBook(STOCK_BOOK, "stock");


### PR DESCRIPTION
## What broke

On the stock/option two-sided montage, a long MPID on the inside ask rendered as `195DRCTED...`. SHARES and MARKET had no column-gap, ask size was `1fr` right-aligned, and MARKET was a fixed 52px cell, so `DRCTEDARK` overflowed left into the size.

Bid side hid the same squeeze: extra space sat between the venue and a right-aligned size hugging the bid.

## Changes

- Market is the flexible column (`minmax(0, 1.15fr)`) with overflow ellipsis.
- Size hugs the price: bid right-aligned, ask left-aligned. Ask SHARES header is no longer `.r`.
- 8px desktop / 6px mobile `column-gap`. Colhead labels clip instead of concatenating (`MARKETSHARES`).
- Venue `title` is always the full MPID.

## Verification

- Vitest: `book-montage-spacing`, `depth-book-render`, `mobile-book-legibility`, `click-to-fill`, `book-tab-l1-bbo-montage`, `synthetic-combo-book-render` — 41 passed, 0 failed.
- Playwright: ask size vs `DRCTEDARK` gap >= 6px at 520px and 360px montage widths.
- Visual: `195` and `DRCTEDARK` are separate cells.