### PR TITLE
Take radon out of group docker, behind a pinned-container root shim

### DIFF
--- a/cloud/CLAUDE.md
+++ b/cloud/CLAUDE.md
@@ -49,6 +49,28 @@ not start, stop, or restart Gateway. Since R-430 the deploy job also runs
 `radon-deploy-root sync-control-plane` first, so privileged diffs (helper,
 sudoers, polkit) converge on GitHub main without root SSH too.
 
+**`radon` is not in group `docker`.** That group is root-equivalent: a member
+mounts the host into a container and walks out as root. The account held it
+only to drive the `ib-gateway` container, and that now goes through
+`/usr/local/sbin/radon-docker-gw` — root-owned, a fixed verb set
+(`compose-up`, `compose-down`, `inspect-running`, `pgrep-jvm`, `pgrep-java`,
+`thread-dump <pid>`, `logs`, `stats`, `ps`) against a pinned container, each
+verb listed in full in `sudoers.d/radon-ops` with no wildcard. Callers:
+`ib-gateway-control.sh` (still `User=radon`, so the 2FA lease and guard files
+under `/var/lib/radon` keep their ownership) and `scripts/jvm_forensics.py`.
+
+The compose body it runs lives at `/etc/radon/ib-gateway-compose.yml`, a
+control-plane artifact, NOT `cloud/docker-compose.yml` in the checkout: root
+acting on a file its caller can rewrite is the same escalation with extra
+steps. The shim refuses a symlinked or non-root-owned body, and
+`--project-name cloud` is pinned so the `cloud_ib-config` volume — the
+Gateway's Jts settings and 2FA state — survives the move.
+
+`inspect-running` passes docker's stdout, stderr and exit code through
+untouched: `gateway_state()` tells `missing` from `unknown` by matching
+"No such object" on stderr, and swallowing it wedges the watchdog's restart
+ladder at `unknown`.
+
 **Refresh installs git blobs, never the working tree.** The sources it copies
 into `/etc/sudoers.d`, `/usr/local/sbin`, `/etc/polkit-1` and the unit
 directory come from `git cat-file blob` at the deployed commit, staged

--- a/cloud/config/sudoers.d/radon-ops
+++ b/cloud/config/sudoers.d/radon-ops
@@ -23,5 +23,15 @@ radon ALL=(root) NOPASSWD: /usr/sbin/faillock --user radon
 radon ALL=(root) NOPASSWD: /usr/bin/journalctl -u radon-*
 radon ALL=(root) NOPASSWD: /usr/bin/docker logs ib-gateway
 
+# --- Gateway container control (replaces radon's group `docker` membership) ---
+# Group docker is root-equivalent; radon held it only to drive ONE container.
+# radon-docker-gw is root-owned and takes a fixed verb set against a pinned
+# container, with no caller-supplied paths, images, mounts or flags. Each verb
+# is listed in full: a trailing wildcard would hand back the arbitrary argv the
+# shim exists to refuse.
+radon ALL=(root) NOPASSWD: /usr/local/sbin/radon-docker-gw compose-up, /usr/local/sbin/radon-docker-gw compose-down, /usr/local/sbin/radon-docker-gw inspect-running
+radon ALL=(root) NOPASSWD: /usr/local/sbin/radon-docker-gw pgrep-jvm, /usr/local/sbin/radon-docker-gw pgrep-java, /usr/local/sbin/radon-docker-gw thread-dump [0-9]*
+radon ALL=(root) NOPASSWD: /usr/local/sbin/radon-docker-gw logs, /usr/local/sbin/radon-docker-gw stats, /usr/local/sbin/radon-docker-gw ps
+
 # Anything else still requires the password; no blanket NOPASSWD or direct
 # systemctl/docker mutator is authorized.

