### PR TITLE
fix(cloud): provision Playwright Chromium in API image

### DIFF
--- a/.github/workflows/app-images.yml
+++ b/.github/workflows/app-images.yml
@@ -40,6 +40,7 @@ jobs:
           context: .
           file: docker/app/Dockerfile.python
           platforms: linux/amd64
+          load: true
           push: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
           tags: |
             ghcr.io/joemccann/radon-python:${{ github.sha }}
@@ -47,6 +48,13 @@ jobs:
           cache-from: type=gha,scope=radon-python
           cache-to: type=gha,mode=max,scope=radon-python
           provenance: false
+      - name: Smoke hardened Python browser runtime
+        run: |
+          docker run --rm --pull=never --init --user 1000:1000 --network none \
+            --cap-drop ALL --security-opt no-new-privileges \
+            --entrypoint python \
+            ghcr.io/joemccann/radon-python:${{ github.sha }} \
+            -c "from playwright.sync_api import sync_playwright; p = sync_playwright().start(); browser = p.chromium.launch(headless=True); page = browser.new_page(); page.set_content('<title>radon-browser-smoke</title>'); assert page.title() == 'radon-browser-smoke'; browser.close(); p.stop()"
 
   node-image:
     name: Build node image

--- a/cloud/tests/test_app_images.py
+++ b/cloud/tests/test_app_images.py
@@ -106,6 +106,21 @@ class TestPythonImage:
         assert "--uid 1000" in text
         assert "chmod 755 /home/radon" in text
 
+    def test_pinned_python_playwright_installs_and_launches_headless_chromium(self) -> None:
+        text = PYTHON_DF.read_text(encoding="utf-8")
+        install = "python -m playwright install --with-deps --only-shell chromium"
+        launch = "chromium.launch(headless=True)"
+
+        assert "ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright" in text
+        assert install in text
+        assert "npx playwright" not in text
+        assert "bun x playwright" not in text
+        assert text.index("RUN python -m pip install") < text.index(install)
+        assert text.index(install) < text.index("COPY --chown=radon:radon scripts")
+        assert "sync_playwright" in text
+        assert launch in text
+        assert text.index("USER radon") < text.index(launch)
+
 
 class TestNodeImage:
     def test_base_copies_and_cmd(self) -> None:

--- a/cloud/tests/test_app_plane_cutover_safety.py
+++ b/cloud/tests/test_app_plane_cutover_safety.py
@@ -250,6 +250,30 @@ class TestImageBuildCarriesPublicEnv:
 
 
 class TestImageBuildUsesRemoteCache:
+    def test_python_image_runs_a_hardened_browser_smoke(self):
+        jobs = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]
+        steps = jobs["python-image"]["steps"]
+        build_index = next(
+            index
+            for index, step in enumerate(steps)
+            if step.get("uses") == BUILD_PUSH_ACTION
+        )
+        build = steps[build_index]
+        smoke = steps[build_index + 1]["run"]
+
+        assert build["with"]["load"] is True
+        assert "docker run" in smoke
+        assert "ghcr.io/joemccann/radon-python:${{ github.sha }}" in smoke
+        assert "--pull=never" in smoke
+        assert "--user 1000:1000" in smoke
+        assert "--network none" in smoke
+        assert "--init" in smoke
+        assert "--cap-drop ALL" in smoke
+        assert "--security-opt no-new-privileges" in smoke
+        assert "sync_playwright" in smoke
+        assert "chromium.launch(headless=True)" in smoke
+        assert "page.title() == 'radon-browser-smoke'" in smoke
+
     @pytest.mark.parametrize(
         ("job_name", "dockerfile", "image", "scope"),
         (

--- a/docker/app/Dockerfile.python
+++ b/docker/app/Dockerfile.python
@@ -18,8 +18,15 @@ RUN python -m pip install --no-cache-dir \
     -r requirements.txt \
     -r scripts/requirements-api.txt
 
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+RUN python -m playwright install --with-deps --only-shell chromium \
+    && chmod -R a+rX /ms-playwright \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY --chown=radon:radon scripts ./scripts
 
 USER radon
+
+RUN python -c "from playwright.sync_api import sync_playwright; p = sync_playwright().start(); browser = p.chromium.launch(headless=True); page = browser.new_page(); page.set_content('<title>radon-browser-smoke</title>'); assert page.title() == 'radon-browser-smoke'; browser.close(); p.stop()"
 
 CMD ["uvicorn", "scripts.api.server:app", "--host", "0.0.0.0", "--port", "8321", "--proxy-headers", "--forwarded-allow-ips", "127.0.0.1"]

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -4528,3 +4528,35 @@ Goal: ≤640px position cards expose the desktop default-ON field set (position 
 - All figures route through the shared positionUtils / impliedValue helpers; the card still resolves ONE market value per position.
 - Full mobile Playwright project: 21–23 failures are pre-existing on main in this environment (same specs, verified in a main worktree); mobile-positions.spec.ts and mobile-same-day-pnl-parity.spec.ts pass.
 - Follow-up candidate (out of scope): InstrumentDetailModal still opens the desktop modal on mobile rather than a BottomSheet.
+# Task: Provision Chromium for the production radon-api runtime (2026-09-04)
+
+## Dependency graph
+
+- T1 depends_on: [] - Audit the current Python image, app-runtime mount contract, systemd API drop-in, production container, browser cache, and MenthorQ bootstrap requirements; choose the smallest durable fix.
+- T2 depends_on: [T1] - Add a failing regression that proves the production API runtime can resolve and launch the Playwright Chromium revision required by the installed Python package.
+- T3 depends_on: [T2] - Implement the minimal image or runtime provisioning change without adding mutable host coupling, exposing credentials, or broadening container privileges.
+- T4 depends_on: [T3] - Run focused cloud/runtime tests, build the production Python image, and smoke the exact browser executable and sandboxed launch path.
+- T5 depends_on: [T4] - Run full project Python verification, static checks, secret scan, and review the isolated diff before committing.
+- T6 depends_on: [T5] - Commit, push, open a PR, verify exact-head CI, send the required green notification, merge, and supervise exact-main production deployment.
+- T7 depends_on: [T6] - Verify the deployed API image contains the expected browser, rerun the local MenthorQ exposure request, and confirm HTTP 200 or isolate any remaining provider-auth requirement without touching IB Gateway/2FA.
+- T8 depends_on: [T7] - Record production evidence, residual risks, and cleanup of only task-created worktree state.
+
+## Checklist
+
+- [x] T1 Establish the image/runtime and production baseline.
+- [x] T2 Pin the missing-browser failure with a regression.
+- [x] T3 Provision Chromium in the production API runtime.
+- [ ] T4 Verify the exact production image and browser launch.
+- [x] T5 Complete full verification and diff review.
+- [ ] T6 Deliver through green PR CI and exact-main production deployment.
+- [ ] T7 Verify the live MenthorQ exposure path.
+- [ ] T8 Record final evidence and clean task artifacts.
+
+## Review
+
+- The Python image installs the Playwright 1.58-matched headless Chromium shell and Linux dependencies in an immutable shared path before application source is copied.
+- Build-time and workflow smokes launch a page as uid 1000; the workflow also reproduces the production capability restrictions and refuses registry fallback.
+- Focused cloud verification passed 132 tests with 2 declared skips after rebasing onto current main. The full Python suite passed 11,699 tests with 1 declared skip; two parallel-load timing failures passed serially.
+- YAML, shell syntax, diff hygiene, and gitleaks checks passed. Docker was unavailable locally, so the exact linux/amd64 image build remains gated by PR CI.
+
+---


### PR DESCRIPTION
## Summary
- bake the Python Playwright 1.58-matched Chromium headless shell and Linux dependencies into the shared API/monitor image
- keep the browser at `/ms-playwright` so uid 1000 resolves the immutable image-owned binary without a host cache mount
- launch Chromium during the image build and again from the exact loaded image with production-equivalent uid, caps, no-new-privileges, init, and network restrictions

## Cause
The production Python image installed the Playwright package but neither its browser binary nor the slim-image shared libraries. MenthorQ dashboard session bootstrap therefore failed before credentials could be used and returned the route's sanitized authentication-unavailable response.

## Verification
- focused cloud/runtime: 132 passed, 2 declared skips
- full Python: 11,699 passed, 1 declared skip; 2 parallel-load timing failures passed serially
- YAML and shell syntax: green
- diff and gitleaks: green
- exact linux/amd64 image build and hardened launch: gated by this PR

## Scope
No runtime mount, network, capability, IB Gateway, credential, or 2FA behavior changes.