### PR TITLE
fix(web): show P&L percentage on order modification

### DIFF
--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,12 @@
 # Lessons
 
+## 2026-09-04 — Close-order P&L must include dollars and percent
+
+- Every close or modify confirmation that renders estimated realized P&L must
+  show both the signed dollar amount and return on absolute signed entry basis.
+- Pin this at the shared `OrderConfirmSummary` boundary and in the modify-order
+  browser path, including option, combo, stock-cover, loss, and missing-basis cases.
+
 ## 2026-09-03 — Assistant identity is Radon, not a provider model
 
 - User-facing assistant speaker labels and generated self-identification must

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,32 @@
+# Task: Restore modify-order P&L percentage (2026-09-04) [DONE]
+
+Ensure order modification confirmation shows estimated realized P&L as both a
+dollar amount and percentage, using the shared order-risk convention.
+
+## Dependency graph
+
+- T1 depends_on: [] - Trace the modify-order data path and reproduce the missing P&L percentage in unit and browser coverage.
+- T2 depends_on: [T1] - Add failing regressions for signed dollar and percentage output across option, combo, and stock-close modifications.
+- T3 depends_on: [T2] - Implement the smallest shared-summary fix without bypassing `useOrderRisk` or hand-building risk data.
+- T4 depends_on: [T3] - Run focused Vitest, relevant Playwright, and visual desktop verification against the reported surface.
+- T5 depends_on: [T4] - Run the full web suite, typecheck, lint, diff review, and document evidence.
+
+## Checklist
+
+- [x] T1 Trace the defect.
+- [x] T2 Re-establish red regression coverage.
+- [x] T3 Implement the shared fix.
+- [x] T4 Complete focused and visual verification.
+- [x] T5 Complete full verification and review.
+
+## Review
+
+- Modify confirmation now renders signed dollar P&L plus a signed one-decimal return on absolute entry basis for option, combo, partial-close, and stock-cover orders.
+- Zero or unavailable basis preserves the dollar estimate without inventing a percentage; mixed basis remains unavailable.
+- Verification: 8,173 Vitest tests passed, 2 focused Chromium tests passed, TypeScript passed, ESLint reported 0 errors and 17 pre-existing warnings, and the combo summary screenshot was visually inspected.
+
+---
+
 # Task: Require PR CI supervision and green notification (2026-09-03) [DONE]
 
 ## Dependency graph

--- a/web/components/ModifyOrderModal.tsx
+++ b/web/components/ModifyOrderModal.tsx
@@ -462,11 +462,9 @@ export default function ModifyOrderModal({ order, loading, prices, portfolio, op
         heldQuantity: heldLong,
         heldShortQuantity: heldShort,
         description: `${action} ${parsedQtyLocal} ${symbol} @ ${fmtPrice(parsedNewLocal)}`,
-        closeOut: closingLong
+        closeOut: closingLong || closingShort
           ? { entryCostDollars: parsedQtyLocal * Math.abs(basisPerShare) }
-          : closingShort
-            ? { entryCostDollars: -parsedQtyLocal * Math.abs(basisPerShare) }
-            : undefined,
+          : undefined,
       };
     }
     if (order.contract.secType !== "OPT") return null;

--- a/web/e2e/modify-combo-order.spec.ts
+++ b/web/e2e/modify-combo-order.spec.ts
@@ -453,9 +453,11 @@ test.describe("Combo order modify flow", () => {
     await expect(summary).toContainText("$40,000");
     await expect(summary).toContainText("Est. Realized P&L:");
     await expect(summary).toContainText("$15,000");
+    await expect(summary.getByTestId("order-confirm-estimated-pnl")).toContainText("(+60.0%)");
     await expect(summary).not.toContainText("Max Gain:");
     await expect(summary).not.toContainText("Max Loss:");
     await modal.screenshot({ path: "test-results/modify-combo-close-pnl.png" });
+    await summary.screenshot({ path: "test-results/modify-combo-close-pnl-summary.png" });
   });
 
   test("shows signed negative risk reversal prices and submits a negative replacement limit", async ({ page }) => {

--- a/web/e2e/modify-order-confirmation.spec.ts
+++ b/web/e2e/modify-order-confirmation.spec.ts
@@ -164,7 +164,7 @@ test.describe("Order modify confirmation", () => {
     await expect(modal).toBeVisible();
     await modal.locator("#modify-price-input").fill("5.55");
     await expect(modal).toContainText("Est. Realized P&L:");
-    await expect(modal).toContainText("$2,750");
+    await expect(modal.getByTestId("order-confirm-estimated-pnl")).toHaveText("$2,750 (+11.0%)");
     await modal.getByRole("button", { name: /modify order/i }).click();
 
     await expect(row).toContainText("$5.70");

--- a/web/lib/order/components/OrderConfirmSummary.tsx
+++ b/web/lib/order/components/OrderConfirmSummary.tsx
@@ -51,6 +51,15 @@ function formatCurrency(value: number | null | undefined): string {
   }).format(value);
 }
 
+function formatSignedPercent(value: number): string {
+  const normalized = Object.is(value, -0) ? 0 : value;
+  const formatted = new Intl.NumberFormat("en-US", {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  }).format(normalized);
+  return `${normalized >= 0 ? "+" : ""}${formatted}%`;
+}
+
 function formatPrice(value: number | null | undefined): string {
   if (value == null) return "---";
   return `$${value.toFixed(2)}`;
@@ -271,8 +280,16 @@ export function OrderConfirmSummary({
         {summary.estimatedPnl != null && (
           <span className="order-confirm-metric">
             <span className="order-confirm-metric-label">{summary.estimatedPnlLabel ?? "Est. P&L:"}</span>
-            <span className={`order-confirm-metric-value ${summary.estimatedPnl >= 0 ? "order-confirm-positive" : "order-confirm-negative"}`}>
-              {formatCurrency(summary.estimatedPnl)}
+            <span
+              className={`order-confirm-metric-value ${summary.estimatedPnl >= 0 ? "order-confirm-positive" : "order-confirm-negative"}`}
+              data-testid="order-confirm-estimated-pnl"
+            >
+              <span>{formatCurrency(summary.estimatedPnl)}</span>
+              {summary.estimatedPnlPct != null && (
+                <span className="order-confirm-pnl-percent">
+                  {` (${formatSignedPercent(summary.estimatedPnlPct)})`}
+                </span>
+              )}
             </span>
           </span>
         )}

--- a/web/lib/order/risk/useOrderRisk.ts
+++ b/web/lib/order/risk/useOrderRisk.ts
@@ -310,6 +310,7 @@ function summaryFiguresAreFinite(summary: OrderPresentationSummary): boolean {
     summary.maxLoss,
     summary.breakeven,
     summary.estimatedPnl,
+    summary.estimatedPnlPct,
     summary.marginImpact?.requirement,
     summary.marginImpact?.availableBefore,
     summary.marginImpact?.availableAfter,
@@ -317,6 +318,23 @@ function summaryFiguresAreFinite(summary: OrderPresentationSummary): boolean {
   return figures.every(
     (value) => typeof value !== "number" || Number.isFinite(value),
   );
+}
+
+function estimatedPnlPct(
+  pnl: number | null,
+  entryCostDollars: number | null,
+): number | null {
+  if (
+    pnl == null
+    || entryCostDollars == null
+    || !Number.isFinite(pnl)
+    || !Number.isFinite(entryCostDollars)
+    || Math.abs(entryCostDollars) === 0
+  ) {
+    return null;
+  }
+
+  return (pnl / Math.abs(entryCostDollars)) * 100;
 }
 
 
@@ -727,6 +745,7 @@ export function useOrderRisk(
               ? "Proceeds:"
               : "Cost to Cover:",
           estimatedPnl: pnl,
+          estimatedPnlPct: estimatedPnlPct(pnl, basis),
           estimatedPnlLabel: input.closeOut.estimatedPnlLabel ?? "Est. Realized P&L:",
           maxLossUnbounded: hasPostCloseUndefinedRisk ? true : undefined,
           undefinedRiskReason: postCloseUndefinedRiskReason,
@@ -821,6 +840,7 @@ export function useOrderRisk(
         totalCost: Math.abs(proceeds),
         totalLabel: opt.totalLabel ?? (proceeds >= 0 ? "Close Credit:" : "Close Debit:"),
         estimatedPnl: pnl,
+        estimatedPnlPct: estimatedPnlPct(pnl, basis),
         estimatedPnlLabel: opt.closeOut.estimatedPnlLabel ?? "Est. Realized P&L:",
         maxLossUnbounded: residualRisk?.unbounded || undefined,
         undefinedRiskReason: residualRisk?.reason ?? null,

--- a/web/lib/order/types.ts
+++ b/web/lib/order/types.ts
@@ -90,6 +90,8 @@ export interface OrderPresentationSummary {
   undefinedRiskReason?: string | null;
   breakeven?: number | null;  // For options/spreads
   estimatedPnl?: number | null;
+  /** Estimated realized P&L divided by the absolute signed entry basis. */
+  estimatedPnlPct?: number | null;
   estimatedPnlLabel?: string;
   /**
    * Phase-1 margin-impact estimate. Optional/nullable so existing producers

--- a/web/tests/modify-order-close-pnl.test.tsx
+++ b/web/tests/modify-order-close-pnl.test.tsx
@@ -47,6 +47,25 @@ function optionOrder(action: "BUY" | "SELL", quantity: number, limitPrice: numbe
   };
 }
 
+function stockOrder(action: "BUY" | "SELL", quantity: number, limitPrice: number): OpenOrder {
+  return {
+    orderId: 96,
+    permId: action === "BUY" ? 653624859 : 653624860,
+    symbol: "SNDK",
+    contract: { conId: 123456, symbol: "SNDK", secType: "STK" },
+    action,
+    orderType: "LMT",
+    totalQuantity: quantity,
+    limitPrice,
+    auxPrice: null,
+    status: "Submitted",
+    filled: 0,
+    remaining: quantity,
+    avgFillPrice: null,
+    tif: "DAY",
+  };
+}
+
 function portfolioWithLeg(direction: "LONG" | "SHORT", contracts: number, avgCost: number): PortfolioData {
   const position: PortfolioPosition = {
     id: 1,
@@ -101,6 +120,31 @@ function portfolioWithLeg(direction: "LONG" | "SHORT", contracts: number, avgCos
       dividends: 0,
     },
   };
+}
+
+function portfolioWithShortStock(shares: number, avgCost: number): PortfolioData {
+  const portfolio = portfolioWithLeg("SHORT", shares, avgCost);
+  portfolio.positions = [{
+    ...portfolio.positions[0],
+    structure: "Short Stock",
+    structure_type: "Stock",
+    risk_profile: "Undefined",
+    expiry: "",
+    contracts: shares,
+    direction: "SHORT",
+    entry_cost: -(shares * avgCost),
+    legs: [{
+      direction: "SHORT",
+      contracts: shares,
+      type: "Stock",
+      strike: 0,
+      entry_cost: -(shares * avgCost),
+      avg_cost: avgCost,
+      market_price: null,
+      market_value: null,
+    }],
+  }];
+  return portfolio;
 }
 
 function renderModifiedOrder(order: OpenOrder, portfolio: PortfolioData, price: string) {
@@ -165,6 +209,7 @@ describe("ModifyOrderModal close-out P&L", () => {
     expect(summary.getByText("$38,000")).toBeTruthy();
     expect(summary.getByText("Est. Realized P&L:")).toBeTruthy();
     expect(summary.getByText("$535")).toBeTruthy();
+    expect(summary.getByTestId("order-confirm-estimated-pnl").textContent).toBe("$535 (+1.4%)");
     expect(summary.queryByText("Max Gain:")).toBeNull();
     expect(summary.queryByText("Max Loss:")).toBeNull();
   });
@@ -180,6 +225,38 @@ describe("ModifyOrderModal close-out P&L", () => {
     expect(summary.getByText("$800")).toBeTruthy();
     expect(summary.getByText("Est. Realized P&L:")).toBeTruthy();
     expect(summary.getByText("$200")).toBeTruthy();
+    expect(summary.getByTestId("order-confirm-estimated-pnl").textContent).toBe("$200 (+20.0%)");
+  });
+
+  it("shows a signed negative percentage when the modified close realizes a loss", () => {
+    const summary = renderModifiedOrder(
+      optionOrder("SELL", 4, 100),
+      portfolioWithLeg("LONG", 4, 9_366.25),
+      "90",
+    );
+
+    expect(summary.getByTestId("order-confirm-estimated-pnl").textContent).toBe("-$1,465 (-3.9%)");
+  });
+
+  it("shows the correct positive percentage when modifying a buy-to-cover stock order", () => {
+    const summary = renderModifiedOrder(
+      stockOrder("BUY", 100, 55),
+      portfolioWithShortStock(100, 60),
+      "50",
+    );
+
+    expect(summary.getByText("Cost to Cover:")).toBeTruthy();
+    expect(summary.getByTestId("order-confirm-estimated-pnl").textContent).toBe("$1,000 (+16.7%)");
+  });
+
+  it("omits the percentage when the signed entry basis is zero", () => {
+    const summary = renderModifiedOrder(
+      optionOrder("SELL", 4, 100),
+      portfolioWithLeg("LONG", 4, 0),
+      "95",
+    );
+
+    expect(summary.getByTestId("order-confirm-estimated-pnl").textContent).toBe("$38,000");
   });
 
   it("does not classify quantity beyond the held contracts as a pure close", () => {
@@ -369,6 +446,7 @@ describe("ModifyOrderModal combo close-out P&L", () => {
     expect(summary.getByText("$40,000")).toBeTruthy();
     expect(summary.getByText("Est. Realized P&L:")).toBeTruthy();
     expect(summary.getByText("$15,000")).toBeTruthy();
+    expect(summary.getByTestId("order-confirm-estimated-pnl").textContent).toBe("$15,000 (+60.0%)");
     expect(summary.queryByText("Max Gain:")).toBeNull();
     expect(summary.queryByText("Max Loss:")).toBeNull();
     expect(summary.queryByText("$1,035,835")).toBeNull();
@@ -440,6 +518,7 @@ describe("ModifyOrderModal combo close-out P&L", () => {
     expect(summary.getByText("Close Credit:")).toBeTruthy();
     expect(summary.getByText("$20,000")).toBeTruthy();
     expect(summary.getByText("$7,500")).toBeTruthy();
+    expect(summary.getByTestId("order-confirm-estimated-pnl").textContent).toBe("$7,500 (+60.0%)");
     expect(summary.queryByText("Max Gain:")).toBeNull();
   });
 

--- a/web/tests/order-cost-quotes.test.tsx
+++ b/web/tests/order-cost-quotes.test.tsx
@@ -152,6 +152,19 @@ describe("useOrderRisk — limit fill is structural max, not quoted-spread net",
     // Close-out short-circuits: max-loss/max-gain are not present; estimatedPnl
     // = proceeds − basis is surfaced instead.
     expect(result.current!.summary.estimatedPnl).toBeCloseTo(200 - 150, 6);
+    expect(result.current!.summary.estimatedPnlPct).toBeCloseTo((50 / 150) * 100, 6);
+  });
+
+  it("omits close P&L percentage when entry basis is zero", () => {
+    const { result } = renderHook(() =>
+      useOrderRisk(
+        bullCallSpreadInput({ closeOut: { entryCostDollars: 0 } }),
+        emptyPortfolio,
+      ),
+    );
+
+    expect(result.current!.summary.estimatedPnl).toBe(200);
+    expect(result.current!.summary.estimatedPnlPct).toBeNull();
   });
 });
 

--- a/web/tests/order-risk-chokepoint.test.tsx
+++ b/web/tests/order-risk-chokepoint.test.tsx
@@ -124,6 +124,7 @@ describe("useOrderRisk — branded output contract", () => {
     const { result } = renderHook(() => useOrderRisk(closeInput, emptyPortfolio));
     expect(result.current!.summary.totalLabel).toMatch(/Close Credit/);
     expect(result.current!.summary.estimatedPnl).toBe(1_400); // $1,900 − $500
+    expect(result.current!.summary.estimatedPnlPct).toBe(280);
     expect(result.current!.summary.maxLoss).toBeUndefined();
     expect(result.current!.summary.maxGain).toBeUndefined();
     expect(result.current!.okToSubmit).toBe(true);

--- a/web/tests/order-risk-linear.test.tsx
+++ b/web/tests/order-risk-linear.test.tsx
@@ -202,6 +202,7 @@ describe("useOrderRisk — linear branch (stock)", () => {
     // Proceeds = 100 × 2.86 = 286; basis = 443; realised P&L = 286 - 443 = -157
     expect(result.current!.summary.totalCost).toBeCloseTo(286, 0);
     expect(result.current!.summary.estimatedPnl).toBeCloseTo(-157, 0);
+    expect(result.current!.summary.estimatedPnlPct).toBeCloseTo((-157 / 443) * 100, 6);
     expect(result.current!.okToSubmit).toBe(true);
   });
 
@@ -286,6 +287,7 @@ describe("useOrderRisk — linear branch (stock)", () => {
     expect(result.current!.summary.totalCost).toBe(5_000);
     expect(result.current!.summary.totalLabel).toMatch(/Cost to Cover/);
     expect(result.current!.summary.estimatedPnl).toBe(1_000);
+    expect(result.current!.summary.estimatedPnlPct).toBeCloseTo((1_000 / 6_000) * 100, 6);
   });
 });
 

--- a/web/tests/position-mixed-basis-refuses-aggregate.test.tsx
+++ b/web/tests/position-mixed-basis-refuses-aggregate.test.tsx
@@ -311,6 +311,7 @@ describe("close ticket carries no realised figure for a `mixed` position (T-315)
     const o = comboClose(MIXED);
     const { result } = renderHook(() => useOrderRisk(o.riskInput, portfolioOf(MIXED)));
     expect(result.current!.summary.estimatedPnl).toBeNull();
+    expect(result.current!.summary.estimatedPnlPct).toBeNull();
     expect(result.current!.okToSubmit).toBe(true);
     render(<OrderConfirmSummary summary={result.current!.summary} />);
     expect(document.body.textContent).not.toContain("Est. Realized P&L");


### PR DESCRIPTION
## Summary
- add signed estimated realized P&L percentage to the shared order confirmation summary
- calculate return from absolute signed entry basis across option, combo, partial-close, and linear close paths
- correct short-stock buy-to-cover basis polarity and preserve unavailable/zero-basis behavior

## Root cause
Prior close-order fixes carried estimated realized P&L dollars through `useOrderRisk`, but the shared presentation model and renderer had no percentage field. The modify-order regressions asserted dollars only, so the missing return remained unpinned.

## Verification
- `NODE_ENV=test ASSISTANT_MOCK=1 ./web/node_modules/.bin/vitest run --config vitest.config.ts web/tests` (8,173 passed)
- focused Vitest after rebase (89 passed)
- focused Chromium Playwright after rebase (2 passed)
- `npm run typecheck`
- `npm run lint` (0 errors, 17 existing warnings)
- visual screenshot confirmed `$15,000 (+60.0%)`