### PR TITLE
feat(web): WebGL flow-mark on /demo-pending

### DIFF
--- a/web/app/demo-pending/DemoPendingLogo.tsx
+++ b/web/app/demo-pending/DemoPendingLogo.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useTheme } from "@/lib/ThemeContext";
+
+// Matches the resting size of the radon-monogram.svg brand mark
+// (web/public/brand/radon-monogram.svg) so the panel keeps the same
+// footprint whether the WebGL sketch renders or not.
+const SIZE = 72;
+
+const VERTEX_SRC = `
+attribute vec2 aPosition;
+void main() {
+  gl_Position = vec4(aPosition, 0.0, 1.0);
+}
+`;
+
+// Reprises the brand monogram's two concentric rings + orbiting flow mark
+// (web/public/brand/radon-monogram.svg) as a live sketch: a slow breathing
+// pulse on the rings and one signal orbiting the outer ring.
+const FRAGMENT_SRC = `
+precision mediump float;
+uniform vec2 uResolution;
+uniform float uTime;
+uniform vec3 uColorCore;
+uniform vec3 uColorAccent;
+
+void main() {
+  vec2 uv = (gl_FragCoord.xy - 0.5 * uResolution) / min(uResolution.x, uResolution.y);
+  float r = length(uv);
+  float breathe = 0.5 + 0.5 * sin(uTime * 1.2);
+
+  float ring1 = smoothstep(0.03, 0.0, abs(r - (0.32 + 0.015 * breathe)));
+  float ring2 = smoothstep(0.02, 0.0, abs(r - 0.20));
+
+  float angle = atan(uv.y, uv.x);
+  float orbitAngle = uTime * 1.4;
+  float delta = mod(angle - orbitAngle + 3.14159265, 6.2831853) - 3.14159265;
+  float orbit = smoothstep(0.4, 0.0, abs(delta)) * smoothstep(0.035, 0.0, abs(r - 0.32));
+
+  vec3 color = uColorCore * (ring1 * 0.85) + uColorAccent * (ring2 * 0.55 + orbit * 0.9);
+  float alpha = clamp(ring1 * 0.85 + ring2 * 0.55 + orbit, 0.0, 1.0);
+  gl_FragColor = vec4(color, alpha);
+}
+`;
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+function hexToRgb01(hex: string): [number, number, number] {
+  const clean = hex.trim().replace("#", "");
+  if (clean.length !== 6) return [0, 0, 0];
+  const num = parseInt(clean, 16);
+  return [((num >> 16) & 255) / 255, ((num >> 8) & 255) / 255, (num & 255) / 255];
+}
+
+function readThemeColor(name: string, fallback: string): [number, number, number] {
+  if (typeof document === "undefined") return hexToRgb01(fallback);
+  const value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  return hexToRgb01(value || fallback);
+}
+
+function compileShader(
+  gl: WebGLRenderingContext,
+  type: number,
+  source: string,
+): WebGLShader | null {
+  const shader = gl.createShader(type);
+  if (!shader) return null;
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    gl.deleteShader(shader);
+    return null;
+  }
+  return shader;
+}
+
+function createProgram(gl: WebGLRenderingContext): WebGLProgram | null {
+  const vertex = compileShader(gl, gl.VERTEX_SHADER, VERTEX_SRC);
+  const fragment = compileShader(gl, gl.FRAGMENT_SHADER, FRAGMENT_SRC);
+  if (!vertex || !fragment) return null;
+  const program = gl.createProgram();
+  if (!program) return null;
+  gl.attachShader(program, vertex);
+  gl.attachShader(program, fragment);
+  gl.linkProgram(program);
+  gl.deleteShader(vertex);
+  gl.deleteShader(fragment);
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    gl.deleteProgram(program);
+    return null;
+  }
+  return program;
+}
+
+function openWebGLContext(canvas: HTMLCanvasElement): WebGLRenderingContext | null {
+  try {
+    return (canvas.getContext("webgl") ||
+      canvas.getContext("experimental-webgl")) as WebGLRenderingContext | null;
+  } catch {
+    return null;
+  }
+}
+
+// Live WebGL sketch of the Radon monogram for the /demo-pending holding
+// page. Purely decorative on a public, unauthenticated leaf (see the
+// "/demo-pending perimeter" tests in demo-provisioning-resilience.test.ts)
+// — never the thing standing between a visitor and the page's content. A
+// visitor with no WebGL support, or prefers-reduced-motion set, gets the
+// mount point with nothing in it: the plain static card, unchanged.
+export default function DemoPendingLogo() {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const { theme } = useTheme();
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || prefersReducedMotion()) return;
+
+    const canvas = document.createElement("canvas");
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    canvas.width = SIZE * dpr;
+    canvas.height = SIZE * dpr;
+    canvas.style.width = `${SIZE}px`;
+    canvas.style.height = `${SIZE}px`;
+
+    const gl = openWebGLContext(canvas);
+    if (!gl) return;
+
+    const program = createProgram(gl);
+    if (!program) return;
+
+    const buffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1, -1, 3, -1, -1, 3]), gl.STATIC_DRAW);
+
+    const positionLoc = gl.getAttribLocation(program, "aPosition");
+    gl.enableVertexAttribArray(positionLoc);
+    gl.vertexAttribPointer(positionLoc, 2, gl.FLOAT, false, 0, 0);
+
+    const resolutionLoc = gl.getUniformLocation(program, "uResolution");
+    const timeLoc = gl.getUniformLocation(program, "uTime");
+    const coreLoc = gl.getUniformLocation(program, "uColorCore");
+    const accentLoc = gl.getUniformLocation(program, "uColorAccent");
+    const core = readThemeColor("--signal-core", "#05AD98");
+    const accent = readThemeColor("--extreme", "#9e80f6");
+
+    gl.useProgram(program);
+    gl.viewport(0, 0, canvas.width, canvas.height);
+    gl.uniform2f(resolutionLoc, canvas.width, canvas.height);
+    gl.uniform3f(coreLoc, core[0], core[1], core[2]);
+    gl.uniform3f(accentLoc, accent[0], accent[1], accent[2]);
+    gl.clearColor(0, 0, 0, 0);
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+
+    container.appendChild(canvas);
+
+    let raf = 0;
+    const start = performance.now();
+    const frame = (now: number) => {
+      gl.uniform1f(timeLoc, (now - start) / 1000);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+      gl.drawArrays(gl.TRIANGLES, 0, 3);
+      raf = requestAnimationFrame(frame);
+    };
+    raf = requestAnimationFrame(frame);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      gl.deleteProgram(program);
+      gl.deleteBuffer(buffer);
+      if (canvas.parentNode === container) container.removeChild(canvas);
+    };
+  }, [theme]);
+
+  return <div ref={containerRef} className="demo-pending-logo" aria-hidden />;
+}

