### PR TITLE
fix(web): modify a partially filled order in REMAINING quantity

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -7407,6 +7407,18 @@ body[data-mobile="true"] .orders-command-strip__jump:active {
   font-size: 12px;
 }
 
+/* Partial fill: the header quantity is the REMAINDER, so name what already
+   filled rather than leaving the smaller number unexplained. */
+.modify-order-filled {
+  padding: 1px 6px;
+  border: 1px solid color-mix(in srgb, var(--warning) 45%, transparent);
+  border-radius: 2px;
+  color: var(--warning);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
 .modify-layout {
   display: flex;
   flex-direction: column;

--- a/web/components/ModifyOrderModal.tsx
+++ b/web/components/ModifyOrderModal.tsx
@@ -8,6 +8,11 @@ import type { ModifyComboLeg, ModifyOrderRequest } from "@/lib/orderModify";
 import Modal from "./Modal";
 import { getQuoteMetrics } from "@/lib/quoteTelemetry";
 import { applyRestingLimitToQuote } from "@/lib/modifyOrderQuote";
+import {
+  filledQuantity,
+  remainingQuantity,
+  toIbTotalQuantity,
+} from "@/lib/orders/modifyQuantity";
 import { fmtPrice, legPriceKey, resolveClosingBasis } from "@/lib/positionUtils";
 import {
   findHeldComboForClose,
@@ -318,8 +323,11 @@ export default function ModifyOrderModal({ order, loading, prices, portfolio, op
     if (order?.limitPrice != null) {
       setNewPrice(order.limitPrice.toFixed(2));
     }
+    // The operator edits what is STILL WORKING. On a partially filled order
+    // that is the remainder, not the original size — seeding the total priced
+    // the ticket as if nothing had filled.
     if (order?.totalQuantity != null) {
-      setNewQuantity(String(order.totalQuantity));
+      setNewQuantity(String(remainingQuantity(order)));
     }
     setOutsideRth(Boolean(order?.outsideRth));
     setEditableLegs(buildEditableComboLegs(order));
@@ -504,7 +512,10 @@ export default function ModifyOrderModal({ order, loading, prices, portfolio, op
   if (!order) return null;
 
   const currentPrice = order.limitPrice ?? 0;
-  const currentQuantity = order.totalQuantity;
+  // Compare against the remainder, so re-submitting an untouched partial
+  // order is correctly seen as "no quantity change".
+  const currentQuantity = remainingQuantity(order);
+  const alreadyFilled = filledQuantity(order);
   const parsedNew = parseFloat(newPrice);
   const parsedQuantity = parsePositiveInteger(newQuantity);
   const isComboOrder = order.contract.secType === "BAG" && editableLegs.length >= 2;
@@ -603,7 +614,9 @@ export default function ModifyOrderModal({ order, loading, prices, portfolio, op
 
     const request: ModifyOrderRequest = {};
     if (priceChanged) request.newPrice = parsedNew;
-    if (quantityChanged) request.newQuantity = parsedQuantity!;
+    // IB's modify assigns the NEW TOTAL (ib_order_manage.py), so the edited
+    // remainder has to carry the already-filled units back with it.
+    if (quantityChanged) request.newQuantity = toIbTotalQuantity(order, parsedQuantity!);
     if (outsideRthChanged) request.outsideRth = outsideRth;
     onConfirm(request);
   };
@@ -623,7 +636,12 @@ export default function ModifyOrderModal({ order, loading, prices, portfolio, op
           </span>
           <span>{order.orderType}</span>
           <span>{order.tif}</span>
-          <span>{order.totalQuantity}x</span>
+          <span>{currentQuantity}x</span>
+          {alreadyFilled > 0 && (
+            <span className="modify-order-filled">
+              {alreadyFilled} of {order.totalQuantity} filled
+            </span>
+          )}
         </div>
 
         <div className={`modify-layout${isComboOrder ? " modify-layout-combo" : ""}`}>

--- a/web/lib/orders/modifyQuantity.ts
+++ b/web/lib/orders/modifyQuantity.ts
@@ -1,0 +1,52 @@
+import type { OpenOrder } from "@/lib/types";
+
+/**
+ * Quantity arithmetic for modifying a PARTIALLY FILLED order.
+ *
+ * Two different numbers meet here and they must not be confused:
+ *
+ *   - What the operator edits is the REMAINING quantity — the part still
+ *     working. A 1000-lot that has filled 16 has 984 left to buy, and 984 is
+ *     what the ticket prices, margins and previews.
+ *   - What IB accepts on a modify is the NEW TOTAL quantity
+ *     (`ib_order_manage.py` assigns `trade.order.totalQuantity`), which
+ *     counts the 16 already filled.
+ *
+ * Sending the remaining figure straight through would silently shrink the
+ * order by everything already filled.
+ */
+
+/** Filled units, clamped to a value that can be reasoned about.
+ *
+ * A payload whose `filled` is absent, negative, non-finite, or not smaller
+ * than the total is treated as "no partial fill" so the dialog behaves
+ * exactly as it always has rather than inventing a remainder.
+ */
+export function filledQuantity(order: Pick<OpenOrder, "filled" | "totalQuantity">): number {
+  const filled = order.filled;
+  if (!Number.isFinite(filled) || filled <= 0) return 0;
+  if (!Number.isFinite(order.totalQuantity) || filled >= order.totalQuantity) return 0;
+  return filled;
+}
+
+/** Units still working — what the operator edits and what the ticket prices. */
+export function remainingQuantity(
+  order: Pick<OpenOrder, "filled" | "totalQuantity">,
+): number {
+  return order.totalQuantity - filledQuantity(order);
+}
+
+/** True when this order has filled in part and is still working. */
+export function isPartiallyFilled(
+  order: Pick<OpenOrder, "filled" | "totalQuantity">,
+): boolean {
+  return filledQuantity(order) > 0;
+}
+
+/** Translate an edited REMAINING quantity into the NEW TOTAL that IB expects. */
+export function toIbTotalQuantity(
+  order: Pick<OpenOrder, "filled" | "totalQuantity">,
+  enteredRemaining: number,
+): number {
+  return filledQuantity(order) + enteredRemaining;
+}

--- a/web/tests/modify-partial-fill-quantity.test.tsx
+++ b/web/tests/modify-partial-fill-quantity.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Modifying a PARTIALLY FILLED order must work in REMAINING quantity.
+ *
+ * A 1000-lot that has filled 16 has 984 still working. The dialog used to
+ * seed the field with `totalQuantity` (1000) and price the ticket as if
+ * 1000 contracts were still to be bought — $61,000 of cost and margin
+ * against a remainder that only costs $60,024.
+ *
+ * The wire is the other half: IB's modify assigns `trade.order.totalQuantity`
+ * (scripts/ib_order_manage.py), so an edited REMAINING figure must be sent
+ * back as `filled + entered`. Sending the remainder raw would silently shrink
+ * the order by everything already filled.
+ */
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { OpenOrder, PortfolioData } from "@/lib/types";
+import ModifyOrderModal from "@/components/ModifyOrderModal";
+import {
+  filledQuantity,
+  isPartiallyFilled,
+  remainingQuantity,
+  toIbTotalQuantity,
+} from "@/lib/orders/modifyQuantity";
+
+vi.mock("@/lib/useRiskFreeRate", () => ({
+  useRiskFreeRate: () => 0,
+}));
+
+vi.mock("@/components/Modal", () => ({
+  default: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? React.createElement("div", { className: "mock-modal" }, children) : null,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+/** The order from the report: VIX C30, 1000 requested, 16 filled. */
+function vixOrder(overrides: Partial<OpenOrder> = {}): OpenOrder {
+  return {
+    orderId: 7,
+    permId: 7007,
+    symbol: "VIX",
+    contract: {
+      conId: 71,
+      symbol: "VIX",
+      secType: "OPT",
+      strike: 30,
+      right: "C",
+      expiry: "20261020",
+    },
+    action: "BUY",
+    orderType: "LMT",
+    totalQuantity: 1000,
+    limitPrice: 0.61,
+    auxPrice: null,
+    status: "Submitted",
+    filled: 16,
+    remaining: 984,
+    avgFillPrice: 0.61,
+    tif: "DAY",
+    ...overrides,
+  };
+}
+
+const PORTFOLIO = { positions: [], bankroll: 1_000_000 } as unknown as PortfolioData;
+
+function renderModal(order: OpenOrder, onConfirm = vi.fn()) {
+  const view = render(
+    <ModifyOrderModal
+      order={order}
+      loading={false}
+      portfolio={PORTFOLIO}
+      onConfirm={onConfirm}
+      onClose={() => {}}
+    />,
+  );
+  return { ...view, onConfirm };
+}
+
+const qtyInput = () =>
+  document.getElementById("modify-quantity-input") as HTMLInputElement;
+const submitBtn = () =>
+  screen.getByRole("button", { name: /Modify Order/i }) as HTMLButtonElement;
+
+describe("modifyQuantity helpers", () => {
+  it("reports the remainder of a partially filled order", () => {
+    const order = vixOrder();
+    expect(filledQuantity(order)).toBe(16);
+    expect(remainingQuantity(order)).toBe(984);
+    expect(isPartiallyFilled(order)).toBe(true);
+  });
+
+  it("treats an unfilled order as wholly remaining", () => {
+    const order = vixOrder({ filled: 0, remaining: 1000 });
+    expect(filledQuantity(order)).toBe(0);
+    expect(remainingQuantity(order)).toBe(1000);
+    expect(isPartiallyFilled(order)).toBe(false);
+  });
+
+  it("converts an edited remainder back to IB's new TOTAL", () => {
+    const order = vixOrder();
+    expect(toIbTotalQuantity(order, 984)).toBe(1000);
+    expect(toIbTotalQuantity(order, 500)).toBe(516);
+    // No partial fill: remaining IS the total, so the wire value is unchanged.
+    expect(toIbTotalQuantity(vixOrder({ filled: 0 }), 400)).toBe(400);
+  });
+
+  it("ignores a nonsensical filled count rather than inventing a remainder", () => {
+    for (const filled of [-5, Number.NaN, Number.POSITIVE_INFINITY, 1000, 1500]) {
+      const order = vixOrder({ filled: filled as number });
+      expect(filledQuantity(order)).toBe(0);
+      expect(remainingQuantity(order)).toBe(1000);
+    }
+  });
+});
+
+describe("ModifyOrderModal prefills the REMAINING quantity", () => {
+  it("seeds 984, not the original 1000", () => {
+    renderModal(vixOrder());
+    expect(qtyInput().value).toBe("984");
+  });
+
+  it("still seeds the full size when nothing has filled", () => {
+    renderModal(vixOrder({ filled: 0, remaining: 1000 }));
+    expect(qtyInput().value).toBe("1000");
+  });
+
+  it("shows the operator what already filled", () => {
+    const { container } = renderModal(vixOrder());
+    const info = container.querySelector(".modify-order-info");
+    expect(info?.textContent).toContain("984x");
+    expect(info?.textContent).toContain("16");
+  });
+});
+
+describe("ModifyOrderModal partial-fill wire contract", () => {
+  it("submits nothing while the remainder is untouched", () => {
+    const { onConfirm } = renderModal(vixOrder());
+    expect(qtyInput().value).toBe("984");
+    expect(submitBtn().disabled).toBe(true);
+    fireEvent.click(submitBtn());
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("sends filled + entered as the new TOTAL", () => {
+    const { onConfirm } = renderModal(vixOrder());
+
+    fireEvent.change(qtyInput(), { target: { value: "500" } });
+    expect(submitBtn().disabled).toBe(false);
+    fireEvent.click(submitBtn());
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    // 16 already filled + 500 still wanted = 516 total, NOT 500.
+    expect(onConfirm.mock.calls[0][0]).toEqual({ newQuantity: 516 });
+  });
+
+  it("sends the entered value unchanged when nothing has filled", () => {
+    const { onConfirm } = renderModal(vixOrder({ filled: 0, remaining: 1000 }));
+
+    fireEvent.change(qtyInput(), { target: { value: "400" } });
+    fireEvent.click(submitBtn());
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm.mock.calls[0][0]).toEqual({ newQuantity: 400 });
+  });
+});


### PR DESCRIPTION
## Symptom

A VIX C30 BUY 1000-lot with 16 filled opened MODIFY seeded **1000**. The order row two lines above it already read `16/1000 · PARTIAL`.

The preview priced the whole thing as if nothing had filled: `BUY 1000x VIX C @ $0.61 · Total: $61,000 · Margin Req: $61,000`, for a remainder that costs $60,024.

## Cause

Two different numbers meet at this dialog and the code used one for both.

- **What the operator edits** is the part still working — 984. That is what the ticket should price, margin and preview.
- **What IB accepts on a modify** is the new TOTAL: `scripts/ib_order_manage.py` does `trade.order.totalQuantity = new_quantity`, which counts the 16 already filled.

`ModifyOrderModal` seeded `order.totalQuantity` and passed the field through untouched. The two errors cancelled out — but only while the quantity was left alone.

`remaining` is already a first-class field on `OpenOrder` (emitted by `ib_orders.py` from `status.remaining`), so nothing upstream changes.

## Fix

`web/lib/orders/modifyQuantity.ts` owns the arithmetic. The field, the header and the `quantityChanged` compare all move to the remainder; submit translates back with `toIbTotalQuantity`.

Editing 984 → 500 now transmits **516**, not 500 — sending the raw remainder would have silently shrunk the order by everything already filled. An untouched partial order still submits nothing.

A payload whose `filled` is absent, negative, non-finite, or not smaller than the total is treated as no-partial-fill, so an unfilled order and a malformed one behave exactly as before rather than inventing a remainder.

The header gains a `16 of 1000 filled` chip — the quantity shown is now the smaller number and needs to say why. `--warning` token, 2px radius, no raw hex.

`isModifyConfirmed` in the modify route needs no change: it compares the refreshed snapshot's `totalQuantity` against what was sent, and what is sent is still the total.

Both surfaces that render the dialog (`WorkspaceSections`, ticker-detail `OrderTab`) share this one component, so both inherit the fix.

## Test

`web/tests/modify-partial-fill-quantity.test.tsx`, red first on four behaviours — including the wire assertion `expected { newQuantity: 500 } to deeply equal { newQuantity: 516 }`.

Covers the helpers (including the malformed-`filled` cases), the 984 prefill, the full-size prefill when nothing has filled, the unchanged-order no-op, and the `filled + entered` payload.

## Verification

- vitest from repo root: **8756 passed, 0 failed**
- `tsc --noEmit` clean; pre-commit types + ESLint green; gitleaks clean

Not verified in a live browser — reproducing it needs a resting order that is partially filled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AvZ1WgrVftoRazZg5hic5
