### PR TITLE
fix(orders): treat IB 202 as cancel confirmation on combo replace

### DIFF
--- a/docs/incident-runbook.md
+++ b/docs/incident-runbook.md
@@ -21,6 +21,38 @@ each artifact's `case_id` anchors into this file. Triage them with the
 
 ---
 
+## combo-replace-ib-202-cancel
+
+**Combo modify cancel-replace treats IB error 202 as a failed cancel and never
+places the replacement.** Peak incident: 2026-09-04, `/orders` modify of a
+working BAG. Toast: `Replacement incomplete during cancellation` /
+`Cancelled: none reported` / `IB error 202: Order Canceled - reason:`. IBKR
+Mobile later pushed that the original was cancelled.
+
+- **Mechanism:** Combo modify always cancel-then-places. `ib_order_manage.cancel_order`
+  waits 5s for the order to leave the book. IB 202 ("Order Canceled - reason:")
+  is the cancel confirmation, not a reject. If the BAG stays `PendingCancel`
+  past the poll, the subprocess exits 1. `_extract_error_message` prefers the
+  last stderr line (`IB error 202: …`) over the JSON timeout. `/orders/replace`
+  then wraps that as `REPLACE_PARTIAL` / `phase=cancellation` with
+  `cancelled=[]` and skips `_orders_place_after_rate_reservation`. Original
+  gone at IB; replacement never transmitted.
+- **Detection:** `/orders` error toast with `replacementOrderRef=radon-replace-`
+  plus `IB error 202`; IBKR push "order cancelled"; open-order snapshot missing
+  the row and no new working replacement.
+- **Discriminating check:** `cancel_order` with errorEvent 202 while the
+  snapshot is still `PendingCancel` must return `status=ok`. `POST /orders/replace`
+  whose cancel step raises `IB error 202` must still call place. A 201 / already
+  Filled cancel must not place.
+- **Fix:** treat 202 as cancel confirmation in `ib_order_manage.cancel_order`;
+  `/orders/replace` records 202 / already-Cancelled as cancelled and continues
+  to place. Already-Filled stays a hard abort.
+- **Regression:**
+  `scripts/tests/test_ib_order_manage.py::TestCancelOrder::test_cancel_succeeds_when_ib_202_arrives_while_order_still_working`,
+  `scripts/api/tests/test_order_replace_state_machine.py::test_replace_treats_ib_202_cancel_as_confirmed_and_places`.
+- **Code:** `scripts/ib_order_manage.py`, `scripts/api/server.py`
+  (`_cancel_already_confirmed`, `_orders_replace_after_rate_reservation`).
+
 ## turso-destroy-storm
 
 **undici Agent destroy storm / Turso per-IP socket exhaustion.**

--- a/scripts/api/server.py
+++ b/scripts/api/server.py
@@ -3089,6 +3089,40 @@ async def orders_replace(request: Request):
         _consume_order_rate_reservation(reserved_ref)
 
 
+_CANCEL_ALREADY_CONFIRMED_MARKERS = (
+    "ib error 202",
+    "order canceled",  # IB spelling of error 202
+    "already cancelled",
+    "already apicancelled",
+)
+
+
+def _cancel_already_confirmed(detail: object) -> bool:
+    """True when a cancel HTTP error means the working order is already gone.
+
+    IB error 202 is the cancel confirmation, not a reject. Combo replace used
+    to abort on it with cancelled=[] and skip the replacement, leaving the
+    position unhedged. Filled / not-found stay failures so we do not place
+    a second ticket on top of an execution.
+    """
+    if isinstance(detail, dict):
+        code = detail.get("ib_error_code")
+        if code == 202 or str(code) == "202":
+            return True
+        text = str(
+            detail.get("message")
+            or detail.get("error")
+            or detail.get("detail")
+            or detail
+        )
+    else:
+        text = str(detail or "")
+    lowered = text.lower()
+    if "already filled" in lowered:
+        return False
+    return any(marker in lowered for marker in _CANCEL_ALREADY_CONFIRMED_MARKERS)
+
+
 async def _orders_replace_after_rate_reservation(cancel_orders, replacement):
     """Body of /orders/replace after the per-minute slot is reserved."""
     # Complete every non-transmitting validation before the first cancellation.
@@ -3102,7 +3136,17 @@ async def _orders_replace_after_rate_reservation(cancel_orders, replacement):
     cancelled = []
     try:
         for target in cancel_orders:
-            result = await orders_cancel(_internal_json_request(target))
+            try:
+                result = await orders_cancel(_internal_json_request(target))
+            except HTTPException as cancel_exc:
+                if not _cancel_already_confirmed(cancel_exc.detail):
+                    raise
+                cancelled.append({
+                    "orderId": target.get("orderId"),
+                    "permId": target.get("permId"),
+                    "status": "Cancelled",
+                })
+                continue
             cancelled.append({
                 "orderId": target.get("orderId"),
                 "permId": target.get("permId"),

--- a/scripts/api/tests/test_order_replace_state_machine.py
+++ b/scripts/api/tests/test_order_replace_state_machine.py
@@ -21,6 +21,39 @@ def trusted_client(monkeypatch, tmp_path):
         server._order_rate_timestamps.clear()
 
 
+class TestCancelAlreadyConfirmed:
+    def test_ib_202_string(self):
+        from scripts.api.server import _cancel_already_confirmed
+
+        assert _cancel_already_confirmed("IB error 202: Order Canceled - reason:")
+
+    def test_ib_202_structured_code(self):
+        from scripts.api.server import _cancel_already_confirmed
+
+        assert _cancel_already_confirmed({
+            "ib_error_code": 202,
+            "ib_error_text": "Order Canceled - reason:",
+            "message": "Order Cancelled — IB error 202: Order Canceled - reason:",
+        })
+
+    def test_already_cancelled(self):
+        from scripts.api.server import _cancel_already_confirmed
+
+        assert _cancel_already_confirmed("Order already Cancelled — cannot cancel")
+
+    def test_filled_is_not_confirmed_cancel(self):
+        from scripts.api.server import _cancel_already_confirmed
+
+        assert not _cancel_already_confirmed("Order already Filled — cannot cancel")
+
+    def test_not_found_is_not_confirmed_cancel(self):
+        from scripts.api.server import _cancel_already_confirmed
+
+        assert not _cancel_already_confirmed(
+            "IB rejected cancel: OrderId that needs to be cancelled is not found"
+        )
+
+
 def _replacement():
     return {
         "type": "combo", "symbol": "SPX", "action": "BUY", "quantity": 1,
@@ -196,3 +229,131 @@ class TestReplaceReservesRateBudgetBeforeCancelling:
 
         assert response.status_code == 200
         cancel.assert_awaited_once()
+
+
+def test_replace_treats_ib_202_cancel_as_confirmed_and_places(trusted_client, monkeypatch):
+    """IB 202 during cancel means the original is already gone.
+
+    The 2026-09-04 combo modify toasted REPLACE_PARTIAL / phase=cancellation
+    with cancelled=[] and never placed. IB later pushed that the order was
+    cancelled. A 202 (or already-Cancelled) from cancel must not abort the
+    replacement.
+    """
+    from scripts.api import server
+
+    monkeypatch.setattr(server, "orders_whatif", AsyncMock(return_value={"status": "ok"}))
+    monkeypatch.setattr(
+        server,
+        "orders_cancel",
+        AsyncMock(side_effect=HTTPException(
+            status_code=502,
+            detail="IB error 202: Order Canceled - reason:",
+        )),
+    )
+    place = AsyncMock(return_value={"status": "ok", "orderId": 99})
+    monkeypatch.setattr(server, "_orders_place_after_rate_reservation", place)
+    server._order_rate_timestamps.clear()
+
+    try:
+        response = trusted_client.post("/orders/replace", json={
+            "cancelOrders": [{"orderId": 10}],
+            "replaceOrder": _replacement(),
+        })
+    finally:
+        server._order_rate_timestamps.clear()
+
+    assert response.status_code == 200
+    place.assert_awaited_once()
+    body = response.json()
+    assert body["cancelled"] == [{"orderId": 10, "permId": None, "status": "Cancelled"}]
+    assert body["orderId"] == 99
+
+
+def test_replace_treats_already_cancelled_as_confirmed_and_places(trusted_client, monkeypatch):
+    from scripts.api import server
+
+    monkeypatch.setattr(server, "orders_whatif", AsyncMock(return_value={"status": "ok"}))
+    monkeypatch.setattr(
+        server,
+        "orders_cancel",
+        AsyncMock(side_effect=HTTPException(
+            status_code=502,
+            detail="Order already Cancelled — cannot cancel",
+        )),
+    )
+    place = AsyncMock(return_value={"status": "ok", "orderId": 8})
+    monkeypatch.setattr(server, "_orders_place_after_rate_reservation", place)
+    server._order_rate_timestamps.clear()
+
+    try:
+        response = trusted_client.post("/orders/replace", json={
+            "cancelOrders": [{"orderId": 10, "permId": 44}],
+            "replaceOrder": _replacement(),
+        })
+    finally:
+        server._order_rate_timestamps.clear()
+
+    assert response.status_code == 200
+    place.assert_awaited_once()
+    assert response.json()["cancelled"][0]["status"] == "Cancelled"
+
+
+def test_replace_still_aborts_on_real_cancel_reject(trusted_client, monkeypatch):
+    from scripts.api import server
+
+    monkeypatch.setattr(server, "orders_whatif", AsyncMock(return_value={"status": "ok"}))
+    place = AsyncMock(return_value={"status": "ok", "orderId": 1})
+    monkeypatch.setattr(
+        server,
+        "orders_cancel",
+        AsyncMock(side_effect=HTTPException(
+            status_code=502,
+            detail="IB rejected cancel: OrderId that needs to be cancelled is not found",
+        )),
+    )
+    monkeypatch.setattr(server, "_orders_place_after_rate_reservation", place)
+    server._order_rate_timestamps.clear()
+
+    try:
+        response = trusted_client.post("/orders/replace", json={
+            "cancelOrders": [{"orderId": 10}],
+            "replaceOrder": _replacement(),
+        })
+    finally:
+        server._order_rate_timestamps.clear()
+
+    assert response.status_code == 502
+    place.assert_not_awaited()
+    detail = response.json()["detail"]
+    assert detail["code"] == "REPLACE_PARTIAL"
+    assert detail["phase"] == "cancellation"
+    assert detail["cancelled"] == []
+
+
+def test_replace_does_not_place_when_original_already_filled(trusted_client, monkeypatch):
+    from scripts.api import server
+
+    monkeypatch.setattr(server, "orders_whatif", AsyncMock(return_value={"status": "ok"}))
+    place = AsyncMock(return_value={"status": "ok", "orderId": 1})
+    monkeypatch.setattr(
+        server,
+        "orders_cancel",
+        AsyncMock(side_effect=HTTPException(
+            status_code=502,
+            detail="Order already Filled — cannot cancel",
+        )),
+    )
+    monkeypatch.setattr(server, "_orders_place_after_rate_reservation", place)
+    server._order_rate_timestamps.clear()
+
+    try:
+        response = trusted_client.post("/orders/replace", json={
+            "cancelOrders": [{"orderId": 10}],
+            "replaceOrder": _replacement(),
+        })
+    finally:
+        server._order_rate_timestamps.clear()
+
+    assert response.status_code == 502
+    place.assert_not_awaited()
+    assert response.json()["detail"]["cancelled"] == []

--- a/scripts/ib_order_manage.py
+++ b/scripts/ib_order_manage.py
@@ -153,10 +153,27 @@ def cancel_order(client: IBClient, order_id: int, perm_id: int,
                 finalStatus=refreshed_trade.orderStatus.status,
             )
 
-        # Check for fatal errors (10147=order not found, 201=rejected)
+        # 10147/201 are real rejects. 202 ("Order Canceled - reason:") is IB's
+        # cancel confirmation — treating it as fatal left combo replacements
+        # unplaced after the original was already gone at the broker.
         fatal = [e for e in error_msgs if e[0] in (10147, 201)]
         if fatal:
             finish("error", f"IB rejected cancel: {fatal[0][1]}")
+        if any(code == 202 for code, _ in error_msgs):
+            finish(
+                "ok",
+                f"Order cancelled (orderId={trade.order.orderId})",
+                orderId=trade.order.orderId,
+                finalStatus="Cancelled",
+            )
+
+    if any(code == 202 for code, _ in error_msgs):
+        finish(
+            "ok",
+            f"Order cancelled (orderId={trade.order.orderId})",
+            orderId=trade.order.orderId,
+            finalStatus="Cancelled",
+        )
 
     final_status = latest_trade.orderStatus.status if latest_trade is not None else trade.orderStatus.status
     finish("error", f"Cancel failed — order still {final_status}",

--- a/scripts/tests/test_ib_order_manage.py
+++ b/scripts/tests/test_ib_order_manage.py
@@ -29,6 +29,25 @@ def make_trade(order_id=10, perm_id=12345, status="Submitted", order_type="LMT",
     return trade
 
 
+class ErrorBus:
+    """Minimal ib_insync-style event so tests can fire errorEvent handlers."""
+
+    def __init__(self):
+        self._handlers = []
+
+    def __iadd__(self, handler):
+        self._handlers.append(handler)
+        return self
+
+    def __isub__(self, handler):
+        self._handlers = [h for h in self._handlers if h is not handler]
+        return self
+
+    def emit(self, req_id, error_code, error_string, extra=""):
+        for handler in list(self._handlers):
+            handler(req_id, error_code, error_string, extra)
+
+
 def make_client(trades=None):
     client = MagicMock()
     client.get_open_orders.return_value = trades or []
@@ -36,6 +55,7 @@ def make_client(trades=None):
     # Expose ib property for error event handling and clientId access
     client.ib = MagicMock()
     client.ib.client.clientId = 0
+    client.ib.errorEvent = ErrorBus()
     return client
 
 
@@ -203,6 +223,70 @@ class TestCancelOrder:
         data = json.loads(captured.out)
         assert data["status"] == "ok"
         assert data["finalStatus"] == "Cancelled"
+
+    def test_cancel_succeeds_when_ib_202_arrives_while_order_still_working(self, capsys):
+        """IB error 202 is the cancel confirmation, not a rejection.
+
+        Combo replace cancelled the BAG, got 202 while the snapshot still
+        showed WORKING/PendingCancel, treated that as failure, and never
+        placed the replacement. IB later pushed that the order was cancelled.
+        """
+        t = make_trade(status="Submitted")
+        t.order.clientId = 0
+        client = make_client([t])
+        client.ib.client.clientId = 0
+
+        def side_effect(order):
+            t.orderStatus.status = "PendingCancel"
+            client.ib.errorEvent.emit(
+                order.orderId, 202, "Order Canceled - reason:",
+            )
+
+        client.cancel_order = MagicMock(side_effect=side_effect)
+
+        with pytest.raises(SystemExit) as exc:
+            cancel_order(client, 10, 12345, "127.0.0.1", 4001)
+        assert exc.value.code == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["status"] == "ok"
+        assert data["finalStatus"] == "Cancelled"
+
+    def test_cancel_succeeds_on_broadcast_202(self, capsys):
+        t = make_trade(status="Submitted")
+        t.order.clientId = 0
+        client = make_client([t])
+        client.ib.client.clientId = 0
+
+        def side_effect(order):
+            client.ib.errorEvent.emit(-1, 202, "Order Canceled - reason:")
+
+        client.cancel_order = MagicMock(side_effect=side_effect)
+
+        with pytest.raises(SystemExit) as exc:
+            cancel_order(client, 10, 12345, "127.0.0.1", 4001)
+        assert exc.value.code == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["status"] == "ok"
+
+    def test_cancel_still_errors_on_201_reject(self, capsys):
+        t = make_trade(status="Submitted")
+        t.order.clientId = 0
+        client = make_client([t])
+        client.ib.client.clientId = 0
+
+        def side_effect(order):
+            client.ib.errorEvent.emit(
+                order.orderId, 201, "Order rejected - reason: cannot cancel",
+            )
+
+        client.cancel_order = MagicMock(side_effect=side_effect)
+
+        with pytest.raises(SystemExit) as exc:
+            cancel_order(client, 10, 12345, "127.0.0.1", 4001)
+        assert exc.value.code == 1
+        data = json.loads(capsys.readouterr().out)
+        assert data["status"] == "error"
+        assert "cannot cancel" in data["message"]
 
 
 # ─── modify_order ───────────────────────────────────────

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,16 @@
 # Lessons
 
+## 2026-09-04 — IB error 202 is cancel confirmation, not a replace abort
+
+- IB error 202 (`Order Canceled - reason:`) is the broker's cancel
+  acknowledgement. On `/orders/replace` it must count as cancelled and the
+  replacement must still place. Treating it as a failed cancel leaves the
+  original gone and the position unhedged.
+- Do not wait for the open-order snapshot to drop a BAG before accepting 202.
+  Combo cancels can sit in `PendingCancel` longer than the 5s poll, then IBKR
+  Mobile pushes the cancel after Radon has already aborted the replacement.
+- Already-Filled is not 202. Do not place a replacement on top of a fill.
+
 ## 2026-09-04 — Close-order P&L must include dollars and percent
 
 - Every close or modify confirmation that renders estimated realized P&L must

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,27 @@
+# Task: Combo replace IB 202 cancel abort (2026-09-04) [DONE]
+
+Combo modify treated IB error 202 as a failed cancel, skipped the replacement,
+and left the original cancelled at IB.
+
+## Dependency graph
+
+- T1 depends_on: [] - Reproduce: cancel 202 while BAG still PendingCancel; replace aborts with cancelled=[].
+- T2 depends_on: [T1] - Fail then fix cancel_order 202 confirmation and replace continue-to-place.
+- T3 depends_on: [T2] - Pin already-Filled does not place; run focused plus full gates.
+
+## Checklist
+
+- [x] T1 Red tests for cancel 202 and replace 202.
+- [x] T2 cancel_order + `_cancel_already_confirmed` + replace loop.
+- [x] T3 Focused green; runbook case `combo-replace-ib-202-cancel`.
+
+## Review
+
+- IB 202 is cancel confirmation. Replace now records it cancelled and places.
+- Already-Filled still aborts without placing.
+
+---
+
 # Task: Restore modify-order P&L percentage (2026-09-04) [DONE]
 
 Ensure order modification confirmation shows estimated realized P&L as both a


### PR DESCRIPTION
## Summary

Combo modify on `/orders` cancel-then-places. IB error 202 (`Order Canceled - reason:`) is the broker's cancel acknowledgement, not a reject. The 5s poll still saw `PendingCancel`, `/orders/replace` aborted with `cancelled=[]` / `phase=cancellation`, and the replacement never transmitted. IBKR Mobile later pushed that the original was cancelled, leaving the position unhedged.

## Fix

- `ib_order_manage.cancel_order` treats error 202 as cancel confirmation even if the snapshot still shows WORKING / `PendingCancel`.
- `/orders/replace` records 202 / already-Cancelled as cancelled and still places.
- Already-Filled stays a hard abort so a fill is not doubled.

## Test plan

- [x] Red: cancel 202 while BAG still `PendingCancel` exited 1; replace 202 returned 502 and skipped place.
- [x] Green: `python3.13 -m pytest scripts/tests/test_ib_order_manage.py scripts/api/tests/test_order_replace_state_machine.py -q` → **46 passed**.
- [x] Already-Filled / 201 still abort without placing.
- Focused order-path extras 79 passed. Full pytest 11212 passed with 26 unrelated credential/scan-gate baseline failures. Full Vitest 8648 passed after restoring leaked WIP (`formatSignedPercent`); 4 untracked montage tests excluded.

## Runbook

New case `combo-replace-ib-202-cancel` in `docs/incident-runbook.md`.