--- a/web/app/demo-pending/page.tsx
+++ b/web/app/demo-pending/page.tsx
@@ -1,3 +1,4 @@
+import DemoPendingLogo from "./DemoPendingLogo";
 import DemoPendingRetry from "./DemoPendingRetry";
 
 // Public holding page for a demo signup whose trial has not landed yet
@@ -13,6 +14,7 @@ export default function DemoPendingPage() {
   return (
     <div className="trial-expired-page">
       <div className="trial-expired-panel" role="status">
+        <DemoPendingLogo />
         <div className="trial-expired-kicker">
           <span className="trial-expired-dot" aria-hidden />
           Radon Terminal

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -6834,6 +6834,19 @@ tr.leg-row td {
   padding: 28px;
 }
 
+/* Mount point for DemoPendingLogo's WebGL sketch. Sized to match the mark;
+   collapses to zero footprint via :empty when WebGL is unavailable or the
+   visitor prefers reduced motion, so the panel renders identically to the
+   plain static card that shipped before the mark existed. */
+.demo-pending-logo {
+  width: 72px;
+  height: 72px;
+  margin: 0 auto 16px;
+}
+.demo-pending-logo:empty {
+  display: none;
+}
+
 .trial-expired-kicker {
   display: flex;
   align-items: center;

--- a/web/tests/demo-pending-logo.test.tsx
+++ b/web/tests/demo-pending-logo.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * DemoPendingLogo renders a small WebGL "flow" mark on /demo-pending — a
+ * public, unauthenticated leaf reachable on both demo.radon.run and
+ * app.radon.run (pinned by demo-provisioning-resilience.test.ts's
+ * "/demo-pending perimeter" describe block). Decoration must never be the
+ * thing standing between a visitor and the plain static card that shipped
+ * before this component existed. These pin the two degrade paths: no WebGL
+ * support (jsdom's real default — no mocking needed), and a visitor's
+ * prefers-reduced-motion preference.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { ThemeProvider } from "@/lib/ThemeContext";
+import DemoPendingLogo from "@/app/demo-pending/DemoPendingLogo";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function mockMatchMedia(reduceMotion: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      matches: query.includes("prefers-reduced-motion") ? reduceMotion : false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("DemoPendingLogo degrade paths", () => {
+  it("renders the empty mount (static card, no canvas) when WebGL is unavailable", async () => {
+    mockMatchMedia(false);
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <ThemeProvider>
+          <DemoPendingLogo />
+        </ThemeProvider>,
+      );
+    });
+
+    const mount = container.querySelector(".demo-pending-logo");
+    expect(mount).not.toBeNull();
+    // jsdom implements HTMLCanvasElement but not a WebGL context — getContext
+    // returns null, so the component must not have appended a canvas.
+    expect(mount!.childElementCount).toBe(0);
+    expect(mount!.querySelector("canvas")).toBeNull();
+  });
+
+  it("never probes for a WebGL context when prefers-reduced-motion is set", async () => {
+    mockMatchMedia(true);
+    const getContextSpy = vi.spyOn(HTMLCanvasElement.prototype, "getContext");
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <ThemeProvider>
+          <DemoPendingLogo />
+        </ThemeProvider>,
+      );
+    });
+
+    expect(getContextSpy).not.toHaveBeenCalled();
+    expect(container.querySelector(".demo-pending-logo")!.childElementCount).toBe(0);
+  });
+
+  it("cleans up its canvas and animation frame on unmount without throwing", async () => {
+    mockMatchMedia(false);
+    // Simulate WebGL support: jsdom's canvas has no real GL, so stub a
+    // minimal-but-functional context covering every call the component makes.
+    const uniforms = new Map<string, unknown>();
+    const fakeGl = {
+      VERTEX_SHADER: 1,
+      FRAGMENT_SHADER: 2,
+      COMPILE_STATUS: 3,
+      LINK_STATUS: 4,
+      ARRAY_BUFFER: 5,
+      STATIC_DRAW: 6,
+      TRIANGLES: 7,
+      COLOR_BUFFER_BIT: 8,
+      FLOAT: 9,
+      SRC_ALPHA: 10,
+      ONE_MINUS_SRC_ALPHA: 11,
+      BLEND: 12,
+      createShader: () => ({}),
+      shaderSource: () => {},
+      compileShader: () => {},
+      getShaderParameter: () => true,
+      deleteShader: () => {},
+      createProgram: () => ({}),
+      attachShader: () => {},
+      linkProgram: () => {},
+      getProgramParameter: () => true,
+      deleteProgram: () => {},
+      useProgram: () => {},
+      createBuffer: () => ({}),
+      bindBuffer: () => {},
+      bufferData: () => {},
+      deleteBuffer: () => {},
+      getAttribLocation: () => 0,
+      enableVertexAttribArray: () => {},
+      vertexAttribPointer: () => {},
+      getUniformLocation: (_: unknown, name: string) => {
+        uniforms.set(name, {});
+        return uniforms.get(name);
+      },
+      uniform1f: () => {},
+      uniform2f: () => {},
+      uniform3f: () => {},
+      viewport: () => {},
+      clearColor: () => {},
+      enable: () => {},
+      blendFunc: () => {},
+      clear: () => {},
+      drawArrays: () => {},
+    };
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
+      fakeGl as unknown as WebGLRenderingContext,
+    );
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <ThemeProvider>
+          <DemoPendingLogo />
+        </ThemeProvider>,
+      );
+    });
+
+    const mount = container.querySelector(".demo-pending-logo");
+    expect(mount!.querySelector("canvas")).not.toBeNull();
+
+    await expect(act(async () => root.unmount())).resolves.not.toThrow();
+    // afterEach's own unmount would double-unmount; give it an empty root.
+    root = createRoot(document.createElement("div"));
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a small raw-WebGL sketch of the Radon monogram (breathing rings + orbiting accent dot, brand-token colored, theme-reactive) above the `/demo-pending` "Setting up your demo" card, so a waiting trial user sees something alive instead of a bare static card.
- No new dependency: the repo ships no three.js/shader library, and the one prior WebGL commit in history (a code-path-map viewer) confirmed raw WebGL is the established pattern, so `DemoPendingLogo.tsx` is plain WebGL1 + a fullscreen-triangle fragment shader.
- `page.tsx` gains only an import + JSX usage of the new component — no `fetch(`, `auth(`, `currentUser`, or `WorkspaceShell` — so the existing "/demo-pending perimeter" pins in `demo-provisioning-resilience.test.ts` (public/unauthenticated route on both `demo.radon.run` and `app.radon.run`) stay green untouched.
- Degrades to a zero-footprint empty mount (`.demo-pending-logo:empty { display: none }`) whenever WebGL context creation fails, or the visitor's `prefers-reduced-motion` is set — the static card then renders exactly as it did before this change.

## Test plan
- [x] New `web/tests/demo-pending-logo.test.tsx` (3 tests): WebGL-unavailable fallback (jsdom's real default), reduced-motion never probes `getContext`, cleanup on unmount doesn't throw.
- [x] `demo-provisioning-resilience.test.ts` "/demo-pending perimeter" suite still green, unmodified.
- [x] Full repo suite: `859 test files / 8675 tests passed` (`npx vitest run` from repo root).
- [x] `cd web && npx tsc --noEmit` clean.
- [x] Playwright screenshot verification (dark + light) with a real headless-Chromium WebGL context (`--use-gl=swiftshader`) against a local `next dev` server: confirmed the animated teal ring + orbiting accent dot renders above the card in both themes, and that a WebGL-less browser (this sandbox's default headless Chromium) mounts an empty container with no visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019UVmbs7twgwSmiUd8ECDeE