### PR TITLE
R-619: deliver the secret-store master key through a group the radon account is not in

### DIFF
--- a/cloud/scripts/radon-app-runtime.sh
+++ b/cloud/scripts/radon-app-runtime.sh
@@ -21,6 +21,7 @@ if [[ "${RADON_APP_RUNTIME_TEST_MODE:-0}" == "1" ]]; then
   LEASE_DIR="${STATE_DIR}/ib-lease"
   CHOWN="${RADON_TEST_CHOWN:?test chown is required}"
   PYTHON="${RADON_TEST_PYTHON:-$(command -v python3)}"
+  GETENT="${RADON_TEST_GETENT:?test getent is required}"
   NOTIFY_PROXY_DIR="${RADON_TEST_NOTIFY_PROXY_DIR:-${STATE_DIR}/notify}"
 else
   if (( EUID != 0 )); then
@@ -36,10 +37,17 @@ else
   LEASE_DIR=/var/lib/radon/ib-lease
   CHOWN=/usr/bin/chown
   PYTHON=/usr/bin/python3
+  GETENT=/usr/bin/getent
   NOTIFY_PROXY_DIR=/run/radon-app-runtime
 fi
 
 readonly SECRET_STORE_CREDENTIAL_NAME=radon-secret-store-key
+# R-619. The container runs --user radon, so a staged key owned by uid radon
+# is readable by every other thing that account can start. The plaintext key
+# is therefore handed over through a group the radon account is NOT in:
+# root:radon-secrets 0040, and the container gets the gid at start via
+# --group-add. Only root can grant that group, and only for this container.
+readonly SECRET_STORE_CREDENTIAL_GROUP=radon-secrets
 readonly SECRET_STORE_CREDENTIAL_CONTAINER_DIR=/run/credentials/radon-api.service
 readonly SECRET_STORE_DB_CONTAINER_PATH=/home/radon/radon/data/secret_store/secrets.db
 readonly SECRET_STORE_CREDENTIAL_STAGE_ROOT="${NOTIFY_PROXY_DIR}/credentials"
@@ -71,8 +79,34 @@ cleanup_staged_credential_on_exit() {
   cleanup_runtime_credential "$STAGED_CREDENTIAL_UNIT"
 }
 