--- a/cloud/scripts/bootstrap-control-plane.sh
+++ b/cloud/scripts/bootstrap-control-plane.sh
@@ -114,6 +114,8 @@ readonly -a SOURCES=(
   scripts/drift_audit.py
   scripts/disk_cleanup.py
   scripts/radon-app-runtime.sh
+  scripts/radon-docker-gw.sh
+  docker-compose.yml
   config/sudoers.d/radon-deploy
   config/sudoers.d/radon-monitor
   config/sudoers.d/radon-ops
@@ -153,6 +155,8 @@ readonly -a LOGICAL_TARGETS=(
   /usr/local/lib/radon/drift_audit.py
   /usr/local/lib/radon/disk_cleanup.py
   /usr/local/sbin/radon-app-runtime
+  /usr/local/sbin/radon-docker-gw
+  /etc/radon/ib-gateway-compose.yml
   /etc/sudoers.d/radon-deploy
   /etc/sudoers.d/radon-monitor
   /etc/sudoers.d/radon-ops
@@ -186,7 +190,7 @@ readonly -a LOGICAL_TARGETS=(
   /etc/systemd/system/radon-newsfeed.service.d/runtime-container.conf
 )
 readonly -a MODES=(
-  0755 0755 0755 0644 0644 0755
+  0755 0755 0755 0644 0644 0755 0755 0644
   0440 0440 0440 0440
   0644
   0644 0644 0644 0644 0644 0644 0644 0644 0644 0644 0644 0644 0644 0644 0644
@@ -194,7 +198,7 @@ readonly -a MODES=(
   0644 0644 0644 0644 0644
 )
 readonly -a KINDS=(
-  shell shell shell python python shell
+  shell shell shell python python shell shell compose
   sudoers sudoers sudoers sudoers
   polkit
   systemd systemd systemd systemd systemd systemd systemd systemd systemd systemd
@@ -336,6 +340,18 @@ for index in "${!SOURCES[@]}"; do
     polkit)
       "$NODE_BIN" --check < "$staged_path" || \
         die "polkit syntax validation failed: $relative_source"
+      ;;
+    # The Gateway compose body radon-docker-gw runs as root. Same gate the
+    # deploy helper's refresh_install_file applies.
+    compose)
+      grep -Eq '^services:' "$staged_path" || \
+        die "compose validation failed: $relative_source declares no services"
+      grep -Eq '^[[:space:]]+container_name:[[:space:]]*ib-gateway[[:space:]]*$' "$staged_path" || \
+        die "compose validation failed: $relative_source does not pin container_name ib-gateway"
+      ! grep -Eq '^[[:space:]]*privileged:[[:space:]]*true' "$staged_path" || \
+        die "compose validation failed: $relative_source requests privileged"
+      ! grep -Eq '^[[:space:]]*-[[:space:]]*/[[:space:]]*:' "$staged_path" || \
+        die "compose validation failed: $relative_source binds the host root"
       ;;
     python)
       # Parse only. Importing or compiling to disk would execute or cache

--- a/cloud/scripts/deploy-root-helper.sh
+++ b/cloud/scripts/deploy-root-helper.sh
@@ -18,6 +18,8 @@ readonly -a CONTROL_PLANE_SOURCES=(
   scripts/drift_audit.py
   scripts/disk_cleanup.py
   scripts/radon-app-runtime.sh
+  scripts/radon-docker-gw.sh
+  docker-compose.yml
   config/sudoers.d/radon-deploy
   config/sudoers.d/radon-monitor
   config/sudoers.d/radon-ops
@@ -57,6 +59,8 @@ readonly -a CONTROL_PLANE_TARGETS=(
   /usr/local/lib/radon/drift_audit.py
   /usr/local/lib/radon/disk_cleanup.py
   /usr/local/sbin/radon-app-runtime
+  /usr/local/sbin/radon-docker-gw
+  /etc/radon/ib-gateway-compose.yml
   /etc/sudoers.d/radon-deploy
   /etc/sudoers.d/radon-monitor
   /etc/sudoers.d/radon-ops
@@ -90,7 +94,7 @@ readonly -a CONTROL_PLANE_TARGETS=(
   /etc/systemd/system/radon-newsfeed.service.d/runtime-container.conf
 )
 readonly -a CONTROL_PLANE_MODES=(
-  755 755 755 644 644 755
+  755 755 755 644 644 755 755 644
   440 440 440 440
   644
   644 644 644 644 644 644 644 644 644 644 644 644 644 644 644 644 644 644 644 644 644
@@ -136,6 +140,7 @@ if [[ "${RADON_DEPLOY_HELPER_TEST_MODE:-0}" == "1" ]]; then
   readonly SHA256SUM="${RADON_TEST_SHA256SUM:-$(command -v sha256sum)}"
   readonly VISUDO="${RADON_TEST_VISUDO:-$(command -v visudo)}"
   readonly NODE="${RADON_TEST_NODE:-$(command -v node || true)}"
+  readonly DOCKER="${RADON_TEST_DOCKER:-}"
   test_replica_prefix="${RADON_TEST_REPLICA_PREFIX:?test replica prefix is required}"
   readonly REPLICA_FILES=(
     "$test_replica_prefix"
@@ -167,6 +172,7 @@ else
   readonly SHA256SUM=/usr/bin/sha256sum
   readonly VISUDO=/usr/sbin/visudo
   readonly NODE=/usr/bin/node
+  readonly DOCKER=/usr/bin/docker
   readonly ROOT_MUTATION_ACTION_TIMEOUT=180
   readonly ROOT_VERIFY_ACTION_TIMEOUT=30
   readonly ROOT_COMMIT_ACTION_TIMEOUT=30
@@ -1320,7 +1326,7 @@ refresh_install_file() {
         return 73
       fi
       ;;
-    */radon-deploy-root|*/radon-ib-gateway-control|*/usr/local/bin/radon|*/radon-app-runtime)
+    */radon-deploy-root|*/radon-ib-gateway-control|*/usr/local/bin/radon|*/radon-app-runtime|*/radon-docker-gw)
       if ! bash -n "$candidate"; then
         echo "shell syntax validation failed: ${dest}" >&2
         "$RM" -f "$candidate"
@@ -1331,6 +1337,22 @@ refresh_install_file() {
     # path runs on every deploy with the app tier STOPPED and used to install
     # the app runtime, polkit rules, python helpers and control-plane units
     # unvalidated; test_refresh_control_plane pins one arm per target. R-437.
+    # The Gateway compose body root acts on. It is a control-plane file for
+    # exactly one reason: radon-docker-gw runs it as root, so it must not be
+    # readable out of the radon-writable checkout. Same shape as publish_caddy's
+    # `caddy validate` gate.
+    */ib-gateway-compose.yml)
+      # `docker compose config` would have to resolve env_file and the whole
+      # variable set, which is not available at install time. Gate on the two
+      # things that make this body safe for root to run instead: it declares
+      # the pinned container, and it does not ask for privilege or the host
+      # filesystem. Provenance (the git blob at the deployed commit) is the
+      # real integrity gate.
+      if ! compose_body_is_valid "$candidate" "$dest"; then
+        "$RM" -f "$candidate"
+        return 73
+      fi
+      ;;
     */polkit-1/rules.d/*.rules)
       if [[ -z "$NODE" || ! -x "$NODE" ]] || ! "$NODE" --check < "$candidate"; then
         echo "polkit syntax validation failed: ${dest}" >&2
@@ -1381,6 +1403,31 @@ refresh_install_file() {
     return 73
   fi
   "$SYNC" -f "$dest"
+}
+
+# Root runs this compose body. It must name the Gateway container and must not
+# request privilege or a host-root bind -- the two shapes that turn "root runs
+# a compose file" into "caller is root".
+compose_body_is_valid() {
+  local candidate="$1" dest="$2"
+
+  grep -Eq '^services:' "$candidate" || {
+    echo "compose validation failed: ${dest} declares no services" >&2
+    return 1
+  }
+  grep -Eq '^[[:space:]]+container_name:[[:space:]]*ib-gateway[[:space:]]*$' "$candidate" || {
+    echo "compose validation failed: ${dest} does not pin container_name ib-gateway" >&2
+    return 1
+  }
+  if grep -Eq '^[[:space:]]*privileged:[[:space:]]*true' "$candidate"; then
+    echo "compose validation failed: ${dest} requests privileged" >&2
+    return 1
+  fi
+  if grep -Eq '^[[:space:]]*-[[:space:]]*/[[:space:]]*:' "$candidate"; then
+    echo "compose validation failed: ${dest} binds the host root" >&2
+    return 1
+  fi
+  return 0
 }
 
 write_control_plane_manifest_and_ready() {

--- a/cloud/scripts/ib-gateway-control.sh
+++ b/cloud/scripts/ib-gateway-control.sh
@@ -31,7 +31,16 @@ fi
 # provisioned by setup-vps rather than the app venv swapped during deploys.
 LOCK_PYTHON="${RADON_LOCK_PYTHON:-/usr/bin/python3.13}"
 LOCK_CLI="${APP_DIR}/scripts/utils/ib_2fa_lock.py"
-DOCKER_BIN="${RADON_DOCKER_BIN:-/usr/bin/docker}"
+# The helper stays radon (the lease and guard files under /var/lib/radon must
+# keep their ownership), but radon is no longer in group `docker` -- that group
+# is root-equivalent. The two docker calls below go through the root shim,
+# which pins the container, the compose body and every flag. Tests keep
+# overriding RADON_DOCKER_BIN with a stub and get no sudo hop.
+if [[ -n "${RADON_DOCKER_BIN:-}" ]]; then
+  DOCKER_CMD=("$RADON_DOCKER_BIN")
+else
+  DOCKER_CMD=("${RADON_SUDO_BIN:-/usr/bin/sudo}" -n /usr/local/sbin/radon-docker-gw)
+fi
 CONSUMED_PATH="${RADON_IB_LEASE_CONSUMED_PATH:-/var/lib/radon/ib-2fa-consumed-lease.json}"
 CONTROL_GUARD_PATH="${RADON_IB_CONTROL_GUARD_PATH:-/var/lib/radon/ib-gateway-control.guard}"
 TRANSITION_PATH="${RADON_IB_TRANSITION_PATH:-/var/lib/radon/ib-gateway-transition.json}"
@@ -211,20 +220,16 @@ except subprocess.TimeoutExpired:
 PY
 }
 
+# The shim owns --env-file, --project-name and -f; this passes only the verb.
 compose() {
-  RADON_COMPOSE_ENV_FILE="$ENV_FILE" run_bounded \
-    "$DOCKER_MUTATION_TIMEOUT_SECS" "$DOCKER_BIN" compose \
-    --env-file "$ENV_FILE" \
-    --project-directory "$CLOUD_DIR" \
-    -f "$CLOUD_DIR/docker-compose.yml" \
-    "$@"
+  run_bounded "$DOCKER_MUTATION_TIMEOUT_SECS" "${DOCKER_CMD[@]}" "$@"
 }
 
 gateway_state() {
   local output rc=0
   output="$(
     run_bounded "$DOCKER_INSPECT_TIMEOUT_SECS" \
-      "$DOCKER_BIN" inspect --format '{{.State.Running}}' "$CONTAINER_NAME" 2>&1
+      "${DOCKER_CMD[@]}" inspect-running 2>&1
   )" || rc=$?
   if (( rc == 0 )); then
     case "$output" in
@@ -448,7 +453,7 @@ start_gateway() {
     return 0
   fi
   require_new_lease
-  compose_to_state running start up -d
+  compose_to_state running start compose-up
   if ! container_running; then
     echo "Gateway start command completed but container is not running" >&2
     return 1
@@ -459,8 +464,8 @@ restart_gateway() {
   refuse_app_role_mutation || return 1
   reconcile_pending_transition
   require_new_lease
-  compose_to_state stopped restart-down down
-  compose_to_state running restart-up up -d
+  compose_to_state stopped restart-down compose-down
+  compose_to_state running restart-up compose-up
   if ! container_running; then
     echo "Gateway restart command completed but container is not running" >&2
     return 1
@@ -472,8 +477,8 @@ restart_gateway_preheld() {
   refuse_app_role_mutation || return 1
   reconcile_pending_transition
   consume_watchdog_lease_once "$expected_holder"
-  compose_to_state stopped preheld-down down
-  compose_to_state running preheld-up up -d
+  compose_to_state stopped preheld-down compose-down
+  compose_to_state running preheld-up compose-up
   if ! container_running; then
     echo "Preheld Gateway restart completed but container is not running" >&2
     return 1
@@ -495,7 +500,7 @@ release_any_lease() {
 
 stop_gateway() {
   reconcile_pending_transition
-  compose_to_state stopped stop down
+  compose_to_state stopped stop compose-down
   # A stopped container has no login session, so no IBKR push can still be
   # pending against it. Leaving the lease held locks operator start, the
   # watchdog, and deploy out for the rest of its 10m TTL — 2026-08-25, an admin

--- a/cloud/scripts/radon-docker-gw.sh
+++ b/cloud/scripts/radon-docker-gw.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Root-owned, argument-validating Gateway docker operator.
+#
+# Group `docker` is root-equivalent: a member can mount the host filesystem
+# into a container and walk out as root. radon was in it (setup-vps.sh) purely
+# so ib-gateway-control.sh and jvm_forensics.py could drive ONE container. This
+# shim is what replaces that membership -- a fixed verb set against a pinned
+# container, with no caller-supplied paths, images, mounts or flags.
+#
+# Every input is a constant here. The compose body is read from
+# /etc/radon/ib-gateway-compose.yml, installed root-owned by the control plane
+# from the git blob at the deployed commit, NOT from /home/radon/radon/cloud
+# which the radon account can write -- root acting on a compose file its caller
+# can rewrite is the same escalation with extra steps.
+
+readonly CONTAINER=ib-gateway
+readonly PROJECT=cloud
+readonly JVM_PGREP_PATTERN=ibcalpha.ibc.IbcGateway
+
+if [[ "${RADON_DOCKER_GW_TEST_MODE:-0}" == "1" ]]; then
+  DOCKER="${RADON_TEST_DOCKER:?test docker is required}"
+  COMPOSE_FILE="${RADON_TEST_COMPOSE_FILE:?test compose file is required}"
+  COMPOSE_ENV_FILE="${RADON_TEST_COMPOSE_ENV_FILE:?test compose env file is required}"
+else
+  if (( EUID != 0 )); then
+    echo "radon-docker-gw must run as root" >&2
+    exit 77
+  fi
+  DOCKER=/usr/bin/docker
+  COMPOSE_FILE=/etc/radon/ib-gateway-compose.yml
+  COMPOSE_ENV_FILE=/etc/radon/env
+fi
+
+usage() {
+  echo "usage: radon-docker-gw {compose-up|compose-down|inspect-running|pgrep-jvm|pgrep-java|thread-dump <pid>|logs|stats|ps}" >&2
+  exit 64
+}
+
+# The compose body must be a root-owned regular file. A symlink or a
+# radon-owned file at that path is the escalation this shim exists to prevent,
+# so it is refused rather than followed.
+require_trusted_compose_file() {
+  local owner
+  if [[ -L "$COMPOSE_FILE" || ! -f "$COMPOSE_FILE" ]]; then
+    echo "radon-docker-gw: ${COMPOSE_FILE} must be a regular, non-symlink file" >&2
+    exit 78
+  fi
+  if [[ "${RADON_DOCKER_GW_TEST_MODE:-0}" != "1" ]]; then
+    owner="$(stat -c '%u' "$COMPOSE_FILE")"
+    if [[ "$owner" != "0" ]]; then
+      echo "radon-docker-gw: ${COMPOSE_FILE} must be owned by root" >&2
+      exit 78
+    fi
+  fi
+}
+
+# --project-name is pinned so the named volume stays cloud_ib-config no matter
+# where the file lives; moving it off the checkout must not orphan the
+# Gateway's Jts settings and 2FA state.
+compose() {
+  require_trusted_compose_file
+  RADON_COMPOSE_ENV_FILE="$COMPOSE_ENV_FILE" \
+    "$DOCKER" compose \
+    --env-file "$COMPOSE_ENV_FILE" \
+    --project-name "$PROJECT" \
+    -f "$COMPOSE_FILE" \
+    "$@"
+}
+
+main() {
+  local verb="${1:-}"
+  [[ -n "$verb" ]] || usage
+  shift || true
+
+  case "$verb" in
+    compose-up)
+      (( $# == 0 )) || usage
+      compose up -d
+      ;;
+    compose-down)
+      (( $# == 0 )) || usage
+      compose down
+      ;;
+    # stdout, stderr and the exit code pass through untouched: gateway_state()
+    # reads the exit code and matches "No such object" on stderr to tell
+    # `missing` from `unknown`, and a swallowed stderr wedges the watchdog's
+    # restart ladder at unknown forever.
+    inspect-running)
+      (( $# == 0 )) || usage
+      exec "$DOCKER" inspect --format '{{.State.Running}}' "$CONTAINER"
+      ;;
+    pgrep-jvm)
+      (( $# == 0 )) || usage
+      exec "$DOCKER" exec "$CONTAINER" pgrep -f "$JVM_PGREP_PATTERN"
+      ;;
+    pgrep-java)
+      (( $# == 0 )) || usage
+      exec "$DOCKER" exec "$CONTAINER" pgrep java
+      ;;
+    thread-dump)
+      (( $# == 1 )) || usage
+      [[ "$1" =~ ^[1-9][0-9]{0,6}$ ]] || {
+        echo "radon-docker-gw: thread-dump takes a numeric pid" >&2
+        exit 64
+      }
+      # bash -c so the shell builtin kill works even if /bin/kill is absent.
+      exec "$DOCKER" exec "$CONTAINER" bash -c "kill -3 $1"
+      ;;
+    logs)
+      (( $# == 0 )) || usage
+      exec "$DOCKER" logs --since 5m "$CONTAINER"
+      ;;
+    stats)
+      (( $# == 0 )) || usage
+      exec "$DOCKER" stats --no-stream "$CONTAINER"
+      ;;
+    ps)
+      (( $# == 0 )) || usage
+      exec "$DOCKER" exec "$CONTAINER" ps aux
+      ;;
+    *)
+      usage
+      ;;
+  esac
+}
+
+main "$@"

--- a/cloud/scripts/setup-vps.sh
+++ b/cloud/scripts/setup-vps.sh
@@ -313,8 +313,13 @@ install_docker() {
   apt update
   apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
-  if id radon &>/dev/null; then
-    usermod -aG docker radon
+  # radon is deliberately NOT in group docker: that group is root-equivalent
+  # (mount the host into a container, walk out as root), and the only reason it
+  # ever held it was driving the ib-gateway container. That goes through the
+  # root-owned radon-docker-gw shim now. Strip a membership left by an older
+  # provision so a re-run of setup converges instead of preserving the hole.
+  if id radon &>/dev/null && id -nG radon 2>/dev/null | grep -qw docker; then
+    gpasswd -d radon docker || true
   fi
 
   log_success "Docker installed"
@@ -438,9 +443,10 @@ preflight_checks() {
     log_warn "radon user already exists -- skipping"
   fi
 
-  # Ensure radon is in the docker group (needed even if Docker was installed before user)
-  if command -v docker &>/dev/null && ! id -nG radon 2>/dev/null | grep -qw docker; then
-    usermod -aG docker radon
+  # Never add radon to group docker -- see install_docker. Converge an older
+  # provision that did.
+  if id -nG radon 2>/dev/null | grep -qw docker; then
+    gpasswd -d radon docker || true
   fi
 
   # R-619: the app-plane API container runs --user radon, so the plaintext
@@ -1117,6 +1123,51 @@ install_app_runtime() {
   log_success "App runtime wrapper installed"
 }
 
+# The root-owned Gateway docker operator that replaces radon's group `docker`
+# membership, plus the compose body it runs. Both must land root-owned: a
+# radon-writable compose file hands root straight back through the shim.
+install_docker_gw() {
+  local source="${CLOUD_DIR}/scripts/radon-docker-gw.sh"
+  local target="/usr/local/sbin/radon-docker-gw"
+  local compose_source="${CLOUD_DIR}/docker-compose.yml"
+  local compose_target="/etc/radon/ib-gateway-compose.yml"
+  local -a owner_args=(-o root -g root)
+  [[ "${RADON_HELPER_SKIP_CHOWN:-0}" == "1" ]] && owner_args=()
+  local staged
+
+  if [[ ! -f "$source" ]]; then
+    log_error "radon-docker-gw.sh missing from ${CLOUD_DIR}/scripts/"
+    return 1
+  fi
+  if [[ ! -f "$compose_source" ]]; then
+    log_error "docker-compose.yml missing from ${CLOUD_DIR}/"
+    return 1
+  fi
+
+  log_info "Installing /usr/local/sbin/radon-docker-gw..."
+  staged="$(mktemp "${target}.tmp.XXXXXX")"
+  if ! stage_from_checkout "$source" "$staged" 0755 ${owner_args[@]+"${owner_args[@]}"}; then
+    rm -f "$staged"
+    return 1
+  fi
+  if ! bash -n "$staged" || [[ ! -x "$staged" ]]; then
+    rm -f "$staged"
+    log_error "Gateway docker shim failed syntax/permission validation"
+    return 1
+  fi
+  mv -f "$staged" "$target"
+
+  log_info "Installing ${compose_target}..."
+  staged="$(mktemp "${compose_target}.tmp.XXXXXX")"
+  if ! stage_from_checkout "$compose_source" "$staged" 0644 ${owner_args[@]+"${owner_args[@]}"}; then
+    rm -f "$staged"
+    return 1
+  fi
+  mv -f "$staged" "$compose_target"
+
+  log_success "Gateway docker shim installed"
+}
+
 # The only direct systemd privilege left to the radon user is the watchdog's
 # fixed preheld adapter. All other mutations route through /usr/local/bin/radon.
 install_admin_polkit_rule() {
@@ -1211,6 +1262,7 @@ main() {
   install_deploy_root_helper
   install_operator_cli
   install_app_runtime
+  install_docker_gw
   configure_sudoers
   install_admin_polkit_rule
   start_services

--- a/cloud/tests/test_bootstrap_control_plane.py
+++ b/cloud/tests/test_bootstrap_control_plane.py
@@ -36,6 +36,11 @@ ARTIFACTS = (
     Artifact("scripts/drift_audit.py", "/usr/local/lib/radon/drift_audit.py", 0o644),
     Artifact("scripts/disk_cleanup.py", "/usr/local/lib/radon/disk_cleanup.py", 0o644),
     Artifact("scripts/radon-app-runtime.sh", "/usr/local/sbin/radon-app-runtime", 0o755),
+    # The Gateway docker operator that replaces radon's group `docker`, and the
+    # compose body it runs as root -- which is why the body cannot stay in the
+    # radon-writable checkout.
+    Artifact("scripts/radon-docker-gw.sh", "/usr/local/sbin/radon-docker-gw", 0o755),
+    Artifact("docker-compose.yml", "/etc/radon/ib-gateway-compose.yml", 0o644),
     Artifact("config/sudoers.d/radon-deploy", "/etc/sudoers.d/radon-deploy", 0o440),
     Artifact("config/sudoers.d/radon-monitor", "/etc/sudoers.d/radon-monitor", 0o440),
     Artifact("config/sudoers.d/radon-ops", "/etc/sudoers.d/radon-ops", 0o440),

--- a/cloud/tests/test_docker_gw_shim.py
+++ b/cloud/tests/test_docker_gw_shim.py
@@ -1,0 +1,186 @@
+"""P1 contract: `radon-docker-gw`, the shim that replaces radon's group docker.
+
+Group `docker` is root-equivalent. radon held it only to drive one container,
+so the shim has to be narrower than that membership in every direction: a fixed
+verb set, a pinned container, no caller-supplied paths or flags, and a compose
+body root owns rather than one the caller can rewrite.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+CLOUD = Path(__file__).resolve().parents[1]
+SHIM = CLOUD / "scripts" / "radon-docker-gw.sh"
+GW_CONTROL = CLOUD / "scripts" / "ib-gateway-control.sh"
+SETUP = CLOUD / "scripts" / "setup-vps.sh"
+OPS_SUDOERS = CLOUD / "config" / "sudoers.d" / "radon-ops"
+
+VERBS = (
+    "compose-up",
+    "compose-down",
+    "inspect-running",
+    "pgrep-jvm",
+    "pgrep-java",
+    "logs",
+    "stats",
+    "ps",
+)
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+@pytest.fixture()
+def box(tmp_path: Path):
+    log = tmp_path / "docker.log"
+    docker = tmp_path / "docker"
+    _write_executable(
+        docker,
+        f'#!/bin/bash\nprintf \'%s\\n\' "$*" >> {log}\n'
+        'if [[ "${RADON_STUB_DOCKER_RC:-0}" != "0" ]]; then\n'
+        '  echo "Error: No such object: ib-gateway" >&2\n'
+        '  exit "${RADON_STUB_DOCKER_RC}"\n'
+        "fi\n"
+        'if [[ "$1" == "inspect" ]]; then echo true; fi\n'
+        "exit 0\n",
+    )
+    compose_file = tmp_path / "ib-gateway-compose.yml"
+    compose_file.write_text("services: {}\n", encoding="utf-8")
+    env_file = tmp_path / "env"
+    env_file.write_text("X=1\n", encoding="utf-8")
+    env = {
+        **os.environ,
+        "RADON_DOCKER_GW_TEST_MODE": "1",
+        "RADON_TEST_DOCKER": str(docker),
+        "RADON_TEST_COMPOSE_FILE": str(compose_file),
+        "RADON_TEST_COMPOSE_ENV_FILE": str(env_file),
+    }
+
+    class Box:
+        def __init__(self) -> None:
+            self.env = env
+            self.log = log
+            self.compose_file = compose_file
+            self.tmp = tmp_path
+
+        def run(self, *args: str, **extra: str) -> subprocess.CompletedProcess[str]:
+            return subprocess.run(
+                ["bash", str(SHIM), *args],
+                env={**env, **extra},
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+    return Box()
+
+
+@pytest.mark.parametrize("verb", VERBS)
+def test_every_verb_pins_the_gateway_container(box, verb: str) -> None:
+    result = box.run(verb)
+    assert result.returncode == 0, result.stderr
+    logged = box.log.read_text(encoding="utf-8")
+    assert "ib-gateway" in logged or "--project-name cloud" in logged
+
+
+def test_compose_pins_file_project_and_env(box) -> None:
+    assert box.run("compose-up").returncode == 0
+    line = box.log.read_text(encoding="utf-8").strip()
+    assert line.startswith("compose ")
+    assert f"-f {box.compose_file}" in line
+    assert "--project-name cloud" in line
+    assert line.endswith("up -d")
+
+
+def test_compose_down_is_the_only_other_lifecycle_verb(box) -> None:
+    assert box.run("compose-down").returncode == 0
+    assert box.log.read_text(encoding="utf-8").strip().endswith("down")
+
+
+def test_inspect_running_passes_through_stderr_and_exit_code(box) -> None:
+    """gateway_state() tells `missing` from `unknown` on these exact bytes."""
+    result = box.run("inspect-running", RADON_STUB_DOCKER_RC="1")
+    assert result.returncode == 1
+    assert "No such object" in result.stderr
+
+
+def test_thread_dump_requires_a_numeric_pid(box) -> None:
+    assert box.run("thread-dump", "1770100").returncode == 0
+    assert "kill -3 1770100" in box.log.read_text(encoding="utf-8")
+
+    for bad in ("; rm -rf /", "$(id)", "-1", "", "12a"):
+        result = box.run("thread-dump", bad)
+        assert result.returncode == 64, bad
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ("run", "--rm", "-v", "/:/host", "alpine"),
+        ("compose-up", "--build"),
+        ("logs", "--follow"),
+        ("inspect-running", "other-container"),
+        ("exec",),
+        (),
+    ],
+)
+def test_arbitrary_argv_is_refused(box, argv) -> None:
+    result = box.run(*argv)
+    assert result.returncode == 64, result.stdout
+    assert not box.log.exists() or box.log.read_text(encoding="utf-8") == ""
+
+
+def test_a_symlinked_compose_body_is_refused(box) -> None:
+    """The whole point: root must not act on a file the caller can swap."""
+    planted = box.tmp / "planted.yml"
+    planted.write_text("services: {}\n", encoding="utf-8")
+    box.compose_file.unlink()
+    box.compose_file.symlink_to(planted)
+
+    result = box.run("compose-up")
+
+    assert result.returncode == 78, result.stdout
+    assert "non-symlink" in result.stderr
+    assert not box.log.exists() or box.log.read_text(encoding="utf-8") == ""
+
+
+def test_a_missing_compose_body_is_refused(box) -> None:
+    box.compose_file.unlink()
+    result = box.run("compose-down")
+    assert result.returncode == 78
+    assert not box.log.exists() or box.log.read_text(encoding="utf-8") == ""
+
+
+# --- wiring ---------------------------------------------------------------
+
+
+def test_gateway_control_no_longer_calls_docker_directly() -> None:
+    """Never assert structure over a comment that quotes the code it explains."""
+    text = GW_CONTROL.read_text(encoding="utf-8")
+    code = "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    )
+    assert "/usr/local/sbin/radon-docker-gw" in code
+    assert "/usr/bin/docker" not in code
+    assert "docker-compose.yml" not in code
+
+
+def test_setup_never_adds_radon_to_group_docker() -> None:
+    text = SETUP.read_text(encoding="utf-8")
+    assert "usermod -aG docker radon" not in text
+    assert "gpasswd -d radon docker" in text
+
+
+def test_sudoers_lists_each_verb_without_a_wildcard() -> None:
+    text = OPS_SUDOERS.read_text(encoding="utf-8")
+    for verb in VERBS:
+        assert f"/usr/local/sbin/radon-docker-gw {verb}" in text
+    assert "/usr/local/sbin/radon-docker-gw *" not in text
+    assert "radon ALL=(root) NOPASSWD: /usr/bin/docker compose" not in text

--- a/cloud/tests/test_ib_gateway_control.py
+++ b/cloud/tests/test_ib_gateway_control.py
@@ -42,7 +42,7 @@ def control_env(tmp_path: Path) -> tuple[dict[str, str], Path, Path, Path]:
         """#!/bin/sh
 set -eu
 printf '%s\n' "$*" >> "$FAKE_DOCKER_LOG"
-if [ "${1:-}" = inspect ]; then
+if [ "${1:-}" = inspect-running ]; then
   if [ -n "${FAKE_DOCKER_INSPECT_MARKER:-}" ] && [ ! -e "$FAKE_DOCKER_INSPECT_MARKER" ]; then
     : > "$FAKE_DOCKER_INSPECT_MARKER"
     sleep "${FAKE_DOCKER_INSPECT_DELAY:-0}"
@@ -60,13 +60,10 @@ if [ "${1:-}" = inspect ]; then
   fi
   exit 0
 fi
-if [ "${1:-}" = compose ]; then
-  case " $* " in
-    *" up -d "*) printf 'running\\n' > "$FAKE_DOCKER_STATE" ;;
-    *" down "*) printf 'stopped\\n' > "$FAKE_DOCKER_STATE" ;;
-  esac
-  exit 0
-fi
+case "${1:-}" in
+  compose-up) printf 'running\\n' > "$FAKE_DOCKER_STATE"; exit 0 ;;
+  compose-down) printf 'stopped\\n' > "$FAKE_DOCKER_STATE"; exit 0 ;;
+esac
 exit 2
 """,
     )
@@ -118,7 +115,7 @@ def test_healthy_start_does_not_take_lease(control_env):
 
     assert result.returncode == 0, result.stderr
     assert not lock.exists()
-    assert "compose up" not in log.read_text()
+    assert "compose-up" not in log.read_text()
 
 
 def test_reset_lease_does_not_touch_compose(control_env):
@@ -131,7 +128,7 @@ def test_reset_lease_does_not_touch_compose(control_env):
 
     assert result.returncode == 0, result.stderr
     assert "released" in result.stdout.lower() or "released" in result.stderr.lower()
-    assert not log.exists() or "compose" not in log.read_text()
+    assert not log.exists() or "compose-" not in log.read_text()
 
 
 def test_app_role_refuses_start_even_if_container_is_stopped(control_env):
@@ -144,7 +141,7 @@ def test_app_role_refuses_start_even_if_container_is_stopped(control_env):
     assert result.returncode != 0
     assert "RADON_HOST_ROLE=app" in result.stderr
     assert state.read_text().strip() == "stopped"
-    assert not log.exists() or "compose up" not in log.read_text()
+    assert not log.exists() or "compose-up" not in log.read_text()
 
 
 def test_dead_container_start_acquires_lease_before_compose(control_env):
@@ -155,7 +152,7 @@ def test_dead_container_start_acquires_lease_before_compose(control_env):
 
     assert result.returncode == 0, result.stderr
     assert state.read_text().strip() == "running"
-    assert re.search(r"compose .* up -d", log.read_text())
+    assert "compose-up" in log.read_text()
     assert lock.exists()
     assert "radon-cloud.ib-gateway-control" in lock.read_text()
 
@@ -184,7 +181,7 @@ def test_held_lease_refuses_dead_container_start(control_env):
     result = _run_control(env, "start")
 
     assert result.returncode != 0
-    assert "compose up" not in log.read_text()
+    assert "compose-up" not in log.read_text()
 
 
 def test_same_holder_restart_reentry_is_refused_before_second_cycle(control_env):
@@ -196,7 +193,7 @@ def test_same_holder_restart_reentry_is_refused_before_second_cycle(control_env)
 
     assert first.returncode == 0, first.stderr
     assert second.returncode == 75
-    assert sum(line.endswith(" down") for line in log.read_text().splitlines()) == 1
+    assert sum(line.strip() == "compose-down" for line in log.read_text().splitlines()) == 1
 
 
 def test_watchdog_preheld_lease_is_consumed_exactly_once(control_env):
@@ -210,7 +207,7 @@ def test_watchdog_preheld_lease_is_consumed_exactly_once(control_env):
 
     assert first.returncode == 0, first.stderr
     assert second.returncode != 0
-    assert sum(line.endswith(" down") for line in log.read_text().splitlines()) == 1
+    assert sum(line.strip() == "compose-down" for line in log.read_text().splitlines()) == 1
 
 
 def _wait_for_path(path: Path, timeout: float = 2.0) -> None:
@@ -307,11 +304,11 @@ def test_restart_and_concurrent_stop_are_serialized(control_env, tmp_path):
     assert stop.returncode == 0, stop.stderr
     assert state.read_text().strip() == "stopped"
     compose_actions = [
-        line.rsplit(" ", 1)[-1]
+        line.strip()
         for line in log.read_text().splitlines()
-        if line.startswith("compose ") and line.rsplit(" ", 1)[-1] in {"down", "-d"}
+        if line.strip() in {"compose-up", "compose-down"}
     ]
-    assert compose_actions == ["down", "-d", "down"]
+    assert compose_actions == ["compose-down", "compose-up", "compose-down"]
 
 
 def test_boot_and_watchdog_units_use_authoritative_control_path():
@@ -599,7 +596,7 @@ def test_gateway_helper_refuses_while_deploy_lock_is_held(control_env):
 
     assert result.returncode == 74
     assert "deploy/control lock held" in result.stderr
-    assert "compose" not in log.read_text()
+    assert "compose-" not in log.read_text()
     assert not lock.exists()
 
 
@@ -614,7 +611,7 @@ def test_healthy_start_is_noop_even_when_operator_holds_deploy_lock(control_env)
     assert result.returncode == 0, result.stderr
     assert "already running" in result.stdout
     assert not lock.exists()
-    assert all("compose" not in line for line in log.read_text().splitlines())
+    assert all("compose-" not in line for line in log.read_text().splitlines())
 
 
 def test_deploy_lock_refusal_releases_unused_watchdog_preheld_lease(control_env):
@@ -1206,7 +1203,7 @@ def test_stop_then_start_is_not_blocked_by_the_prior_lease(control_env):
 
     assert result.returncode == 0, result.stderr
     assert state.read_text().strip() == "running"
-    assert re.search(r"compose .* up -d", log.read_text())
+    assert "compose-up" in log.read_text()
 
 
 def test_start_ignores_a_lease_orphaned_while_the_gateway_stayed_down(control_env):
@@ -1276,7 +1273,7 @@ def test_app_role_in_canonical_env_file_refuses_start(control_env, tmp_path):
     assert result.returncode != 0
     assert "RADON_HOST_ROLE=app" in result.stderr
     assert state.read_text().strip() == "stopped"
-    assert not log.exists() or "compose up" not in log.read_text()
+    assert not log.exists() or "compose-up" not in log.read_text()
 
 
 def test_role_in_legacy_env_file_still_read_when_canonical_is_absent(control_env, tmp_path):

--- a/cloud/tests/test_monorepo_cutover.py
+++ b/cloud/tests/test_monorepo_cutover.py
@@ -97,10 +97,11 @@ def test_compose_renders_with_external_env_and_no_project_dotenv(tmp_path: Path)
 
 
 def test_deploy_exports_external_compose_env_for_preflight_and_gateway() -> None:
+    """The env-file pin moved into the root shim; the helper only names a verb."""
     deploy = DEPLOY.read_text(encoding="utf-8")
-    gateway = GATEWAY_HELPER.read_text(encoding="utf-8")
+    shim = (CLOUD_ROOT / "scripts" / "radon-docker-gw.sh").read_text(encoding="utf-8")
     preflight = _function_body(deploy, "preflight_env")
-    compose = _function_body(gateway, "compose")
+    compose = _function_body(shim, "compose")
 
     assert "RADON_COMPOSE_ENV_FILE" in preflight
     assert "RADON_COMPOSE_ENV_FILE" in compose

--- a/scripts/jvm_forensics.py
+++ b/scripts/jvm_forensics.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import shutil
 import subprocess
@@ -46,6 +47,18 @@ STEP_TIMEOUT_SECS = 6.0
 THREAD_DUMP_SETTLE_SECS = 3.0
 # Match the gateway JVM specifically; plain `pgrep java` is the fallback.
 JVM_PGREP_PATTERN = "ibcalpha.ibc.IbcGateway"
+
+# The watchdog runs as radon, which is not in group `docker` -- that group is
+# root-equivalent. Every capture goes through the root shim, which pins the
+# container and the verb set. RADON_DOCKER_GW lets a test point at a stub.
+DOCKER_GW = os.environ.get("RADON_DOCKER_GW", "/usr/local/sbin/radon-docker-gw")
+SUDO = os.environ.get("RADON_SUDO_BIN", "/usr/bin/sudo")
+
+
+def _gw(*verb: str) -> list[str]:
+    if os.environ.get("RADON_DOCKER_GW_NO_SUDO") == "1":
+        return [DOCKER_GW, *verb]
+    return [SUDO, "-n", DOCKER_GW, *verb]
 
 _CAPTURE_DIR_RE = re.compile(r"^\d{8}T\d{6}Z$")
 
@@ -137,12 +150,12 @@ class _Capture:
     def _find_jvm_pid(self) -> Optional[str]:
         out = self._run(
             "find_pid",
-            ["docker", "exec", self.container, "pgrep", "-f", JVM_PGREP_PATTERN],
+            _gw("pgrep-jvm"),
         )
         if not out or not out.strip():
             out = self._run(
                 "find_pid_fallback",
-                ["docker", "exec", self.container, "pgrep", "java"],
+                _gw("pgrep-java"),
             )
         if not out or not out.strip():
             self.result.steps["find_pid"] = self.result.steps.get("find_pid", "") + ";no_pid"
@@ -153,7 +166,7 @@ class _Capture:
         # `bash -c` so the shell-builtin kill works even if /bin/kill is absent.
         out = self._run(
             "kill_minus_3",
-            ["docker", "exec", self.container, "bash", "-c", f"kill -3 {pid}"],
+            _gw("thread-dump", str(pid)),
         )
         if out is None:
             return False
@@ -161,16 +174,16 @@ class _Capture:
         return True
 
     def _snapshot_logs(self) -> bool:
-        out = self._run("docker_logs", ["docker", "logs", "--since", "5m", self.container])
+        out = self._run("docker_logs", _gw("logs"))
         self._persist("docker_logs", "docker_logs.txt", out)
         return out is not None
 
     def _snapshot_stats(self) -> None:
-        out = self._run("docker_stats", ["docker", "stats", "--no-stream", self.container])
+        out = self._run("docker_stats", _gw("stats"))
         self._persist("docker_stats", "docker_stats.txt", out)
 
     def _snapshot_process_table(self) -> None:
-        out = self._run("ps_aux", ["docker", "exec", self.container, "ps", "aux"])
+        out = self._run("ps_aux", _gw("ps"))
         self._persist("ps_aux", "ps_aux.txt", out)
 
     def _write_manifest(self) -> None:

--- a/scripts/tests/test_jvm_forensics.py
+++ b/scripts/tests/test_jvm_forensics.py
@@ -107,7 +107,7 @@ class TestCaptureHappyPath:
     def test_kill_minus_3_targets_discovered_pid(self, out_dir):
         runner = FakeRunner()
         capture_jvm_forensics(output_dir=out_dir, runner=runner, sleeper=lambda s: None)
-        kill_cmds = [c for c in runner.commands() if "kill -3" in c]
+        kill_cmds = [c for c in runner.commands() if "thread-dump" in c]
         assert len(kill_cmds) == 1
         assert "1770100" in kill_cmds[0]
 


### PR DESCRIPTION
Third and last piece of the R-619 thread, after #283 (key delivery) and #291 (control-plane provenance).

## Why

Group `docker` is root-equivalent — a member mounts the host into a container and walks out as root. `setup-vps.sh:309,434` put `radon` in it. The account needed it only to drive the one `ib-gateway` container, and two files already state the opposite as the contract: `cloud/scripts/radon-app-runtime.sh:5` ("radon is not in group docker") and `cloud/scripts/disk_cleanup.py:30`. The membership was drift.

## The shim

`/usr/local/sbin/radon-docker-gw`, root-owned, fixed verb set against the pinned `ib-gateway` container:

`compose-up` · `compose-down` · `inspect-running` · `pgrep-jvm` · `pgrep-java` · `thread-dump <pid>` · `logs` · `stats` · `ps`

No caller-supplied paths, images, mounts or flags. `thread-dump` validates its pid. Every verb is listed in full in `sudoers.d/radon-ops` — a trailing wildcard would hand back the arbitrary argv the shim exists to refuse.

## What was careful

- **`ib-gateway-control.sh` stays `User=radon`.** It self-demotes on purpose so the 2FA lease and guard files under `/var/lib/radon` keep their ownership. Only its two docker calls moved.
- **`inspect-running` passes stdout, stderr and the exit code through untouched.** `gateway_state()` tells `missing` from `unknown` by matching "No such object" on stderr; swallowing it wedges the watchdog's restart ladder at `unknown`.
- **The compose body moves to `/etc/radon/ib-gateway-compose.yml`** as a control-plane artifact. Root running `cloud/docker-compose.yml` — which radon can write — is the same escalation with extra steps. The shim refuses a symlinked or non-root-owned body.
- **`--project-name cloud` is pinned**, so the `cloud_ib-config` volume (the Gateway's Jts settings and 2FA state) survives the file moving. Verified live: project `cloud`, volume `cloud_ib-config`.
- **The compose control-plane arm gates on content, not `docker compose config`** — that would need `env_file` and the whole variable set resolved at install time. It requires the pinned `container_name` and refuses `privileged: true` or a host-root bind. Provenance is the git-blob gate from #291.
- **`jvm_forensics.py`** routes through the shim; it was already behind an injected `runner`, so its tests hold.

## Tests

New `cloud/tests/test_docker_gw_shim.py` (23): every verb pins the container; compose pins file/project/env; `inspect-running` preserves stderr and exit code; `thread-dump` rejects `; rm -rf /`, `$(id)`, `-1`, empty, `12a`; arbitrary argv (`run --rm -v /:/host alpine`, `--build`, `--follow`, another container name) refused with 64 and nothing reaching docker; symlinked and missing compose bodies refused with 78; plus wiring assertions that the helper calls no docker directly, setup never re-adds the group, and the sudoers has no wildcard.

`cloud/tests`: 1716 passed, 7 skipped, 5 pre-existing local failures (caddy not on PATH; CI installs it). `scripts/tests/test_jvm_forensics.py` + `test_ib_watchdog.py`: 35 passed.

## Operator step — after merge, not before

Nothing here changes a running host. `setup-vps.sh` now strips the membership on a re-run, but the live hosts keep theirs until you run, as root on both (`5.78.148.38`, `100.67.204.57`):

```
gpasswd -d radon docker
id -nG radon        # docker must be gone
sudo -u radon sudo -n /usr/local/sbin/radon-docker-gw inspect-running
```

Do that only after this deploys, so the shim and the root-owned compose body exist first. The third command is the one that proves the cutover: it must print `true`/`false` rather than a sudo refusal. If anything goes wrong, `gpasswd -a radon docker` puts it back immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXaiDhMkTcXjJmyT14Z4Eg