### PR TITLE
fix(api): pin demo-api.radon.run in the trusted-host list

### DIFF
--- a/docs/demo-environment.md
+++ b/docs/demo-environment.md
@@ -169,3 +169,28 @@ operator locks them out of `app.radon.run`. Affected users re-sign-up.
 
 **Set `PUSHOVER_TOKEN` / `PUSHOVER_USER` on the `radon-demo` Vercel project** to
 arm the provisioning alert; it no-ops silently while unset.
+
+### VM backend redeploy, 2026-09-04
+
+The demo VM was frozen at 2026-07-03 (~50 commits behind on `scripts/api`).
+Redeployed by shipping `scripts/ requirements.txt pyproject.toml` over ssh+tar
+to `/opt/radon-demo/app` and rebuilding (`docker compose build api && up -d`).
+`data/` on the VM is NOT shipped — it holds the copied `flow_reports/*.json`
+that the TEST_MODE per-ticker flow guard serves.
+
+Rollback: `radon-demo-api:rollback` (the pre-redeploy image) and
+`/opt/radon-demo/app.bak` are both kept on the VM.
+
+The redeploy surfaced one break: `TrustedHostMiddleware` gained a host pin
+after the VM's last deploy, and `demo-api.radon.run` was never on the list, so
+every proxied request returned `400 Invalid host header` while `127.0.0.1`
+health stayed 200. The host is now pinned in `scripts/api/server.py`
+`_ALLOWED_HOSTS` rather than left to `RADON_ALLOWED_HOSTS` on the VM, so a
+fresh VM cannot reproduce it. Pinned by
+`scripts/api/tests/test_loopback_browser_bypass.py`.
+
+Post-redeploy verification: `/health` 200 externally, `/health/lite` 401 without
+the service token and 200 with it, `POST /vcg/scan` and `/breadth/scan` 200 from
+the seeded snapshots, `RADON_API_TEST_MODE=1` confirmed in the running
+container, container `TURSO_DB_URL` on `radon-demo-joemccann`, no tailscale and
+no reachable IB port on any prod host.

--- a/scripts/api/server.py
+++ b/scripts/api/server.py
@@ -958,6 +958,10 @@ _ALLOWED_HOSTS = [
     "0.0.0.0",
     "app.radon.run",
     "demo.radon.run",
+    # The demo VM's FastAPI, reached by the Vercel frontend over the public
+    # proxy. Pinned in code, not left to RADON_ALLOWED_HOSTS on the VM: a fresh
+    # VM or a wiped .env otherwise 400s the entire demo backend silently.
+    "demo-api.radon.run",
     "ib-gateway",
     "*.ts.net",
 ] + parse_allowed_hosts_env(os.environ.get("RADON_ALLOWED_HOSTS", ""))

--- a/scripts/api/tests/test_loopback_browser_bypass.py
+++ b/scripts/api/tests/test_loopback_browser_bypass.py
@@ -240,6 +240,11 @@ class TestTrustedHostMiddleware:
                 assert "*" not in allowed, "Host pinning must not be a wildcard"
                 assert "app.radon.run" in allowed
                 assert "demo.radon.run" in allowed
+                # The demo VM's FastAPI answers on demo-api.radon.run behind
+                # Caddy. It was absent when the host pin shipped, so the demo
+                # backend returned "Invalid host header" (400) on every request
+                # the moment the VM was redeployed onto current code.
+                assert "demo-api.radon.run" in allowed
                 assert "beta.radon.run" not in allowed
                 return
         raise AssertionError("TrustedHostMiddleware not installed on app")


### PR DESCRIPTION
Redeploying the demo VM onto current code (it was frozen at 2026-07-03, ~50 commits behind on `scripts/api`) returned `400 Invalid host header` on every proxied request, while `127.0.0.1` health stayed 200.

`TrustedHostMiddleware` gained a host pin after the VM's last deploy. `_ALLOWED_HOSTS` carries `demo.radon.run` — the Vercel **frontend** — but never `demo-api.radon.run`, the backend host the demo VM actually answers on.

Pinned in code rather than left to `RADON_ALLOWED_HOSTS` on the VM. The env var is the documented extension point, but this is a first-party, code-reviewed name, and leaving it only in a VM `.env` means a fresh VM or a wiped file silently 400s the entire demo backend. The rule the list documents is "extending the pin is allowed; deleting it is not" — this extends it.

### Verified live after the fix

| Check | Result |
|---|---|
| `GET /health` externally | 200 |
| `GET /health/lite` no token / service token / wrong token | 401 / 200 / 401 |
| `POST /vcg/scan`, `POST /breadth/scan` | 200, served from the seeded snapshots |
| `RADON_API_TEST_MODE` in the running container | `1` |
| container `TURSO_DB_URL` | `radon-demo-joemccann` (not the prod marker) |
| tailscale on the VM | absent |
| TCP to `:4001` on `5.78.148.38`, `10.0.0.2`, `100.67.204.57` | all unreachable |

`scripts/api/tests`: **924 passed**.

Rollback for the VM redeploy itself is kept on the box: image `radon-demo-api:rollback` and `/opt/radon-demo/app.bak`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019UVmbs7twgwSmiUd8ECDeE