+# The gid the plaintext key is handed to. Absent group, or a radon account that
+# has been added to it, means the delivery channel is open to the account the
+# container runs as -- refuse to start rather than stage a readable key.
+credential_group_gid() {
+  local entry gid
+  entry="$("$GETENT" group "$SECRET_STORE_CREDENTIAL_GROUP" 2>/dev/null)" || entry=""
+  gid="$(printf '%s' "$entry" | cut -d: -f3)"
+  [[ "$gid" =~ ^[0-9]+$ ]] || {
+    echo "radon-app-runtime: group ${SECRET_STORE_CREDENTIAL_GROUP} does not exist" >&2
+    return 78
+  }
+  printf '%s\n' "$gid"
+}
+
+assert_radon_cannot_open_credential_group() {
+  local groups
+  groups="$("$ID_BIN" -nG radon 2>/dev/null)" || groups=""
+  case " $groups " in
+    *" ${SECRET_STORE_CREDENTIAL_GROUP} "*)
+      echo "radon-app-runtime: radon must not be a member of ${SECRET_STORE_CREDENTIAL_GROUP}" >&2
+      return 78
+      ;;
+  esac
+  return 0
+}
+
 stage_api_credential() {
-  local unit="$1" ids="$2"
+  local unit="$1" gid="$2"
   local source credential_dir credential_file staged_size
   validate_api_startup_inputs
   source="${CREDENTIALS_DIRECTORY}/${SECRET_STORE_CREDENTIAL_NAME}"
@@ -83,13 +117,14 @@ stage_api_credential() {
   STAGED_CREDENTIAL_UNIT="$unit"
   install -d -m 0700 "$SECRET_STORE_CREDENTIAL_STAGE_ROOT" "$credential_dir"
   install -m 0400 "$source" "$credential_file"
-  "$CHOWN" "$ids" "$credential_dir" "$credential_file"
-  chmod 0500 "$credential_dir"
   staged_size="$(wc -c < "$credential_file" | tr -d '[:space:]')"
   [[ "$staged_size" == "32" ]] || {
     echo "radon-app-runtime: staged ${SECRET_STORE_CREDENTIAL_NAME} must be exactly 32 bytes" >&2
     return 78
   }
+  "$CHOWN" "root:${gid}" "$credential_dir" "$credential_file"
+  chmod 0040 "$credential_file"
+  chmod 0050 "$credential_dir"
 }
 
 validate_api_startup_inputs() {
@@ -392,8 +427,11 @@ cmd_run() {
     *) exit 64 ;;
   esac
 
+  local credential_gid=""
   if [[ "$unit" == "radon-api.service" ]]; then
     validate_api_startup_inputs
+    assert_radon_cannot_open_credential_group || exit $?
+    credential_gid="$(credential_group_gid)" || exit $?
   fi
 
   # R-232, and its limit: the container's processes land in
@@ -415,7 +453,7 @@ cmd_run() {
     local secret_store_dir="${DATA_DIR}/secret_store"
     install -d -m 0700 "$secret_store_dir"
     "$CHOWN" "$ids" "$secret_store_dir"
-    stage_api_credential "$unit" "$ids"
+    stage_api_credential "$unit" "$credential_gid"
   fi
 
   # The container gets NARROW binds, never $STATE_DIR itself. /var/lib/radon
@@ -458,6 +496,7 @@ cmd_run() {
     fi
     local credential_host_dir="${SECRET_STORE_CREDENTIAL_STAGE_ROOT}/${unit}"
     set -- "$@" \
+      --group-add "$credential_gid" \
       --env "CREDENTIALS_DIRECTORY=${SECRET_STORE_CREDENTIAL_CONTAINER_DIR}" \
       --env "RADON_SECRET_STORE_PATH=${SECRET_STORE_DB_CONTAINER_PATH}" \
       --mount "type=bind,src=${credential_host_dir},dst=${SECRET_STORE_CREDENTIAL_CONTAINER_DIR},readonly"

--- a/cloud/scripts/setup-vps.sh
+++ b/cloud/scripts/setup-vps.sh
@@ -435,6 +435,20 @@ preflight_checks() {
     usermod -aG docker radon
   fi
 
+  # R-619: the app-plane API container runs --user radon, so the plaintext
+  # secret-store master key must not be handed over as a file uid radon can
+  # open. radon-app-runtime stages it root:radon-secrets 0040 and grants the
+  # gid to that one container with --group-add. radon is never a member --
+  # the runtime refuses to start the API if it ever becomes one.
+  if ! getent group radon-secrets &>/dev/null; then
+    log_info "Creating radon-secrets group..."
+    groupadd --system radon-secrets
+  fi
+  if id -nG radon 2>/dev/null | grep -qw radon-secrets; then
+    log_error "radon must not be a member of radon-secrets (R-619)"
+    exit 1
+  fi
+
   # radon owns its home, so root never writes through a link under it.
   local ssh_path
   for ssh_path in /home/radon/.ssh /home/radon/.ssh/authorized_keys \

--- a/cloud/tests/test_app_runtime.py
+++ b/cloud/tests/test_app_runtime.py
@@ -73,7 +73,25 @@ exit 0
 
 def _runtime_env(tmp_path: Path, fake_docker: Path | None = None) -> dict[str, str]:
     fake_id = tmp_path / "id"
-    _write_executable(fake_id, "#!/bin/bash\necho 1000\n")
+    # `id -nG radon` must answer with real group NAMES so the runtime can
+    # refuse to start when the radon account has been added to the
+    # credential-delivery group. Every other form still answers 1000.
+    _write_executable(
+        fake_id,
+        "#!/bin/bash\n"
+        'if [[ "$1" == "-nG" ]]; then\n'
+        '  echo "${RADON_TEST_RADON_GROUPS:-radon docker}"\n'
+        "  exit 0\n"
+        "fi\n"
+        "echo 1000\n",
+    )
+    fake_getent = tmp_path / "getent"
+    _write_executable(
+        fake_getent,
+        "#!/bin/bash\n"
+        'if [[ "${RADON_TEST_SECRET_GROUP_MISSING:-0}" == "1" ]]; then exit 2; fi\n'
+        'echo "$2:x:${RADON_TEST_SECRET_GROUP_GID:-1001}:"\n',
+    )
     env_file = tmp_path / "env"
     env_file.write_text("NODE_ENV=production\n", encoding="utf-8")
     data_dir = tmp_path / "data"
@@ -99,6 +117,7 @@ def _runtime_env(tmp_path: Path, fake_docker: Path | None = None) -> dict[str, s
         "RADON_APP_RUNTIME_TEST_MODE": "1",
         "RADON_TEST_DOCKER": str(fake_docker or tmp_path / "docker"),
         "RADON_TEST_ID": str(fake_id),
+        "RADON_TEST_GETENT": str(fake_getent),
         "RADON_TEST_ENV_FILE": str(env_file),
         "RADON_TEST_DATA_DIR": str(data_dir),
         "RADON_TEST_MEDIA_DIR": str(media_dir),
@@ -523,12 +542,67 @@ def test_run_api_mounts_systemd_credential_and_persists_store(tmp_path: Path) ->
     assert f"--env CREDENTIALS_DIRECTORY={container_dir}" in log
     assert f"type=bind,src={host_dir},dst={container_dir},readonly" in log
     assert "RADON_SECRET_STORE_PATH=/home/radon/radon/data/secret_store/secrets.db" in log
+    # R-619: the master key is delivered through the radon-secrets group, which
+    # the host radon account is not a member of. Owner is root and the owner
+    # bits are empty, so uid radon -- the uid the container itself runs as --
+    # cannot read the plaintext key outside the container.
+    assert stat.S_IMODE(host_dir.stat().st_mode) == 0o050
+    host_dir.chmod(0o700)  # the test user owns these; root ownership is stubbed
+    assert stat.S_IMODE(staged.stat().st_mode) == 0o040
+    staged.chmod(0o400)
     assert staged.read_bytes() == (tmp_path / "credentials" / staged.name).read_bytes()
-    assert stat.S_IMODE(staged.stat().st_mode) == 0o400
     assert stat.S_IMODE((tmp_path / "data" / "secret_store").stat().st_mode) == 0o700
     chowns = (tmp_path / "chown.log").read_text(encoding="utf-8")
-    assert f"1000:1000 {host_dir} {staged}" in chowns
+    assert f"root:1001 {host_dir} {staged}" in chowns
+    assert f"1000:1000 {tmp_path / 'data' / 'secret_store'}" in chowns
+    assert "--group-add 1001" in _run_line(result)
     assert "python scripts/secret_store.py && exec uvicorn" in _run_line(result)
+
+
+def test_run_api_refuses_when_credential_group_is_absent(tmp_path: Path) -> None:
+    result = _run(
+        tmp_path,
+        ["run", "radon-api.service"],
+        extra_env={"RADON_TEST_SECRET_GROUP_MISSING": "1"},
+    )
+    assert result.returncode == 78, result.stderr
+    assert "radon-secrets" in result.stderr
+    assert not [
+        line
+        for line in result.docker_log.read_text(encoding="utf-8").splitlines()  # type: ignore[attr-defined]
+        if line.startswith("run ")
+    ]
+
+
+def test_run_api_refuses_when_radon_can_open_the_credential_group(
+    tmp_path: Path,
+) -> None:
+    """The delivery channel is only closed while radon is outside the group."""
+    result = _run(
+        tmp_path,
+        ["run", "radon-api.service"],
+        extra_env={"RADON_TEST_RADON_GROUPS": "radon docker radon-secrets"},
+    )
+    assert result.returncode == 78, result.stderr
+    assert "radon must not be a member of radon-secrets" in result.stderr
+    assert not [
+        line
+        for line in result.docker_log.read_text(encoding="utf-8").splitlines()  # type: ignore[attr-defined]
+        if line.startswith("run ")
+    ]
+
+
+def test_setup_creates_the_credential_group_without_radon_in_it() -> None:
+    setup = SETUP.read_text(encoding="utf-8")
+    assert "groupadd --system radon-secrets" in setup
+    assert "radon must not be a member of radon-secrets" in setup
+    assert "usermod -aG radon-secrets radon" not in setup
+
+
+def test_non_api_units_are_not_given_the_credential_group(tmp_path: Path) -> None:
+    result = _run(tmp_path, ["run", "radon-nextjs.service"])
+    assert result.returncode == 0, result.stderr
+    assert "--group-add" not in _run_line(result)
 
 
 def test_run_api_refuses_noncanonical_production_store_before_removal(

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -96,11 +96,26 @@ auto-generated 0600 on first use). Production
 `radon-api.service` loads
 `/etc/credstore.encrypted/radon-secret-store-key` with
 `LoadCredentialEncrypted=`. The root container wrapper validates the decrypted
-value is a regular, non-symlink 32-byte file, stages a `0400` copy owned by the
-numeric `radon` UID/GID under `/run/radon-app-runtime/credentials/`, and mounts
-only that directory read-only into the API container. The key is never passed
-through Docker arguments or environment values; the staged plaintext is
-removed by `ExecStopPost` after the container stops.
+value is a regular, non-symlink 32-byte file, stages a copy under
+`/run/radon-app-runtime/credentials/`, and mounts only that directory
+read-only into the API container. The key is never passed through Docker
+arguments or environment values; the staged plaintext is removed by
+`ExecStopPost` after the container stops.
+
+The staged copy is `root:radon-secrets 0040` in a `root:radon-secrets 0050`
+directory, and the container is granted that gid at start with
+`--group-add` (R-619). The API container runs `--user radon`, so a copy owned
+by uid `radon` would be readable by anything else that account can start; the
+owner bits are empty and only root can grant `radon-secrets`, so the delivery
+channel is one the `radon` account cannot open for itself. `radon` is never a
+member: `setup-vps.sh` creates the system group and refuses to continue if it
+finds the account in it, and `radon-app-runtime` exits 78 before staging
+anything if the group is missing or `radon` has joined it.
+
+Residual: `radon` is in group `docker` (`setup-vps.sh`), which is
+root-equivalent on this host, so the group boundary is defense in depth
+against direct file reads, not against an operator-level compromise of that
+account.
 
 There is no escrow, and `secrets.db` is
 bound to its key by fingerprint (`key_binding` table): with rows present and


### PR DESCRIPTION
## Issue

PR #273 shipped with R-619 open: `radon-app-runtime` staged the decrypted 32-byte secret-store master key as a `0400` file owned by the numeric `radon` uid, and the API container runs `--user radon`. Anything else the `radon` account can start could open the plaintext key. The only thing standing between them was the `0700` mode on a root-owned parent directory, which nothing asserted.

## Fix

The key is handed over through a channel that account cannot open for itself.

- staged copy is `root:radon-secrets 0040` inside a `root:radon-secrets 0050` directory — owner bits empty, so uid `radon` has no path to the plaintext outside the container
- the API container is granted the gid at start with `--group-add`, by root, for that one container
- `radon` is never a member: `setup-vps.sh` creates the system group and refuses to continue if it finds the account in it
- the runtime fails closed with exit 78 — before `docker rm -f` and before anything is staged — when the group is absent or when `radon` has joined it
- the size check now runs while the file is still root-readable, before the mode is dropped

## Residual (documented)

`radon` is in group `docker` (`setup-vps.sh:309,435`), which is root-equivalent on this host. This change is defense in depth against direct file reads, not against a compromise of the `radon` account itself. Removing `radon` from group `docker` would break `ib-gateway-control.sh`, `docker_ib_gateway.sh` and `ib_watchdog.py`, all of which drive the Gateway container as `radon`; that is a separate operator decision, recorded in `docs/operations.md`.

## Tests

Red first, then green.

- `test_run_api_mounts_systemd_credential_and_persists_store` — asserts `0o040` file, `0o050` dir, `root:<gid>` chown, `--group-add <gid>`
- `test_run_api_refuses_when_credential_group_is_absent` — exit 78, no `run` line reaches docker
- `test_run_api_refuses_when_radon_can_open_the_credential_group` — exit 78 when `id -nG radon` contains `radon-secrets`
- `test_non_api_units_are_not_given_the_credential_group`
- `test_setup_creates_the_credential_group_without_radon_in_it`

`cloud/tests/test_app_runtime.py`: 59 passed. `cloud/tests`: 1670 passed, 7 skipped, 5 pre-existing local failures (caddy not on PATH; CI installs it).

## Operator steps before merge takes effect

On both hosts (app `5.78.148.38`, broker `100.67.204.57`), as root:

```
groupadd --system radon-secrets
id -nG radon   # must NOT list radon-secrets
```

Then let the deploy restart `radon-api.service`. Without the group present the unit fails closed with exit 78 rather than staging a readable key — deliberate, but it means the group must exist before the API restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXaiDhMkTcXjJmyT14Z4Eg