### PR TITLE
Fix demo quota isolation and VIX spread marks

### DIFF
--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -49,7 +49,7 @@ parent-row P&L from the resolved leg economics.
 - [x] T3 Correct demo quota/identity behavior.
 - [x] T4 Complete focused and browser verification.
 - [x] T5 Record review evidence.
-- [ ] T6 Publish and verify the pull request.
+- [x] T6 Publish and verify the pull request.
 
 ## Review
 
@@ -58,6 +58,7 @@ parent-row P&L from the resolved leg economics.
 - A/B are now scoped by the first API resource, nested routes share that resource key, and passive shell GETs use a user-global 60/minute plus 50,000/day budget. Mutation, AI, reconnect, and endpoint-local controls remain in place.
 - Regression was red with 4 failures, then green: 55 focused Vitest tests passed and typecheck was clean. Scanner Playwright checks passed 2/2 and the mobile screenshot was visually clean.
 - Playwright's authless harness intentionally bypasses Clerk middleware, so browser checks validate the rendered scanner but not the demo gate. The gate itself is covered directly through `handleDemoGate` with an exhausted regime bucket and a fresh scanner request.
+- PR #289 passed the complete exact-head suite after the ambiguous WULF smoke selector was narrowed to the exact order-action button.
 
 ---
 
@@ -79,7 +80,7 @@ parent-row P&L from the resolved leg economics.
 - [x] T3 Correct the source-of-truth selection.
 - [x] T4 Complete focused, full, and visual verification.
 - [x] T5 Review the final diff and evidence.
-- [ ] T6 Publish and verify the pull request.
+- [x] T6 Publish and verify the pull request.
 
 ## Review
 
@@ -88,6 +89,7 @@ parent-row P&L from the resolved leg economics.
 - Synthetic combo depth is suppressed when display and executable denominators differ, preventing a normalized display row from pre-filling an incompatible BAG limit.
 - Regression was red with the displayed bid at $380.63, then green: 54 combined focused Vitest tests passed; the complete instrument-switcher Playwright spec passed 5 with 1 intentional mobile skip; TypeScript passed; ESLint passed with 0 errors and 17 existing warnings; visual screenshot inspection passed.
 - The first full Vitest run passed 8,266/8,267 assertions before exposing one stale ratio-display expectation, corrected and rerun 22/22 green; one unrelated REL-148 suite has a pre-existing `web/web` fixture path. A second full run under severe host contention passed 8,176/8,246 with widespread timeouts; all touched suites reran 54/54 green after load cleared.
+- PR #289 passed the complete exact-head suite, including all eight Vitest shards, the coverage ratchet, and the 60-test Playwright P0-financial smoke.
 
 ---
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -31,6 +31,66 @@ parent-row P&L from the resolved leg economics.
 
 ---
 
+# Task: Prevent first-visit demo scanner rate limiting (2026-09-04) [DONE]
+
+## Dependency graph
+
+- T1 depends_on: [] - Reproduce the first-visit demo scanner rate-limit state and trace request identity, tier, and quota accounting.
+- T2 depends_on: [T1] - Add a failing regression for a fresh demo visitor.
+- T3 depends_on: [T2] - Implement the smallest durable quota/identity correction while preserving abuse controls.
+- T4 depends_on: [T3] - Run focused tests and browser verification on the demo scanner.
+- T5 depends_on: [T4] - Document cause, evidence, and residual limits without exposing sensitive configuration.
+- T6 depends_on: [T5] - Commit the combined fix, open a pull request, supervise exact-head CI to green, and send the required notification.
+
+## Checklist
+
+- [x] T1 Reproduce and isolate first-visit rate limiting.
+- [x] T2 Record the regression red.
+- [x] T3 Correct demo quota/identity behavior.
+- [x] T4 Complete focused and browser verification.
+- [x] T5 Record review evidence.
+- [ ] T6 Publish and verify the pull request.
+
+## Review
+
+- Live read-only evidence at 19:00:52Z showed both initial `/api/scanner` requests returning 429 while Upstash answered `PONG`; the affected identity's shared middleware counters were already A=100 and B=10.
+- The quotas were sized as operator actions but keyed every resource into one user-wide bucket. Three futures fallbacks alone poll six times/minute, so ordinary workstation fan-out could consume A=100/hour, while dashboard regime/GEX/VCG traffic could consume B=10/hour before the first scanner visit.
+- A/B are now scoped by the first API resource, nested routes share that resource key, and passive shell GETs use a user-global 60/minute plus 50,000/day budget. Mutation, AI, reconnect, and endpoint-local controls remain in place.
+- Regression was red with 4 failures, then green: 55 focused Vitest tests passed and typecheck was clean. Scanner Playwright checks passed 2/2 and the mobile screenshot was visually clean.
+- Playwright's authless harness intentionally bypasses Clerk middleware, so browser checks validate the rendered scanner but not the demo gate. The gate itself is covered directly through `handleDemoGate` with an exhausted regime bucket and a fresh scanner request.
+
+---
+
+# Task: Correct VIX option implied-spread quote (2026-09-04) [DONE]
+
+## Dependency graph
+
+- T1 depends_on: [] - Trace VIX contract selection, per-leg quote normalization, and cockpit implied-spread rendering; reproduce the displayed-value mismatch.
+- T2 depends_on: [T1] - Add a failing focused regression for the VIX bull-call spread using the observed $20C/$30C quotes.
+- T3 depends_on: [T2] - Implement the smallest source-of-truth correction without changing combo action, ratio, or debit/credit semantics.
+- T4 depends_on: [T3] - Run focused Vitest and Playwright coverage, typecheck, full web tests, and visual browser verification.
+- T5 depends_on: [T4] - Review the isolated diff and document results.
+- T6 depends_on: [T5] - Commit the combined fix, open a pull request, supervise exact-head CI to green, and send the required notification.
+
+## Checklist
+
+- [x] T1 Reproduce and isolate the quote mismatch.
+- [x] T2 Record the regression red.
+- [x] T3 Correct the source-of-truth selection.
+- [x] T4 Complete focused, full, and visual verification.
+- [x] T5 Review the final diff and evidence.
+- [ ] T6 Publish and verify the pull request.
+
+## Review
+
+- The 500x499 holding was displayed as one GCD-reduced executable BAG, producing $380.63/$390.62/$400.61 instead of the portfolio's per-contract reporting quote. Display quotes now divide by the first-long contract denominator while `resolveNaturalSpreadQuote` retains exact executable BAG economics.
+- The observed leg markets now produce $0.76 bid, $0.78 mark, $0.80 ask, and $0.04 / 5.13% width. Focusing either option updates the cockpit header to that leg's quote, and the VIX futures ticket remains anchored to the $18.91 cash index.
+- Synthetic combo depth is suppressed when display and executable denominators differ, preventing a normalized display row from pre-filling an incompatible BAG limit.
+- Regression was red with the displayed bid at $380.63, then green: 54 combined focused Vitest tests passed; the complete instrument-switcher Playwright spec passed 5 with 1 intentional mobile skip; TypeScript passed; ESLint passed with 0 errors and 17 existing warnings; visual screenshot inspection passed.
+- The first full Vitest run passed 8,266/8,267 assertions before exposing one stale ratio-display expectation, corrected and rerun 22/22 green; one unrelated REL-148 suite has a pre-existing `web/web` fixture path. A second full run under severe host contention passed 8,176/8,246 with widespread timeouts; all touched suites reran 54/54 green after load cleared.
+
+---
+
 # Task: Combo replace IB 202 cancel abort (2026-09-04) [DONE]
 
 Combo modify treated IB error 202 as a failed cancel, skipped the replacement,

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from "next";
+import { headers } from "next/headers";
 import localFont from "next/font/local";
 import Providers from "@/components/Providers";
 import PwaRegister from "@/components/PwaRegister";
@@ -82,7 +83,18 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  // The Playwright bypass is server-only and token-bound in middleware. Carry
+  // the same verified request into the client provider tree so realtime specs
+  // do not request WS credentials from the deliberately fake Clerk instance
+  // in the test config. A deployment flag alone cannot enter this branch.
+  const requestHeaders = await headers();
+  const authlessTestToken = process.env.RADON_AUTHLESS_TEST_TOKEN;
+  const authlessTestBypass =
+    process.env.RADON_AUTHLESS_TEST === "1" &&
+    Boolean(authlessTestToken) &&
+    requestHeaders.get("x-radon-authless-test") === authlessTestToken;
+
   return (
     <html
       lang="en"
@@ -94,7 +106,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <ThemeBootstrap />
       </head>
       <body className="app-root">
-        <Providers>{children}</Providers>
+        <Providers authlessTestBypass={authlessTestBypass}>{children}</Providers>
         <PwaRegister />
       </body>
     </html>

--- a/web/components/Providers.tsx
+++ b/web/components/Providers.tsx
@@ -17,14 +17,20 @@ import SignOutCachePurge from "@/components/SignOutCachePurge";
 // realtime prices provider, still must. Once keys exist this branch is dead.
 const CLERK_CONFIGURED = Boolean(process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY);
 
-export default function Providers({ children }: { children: React.ReactNode }) {
+export default function Providers({
+  children,
+  authlessTestBypass = false,
+}: {
+  children: React.ReactNode;
+  authlessTestBypass?: boolean;
+}) {
   // Mounted on EVERY boot path, Clerk configured or not — an early keyless
   // exit here once silently dropped the realtime tree (T-389).
   const core = (
-    <RealtimeAuthProvider>
+    <RealtimeAuthProvider authlessTestBypass={authlessTestBypass}>
       <OfflineStatusProvider>
         <RouteRefreshProvider>
-          <IBStatusProvider>
+          <IBStatusProvider authlessTestBypass={authlessTestBypass}>
             {/* Owns the realtime prices socket for the life of the tab.
                 Lives here (not in the per-page WorkspaceShell) so App
                 Router navigations never tear the connection down. */}

--- a/web/components/TickerDetailContent.tsx
+++ b/web/components/TickerDetailContent.tsx
@@ -237,22 +237,23 @@ export default function TickerDetailContent({
   // while the depth book is correct; deriveBookHeader is the same source the
   // OrderBook header uses, so the two never diverge. Falls through to raw
   // priceData (incl. the closed-market fallback) when there is no entitled book.
+  const bookIsSpreadNet = bookKey === comboBookKey && Boolean(isSpreadNet);
   const quotePriceData = useMemo<PriceData | null>(() => {
-    if (!priceData || isSpreadNet || !bookDepth || bookDepth.entitled !== true) return priceData;
+    if (!bookPriceData || bookIsSpreadNet || !bookDepth || bookDepth.entitled !== true) return bookPriceData;
     const head = deriveBookHeader(bookDepth, {
-      bid: priceData.bid,
-      ask: priceData.ask,
-      last: priceData.last,
-      lastLabel: priceData.lastIsCalculated ? "MARK" : "LAST",
+      bid: bookPriceData.bid,
+      ask: bookPriceData.ask,
+      last: bookPriceData.last,
+      lastLabel: bookPriceData.lastIsCalculated ? "MARK" : "LAST",
     });
     return {
-      ...priceData,
+      ...bookPriceData,
       bid: head.bid,
       ask: head.ask,
       last: head.last,
       lastIsCalculated: head.lastLabel !== "LAST",
     };
-  }, [priceData, isSpreadNet, bookDepth]);
+  }, [bookPriceData, bookIsSpreadNet, bookDepth]);
 
   // Resolve instrument kind for the depth panel. depth.kind wins when the relay
   // has classified it; else a relay-supported futures root (ES/NQ/...) or an
@@ -261,10 +262,10 @@ export default function TickerDetailContent({
   // pre-depth hint so the page subscribes depth and routes to the ladder before
   // any DepthBook has arrived; once it does, depth.kind is authoritative.
   const bookKind: "stock" | "option" | "future" | "combo" = bookDepth?.kind
-    ?? (isFuturesRoot(ticker) || (isIndexSymbol(ticker) && hasFuturesSupport(ticker))
-      ? "future"
-      : bookKey === comboBookKey
-        ? "combo"
+    ?? (bookKey === comboBookKey
+      ? "combo"
+      : isFuturesRoot(ticker) || (isIndexSymbol(ticker) && hasFuturesSupport(ticker))
+        ? "future"
       : !viewUnderlying && comboBookKeys.includes(bookKey) && bookKey !== ticker
         ? "option"
         : "stock");
@@ -332,7 +333,7 @@ export default function TickerDetailContent({
       bookPriceData={bookPriceData}
       quotePriceData={quotePriceData}
       priceData={priceData}
-      isSpreadNet={isSpreadNet}
+      isSpreadNet={bookIsSpreadNet}
       tickerOrders={tickerOrders}
       stockFallback={stockFallback}
       theme={theme}

--- a/web/components/ticker-detail/AssetCockpit.tsx
+++ b/web/components/ticker-detail/AssetCockpit.tsx
@@ -8,6 +8,7 @@ import { useTickerDetailOptional, type OrderPrefill } from "@/lib/TickerDetailCo
 import { MetricCell } from "@/components/mobile/MetricCell";
 import { resolveMarketValue, resolveEntryCost, getAvgEntry, fmtPrice } from "@/lib/positionUtils";
 import { fmtMoneySigned } from "@/lib/format/money";
+import { isIndexSymbol } from "@/lib/indexSymbols";
 import BookTab from "./BookTab";
 import OrderTab from "./OrderTab";
 import ActHeldSummary from "./ActHeldSummary";
@@ -104,6 +105,7 @@ export default function AssetCockpit({
   viewUnderlying,
 }: AssetCockpitProps) {
   const live = (quotePriceData?.bid != null && quotePriceData?.ask != null) || quotePriceData?.last != null;
+  const ticketPriceData = isIndexSymbol(ticker) ? prices[ticker] ?? null : priceData;
 
   // When the underlying is in focus, the order ticket acts on the STOCK (a
   // fresh order), not the held option — OrderTab renders its linear stock form
@@ -183,7 +185,7 @@ export default function AssetCockpit({
               portfolio={portfolio}
               prices={prices}
               openOrders={tickerOrders}
-              tickerPriceData={priceData}
+              tickerPriceData={ticketPriceData}
             />
           </div>
           <div className="act-position">
@@ -215,7 +217,7 @@ export default function AssetCockpit({
         position={position}
         quotePriceData={quotePriceData}
         openOrders={tickerOrders}
-        tickerPriceData={priceData}
+        tickerPriceData={ticketPriceData}
       />
 
       <GlyphRail activeDeck={activeDeck} onDeckChange={onDeckChange} includeOrder={mobile} />

--- a/web/components/ticker-detail/BookTab.tsx
+++ b/web/components/ticker-detail/BookTab.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from "react";
 import type { OpenOrder, PortfolioData, PortfolioPosition } from "@/lib/types";
 import type { DepthBook, PriceData, Trade } from "@/lib/pricesProtocol";
 import { useTickerDetailOptional, type OrderPrefill } from "@/lib/TickerDetailContext";
-import { fmtPrice, legPriceKey } from "@/lib/positionUtils";
+import { fmtPrice, legPriceKey, positionSpreadQuoteScale } from "@/lib/positionUtils";
 import { useViewport } from "@/lib/useViewport";
 import SingleLegOrderTicket, { type SingleLegOrderAction } from "@/components/SingleLegOrderTicket";
 import { resolvePlacementTarget, type LinearOrderRiskInput } from "@/lib/order";
@@ -522,6 +522,7 @@ export default function BookTab({
 
   const selectedOptionLeg = optionLegBooks.find((leg) => leg.key === resolvedBookKey) ?? null;
   const isComboBook = bookKind === "combo" && comboLegBooks.length >= 2;
+  const comboQuoteScale = position ? positionSpreadQuoteScale(ticker, position) ?? 1 : 1;
   const depth = useMemo(() => {
     if (!isComboBook) {
       const live = depths?.[resolvedBookKey] ?? null;
@@ -543,6 +544,11 @@ export default function BookTab({
       }
       return live;
     }
+    // Display quotes are normalized to the portfolio's reporting-contract
+    // denominator. When that differs from the executable integer BAG unit,
+    // use the normalized L1 fallback: publishing BAG-scaled depth rows would
+    // make click-to-fill send a materially different limit price.
+    if (comboQuoteScale !== 1) return null;
     let depthCount = 0;
     let bboCount = 0;
     const legs = comboLegBooks.map((leg) => {
@@ -575,7 +581,7 @@ export default function BookTab({
         ? `HYBRID IMPLIED · ${depthCount} DEPTH + ${bboCount} BBO`
         : "IMPLIED LEG BBO",
     };
-  }, [ask, bid, bookKind, comboLegBooks, depths, isComboBook, priceData, prices, resolvedBookKey]);
+  }, [ask, bid, bookKind, comboLegBooks, comboQuoteScale, depths, isComboBook, priceData, prices, resolvedBookKey]);
   // depth.kind wins; else the kind resolved by the parent; else stock.
   const kind = depth?.kind ?? bookKind ?? "stock";
   // Time & Sales rides the same focused book key as depth. Newest-first from

--- a/web/e2e/mobile-combo-instrument-switcher.spec.ts
+++ b/web/e2e/mobile-combo-instrument-switcher.spec.ts
@@ -20,7 +20,7 @@ const PORTFOLIO_MOCK = {
   total_deployed_pct: 1.2,
   total_deployed_dollars: 1_200,
   remaining_capacity_pct: 98.8,
-  position_count: 1,
+  position_count: 2,
   defined_risk_count: 0,
   undefined_risk_count: 1,
   avg_kelly_optimal: null,
@@ -70,6 +70,49 @@ const PORTFOLIO_MOCK = {
       stop: null,
       entry_date: daysFromToday(-7),
     },
+    {
+      id: 9,
+      ticker: "VIX",
+      structure: "Ratio Bull Call Spread 500x499 $20/$30",
+      structure_type: "Ratio Bull Call Spread",
+      risk_profile: "undefined",
+      expiry: EXPIRY,
+      contracts: 500,
+      direction: "DEBIT",
+      entry_cost: 40_000,
+      max_risk: null,
+      market_value: 39_062,
+      market_price_is_calculated: true,
+      ib_daily_pnl: 0,
+      legs: [
+        {
+          direction: "LONG",
+          contracts: 500,
+          type: "Call",
+          strike: 20,
+          entry_cost: 70_000,
+          avg_cost: 140,
+          market_price: 1.4,
+          market_value: 70_000,
+          market_price_is_calculated: false,
+        },
+        {
+          direction: "SHORT",
+          contracts: 499,
+          type: "Call",
+          strike: 30,
+          entry_cost: 30_000,
+          avg_cost: 60.12,
+          market_price: 0.62,
+          market_value: 30_938,
+          market_price_is_calculated: false,
+        },
+      ],
+      kelly_optimal: null,
+      target: null,
+      stop: null,
+      entry_date: daysFromToday(-7),
+    },
   ],
   account_summary: {
     net_liquidation: 100_000,
@@ -93,6 +136,78 @@ const ORDERS_EMPTY = {
 };
 
 const PRICE_FIXTURES: Record<string, unknown> = {
+  VIX: {
+    symbol: "VIX",
+    last: 18.91,
+    lastIsCalculated: false,
+    bid: 18.9,
+    ask: 18.92,
+    bidSize: 10,
+    askSize: 10,
+    volume: 10,
+    high: null,
+    low: null,
+    open: null,
+    close: 18.5,
+    week52High: null,
+    week52Low: null,
+    avgVolume: null,
+    delta: null,
+    gamma: null,
+    theta: null,
+    vega: null,
+    impliedVol: null,
+    undPrice: null,
+    timestamp: now,
+  },
+  [`VIX_${EXPIRY_KEY}_20_C`]: {
+    symbol: `VIX_${EXPIRY_KEY}_20_C`,
+    last: 1.4,
+    lastIsCalculated: false,
+    bid: 1.39,
+    ask: 1.41,
+    bidSize: 50,
+    askSize: 8_933,
+    volume: 10,
+    high: null,
+    low: null,
+    open: null,
+    close: 1.38,
+    week52High: null,
+    week52Low: null,
+    avgVolume: null,
+    delta: null,
+    gamma: null,
+    theta: null,
+    vega: null,
+    impliedVol: null,
+    undPrice: 18.91,
+    timestamp: now,
+  },
+  [`VIX_${EXPIRY_KEY}_30_C`]: {
+    symbol: `VIX_${EXPIRY_KEY}_30_C`,
+    last: 0.62,
+    lastIsCalculated: false,
+    bid: 0.61,
+    ask: 0.63,
+    bidSize: 999,
+    askSize: 4_566,
+    volume: 10,
+    high: null,
+    low: null,
+    open: null,
+    close: 0.6,
+    week52High: null,
+    week52Low: null,
+    avgVolume: null,
+    delta: null,
+    gamma: null,
+    theta: null,
+    vega: null,
+    impliedVol: null,
+    undPrice: 18.91,
+    timestamp: now,
+  },
   IWM: {
     symbol: "IWM",
     last: 244.65,
@@ -284,6 +399,45 @@ async function stubApis(page: Page) {
   await page.route("**/api/ib/ws-ticket", (route) =>
     route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ticket: "test" }) }),
   );
+  await page.route("**/api/futures/chain?*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        symbol: "VIX",
+        exchange: "CFE",
+        contracts: [
+          {
+            conId: 9_001,
+            symbol: "VIX",
+            localSymbol: "VIXU6",
+            exchange: "CFE",
+            currency: "USD",
+            lastTradeDateOrContractMonth: EXPIRY_KEY,
+            multiplier: "1000",
+            tradingClass: "VX",
+            marketName: "VIX",
+            minTick: 0.05,
+          },
+        ],
+        count: 1,
+      }),
+    }),
+  );
+  await page.route("**/api/index-options/chain?*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        symbol: "VIX",
+        exchange: "CBOE",
+        tradingClass: "VIX",
+        expirations: [EXPIRY_KEY],
+        contracts: [],
+        count: 0,
+      }),
+    }),
+  );
   await page.route("**/api/blotter", (route) =>
     route.fulfill({
       status: 200,
@@ -364,4 +518,54 @@ test("STOCK|OPTION labels are vertically centered in their segments", async ({ p
     });
     expect(offset, `${name} label off vertical center by ${offset}px`).toBeLessThanOrEqual(1.5);
   }
+});
+
+test("VIX 500x499 holdings show a per-contract implied quote", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium", "desktop cockpit regression");
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await installMockWebSocket(page);
+  await stubApis(page);
+
+  await page.goto("/VIX?posId=9");
+  await expect(page.locator(".cockpit-host")).toBeVisible({ timeout: 30_000 });
+
+  const implied = page.getByRole("button", { name: "Implied spread book" });
+  const long = page.getByRole("button", { name: "$20 Call book" });
+  const short = page.getByRole("button", { name: "$30 Call book" });
+  const header = page.locator(".cockpit-head");
+  const book = page.locator(".book-window");
+
+  await expect(implied).toHaveAttribute("aria-pressed", "true");
+  await expect(page.locator(".book-kind")).toHaveText("IMPLIED SPREAD");
+  await expect(header).toContainText("$0.78");
+  await expect(header).toContainText("NET $0.04 / 5.13%");
+  await expect(book).toContainText("$0.76");
+  await expect(book).toContainText("$0.80");
+  await expect(book).not.toContainText("390.62");
+
+  await expect(page.locator(".act-ticket")).toContainText("VIX Index");
+  await expect(page.locator(".act-ticket")).toContainText("$18.91");
+  await expect(page.locator(".act-ticket")).not.toContainText("$0.78");
+
+  await long.click();
+  await expect(long).toHaveAttribute("aria-pressed", "true");
+  await expect(page.locator(".book-kind")).toHaveText("OPTION");
+  await expect(header).toContainText("$1.40");
+  await expect(header).toContainText("SPREAD $0.02 / 1.43%");
+
+  await short.click();
+  await expect(short).toHaveAttribute("aria-pressed", "true");
+  await expect(header).toContainText("$0.62");
+  await expect(header).toContainText("SPREAD $0.02 / 3.23%");
+
+  await implied.click();
+  await expect(implied).toHaveAttribute("aria-pressed", "true");
+  await expect(header).toContainText("$0.78");
+
+  const screenshotPath = testInfo.outputPath("vix-implied-spread-desktop.png");
+  await page.screenshot({ path: screenshotPath, fullPage: true });
+  await testInfo.attach("vix-implied-spread-desktop", {
+    path: screenshotPath,
+    contentType: "image/png",
+  });
 });

--- a/web/e2e/wulf-close-order-naked-short.spec.ts
+++ b/web/e2e/wulf-close-order-naked-short.spec.ts
@@ -260,7 +260,7 @@ test("WULF close-position order tab does not show a false naked-short warning", 
 
   await expect(page.locator(".existing-orders-title").first()).toContainText("Close Position");
 
-  await page.getByRole("button", { name: "SELL" }).click();
+  await page.getByRole("button", { name: "SELL", exact: true }).click();
   await page.locator(".order-input").fill("77");
   await page.locator(".modify-price-input").fill("4.47");
   await expect(page.locator(".order-error").filter({ hasText: /Naked short call/i })).toHaveCount(0);

--- a/web/lib/IBStatusContext.tsx
+++ b/web/lib/IBStatusContext.tsx
@@ -200,7 +200,13 @@ export function parseIbHealth(
 
 /* ─── Provider ────────────────────────────────────────── */
 
-export function IBStatusProvider({ children }: { children: ReactNode }) {
+export function IBStatusProvider({
+  children,
+  authlessTestBypass = false,
+}: {
+  children: ReactNode;
+  authlessTestBypass?: boolean;
+}) {
   // Demo deployment is seed-data only — there is no IB gateway and no realtime
   // relay by design. Short-circuit with a static neutral "demo" context so we
   // never open the WS or poll /health (which 404s on /edge-health/status) and
@@ -224,11 +230,21 @@ export function IBStatusProvider({ children }: { children: ReactNode }) {
       </IBStatusContext.Provider>
     );
   }
-  return <AuthenticatedIBStatusProvider>{children}</AuthenticatedIBStatusProvider>;
+  return (
+    <AuthenticatedIBStatusProvider authlessTestBypass={authlessTestBypass}>
+      {children}
+    </AuthenticatedIBStatusProvider>
+  );
 }
 
-function AuthenticatedIBStatusProvider({ children }: { children: ReactNode }) {
-  if (process.env.NODE_ENV === "test") {
+function AuthenticatedIBStatusProvider({
+  children,
+  authlessTestBypass,
+}: {
+  children: ReactNode;
+  authlessTestBypass: boolean;
+}) {
+  if (process.env.NODE_ENV === "test" || authlessTestBypass) {
     return <IBStatusCoreProvider getToken={undefined}>{children}</IBStatusCoreProvider>;
   }
   return <ClerkIBStatusProvider>{children}</ClerkIBStatusProvider>;

--- a/web/lib/RealtimeAuthContext.tsx
+++ b/web/lib/RealtimeAuthContext.tsx
@@ -13,7 +13,20 @@ const CLERK_CONFIGURED = Boolean(process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY);
 
 const anonymousToken: RealtimeTokenGetter = async () => null;
 
-export function RealtimeAuthProvider({ children }: { children: ReactNode }) {
+export function RealtimeAuthProvider({
+  children,
+  authlessTestBypass = false,
+}: {
+  children: ReactNode;
+  authlessTestBypass?: boolean;
+}) {
+  if (authlessTestBypass) {
+    return (
+      <RealtimeAuthContext.Provider value={undefined}>
+        {children}
+      </RealtimeAuthContext.Provider>
+    );
+  }
   if (!CLERK_CONFIGURED) {
     return (
       <RealtimeAuthContext.Provider value={anonymousToken}>

--- a/web/lib/demo/demoGate.ts
+++ b/web/lib/demo/demoGate.ts
@@ -15,7 +15,7 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { resolveDemoContext, type DemoPublicMetadata } from "./demoRole";
-import { classifyRateTier } from "./rateTier";
+import { classifyRateTier, demoRateLimitKey } from "./rateTier";
 import { demoRateLimit, type DemoRateLimitResult, type DemoRateTier } from "./rateLimit";
 
 function isApiPath(pathname: string): boolean {
@@ -88,7 +88,7 @@ export async function handleDemoGate(
   if (api) {
     const tier = classifyRateTier(request.method, pathname);
     const limiter = deps.rateLimiter ?? demoRateLimit;
-    const rl = await limiter(tier, userId);
+    const rl = await limiter(tier, demoRateLimitKey(tier, userId, pathname));
     if (!rl.success) {
       const res = NextResponse.json(
         {
@@ -106,7 +106,13 @@ export async function handleDemoGate(
       }
       return noStore(res);
     }
-    const dailyTier = tier === "E" ? "F" : tier === "G" ? "H" : null;
+    const dailyTier = tier === "E"
+      ? "F"
+      : tier === "G"
+        ? "H"
+        : tier === "I"
+          ? "J"
+          : null;
     if (dailyTier) {
       const daily = await limiter(dailyTier, userId);
       if (!daily.success) {

--- a/web/lib/demo/rateLimit.ts
+++ b/web/lib/demo/rateLimit.ts
@@ -1,7 +1,7 @@
 // Tiered Upstash sliding-window rate limiter, keyed by Clerk userId
 // (demo.radon.run, plan §Guardrails — Rate-limit / DOS).
 //
-// Eight tiers:
+// Ten tiers:
 //   A — reads        ~100/hr   (cheap GETs)
 //   B — expensive    ~10/hr    (scans, heavy aggregations)
 //   C — mutations    5/day     (writes: notes, watchlist, alerts)
@@ -11,6 +11,8 @@
 //   F — WS tickets   200/day   (daily reconnect ceiling)
 //   G — headlines    5/min     (bounded snapshot-poll bursts)
 //   H — headlines    5,000/day (three persistent one-minute polling tabs)
+//   I — shell polls   60/min    (portfolio/orders/health/quote refreshes)
+//   J — shell polls   50,000/day (three persistent tabs through Globex)
 //
 // The limiter is constructed LAZILY from UPSTASH_REDIS_REST_URL / _TOKEN.
 // Production and demo deployments fail closed if it is unavailable; local
@@ -26,7 +28,9 @@ import {
   DEMO_HEADLINES_DAILY_LIMIT,
 } from "./headlinesPolicy";
 
-export type DemoRateTier = "A" | "B" | "C" | "D" | "E" | "F" | "G" | "H";
+export type DemoRateTier =
+  | "A" | "B" | "C" | "D" | "E"
+  | "F" | "G" | "H" | "I" | "J";
 
 export type DemoRateLimitResult = {
   success: boolean;
@@ -46,6 +50,8 @@ const TIER_CONFIG: Record<DemoRateTier, TierConfig> = {
   F: { limit: 200, window: "1 d" },
   G: { limit: DEMO_HEADLINES_BURST_PER_MINUTE, window: "1 m" },
   H: { limit: DEMO_HEADLINES_DAILY_LIMIT, window: "1 d" },
+  I: { limit: 60, window: "1 m" },
+  J: { limit: 50_000, window: "1 d" },
 };
 
 // Generous no-op result for builds without Upstash configured.

--- a/web/lib/demo/rateTier.ts
+++ b/web/lib/demo/rateTier.ts
@@ -2,9 +2,9 @@
 //
 // Pure mapping consumed by the middleware demo rate-limiter. Tiers + budgets
 // are defined in rateLimit.ts (A reads 100/hr, B expensive 10/hr, C mutations
-// 5/day, D AI 5/day, E/F WS reconnects, G/H headline polling). Keeping the
-// classifier pure makes the policy a unit test instead of a thing you discover
-// in production.
+// 5/day, D AI 5/day, E/F WS reconnects, G/H headline polling, I/J shell
+// polling). Keeping the classifier pure makes the policy a unit test instead
+// of a thing you discover in production.
 
 import type { DemoRateTier } from "./rateLimit";
 
@@ -28,6 +28,19 @@ const EXPENSIVE_PATTERNS: RegExp[] = [
 
 const WRITE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
+// These GETs are automatic workstation refreshes, not operator actions. Their
+// shipped cadence is much higher than tier A's 100/hour (the three futures
+// fallbacks alone issue six requests/minute), so they need a bounded budget
+// that matches the UI instead of consuming every ordinary read token.
+const PASSIVE_POLL_PATHS = new Set<string>([
+  "/api/flex-token",
+  "/api/futures-quote",
+  "/api/orders",
+  "/api/portfolio",
+  "/api/risk-free-rate",
+  "/api/service-health",
+]);
+
 /**
  * Map an API request to its rate-limit tier. Order matters: AI routes (some are
  * GET) are classified before the generic read bucket, and expensive scans
@@ -40,8 +53,25 @@ export function classifyRateTier(
   const normalizedMethod = method.toUpperCase();
   if (normalizedMethod === "POST" && pathname === "/api/ib/ws-ticket") return "E";
   if (normalizedMethod === "GET" && pathname === "/api/headlines") return "G";
+  if (normalizedMethod === "GET" && PASSIVE_POLL_PATHS.has(pathname)) return "I";
   if (AI_PATHS.has(pathname)) return "D";
   if (EXPENSIVE_PATTERNS.some((re) => re.test(pathname))) return "B";
   if (WRITE_METHODS.has(normalizedMethod)) return "C";
   return "A";
+}
+
+/**
+ * Cheap and expensive resources receive independent per-user budgets. A busy
+ * dashboard may exhaust its own regime allowance, but cannot spend the first
+ * scanner visit's allowance. Grouping on the first API segment keeps nested
+ * routes together so changing a suffix cannot evade the cap.
+ */
+export function demoRateLimitKey(
+  tier: DemoRateTier,
+  userId: string,
+  pathname: string,
+): string {
+  if (tier !== "A" && tier !== "B") return userId;
+  const resource = /^\/api\/([^/]+)/.exec(pathname)?.[1] ?? "api";
+  return `${userId}:resource:${resource}`;
 }

--- a/web/lib/positionUtils.ts
+++ b/web/lib/positionUtils.ts
@@ -496,13 +496,10 @@ function integerGcd(a: number, b: number): number {
   return a;
 }
 
-/** Natural executable spread market from cross-sided leg quotes. */
-export function resolveNaturalSpreadQuote(
+function netPositionLegs(
   ticker: string,
   position: PortfolioPosition,
-  prices: Record<string, PriceData>,
-): { bid: number; ask: number; mid: number; asOf?: string } | null {
-  if (position.legs.length < 2) return null;
+): Array<[key: string, signedContracts: number]> | null {
   const signedByKey = new Map<string, number>();
   for (const leg of position.legs) {
     if (!Number.isInteger(leg.contracts) || leg.contracts <= 0) return null;
@@ -512,7 +509,37 @@ export function resolveNaturalSpreadQuote(
     signedByKey.set(key, (signedByKey.get(key) ?? 0) + signed);
   }
   const netLegs = [...signedByKey.entries()].filter(([, signed]) => signed !== 0);
-  if (netLegs.length < 2) return null;
+  return netLegs.length >= 2 ? netLegs : null;
+}
+
+/**
+ * Scale between one executable integer-ratio BAG and one reporting contract.
+ *
+ * IB requires BAG ratios reduced by GCD, but portfolio `contracts` is the
+ * display denominator used by Avg Entry / Last. A nearly balanced 500x499
+ * holding is therefore one enormous executable BAG yet 500 reporting units.
+ */
+export function positionSpreadQuoteScale(
+  ticker: string,
+  position: PortfolioPosition,
+): number | null {
+  const netLegs = netPositionLegs(ticker, position);
+  const displayContracts = Math.abs(position.contracts);
+  if (!netLegs || !Number.isInteger(displayContracts) || displayContracts <= 0) return null;
+  const bagUnits = netLegs.map(([, signed]) => Math.abs(signed)).reduce(integerGcd);
+  const scale = displayContracts / bagUnits;
+  return Number.isFinite(scale) && scale > 0 ? scale : null;
+}
+
+/** Natural executable spread market from cross-sided leg quotes. */
+export function resolveNaturalSpreadQuote(
+  ticker: string,
+  position: PortfolioPosition,
+  prices: Record<string, PriceData>,
+): { bid: number; ask: number; mid: number; asOf?: string } | null {
+  if (position.legs.length < 2) return null;
+  const netLegs = netPositionLegs(ticker, position);
+  if (!netLegs) return null;
   const divisor = netLegs.map(([, signed]) => Math.abs(signed)).reduce(integerGcd);
   let bid = 0;
   let ask = 0;
@@ -549,8 +576,9 @@ export function resolveSpreadPriceData(
 
   const natural = resolveNaturalSpreadQuote(ticker, position, prices);
   if (!natural) return null;
-  const lo = Math.round(natural.bid * 100) / 100;
-  const hi = Math.round(natural.ask * 100) / 100;
+  const displayScale = positionSpreadQuoteScale(ticker, position) ?? 1;
+  const lo = Math.round((natural.bid / displayScale) * 100) / 100;
+  const hi = Math.round((natural.ask / displayScale) * 100) / 100;
   const mid = Number((((lo + hi) / 2)).toFixed(2));
 
   return {

--- a/web/tests/demo-gate.test.ts
+++ b/web/tests/demo-gate.test.ts
@@ -99,4 +99,66 @@ describe("handleDemoGate", () => {
     expect(res).toBeNull();
     expect(limiter.mock.calls.map(([tier]) => tier)).toEqual(["G", "H"]);
   });
+
+  it("keeps a first scanner visit out of an exhausted regime budget", async () => {
+    const usage = new Map<string, number>();
+    const limiter = vi.fn(async (tier: string, key: string): Promise<DemoRateLimitResult> => {
+      const counterKey = `${tier}:${key}`;
+      const next = (usage.get(counterKey) ?? 0) + 1;
+      usage.set(counterKey, next);
+      return {
+        success: next <= 10,
+        limit: 10,
+        remaining: Math.max(0, 10 - next),
+        reset: NOW + 60_000,
+      };
+    });
+
+    for (let requestNumber = 0; requestNumber < 10; requestNumber += 1) {
+      const res = await handleDemoGate(
+        { userId: "fresh-demo-user", metadata: activeMeta, request: apiReq("/api/regime") },
+        { now: NOW, rateLimiter: limiter },
+      );
+      expect(res).toBeNull();
+    }
+
+    const scanner = await handleDemoGate(
+      { userId: "fresh-demo-user", metadata: activeMeta, request: apiReq("/api/scanner") },
+      { now: NOW, rateLimiter: limiter },
+    );
+
+    expect(scanner).toBeNull();
+    expect(limiter.mock.calls.at(-1)).toEqual([
+      "B",
+      "fresh-demo-user:resource:scanner",
+    ]);
+  });
+
+  it("shares one abuse budget across nested routes for the same resource", async () => {
+    const limiter = vi.fn(async () => allow);
+
+    await handleDemoGate(
+      { userId: "user", metadata: activeMeta, request: apiReq("/api/scanner") },
+      { now: NOW, rateLimiter: limiter },
+    );
+    await handleDemoGate(
+      { userId: "user", metadata: activeMeta, request: apiReq("/api/scanner/theta") },
+      { now: NOW, rateLimiter: limiter },
+    );
+
+    expect(limiter.mock.calls).toEqual([
+      ["B", "user:resource:scanner"],
+      ["B", "user:resource:scanner"],
+    ]);
+  });
+
+  it("shell polling consumes isolated minute and daily ceilings", async () => {
+    const limiter = vi.fn(async () => allow);
+    const res = await handleDemoGate(
+      { userId: "u", metadata: activeMeta, request: apiReq("/api/futures-quote") },
+      { now: NOW, rateLimiter: limiter },
+    );
+    expect(res).toBeNull();
+    expect(limiter.mock.calls.map(([tier]) => tier)).toEqual(["I", "J"]);
+  });
 });

--- a/web/tests/demo-rate-limit-fail-closed.test.ts
+++ b/web/tests/demo-rate-limit-fail-closed.test.ts
@@ -27,6 +27,17 @@ describe("durable demo rate limiter configuration", () => {
     __resetRateLimitForTests();
     expect((await demoRateLimit("B", "user")).success).toBe(true);
   });
+
+  it("sizes passive shell polling for three persistent workstation tabs", async () => {
+    vi.stubEnv("NODE_ENV", "test");
+    vi.stubEnv("NEXT_PUBLIC_RADON_DEMO", "");
+    vi.stubEnv("UPSTASH_REDIS_REST_URL", "");
+    vi.stubEnv("UPSTASH_REDIS_REST_TOKEN", "");
+    __resetRateLimitForTests();
+
+    expect(await demoRateLimit("I", "user")).toMatchObject({ limit: 60, success: true });
+    expect(await demoRateLimit("J", "user")).toMatchObject({ limit: 50_000, success: true });
+  });
 });
 
 describe("a dead Upstash instance denies, it does not crash the request", () => {

--- a/web/tests/demo-rate-tier.test.ts
+++ b/web/tests/demo-rate-tier.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { classifyRateTier } from "@/lib/demo/rateTier";
+import { classifyRateTier, demoRateLimitKey } from "@/lib/demo/rateTier";
 
 describe("classifyRateTier", () => {
   it("AI routes are tier D regardless of method", () => {
@@ -31,9 +31,24 @@ describe("classifyRateTier", () => {
     expect(classifyRateTier("GET", "/api/headlines")).toBe("G");
   });
 
+  it("passive shell polling uses a budget sized for the shipped cadence", () => {
+    expect(classifyRateTier("GET", "/api/futures-quote")).toBe("I");
+    expect(classifyRateTier("GET", "/api/service-health")).toBe("I");
+    expect(classifyRateTier("GET", "/api/flex-token")).toBe("I");
+    expect(classifyRateTier("GET", "/api/risk-free-rate")).toBe("I");
+    expect(classifyRateTier("GET", "/api/portfolio")).toBe("I");
+    expect(classifyRateTier("GET", "/api/orders")).toBe("I");
+    expect(classifyRateTier("POST", "/api/orders")).toBe("C");
+  });
+
   it("plain reads are tier A", () => {
-    expect(classifyRateTier("GET", "/api/portfolio")).toBe("A");
-    expect(classifyRateTier("GET", "/api/orders")).toBe("A");
     expect(classifyRateTier("get", "/api/blotter")).toBe("A"); // case-insensitive
+    expect(classifyRateTier("GET", "/api/preferences")).toBe("A");
+  });
+
+  it("keeps spend and mutation controls user-global", () => {
+    expect(demoRateLimitKey("C", "user", "/api/watchlist")).toBe("user");
+    expect(demoRateLimitKey("D", "user", "/api/assistant")).toBe("user");
+    expect(demoRateLimitKey("E", "user", "/api/ib/ws-ticket")).toBe("user");
   });
 });

--- a/web/tests/position-tab-trade.test.tsx
+++ b/web/tests/position-tab-trade.test.tsx
@@ -68,12 +68,12 @@ describe("PositionTab — trade affordances", () => {
     expect(screen.getByTestId("pos-leg-trade-1").textContent).toBe("SELL"); // long put → sell to close
   });
 
-  it("uses canonical combo units once when valuing a ratio spread", () => {
+  it("uses portfolio reporting contracts once when valuing a ratio spread", () => {
     renderTab();
     const marketValue = screen.getByText("Market Value").parentElement?.textContent ?? "";
     expect(marketValue).toContain("$19,100");
     const mark = screen.getByText("Mark Price").parentElement?.textContent ?? "";
-    expect(mark).toContain("-$191.00");
+    expect(mark).toContain("-$38.20");
   });
 
   it("opens the combo ticket on the Close/Adjust Combo CTA", () => {

--- a/web/tests/spread-price-bar.test.ts
+++ b/web/tests/spread-price-bar.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveSpreadPriceData } from "@/lib/positionUtils";
+import { resolveNaturalSpreadQuote, resolveSpreadPriceData } from "@/lib/positionUtils";
 import type { PortfolioPosition } from "@/lib/types";
 import type { PriceData } from "@/lib/pricesProtocol";
 
@@ -81,6 +81,38 @@ describe("resolveSpreadPriceData", () => {
     expect(result!.symbol).toBe("GOOG");
   });
 
+  it("quotes an imbalanced VIX spread per displayed contract instead of as one 500x499 BAG", () => {
+    const vixSpread: PortfolioPosition = {
+      ...bullCallSpread,
+      ticker: "VIX",
+      structure: "Ratio Bull Call Spread 500x499 $20/$30",
+      structure_type: "Ratio Bull Call Spread",
+      expiry: "2026-09-09",
+      contracts: 500,
+      legs: [
+        { ...bullCallSpread.legs[0], strike: 20, direction: "LONG", contracts: 500 },
+        { ...bullCallSpread.legs[1], strike: 30, direction: "SHORT", contracts: 499 },
+      ],
+    };
+    const prices: Record<string, PriceData> = {
+      "VIX_20260909_20_C": makePriceData({ symbol: "VIX_20260909_20_C", bid: 1.39, ask: 1.41 }),
+      "VIX_20260909_30_C": makePriceData({ symbol: "VIX_20260909_30_C", bid: 0.61, ask: 0.63 }),
+    };
+
+    const result = resolveSpreadPriceData("VIX", vixSpread, prices);
+    const executableBag = resolveNaturalSpreadQuote("VIX", vixSpread, prices);
+
+    expect(result).not.toBeNull();
+    expect(result!.bid).toBe(0.76);
+    expect(result!.last).toBe(0.78);
+    expect(result!.ask).toBe(0.80);
+    // Order entry still closes the exact integer 500:499 BAG. Only the
+    // position/reporting quote is normalized to the displayed 500 contracts.
+    expect(executableBag?.bid).toBeCloseTo(380.63, 5);
+    expect(executableBag?.mid).toBeCloseTo(390.62, 5);
+    expect(executableBag?.ask).toBeCloseTo(400.61, 5);
+  });
+
   it("returns null when per-leg prices are missing", () => {
     const prices: Record<string, PriceData> = {
       "GOOG_20260320_315_C": makePriceData({ symbol: "GOOG", bid: 8.50, ask: 8.80 }),
@@ -157,6 +189,7 @@ describe("resolveSpreadPriceData", () => {
     const bearPut: PortfolioPosition = {
       ...bullCallSpread,
       structure: "DEBIT 10X BEAR PUT SPREAD $340.0/$315.0",
+      contracts: 10,
       legs: [
         { type: "Put", strike: 340, direction: "LONG", contracts: 10, entry_cost: 20000, market_value: 18000, market_price_is_calculated: false },
         { type: "Put", strike: 315, direction: "SHORT", contracts: 10, entry_cost: 8000, market_value: 6000, market_price_is_calculated: false },

--- a/web/tests/vix-implied-spread.test.tsx
+++ b/web/tests/vix-implied-spread.test.tsx
@@ -1,0 +1,183 @@
+/** @vitest-environment jsdom */
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import TickerDetailContent from "@/components/TickerDetailContent";
+import { OrderActionsProvider } from "@/lib/OrderActionsContext";
+import { TickerDetailProvider } from "@/lib/TickerDetailContext";
+import type { DepthBook, PriceData } from "@/lib/pricesProtocol";
+import type { OrdersData, PortfolioData, PortfolioPosition } from "@/lib/types";
+
+vi.mock("@/lib/useViewport", () => ({
+  useViewport: () => ({ isMobile: false, hasMounted: true }),
+}));
+
+vi.mock("@/lib/useWatchlist", () => ({
+  useWatchlist: () => ({ isWatched: () => false, toggleWatch: vi.fn() }),
+}));
+
+vi.mock("@/lib/useStockState", () => ({
+  useStockState: () => ({ fallback: null }),
+}));
+
+vi.mock("@/components/ticker-detail/FuturesOrderForm", () => ({
+  FuturesOrderForm: () => React.createElement("div", { "data-testid": "futures-order-form" }),
+}));
+
+vi.mock("@/components/ticker-detail/IndexOptionOrderForm", () => ({
+  IndexOptionOrderForm: () => React.createElement("div", { "data-testid": "index-option-order-form" }),
+}));
+
+const timestamp = "2026-09-04T18:55:00.000Z";
+const expiry = "2026-09-09";
+const longKey = "VIX_20260909_20_C";
+const shortKey = "VIX_20260909_30_C";
+
+function price(symbol: string, bid: number, ask: number): PriceData {
+  return {
+    symbol,
+    last: (bid + ask) / 2,
+    lastIsCalculated: false,
+    bid,
+    ask,
+    bidSize: 10,
+    askSize: 10,
+    volume: null,
+    high: null,
+    low: null,
+    open: null,
+    close: null,
+    week52High: null,
+    week52Low: null,
+    avgVolume: null,
+    delta: null,
+    gamma: null,
+    theta: null,
+    vega: null,
+    impliedVol: null,
+    undPrice: null,
+    timestamp,
+  };
+}
+
+function depth(symbol: string, bid: number, ask: number, bidSize: number, askSize: number): DepthBook {
+  return {
+    symbol,
+    kind: "option",
+    bid: [{ price: bid, size: bidSize, marketMaker: null, exchange: "CBOE", nbbo: true }],
+    ask: [{ price: ask, size: askSize, marketMaker: null, exchange: "CBOE", nbbo: true }],
+    isSmartDepth: true,
+    feed: "OPRA BBO",
+    entitled: true,
+    timestamp,
+  };
+}
+
+const position: PortfolioPosition = {
+  id: 9,
+  ticker: "VIX",
+  structure: "Ratio Bull Call Spread 500x499 $20/$30",
+  structure_type: "Ratio Bull Call Spread",
+  risk_profile: "undefined",
+  expiry,
+  contracts: 500,
+  direction: "DEBIT",
+  entry_cost: 40_000,
+  max_risk: null,
+  market_value: 39_062,
+  market_price_is_calculated: true,
+  legs: [
+    { direction: "LONG", contracts: 500, type: "Call", strike: 20, entry_cost: 70_000, avg_cost: 140, market_price: 1.40, market_value: 70_000 },
+    { direction: "SHORT", contracts: 499, type: "Call", strike: 30, entry_cost: 30_000, avg_cost: 60.12, market_price: 0.62, market_value: 30_938 },
+  ],
+};
+
+const portfolio = {
+  bankroll: 100_000,
+  peak_value: 100_000,
+  last_sync: timestamp,
+  total_deployed_pct: 0,
+  total_deployed_dollars: 0,
+  remaining_capacity_pct: 100,
+  position_count: 1,
+  defined_risk_count: 0,
+  undefined_risk_count: 1,
+  avg_kelly_optimal: null,
+  positions: [position],
+} as PortfolioData;
+
+const orders: OrdersData = {
+  last_sync: timestamp,
+  open_orders: [],
+  executed_orders: [],
+  open_count: 0,
+  executed_count: 0,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("VIX imbalanced option spread book", () => {
+  it("shows the per-contract implied spread and follows each focused option book", async () => {
+    render(
+      <OrderActionsProvider>
+        <TickerDetailProvider>
+          <TickerDetailContent
+            ticker="VIX"
+            positionId={9}
+            activeTab="book"
+            onTabChange={vi.fn()}
+            prices={{
+              VIX: price("VIX", 18.90, 18.92),
+              [longKey]: price(longKey, 1.39, 1.41),
+              [shortKey]: price(shortKey, 0.61, 0.63),
+            }}
+            fundamentals={{}}
+            portfolio={portfolio}
+            orders={orders}
+            depths={{
+              [longKey]: depth(longKey, 1.39, 1.41, 50, 8_933),
+              [shortKey]: depth(shortKey, 0.61, 0.63, 999, 4_566),
+            }}
+            tape={{}}
+            theme="dark"
+          />
+        </TickerDetailProvider>
+      </OrderActionsProvider>,
+    );
+
+    const cockpitHeader = document.querySelector(".cockpit-head") as HTMLElement;
+    const bookWindow = document.querySelector(".book-window") as HTMLElement;
+    const implied = screen.getByRole("button", { name: "Implied spread book" });
+    const long = screen.getByRole("button", { name: "$20 Call book" });
+    const short = screen.getByRole("button", { name: "$30 Call book" });
+
+    expect(implied.getAttribute("aria-pressed")).toBe("true");
+    expect(document.querySelector(".book-kind")?.textContent).toBe("IMPLIED SPREAD");
+    expect(cockpitHeader.textContent).toContain("$0.78");
+    expect(cockpitHeader.textContent).toContain("NET $0.04 / 5.13%");
+    expect(bookWindow.textContent).toContain("BID$0.76");
+    expect(bookWindow.textContent).toContain("ASK$0.80");
+    expect(bookWindow.textContent).not.toContain("390.62");
+
+    fireEvent.click(long);
+    await waitFor(() => expect(long.getAttribute("aria-pressed")).toBe("true"));
+    expect(document.querySelector(".book-kind")?.textContent).toBe("OPTION");
+    expect(cockpitHeader.textContent).toContain("$1.40");
+    expect(cockpitHeader.textContent).toContain("SPREAD $0.02 / 1.43%");
+
+    fireEvent.click(short);
+    await waitFor(() => expect(short.getAttribute("aria-pressed")).toBe("true"));
+    expect(cockpitHeader.textContent).toContain("$0.62");
+    expect(cockpitHeader.textContent).toContain("SPREAD $0.02 / 3.23%");
+
+    fireEvent.click(implied);
+    await waitFor(() => expect(implied.getAttribute("aria-pressed")).toBe("true"));
+    expect(document.querySelector(".book-kind")?.textContent).toBe("IMPLIED SPREAD");
+    expect(cockpitHeader.textContent).toContain("$0.78");
+    expect(cockpitHeader.textContent).toContain("NET $0.04 / 5.13%");
+  });
+});


### PR DESCRIPTION
## Summary
- Scope demo read and scan quotas by API resource so unrelated workstation traffic cannot exhaust a first scanner visit.
- Move passive shell polling into bounded minute and daily tiers while retaining mutation, AI, reconnect, and endpoint controls.
- Normalize imbalanced option-spread display quotes to portfolio reporting contracts while preserving exact executable BAG ratios.
- Keep focused leg headers and VIX futures ticket telemetry on their own quote sources.

## Root cause
The demo middleware placed every cheap read into one user-wide A bucket and every scan or aggregation into one user-wide B bucket. Normal shell polling and dashboard fan-out consumed those counters before a fresh scanner visit. The VIX position display independently reused a GCD-reduced executable 500:499 BAG quote as its per-contract reporting mark.

## Verification
- Red-green demo gate and VIX quote regressions.
- 54/54 combined focused Vitest tests passed.
- Instrument switcher Playwright: 5 passed, 1 intentional mobile skip.
- Scanner Playwright: 2/2 passed with visual screenshot inspection.
- TypeScript passed; ESLint passed with 0 errors and 17 existing warnings.
- Full local Vitest first run passed 8,266/8,267 assertions before exposing one stale ratio expectation, then that touched surface reran 22/22 green. One unrelated REL-148 test has a pre-existing doubled web/web fixture path; a later host-contention run produced broad timeouts, while every touched suite reran 54/54 green after load cleared.