### PR TITLE
fix(portfolio): restore bounded combo aggregate P&L

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -746,6 +746,7 @@ jobs:
           e2e/realized-pnl.spec.ts
           e2e/share-pnl.spec.ts
           e2e/wulf-close-order-naked-short.spec.ts
+          e2e/portfolio-defined-combo-pnl.spec.ts
           e2e/portfolio-same-day-combo-pnl.spec.ts
           e2e/portfolio-same-day-equity-pnl.spec.ts
           e2e/stop-order-desktop.spec.ts

--- a/scripts/ib_sync.py
+++ b/scripts/ib_sync.py
@@ -309,8 +309,44 @@ def detect_structure_type(legs: list) -> Tuple[str, str]:
             return f"Long Put Combo ({len(opt_legs)} legs)", "defined"
         return f"Long Combo ({len(opt_legs)} legs)", "defined"
 
+    # Mixed-direction option combos can still have fully bounded loss. Every
+    # short must be capped by at least the same quantity of long options of
+    # the same right; grouping already guarantees a common expiry. Extra long
+    # legs can add premium at risk, but cannot create naked tail exposure.
+    if opt_legs and len(opt_legs) == len(legs) and short_legs:
+        covered = all(
+            sum(max(0, l['position']) for l in opt_legs if l.get('right') == right)
+            >= sum(max(0, -l['position']) for l in opt_legs if l.get('right') == right)
+            for right in ('C', 'P')
+        )
+        if covered:
+            return f"Combo ({len(legs)} legs)", "defined"
+
     # Default for complex structures
     return f"Combo ({len(legs)} legs)", "complex"
+
+
+def _defined_option_combo_max_risk(legs: list, total_entry_cost: float) -> Optional[float]:
+    """Exact expiry max loss for a same-expiry, structurally bounded combo."""
+    strikes = sorted({float(l.get('strike', 0)) for l in legs if l['secType'] == 'OPT'})
+    if not strikes:
+        return None
+
+    min_pnl = float('inf')
+    for spot in [0.0, *strikes]:
+        intrinsic_value = 0.0
+        for leg in legs:
+            strike = float(leg.get('strike', 0))
+            intrinsic = (
+                max(0.0, spot - strike)
+                if leg.get('right') == 'C'
+                else max(0.0, strike - spot)
+            )
+            multiplier = float(leg.get('multiplier') or 100)
+            intrinsic_value += float(leg['position']) * intrinsic * multiplier
+        min_pnl = min(min_pnl, intrinsic_value - total_entry_cost)
+
+    return max(0.0, -min_pnl)
 
 
 def _raw_ratio_label(legs: list) -> str:
@@ -576,7 +612,9 @@ def collapse_positions(positions: list) -> list:
         # Calculate max risk
         if risk_profile == "defined":
             # For defined risk, max loss is net debit paid
-            if "Spread" in structure_type:
+            if structure_type.startswith("Combo ("):
+                max_risk = _defined_option_combo_max_risk(legs, total_entry_cost)
+            elif "Spread" in structure_type:
                 strikes = sorted([l.get('strike', 0) for l in legs if l['secType'] == 'OPT'])
                 width = (strikes[-1] - strikes[0]) * 100 * contracts if len(strikes) >= 2 else 0
                 if direction == "DEBIT":

--- a/scripts/tests/test_all_long_combo.py
+++ b/scripts/tests/test_all_long_combo.py
@@ -80,17 +80,15 @@ class TestAllLongComboDetection:
         structure, risk = detect_structure_type(legs)
         assert risk == "defined", f"Expected 'defined' but got '{risk}' for three long calls"
 
-    def test_mixed_long_short_still_complex(self):
-        """3 legs with mixed directions that don't match a known pattern stay complex."""
+    def test_protected_short_call_with_extra_long_put_is_defined(self):
+        """A capped call spread plus an extra long put remains defined risk."""
         legs = [
             _make_leg("C", 100.0, 10),   # long
             _make_leg("C", 110.0, -10),   # short
             _make_leg("P", 90.0, 10),     # long
         ]
-        structure, risk = detect_structure_type(legs)
-        # This should NOT be "defined" unless it matches a known safe pattern
-        # (it has a short leg), but it should at least not crash
-        assert risk in ("defined", "undefined", "complex")
+        _, risk = detect_structure_type(legs)
+        assert risk == "defined"
 
     def test_bull_call_spread_still_works(self):
         """Existing vertical spread detection still works (1 long, 1 short call)."""

--- a/scripts/tests/test_defined_option_combo.py
+++ b/scripts/tests/test_defined_option_combo.py
@@ -1,0 +1,67 @@
+"""Regression coverage for bounded option combos beyond named two-leg spreads."""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from ib_sync import collapse_positions, detect_structure_type
+
+
+def _arm_leg(*, right: str, strike: float, position: int, entry: float, mark: float) -> dict:
+    return {
+        "account_id": "U1",
+        "symbol": "ARM",
+        "secType": "OPT",
+        "right": right,
+        "strike": strike,
+        "position": position,
+        "expiry": "2026-09-18",
+        "entry_cost": entry,
+        "avgCost": entry / abs(position),
+        "marketPrice": mark / abs(position) / 100,
+        "marketValue": mark,
+        "basis_source": "ib",
+    }
+
+
+ARM_LEGS = [
+    _arm_leg(right="C", strike=260, position=-10, entry=8_000, mark=8_600),
+    _arm_leg(right="C", strike=270, position=10, entry=10_380, mark=5_530),
+    _arm_leg(right="P", strike=220, position=10, entry=7_030, mark=1_680),
+]
+
+
+def test_protected_short_call_plus_long_put_is_defined_risk():
+    structure, risk = detect_structure_type(ARM_LEGS)
+
+    assert structure == "Combo (3 legs)"
+    assert risk == "defined"
+
+
+def test_collapsed_defined_combo_has_exact_expiry_max_risk():
+    [position] = collapse_positions(ARM_LEGS)
+
+    assert position["risk_profile"] == "defined"
+    assert position["max_risk"] == pytest.approx(19_410)
+
+
+def test_defined_combo_detection_is_leg_order_invariant():
+    assert detect_structure_type(list(reversed(ARM_LEGS))) == (
+        "Combo (3 legs)",
+        "defined",
+    )
+
+
+def test_extra_long_with_uncovered_short_call_stays_undefined():
+    legs = [
+        _arm_leg(right="C", strike=260, position=-20, entry=16_000, mark=17_200),
+        _arm_leg(right="C", strike=270, position=10, entry=10_380, mark=5_530),
+        _arm_leg(right="P", strike=220, position=10, entry=7_030, mark=1_680),
+    ]
+
+    _, risk = detect_structure_type(legs)
+
+    assert risk == "complex"

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,13 @@
 # Lessons
 
+## 2026-09-04 — Defined-risk combinations need whole-structure coverage
+
+- Classify multi-leg risk from the complete same-expiry payoff, including
+  protective long legs outside a vertical spread; do not reduce recognition to
+  named two-leg structures.
+- When every leg has resolved entry and market values, the parent row must sum
+  per-leg P&L even if a separate return-capital input is unavailable.
+
 ## 2026-09-04 — IB error 202 is cancel confirmation, not a replace abort
 
 - IB error 202 (`Order Canceled - reason:`) is the broker's cancel

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,36 @@
+# Task: Restore ARM defined-risk aggregate P&L (2026-09-04) [DONE]
+
+Recognize the reported three-leg ARM structure as defined risk and render its
+parent-row P&L from the resolved leg economics.
+
+## Dependency graph
+
+- T1 depends_on: [] - Reproduce the ARM classification and missing aggregate P&L, then trace the risk and valuation paths.
+- T2 depends_on: [T1] - Add failing unit and Playwright regressions for the exact three-leg structure.
+- T3 depends_on: [T2] - Implement the smallest structural-risk and aggregate-P&L correction.
+- T4 depends_on: [T3] - Run focused Vitest, Playwright, and visual browser verification.
+- T5 depends_on: [T4] - Run the full web suite, typecheck, lint, review the diff, and document evidence.
+- T6 depends_on: [T5] - Commit, open the PR, supervise exact-head CI to green, and send the required notification.
+
+## Checklist
+
+- [x] T1 Reproduce and trace the defect.
+- [x] T2 Establish red regression coverage.
+- [x] T3 Implement the minimal fix.
+- [x] T4 Complete focused and visual verification.
+- [x] T5 Complete full verification and review.
+- [x] T6 Open and supervise the PR.
+
+## Review
+
+- Same-expiry option combos now classify from whole-structure short coverage; ARM's protected call wing plus long put is defined, while an uncovered ratio remains complex.
+- Generic bounded combos compute exact expiry max loss at zero and every strike kink, producing $19,410 for the ARM fixture rather than using the unrelated outer-strike width.
+- Parent dollar P&L sums resolved signed leg economics even when aggregate basis provenance is mixed; Avg Entry, Return %, max risk, and close-out basis remain unavailable in that state.
+- Verification: focused Python 73 passed; focused Vitest 22 passed; CI-style Vitest 8,196 passed; Playwright passed once in dev and 3/3 under `next start`; typecheck/build clean; lint 0 errors and 17 existing warnings.
+- Full Python reached 11,558 passed, 1 skipped, with the new CI-curation contract and one load-sensitive GARCH retry failing; registration checks then passed 33/33 and the GARCH test passed alone.
+
+---
+
 # Task: Combo replace IB 202 cancel abort (2026-09-04) [DONE]
 
 Combo modify treated IB error 202 as a failed cancel, skipped the replacement,

--- a/web/e2e/portfolio-defined-combo-pnl.spec.ts
+++ b/web/e2e/portfolio-defined-combo-pnl.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const LAST_SYNC = "2026-09-04T14:30:00Z";
+
+const PORTFOLIO_MOCK = {
+  bankroll: 400_000,
+  peak_value: 400_000,
+  last_sync: LAST_SYNC,
+  total_deployed_pct: 0,
+  total_deployed_dollars: 0,
+  remaining_capacity_pct: 100,
+  position_count: 1,
+  defined_risk_count: 1,
+  undefined_risk_count: 0,
+  avg_kelly_optimal: null,
+  exposure: {},
+  violations: [],
+  account_summary: {
+    net_liquidation: 400_000,
+    daily_pnl: -120,
+    unrealized_pnl: -10_803,
+    realized_pnl: 0,
+    settled_cash: 100_000,
+    maintenance_margin: 0,
+    excess_liquidity: 100_000,
+    buying_power: 400_000,
+    dividends: 0,
+  },
+  positions: [{
+    id: 1,
+    ticker: "ARM",
+    structure: "Combo (3 legs)",
+    structure_type: "Combo (3 legs)",
+    risk_profile: "defined",
+    expiry: "2026-09-18",
+    contracts: 10,
+    direction: "LONG",
+    entry_cost: null,
+    max_risk: null,
+    market_value: -1_393,
+    basis_source: "mixed",
+    ib_daily_pnl: -120,
+    kelly_optimal: null,
+    target: null,
+    stop: null,
+    legs: [
+      { direction: "SHORT", contracts: 10, type: "Call", strike: 260, entry_cost: 8_000, avg_cost: 800, market_price: 8.6, market_value: 8_600, basis_source: "session_fills" },
+      { direction: "LONG", contracts: 10, type: "Call", strike: 270, entry_cost: 10_380, avg_cost: 1_038, market_price: 5.525, market_value: 5_525, basis_source: "ib" },
+      { direction: "LONG", contracts: 10, type: "Put", strike: 220, entry_cost: 7_030, avg_cost: 703, market_price: 1.682, market_value: 1_682, basis_source: "ib" },
+    ],
+  }],
+};
+
+async function setupMocks(page: Page) {
+  await page.route("**/api/portfolio", (route) => route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(PORTFOLIO_MOCK),
+  }));
+  await page.route("**/api/orders", (route) => route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({ last_sync: LAST_SYNC, open_orders: [], executed_orders: [] }),
+  }));
+  await page.route("**/api/flex-token", (route) => route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({ ok: true, days_until_expiry: 14 }),
+  }));
+  await page.route("**/api/ib-status", (route) => route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({ connected: true }),
+  }));
+  await page.route("**/api/blotter", (route) => route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({ as_of: LAST_SYNC, summary: { realized_pnl: 0 }, closed_trades: [], open_trades: [] }),
+  }));
+  await page.route("**/api/profile", (route) => route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({ username: "Operator", avatar_url: null, ui_preferences: null }),
+  }));
+  await page.route("**/api/preferences", (route) => route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({}),
+  }));
+  await page.route("**/api/prices**", (route) => route.abort());
+}
+
+test("ARM protected combo is defined risk and shows aggregate P&L", async ({ page }, testInfo) => {
+  await page.setViewportSize({ width: 1800, height: 900 });
+  await page.addInitScript(() => window.localStorage.setItem("theme", "dark"));
+  await setupMocks(page);
+  await page.goto("/portfolio", { waitUntil: "domcontentloaded" });
+
+  const definedSection = page.locator(".section").filter({ hasText: "Defined Risk Positions" });
+  const armRow = definedSection.locator("tr").filter({ hasText: "ARM" });
+  await expect(definedSection).toBeVisible();
+  await expect(armRow).toHaveCount(1);
+  await expect(armRow).toContainText("-$10,803");
+  await expect(armRow).toContainText("N/A");
+  await expect(page.getByText("Undefined Risk Positions")).toHaveCount(0);
+
+  await armRow.getByRole("button", { name: "Expand legs for ARM" }).click();
+  await expect(definedSection.locator("tr").filter({ hasText: "SHORT Call $260" })).toContainText("-$600");
+  await expect(definedSection.locator("tr").filter({ hasText: "LONG Call $270" })).toContainText("-$4,855");
+  await expect(definedSection.locator("tr").filter({ hasText: "LONG Put $220" })).toContainText("-$5,348");
+
+  const screenshotPath = testInfo.outputPath("arm-defined-combo-pnl.png");
+  await page.screenshot({ path: screenshotPath, fullPage: true });
+  await testInfo.attach("arm-defined-combo-pnl", { path: screenshotPath, contentType: "image/png" });
+});

--- a/web/lib/positionUtils.ts
+++ b/web/lib/positionUtils.ts
@@ -152,8 +152,7 @@ export function hasBlendedLegBasis(pos: PortfolioPosition): boolean {
 /**
  * Signed aggregate basis, or `null` when the legs disagree about their basis
  * source (T-315): the blend is the basis of a trade that was never placed, so
- * every P&L, return, Today P&L and close-ticket figure downstream goes null
- * with it rather than presenting mv − blend as fact.
+ * capital, average-entry, return, and close-ticket calculations must not use it.
  */
 export function resolveEntryCost(pos: PortfolioPosition): number | null {
   if (hasBlendedLegBasis(pos)) return null;
@@ -415,13 +414,27 @@ export function describeReturnCapital(basis: ReturnCapitalBasis | null): string 
   return `Return on exact opening capital · ${amount} · as of ${basis.asOf}`;
 }
 
-/** Unrealized P&L $ = market value − signed entry cost. */
+/** Signed sum of leg entry values, available even when their sources differ. */
+function resolveLegPnlBasis(pos: PortfolioPosition): number | null {
+  if (pos.legs.length < 2) return resolveEntryCost(pos);
+  if (pos.legs.some((leg) => !Number.isFinite(leg.entry_cost))) return null;
+  return pos.legs.reduce((sum, leg) => {
+    const sign = leg.direction === "LONG" ? 1 : -1;
+    return sum + sign * Math.abs(leg.entry_cost);
+  }, 0);
+}
+
+/**
+ * Unrealized P&L $ = the signed sum of every leg's market value minus entry
+ * value. A mixed-provenance combo still has measurable per-leg P&L even though
+ * its aggregate basis remains unavailable for Return %, risk, and close-outs.
+ */
 export function getPnlDollars(
   pos: PortfolioPosition,
   marketValue?: number | null,
 ): number | null {
   const mv = marketValue !== undefined ? marketValue : resolveMarketValue(pos);
-  const entryCost = resolveEntryCost(pos);
+  const entryCost = resolveLegPnlBasis(pos);
   if (mv == null || entryCost == null) return null;
   return mv - entryCost;
 }

--- a/web/lib/unrealizedBreakdown.ts
+++ b/web/lib/unrealizedBreakdown.ts
@@ -48,6 +48,9 @@ export function computeUnrealizedBreakdown(
 export function sumUnrealizedBreakdown(portfolio: PortfolioData): number {
   let total = 0;
   for (const pos of portfolio.positions) {
+    // The account-level total remains reconcilable with the breakdown table,
+    // which cannot publish a mixed aggregate entry column.
+    if (hasBlendedLegBasis(pos)) continue;
     const pnl = getPnlDollars(pos, resolveMarketValue(pos));
     if (pnl != null) total += pnl;
   }

--- a/web/tests/position-mixed-basis-refuses-aggregate.test.tsx
+++ b/web/tests/position-mixed-basis-refuses-aggregate.test.tsx
@@ -13,15 +13,12 @@
  * sized off.
  *
  * The server already refuses to publish the aggregate (`entry_cost` and
- * `max_risk` arrive `null`). The display layer must refuse too, because
- * `resolveEntryCost` recomputes the same blend from the legs.
+ * `max_risk` arrive `null`). Capital and return calculations must keep that
+ * refusal, while dollar P&L may sum the independently measured leg P&Ls.
  *
  * T-315: the T-253 fixture carried no leg marks, so `resolveMarketValue` was
- * null and every P&L branch was unreachable — the cells it did not fix (P&L,
- * the portfolio Open P&L total, the unrealized breakdown, Today P&L and the
- * close ticket's realised figure) still subtracted the blend. The fixture
- * now marks both legs (mv = $4,500) so a blended P&L of +$3,500 is exactly
- * what an ungated path prints.
+ * null and every P&L branch was unreachable. The fixture marks both legs (mv
+ * = $4,500), making their signed P&L sum exactly +$3,500.
  */
 
 import React from "react";
@@ -212,10 +209,9 @@ describe("PositionTable renders no basis for a `mixed` position", () => {
     expect(cellTexts()).not.toContain("-$1,000");
   });
 
-  it("the P&L cell reads — and Return % N/A rather than mv − blend (T-315)", () => {
+  it("the P&L cell sums measured legs while Return % stays unavailable", () => {
     render(<PositionTable positions={[MIXED]} prices={{}} />);
-    expect(cellTexts()).not.toContain(BLENDED_PNL);
-    expect(cellUnder("P&L")).toBe("—");
+    expect(cellUnder("P&L")).toBe(BLENDED_PNL);
     expect(cellUnder("Return %")).toBe("N/A");
   });
 
@@ -230,20 +226,20 @@ describe("PositionTable renders no basis for a `mixed` position", () => {
   });
 });
 
-describe("resolveEntryCost / getPnlDollars refuse a blended leg basis (T-315)", () => {
+describe("mixed basis separates capital from measurable leg P&L", () => {
   it("resolveEntryCost is null for a `mixed` position", () => {
     expect(resolveEntryCost(MIXED)).toBeNull();
     expect(resolveEntryCost(CLEAN)).toBe(1000);
   });
 
-  it("getPnlDollars is null even with a real mark", () => {
-    expect(getPnlDollars(MIXED, 4500)).toBeNull();
+  it("getPnlDollars sums the independently measured legs", () => {
+    expect(getPnlDollars(MIXED, 4500)).toBe(3500);
     expect(getPnlDollars(CLEAN, 4500)).toBe(3500);
   });
 
-  it("Today P&L for a same-day `mixed` position is null, not mv − blend", () => {
+  it("Today P&L for a same-day `mixed` position uses the measured leg sum", () => {
     const sameDay = partiallyRolledVertical("mixed", { entry_date: todayET() });
-    expect(getTodayPnlDollars(sameDay, {})).toBeNull();
+    expect(getTodayPnlDollars(sameDay, {})).toBe(3500);
     const sameDayClean = partiallyRolledVertical("session_fills", { entry_date: todayET() });
     expect(getTodayPnlDollars(sameDayClean, {})).toBe(3500);
   });

--- a/web/tests/position-table-defined-combo-pnl.test.tsx
+++ b/web/tests/position-table-defined-combo-pnl.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * A mixed-provenance combo has no trustworthy aggregate entry-cost or return
+ * denominator, but its displayed per-leg P&Ls are each measured. The parent
+ * P&L must equal their signed sum.
+ */
+
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import PositionTable from "../components/PositionTable";
+import { getPnlDollars, resolveEntryCost } from "../lib/positionUtils";
+import type { PortfolioPosition } from "../lib/types";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock("../components/InstrumentDetailModal", () => ({ default: () => null }));
+
+afterEach(cleanup);
+
+const ARM: PortfolioPosition = {
+  id: 1,
+  ticker: "ARM",
+  structure: "Combo (3 legs)",
+  structure_type: "Combo (3 legs)",
+  risk_profile: "defined",
+  expiry: "2026-09-18",
+  contracts: 10,
+  direction: "LONG",
+  entry_cost: null,
+  max_risk: null,
+  market_value: -1_393,
+  basis_source: "mixed",
+  kelly_optimal: null,
+  target: null,
+  stop: null,
+  legs: [
+    {
+      direction: "SHORT", contracts: 10, type: "Call", strike: 260,
+      entry_cost: 8_000, avg_cost: 800, market_price: 8.6, market_value: 8_600,
+      basis_source: "session_fills",
+    },
+    {
+      direction: "LONG", contracts: 10, type: "Call", strike: 270,
+      entry_cost: 10_380, avg_cost: 1_038, market_price: 5.525, market_value: 5_525,
+      basis_source: "ib",
+    },
+    {
+      direction: "LONG", contracts: 10, type: "Put", strike: 220,
+      entry_cost: 7_030, avg_cost: 703, market_price: 1.682, market_value: 1_682,
+      basis_source: "ib",
+    },
+  ],
+} as PortfolioPosition;
+
+function cellUnder(header: string): string {
+  const headers = Array.from(document.querySelectorAll("thead th")).map(
+    (th) => th.textContent?.trim() ?? "",
+  );
+  const index = headers.findIndex((value) => value.startsWith(header));
+  const row = screen.getByText("ARM").closest("tr")!;
+  return row.querySelectorAll("td")[index]?.textContent?.trim() ?? "";
+}
+
+describe("defined option combo aggregate P&L", () => {
+  it("sums the three measured leg P&Ls while aggregate basis stays unavailable", () => {
+    expect(resolveEntryCost(ARM)).toBeNull();
+    expect(getPnlDollars(ARM)).toBe(-10_803);
+  });
+
+  it("renders the signed leg sum on the parent row and keeps Return unavailable", () => {
+    render(<PositionTable positions={[ARM]} prices={{}} />);
+
+    expect(cellUnder("P&L")).toBe("-$10,803");
+    expect(cellUnder("Return %")).toBe("N/A");
+
+    fireEvent.click(screen.getByRole("button", { name: "Expand legs for ARM" }));
+    expect(screen.getByText("SHORT Call $260").closest("tr")?.textContent).toContain("-$600");
+    expect(screen.getByText("LONG Call $270").closest("tr")?.textContent).toContain("-$4,855");
+    expect(screen.getByText("LONG Put $220").closest("tr")?.textContent).toContain("-$5,348");
+  });
+});


### PR DESCRIPTION
## Summary
- classify same-expiry multi-leg option positions as defined when every short contract is capped by same-right long quantity
- compute generic-combo max loss from expiry payoff kinks; the ARM fixture resolves to $19,410
- restore parent dollar P&L as the signed leg sum while keeping mixed aggregate basis, Return %, and close basis unavailable
- add unit, component, and production-server browser regressions, including the curated P0 financial E2E

## Root cause
Portfolio sync only recognized named two-leg spreads and all-long combinations, so ARM's protected short call plus extra long put fell through to complex. Separately, mixed leg-basis provenance correctly suppressed aggregate capital, but parent dollar P&L reused that capital resolver even though every leg had independently measurable entry and market values.

## Verification
- red/green Python and Vitest regressions established before implementation
- focused Python: 106 passed
- focused Vitest: 22 passed
- CI-style Vitest: 8,196 passed
- production Playwright: 3/3 passed after current-main rebase
- Next production build and 195-manifest trace audit passed after current-main rebase
- TypeScript clean; ESLint 0 errors with 17 existing warnings
- full Python: 11,558 passed, 1 skipped; one load-sensitive GARCH retry failed in-suite and passed alone

## Visual result
The ARM parent now renders under Defined Risk Positions with -$10,803 P&L, exactly matching the expanded leg sum (-$600, -$4,855, -$5,348).