### PR TITLE
fix(web): make demo workstation data deterministic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -761,6 +761,21 @@ jobs:
           e2e/mobile-orders-session.spec.ts
           e2e/orders-session-window.spec.ts
           e2e/vixts-tab.spec.ts
+      # Demo behavior is compile-time gated by NEXT_PUBLIC_RADON_DEMO. Rebuild
+      # once with that boundary enabled so the transport-isolation spec proves
+      # the deployed demo contract instead of silently skipping in prod mode.
+      - name: Build demo workstation
+        working-directory: web
+        env:
+          NEXT_PUBLIC_RADON_DEMO: "1"
+        run: bun run build
+      - name: Run demo workstation spec
+        working-directory: web
+        env:
+          NEXT_PUBLIC_RADON_DEMO: "1"
+        run: >-
+          npx playwright test
+          e2e/demo-workstation-data.spec.ts
       - name: Upload traces on failure
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/docs/demo-environment.md
+++ b/docs/demo-environment.md
@@ -10,7 +10,7 @@ A public, Clerk-gated demo of Radon that real users can self-serve try for **max
 | 2 | Host | **New Hetzner VM** (hard physical isolation from prod) |
 | 3 | Demo data | **Separate Turso DB** (`radon-demo-*`) |
 | 4 | Rate limiting | **Upstash** Redis + `@upstash/ratelimit` |
-| 5 | Quote feed | **Realtime** (real entitled relay feed) |
+| 5 | Quote feed | **Request-time sample snapshots** (no IB ticket or WebSocket) |
 | 6 | AI keys | **Reuse the existing prod Anthropic/Cerebras/Exa keys** (revised 2026-06-27 — per-user `demo_ai_usage` quota + Upstash tier-D are the only spend guard; no separate provider cap) |
 | 7 | Signup gating | **Email-verify** required before a trial starts |
 
@@ -20,10 +20,10 @@ FastAPI short-circuits auth on `is_trusted_local_request` (`scripts/api/auth.py:
 
 ## Architecture
 
-- **New Hetzner VM** (own public IP) running its own docker-compose: `radon-nextjs-demo:3000`, `radon-api-demo:8321`, `ib-realtime-relay-demo:8765`, Caddy terminating TLS for `demo.radon.run`.
+- **New Hetzner VM** (own public IP) running FastAPI for bounded demo-only operations. The Vercel frontend does not require an IB relay for workstation reads.
 - **Cloudflare** (orange-cloud) in front: WAF + volumetric DDoS + IP rate-limiting before origin.
 - FastAPI runs **`RADON_API_TEST_MODE=1`** → every IB path stubbed at source (`server.py:1760` returns synthetic permIds without calling `ib_place_order.py`). **No IB Gateway container, no Tailscale route to `ib-gateway:4001`** — IB is physically unreachable.
-- **Realtime quote feed (decision 5):** the demo relay connects to the entitled market-data feed for realism. It is READ-ONLY market data; it can never trade. (Risk: shares IB data-farm entitlement capacity — monitor; fall back to a delayed feed if it pressures prod.)
+- **Sample quote feed (decision 5):** the client builds deterministic minute-bucketed quotes, depth, tape, fundamentals, and option marks for requested instruments. Demo pages never request an IB ticket or open a market-data WebSocket.
 - Same git repo deploys both; a **CI isolation guard** (`scripts/ci/check_demo_isolation.py`, run by the `py-coverage` job in `.github/workflows/ci.yml` — skipped with a workflow warning annotation until the `TURSO_DEMO_DB_URL` / `TURSO_DEMO_APP_DB_URL` secrets are provisioned, TEST_AUDIT T-130) rejects any demo deploy whose env carries a prod `TURSO_DB_URL` or a reachable IB host. It checks BOTH `TURSO_DEMO_DB_URL` and `TURSO_DB_URL` against the prod marker: every account route reads through `dbExecute` → `getDb()` → `TURSO_DB_URL`, so that variable is the isolation boundary (`getDemoDb()` serves only `/api/admin/demo-users`). The two being equal on the demo VM is the desired state. Until 2026-08-23 nothing invoked the guard and it never inspected `TURSO_DB_URL` at all (RELIABILITY_AUDIT R-156).
 
 ## Isolation model (three independent guarantees)
@@ -34,11 +34,13 @@ FastAPI short-circuits auth on `is_trusted_local_request` (`scripts/api/auth.py:
 
 **Synthetic demo dataset:** `scripts/db/demo_seed.py` seeds the demo Turso once with a fabricated-but-consistent `portfolio_snapshots` row (~500K net liq, 3-4 synthetic SPY/QQQ/TSLA positions), matching journal + open-orders rows, modeled on `marketing-mockups/portfolio-recreation.html`. Demo users' simulated orders land in `paper_fills` (`account='PAPER'`), never mutating the seed.
 
+**Workstation sample contract:** live-service-dependent read surfaces are completed at request time after the Clerk principal resolves to `demo`. Performance, current executions, cash flows, theta, ticker flow, option calendars/chains/exposure, CRI, VCG, GRG, GEX, dispersion, TRIN, and BPI therefore remain current without disk writers, Turso snapshots, FastAPI producers, or vendor credentials. Fixtures accept an injected clock, carry explicit sample provenance, and are covered at the route boundary. Seeded open orders remain intact when current-session executions are added.
+
 ## Guardrails (enforcement points)
 
 - **No real orders** — (backend) VM `RADON_API_TEST_MODE=1`; (UX) `web/app/api/orders/place/route.ts` detects `demoRole` via `auth()` and routes to `/paper/place` → `paper_fills`. Both present; neither load-bearing alone.
 - **AI quotas** — new `demo_ai_usage` table (PK user_id+endpoint+day_et); guard at the top of the 3 Next.js LLM routes (`assistant` 5/day, `ticker/seasonality` 10/day, `ticker/info` 20/day) where Clerk identity exists; 429 on exceed; reset 00:00 ET. Backstop (revised 2026-06-27): demo **reuses the prod AI keys**, so the per-user quota + the Upstash tier-D limiter (5/day) are the only AI-spend guard — no separate provider cap.
-- **Rate-limit / DOS** — Cloudflare edge (IP limits, Bot Fight, OWASP WAF) + a **greenfield** app-layer tiered sliding-window limiter via `@upstash/ratelimit` keyed by Clerk userId (Tier A reads ~100/hr, B expensive ~10/hr, C mutations 5/day, D AI 5/day). No rate-limiting exists today.
+- **Rate-limit / DOS** — Vercel edge controls plus an app-layer Upstash sliding-window limiter keyed by Clerk userId. Cached GETs use Tier A; only producer mutations use Tier B; writes, AI, WebSocket tickets, headlines, and shell polling retain their dedicated tiers. Every handler with a local limiter declares its durable tier explicitly. Demo sync hooks load one GET, suppress automatic producer POSTs/polling/retries, and make manual refresh another GET.
 - **Write spam** — per-trial caps in demo DB (journal ≤1000 + 10KB/note + 1/5s; alerts/watchlist bounded).
 
 ## Trial: 3 trading days
@@ -116,7 +118,7 @@ Tests: 55 new Vitest (10 files) + 2 extended perimeter pins + 4 new pytest, all 
 - **Edge-runtime middleware trap** → keep the trial-expiry gate free of `node:*` imports (Edge runtime; a prior prod bug — `feedback_middleware_edge_runtime`).
 - **FastAPI per-user blindness** → never rely on FastAPI to gate per-user; VM `TEST_MODE` + Next.js `auth()` are the two guarantees.
 - **Clerk webhook failure** → a user could exist without `demoRole`/expiry → unlimited access. Add a reconciliation sweep + default-deny (no `demoRole` = no demo access).
-- **Realtime feed entitlement pressure** (decision 5) → monitor IB data-farm capacity; fall back to delayed feed if it pressures prod.
+- **Sample-feed realism** (decision 5) → keep sample provenance visible and validate quote/depth/option relationships in fixture tests; never imply broker entitlement or execution availability.
 - **Prod AI-budget burn** (revised 2026-06-27) → demo reuses the prod Anthropic/Cerebras/Exa keys, so a demo quota bug spends the *prod* AI budget. The only guard is the `demo_ai_usage` per-user quota + Upstash tier-D (5/day); add a provider spend cap if abuse appears.
 - **Cost/ops** → second VM + Turso + Upstash + Cloudflare zone. No separate IB paper account needed (TEST_MODE).
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,42 @@
+# Task: Make every demo workstation surface deterministic (2026-09-04)
+
+Restore representative demo data across performance, orders, instruments,
+options, scanners, flow, and regime pages, and prevent ordinary demo navigation
+from exhausting shared quotas.
+
+## Dependency graph
+
+- T1 depends_on: [] - Reproduce and classify all 14 reported demo failures; trace shared fixture, route, auth, cache, and quota paths.
+- T2 depends_on: [T1] - Add failing unit and Playwright regressions for every missing demo dataset and first-visit quota isolation.
+- T3 depends_on: [T2] - Implement deterministic performance, orders, cash-flow, instrument, option, scanner, and flow demo responses.
+- T4 depends_on: [T2] - Implement deterministic CRI, VCG, dispersion, GEX, TRIN, and BPI demo responses.
+- T5 depends_on: [T3, T4] - Eliminate demo request amplification and ensure sync/retry controls recover without consuming unrelated quotas.
+- T6 depends_on: [T5] - Run focused Vitest and Playwright coverage and visually verify every reported route.
+- T7 depends_on: [T6] - Run the full web test suite, typecheck, lint, production compile, and review the complete diff.
+- T8 depends_on: [T7] - Commit, push, open the PR, supervise exact-head CI to green, send the required Pushover notification, and record evidence.
+
+## Checklist
+
+- [x] T1 Reproduce and trace all reported failures.
+- [x] T2 Establish red regression coverage.
+- [x] T3 Restore non-regime demo datasets.
+- [x] T4 Restore regime demo datasets.
+- [x] T5 Correct request amplification and quota isolation.
+- [x] T6 Complete focused and visual verification.
+- [x] T7 Complete full verification and review.
+- [ ] T8 Publish, supervise, notify, and document the PR.
+
+## Review
+
+- Request-time typed fixtures now keep all 14 reported demo surfaces populated with current, internally coherent sample data while preserving base open orders.
+- Demo ticker search, quote, depth, tape, fundamentals, and option snapshots are local and deterministic; demo navigation no longer opens broker tickets, relay sockets, or background chain-prefetch traffic.
+- Demo sync hooks perform one passive GET and manual GET refreshes, while every locally rate-limited route now declares an explicit durable tier; cached reads no longer consume producer budgets.
+- Verification: 70 focused Vitest tests and the dedicated demo Playwright test passed; 8,322 collected full-suite assertions passed, with one unrelated REL-148 suite retaining its pre-existing `web/web` collection path failure.
+- TypeScript and production compilation passed; ESLint reported 0 errors and 17 existing warnings. The post-build trace audit retained only the existing assistant and orders/place file-count/size failures.
+- Relevant surface Playwright coverage passed 30/31; the sole failure is the unchanged options-exposure sticky-header geometry baseline, after its demo data, controls, and table assertions passed.
+
+---
+
 # Task: Restore ARM defined-risk aggregate P&L (2026-09-04) [DONE]
 
 Recognize the reported three-leg ARM structure as defined risk and render its

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -34,6 +34,7 @@ from exhausting shared quotas.
 - Verification: 70 focused Vitest tests and the dedicated demo Playwright test passed; 8,322 collected full-suite assertions passed, with one unrelated REL-148 suite retaining its pre-existing `web/web` collection path failure.
 - TypeScript and production compilation passed; ESLint reported 0 errors and 17 existing warnings. The post-build trace audit retained only the existing assistant and orders/place file-count/size failures.
 - Relevant surface Playwright coverage passed 30/31; the sole failure is the unchanged options-exposure sticky-header geometry baseline, after its demo data, controls, and table assertions passed.
+- CI curation passed 4/4 after the demo browser contract was added to the production-server smoke job; a demo-mode compile and the exact Playwright spec passed locally under `next start`.
 
 ---
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,4 +1,4 @@
-# Task: Make every demo workstation surface deterministic (2026-09-04)
+# Task: Make every demo workstation surface deterministic (2026-09-04) [DONE]
 
 Restore representative demo data across performance, orders, instruments,
 options, scanners, flow, and regime pages, and prevent ordinary demo navigation
@@ -24,7 +24,7 @@ from exhausting shared quotas.
 - [x] T5 Correct request amplification and quota isolation.
 - [x] T6 Complete focused and visual verification.
 - [x] T7 Complete full verification and review.
-- [ ] T8 Publish, supervise, notify, and document the PR.
+- [x] T8 Publish, supervise, notify, and document the PR.
 
 ## Review
 
@@ -35,6 +35,7 @@ from exhausting shared quotas.
 - TypeScript and production compilation passed; ESLint reported 0 errors and 17 existing warnings. The post-build trace audit retained only the existing assistant and orders/place file-count/size failures.
 - Relevant surface Playwright coverage passed 30/31; the sole failure is the unchanged options-exposure sticky-header geometry baseline, after its demo data, controls, and table assertions passed.
 - CI curation passed 4/4 after the demo browser contract was added to the production-server smoke job; a demo-mode compile and the exact Playwright spec passed locally under `next start`.
+- PR #293 implementation head `760368c5` passed every applicable exact-head check, including the full Python matrix, eight Vitest shards, both coverage ratchets, demo Playwright, images, security, and Vercel.
 
 ---
 

--- a/web/app/api/attribution/route.ts
+++ b/web/app/api/attribution/route.ts
@@ -9,7 +9,7 @@ export const runtime = "nodejs";
 export const radonCapability = "read";
 
 export async function GET() {
-  const access = await requireRouteAccess(undefined, { rate: { key: "attribution:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "attribution:route", limit: 20, windowMs: 60_000 }, durableRateTier: "A" });
   if (!access.ok) return access.response;
   try {
     const data = await radonFetch("/attribution", { timeout: 20_000 });

--- a/web/app/api/blotter/route.ts
+++ b/web/app/api/blotter/route.ts
@@ -74,7 +74,7 @@ async function buildFromJournal(): Promise<BlotterPayload | null> {
 export const radonCapability = { GET: "read", POST: "mutate.workspace" };
 
 export async function GET(): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "blotter:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "blotter:route", limit: 20, windowMs: 60_000 }, durableRateTier: "A" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
   try {

--- a/web/app/api/bpi/route.ts
+++ b/web/app/api/bpi/route.ts
@@ -6,6 +6,8 @@ import { getRequestId, setNoStoreResponseHeaders } from "@/lib/apiContracts";
 import { BPI_INDEX_SYMBOLS, type BpiIndexEntry, type BpiIndexSymbol } from "@/lib/bpi";
 import { getDb } from "@/lib/db";
 import { contentTimestampMs, dbFirstRead, type TimestampedRead } from "@/lib/dbFirstRead";
+import { requireRouteAccess } from "@/lib/routeAccess";
+import { buildDemoBpiFixture } from "@/lib/demo/fixtures/regime";
 
 // Disable Next.js static caching: this handler reads live disk state
 // (data/bpi.json) as the Turso fallback.
@@ -73,7 +75,12 @@ function withAllIndices(doc: BpiDoc): {
 export const radonCapability = "read";
 
 export async function GET(): Promise<Response> {
+  const access = await requireRouteAccess();
+  if (!access.ok) return access.response;
   const requestId = getRequestId();
+  if (access.principal.kind === "demo") {
+    return setNoStoreResponseHeaders(NextResponse.json(buildDemoBpiFixture()), requestId);
+  }
   const result = await dbFirstRead({
     fromDb: readBpiFromDb,
     fromDisk: readBpiFromDisk,

--- a/web/app/api/breadth/route.ts
+++ b/web/app/api/breadth/route.ts
@@ -64,7 +64,7 @@ async function readCachedBreadth(): Promise<Record<string, unknown> | null> {
 export const radonCapability = { GET: "read", POST: "read.spawn" };
 
 export async function GET(): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "breadth:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "breadth:route", limit: 20, windowMs: 60_000 }, durableRateTier: "A" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
   const cached = await readCachedBreadth();
@@ -79,7 +79,7 @@ export async function GET(): Promise<Response> {
 }
 
 export async function POST(): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "breadth:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "breadth:route", limit: 20, windowMs: 60_000 }, durableRateTier: "B" });
   if (!access.ok) return access.response;
   try {
     const data = await radonFetch<Record<string, unknown>>("/breadth/scan", {

--- a/web/app/api/cash-flows/route.ts
+++ b/web/app/api/cash-flows/route.ts
@@ -3,6 +3,7 @@ import { requireRouteAccess } from "@/lib/routeAccess";
 import { NextRequest, NextResponse } from "next/server";
 import { radonFetch } from "@/lib/radonApi";
 import { getRequestId, setNoStoreResponseHeaders } from "@/lib/apiContracts";
+import { buildDemoCashFlows } from "@/lib/demo/fixtures/cashFlows";
 
 // Disable Next.js static caching: cash flows update once per day but the
 // Turso query is cheap. Without this, the framework freezes the first
@@ -19,6 +20,16 @@ export async function GET(req: NextRequest) {
   const days = url.searchParams.get("days") ?? "90";
   const types = url.searchParams.get("types") ?? "";
   const requestId = getRequestId();
+
+  if (access.principal.kind === "demo") {
+    const parsedDays = Number.parseInt(days, 10);
+    const data = buildDemoCashFlows({
+      now: new Date(),
+      days: Number.isFinite(parsedDays) ? parsedDays : 90,
+      types,
+    });
+    return setNoStoreResponseHeaders(NextResponse.json(data), requestId);
+  }
 
   try {
     const data = await radonFetch(`/cash-flows?days=${encodeURIComponent(days)}&types=${encodeURIComponent(types)}`);

--- a/web/app/api/discover/route.ts
+++ b/web/app/api/discover/route.ts
@@ -87,7 +87,7 @@ function buildCacheMetaFromMs(ms: number): CacheMeta {
 export const radonCapability = { GET: "read", POST: "read.spawn" };
 
 export async function GET(): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "discover:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "discover:route", limit: 20, windowMs: 60_000 }, durableRateTier: "A" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
   // Fresher of DB row and disk JSON, so a stalled writer on either side
@@ -124,7 +124,7 @@ export async function GET(): Promise<Response> {
 }
 
 export async function POST(): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "discover:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "discover:route", limit: 20, windowMs: 60_000 }, durableRateTier: "B" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
   try {

--- a/web/app/api/dispersion/route.ts
+++ b/web/app/api/dispersion/route.ts
@@ -1,11 +1,13 @@
 import { NextResponse } from "next/server";
 import { readFile } from "fs/promises";
 import { join } from "path";
-import { getRequestId, setCacheResponseHeaders } from "@/lib/apiContracts";
+import { getRequestId, setCacheResponseHeaders, setNoStoreResponseHeaders } from "@/lib/apiContracts";
 import { getDb } from "@/lib/db";
 import { contentTimestampMs, dbFirstRead, isMissingPayload, staleCollapse, type TimestampedRead } from "@/lib/dbFirstRead";
 import { MISSING_DISPERSION } from "@/lib/dispersion";
 import { getFreshnessWindowMs } from "@/lib/serviceHealthWindows";
+import { requireRouteAccess } from "@/lib/routeAccess";
+import { buildDemoDispersionFixture } from "@/lib/demo/fixtures/regime";
 // Disable Next.js static caching: this handler reads live disk state
 // (data/*.json, cache files). Without this, the framework freezes the
 // first response and serves stale data until the dev server restarts.
@@ -47,7 +49,12 @@ async function readDispersionFromDisk(): Promise<TimestampedRead<Record<string, 
 export const radonCapability = "read";
 
 export async function GET(): Promise<Response> {
+  const access = await requireRouteAccess();
+  if (!access.ok) return access.response;
   const requestId = getRequestId();
+  if (access.principal.kind === "demo") {
+    return setNoStoreResponseHeaders(NextResponse.json(buildDemoDispersionFixture()), requestId);
+  }
   const result = await dbFirstRead({
     fromDb: readDispersionFromDb,
     fromDisk: readDispersionFromDisk,

--- a/web/app/api/flow-analysis/[ticker]/route.ts
+++ b/web/app/api/flow-analysis/[ticker]/route.ts
@@ -6,6 +6,7 @@ import { statSync } from "fs";
 import { join } from "path";
 import { radonFetch } from "@/lib/radonApi";
 import { getRequestId, setNoStoreResponseHeaders } from "@/lib/apiContracts";
+import { buildDemoFlowReport } from "@/lib/demo/fixtures/flowAnalysis";
 
 // Disable Next.js static caching: this handler reads live disk state
 // (data/flow_reports/<TICKER>.json). Without this, Next 16 freezes the
@@ -71,7 +72,7 @@ type Params = { params: Promise<{ ticker: string }> };
 export const radonCapability = { GET: "read", POST: "read.spawn" };
 
 export async function GET(_req: Request, ctx: Params): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "flow-analysis/[ticker]:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "flow-analysis/[ticker]:route", limit: 20, windowMs: 60_000 }, durableRateTier: "A" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
   const { ticker: raw } = await ctx.params;
@@ -79,6 +80,13 @@ export async function GET(_req: Request, ctx: Params): Promise<Response> {
   if (!ticker) {
     return setNoStoreResponseHeaders(
       NextResponse.json({ error: "Invalid ticker symbol" }, { status: 400 }),
+      requestId,
+    );
+  }
+
+  if (access.principal.kind === "demo") {
+    return setNoStoreResponseHeaders(
+      NextResponse.json(buildDemoFlowReport(ticker, new Date())),
       requestId,
     );
   }
@@ -105,7 +113,7 @@ export async function GET(_req: Request, ctx: Params): Promise<Response> {
 }
 
 export async function POST(_req: Request, ctx: Params): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "flow-analysis/[ticker]:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "flow-analysis/[ticker]:route", limit: 20, windowMs: 60_000 }, durableRateTier: "B" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
   const { ticker: raw } = await ctx.params;
@@ -113,6 +121,13 @@ export async function POST(_req: Request, ctx: Params): Promise<Response> {
   if (!ticker) {
     return setNoStoreResponseHeaders(
       NextResponse.json({ error: "Invalid ticker symbol" }, { status: 400 }),
+      requestId,
+    );
+  }
+
+  if (access.principal.kind === "demo") {
+    return setNoStoreResponseHeaders(
+      NextResponse.json(buildDemoFlowReport(ticker, new Date())),
       requestId,
     );
   }

--- a/web/app/api/flow-analysis/route.ts
+++ b/web/app/api/flow-analysis/route.ts
@@ -73,7 +73,7 @@ async function readFlowAnalysisFromDisk(): Promise<TimestampedRead<Record<string
 export const radonCapability = { GET: "read", POST: "read.spawn" };
 
 export async function GET(): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "flow-analysis:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "flow-analysis:route", limit: 20, windowMs: 60_000 }, durableRateTier: "A" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
   // Fresher of DB row and disk JSON, so a stalled writer on either side

--- a/web/app/api/futures/chain/route.ts
+++ b/web/app/api/futures/chain/route.ts
@@ -44,7 +44,7 @@ export const runtime = "nodejs";
 export const radonCapability = "read";
 
 export async function GET(request: Request): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "futures/chain:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "futures/chain:route", limit: 20, windowMs: 60_000 }, durableRateTier: "A" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
   const { searchParams } = new URL(request.url);

--- a/web/app/api/gamma-rotation/route.ts
+++ b/web/app/api/gamma-rotation/route.ts
@@ -6,8 +6,9 @@ import { join } from "path";
 import { dbExecute } from "@/lib/dbExecute";
 import { cachedRead, invalidateCache } from "@/lib/dbCache";
 import { radonFetch } from "@/lib/radonApi";
-import { getRequestId, setCacheResponseHeaders } from "@/lib/apiContracts";
+import { getRequestId, setCacheResponseHeaders, setNoStoreResponseHeaders } from "@/lib/apiContracts";
 import { isGammaRotationStale } from "@/lib/gammaRotationStaleness";
+import { buildDemoGammaRotationFixture } from "@/lib/demo/fixtures/regime";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -164,9 +165,12 @@ function triggerBackgroundScan(): void {
 export const radonCapability = { GET: "read", POST: "read.spawn" };
 
 export async function GET(): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "gamma-rotation:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "gamma-rotation:route", limit: 20, windowMs: 60_000 }, durableRateTier: "A" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
+  if (access.principal.kind === "demo") {
+    return setNoStoreResponseHeaders(NextResponse.json(buildDemoGammaRotationFixture()), requestId);
+  }
   const cached = await readCachedGammaRotation();
   const data = normalizeGammaRotationPayload(cached ?? {});
   const currentMarketOpen = isMarketOpenNow();
@@ -188,8 +192,12 @@ export async function GET(): Promise<Response> {
 }
 
 export async function POST(): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "gamma-rotation:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "gamma-rotation:route", limit: 20, windowMs: 60_000 }, durableRateTier: "B" });
   if (!access.ok) return access.response;
+  if (access.principal.kind === "demo") {
+    const requestId = getRequestId();
+    return setNoStoreResponseHeaders(NextResponse.json(buildDemoGammaRotationFixture()), requestId);
+  }
   try {
     const rawData = await radonFetch<Record<string, unknown>>("/gamma-rotation/scan", { method: "POST", timeout: 130_000 });
     invalidateCache("gamma-rotation:snapshot");

--- a/web/app/api/garch-convergence/scan/route.ts
+++ b/web/app/api/garch-convergence/scan/route.ts
@@ -25,6 +25,7 @@ export async function POST(request: Request): Promise<Response> {
   // leap/scan sibling has carried the same guard since R-079.
   const access = await requireRouteAccess(request, {
     rate: { key: "garch-convergence/scan:route", limit: 20, windowMs: 60_000 },
+    durableRateTier: "B",
   });
   if (!access.ok) return access.response;
   const requestId = getRequestId();

--- a/web/app/api/gex/route.ts
+++ b/web/app/api/gex/route.ts
@@ -6,9 +6,10 @@ import { join } from "path";
 import { isGexDataStale } from "@/lib/gexStaleness";
 import { radonFetch } from "@/lib/radonApi";
 import { createBackgroundScanTrigger } from "@/lib/backgroundScan";
-import { getRequestId, setCacheResponseHeaders } from "@/lib/apiContracts";
+import { getRequestId, setCacheResponseHeaders, setNoStoreResponseHeaders } from "@/lib/apiContracts";
 import { dbExecute } from "@/lib/dbExecute";
 import { cachedRead } from "@/lib/dbCache";
+import { buildDemoGexFixture } from "@/lib/demo/fixtures/regime";
 // Disable Next.js static caching: this handler reads live disk state
 // (data/*.json, cache files). Without this, the framework freezes the
 // first response and serves stale data until the dev server restarts.
@@ -146,9 +147,12 @@ const GEX_CACHE_TTL_MS = 5_000;
 export const radonCapability = { GET: "read", POST: "read.spawn" };
 
 export async function GET(): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "gex:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "gex:route", limit: 20, windowMs: 60_000 }, durableRateTier: "A" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
+  if (access.principal.kind === "demo") {
+    return setNoStoreResponseHeaders(NextResponse.json(buildDemoGexFixture()), requestId);
+  }
   const cached = await cachedRead("gex:SPX", GEX_CACHE_TTL_MS, readCachedGex, {
     staleWhileError: true,
   });
@@ -176,8 +180,12 @@ export async function GET(): Promise<Response> {
 }
 
 export async function POST(): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "gex:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "gex:route", limit: 20, windowMs: 60_000 }, durableRateTier: "B" });
   if (!access.ok) return access.response;
+  if (access.principal.kind === "demo") {
+    const requestId = getRequestId();
+    return setNoStoreResponseHeaders(NextResponse.json(buildDemoGexFixture()), requestId);
+  }
   try {
     const rawData = await radonFetch<Record<string, unknown>>("/gex/scan", { method: "POST", timeout: 130_000 });
     const data = normalizeGexPayload(rawData);

--- a/web/app/api/gex/share/route.ts
+++ b/web/app/api/gex/share/route.ts
@@ -10,7 +10,7 @@ export const runtime = "nodejs";
 export const radonCapability = "internal";
 
 export async function POST(request: Request): Promise<Response> {
-  const access = await requireRouteAccess(request, { rate: { key: "share-generator", limit: 10, windowMs: 60_000 } });
+  const access = await requireRouteAccess(request, { rate: { key: "share-generator", limit: 10, windowMs: 60_000 }, durableRateTier: "B" });
   if (!access.ok) return access.response;
   const limit = rateLimit(clientIp(request), { limit: SHARE_CARD_LIMIT, windowMs: SHARE_WINDOW_MS });
   if (!limit.ok) {

--- a/web/app/api/ib/ws-ticket/route.ts
+++ b/web/app/api/ib/ws-ticket/route.ts
@@ -21,6 +21,7 @@ export const radonCapability = "admin";
 export async function POST(request?: Request) {
   const access = await requireRouteAccess(request, {
     rate: { key: "ib/ws-ticket:route", limit: 30, windowMs: 60_000 },
+    durableRateTier: "E",
   });
   if (!access.ok) return access.response;
   const requestId = getRequestId();

--- a/web/app/api/index-options/chain/route.ts
+++ b/web/app/api/index-options/chain/route.ts
@@ -21,7 +21,7 @@ export const runtime = "nodejs";
 export const radonCapability = "read";
 
 export async function GET(request: Request): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "index-options/chain:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "index-options/chain:route", limit: 20, windowMs: 60_000 }, durableRateTier: "A" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
   const { searchParams } = new URL(request.url);

--- a/web/app/api/internals/route.ts
+++ b/web/app/api/internals/route.ts
@@ -603,7 +603,7 @@ function triggerBackgroundScan(): void {
 export const radonCapability = { GET: "read", POST: "read.spawn" };
 
 export async function GET(): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "internals:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "internals:route", limit: 20, windowMs: 60_000 }, durableRateTier: "A" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
   const result = await readLatestCri();
@@ -627,7 +627,7 @@ export async function GET(): Promise<Response> {
 }
 
 export async function POST(): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "internals:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "internals:route", limit: 20, windowMs: 60_000 }, durableRateTier: "B" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
   try {

--- a/web/app/api/internals/share/route.ts
+++ b/web/app/api/internals/share/route.ts
@@ -10,7 +10,7 @@ export const runtime = "nodejs";
 export const radonCapability = "internal";
 
 export async function POST(request: Request): Promise<Response> {
-  const access = await requireRouteAccess(request, { rate: { key: "share-generator", limit: 10, windowMs: 60_000 } });
+  const access = await requireRouteAccess(request, { rate: { key: "share-generator", limit: 10, windowMs: 60_000 }, durableRateTier: "B" });
   if (!access.ok) return access.response;
   const limit = rateLimit(clientIp(request), { limit: SHARE_CARD_LIMIT, windowMs: SHARE_WINDOW_MS });
   if (!limit.ok) {

--- a/web/app/api/journal/route.ts
+++ b/web/app/api/journal/route.ts
@@ -15,7 +15,7 @@ export const runtime = "nodejs";
 export const radonCapability = { GET: "read", POST: "mutate.workspace" };
 
 export async function GET(): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "journal:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "journal:route", limit: 20, windowMs: 60_000 }, durableRateTier: "A" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
   try {

--- a/web/app/api/knowledge/search/route.ts
+++ b/web/app/api/knowledge/search/route.ts
@@ -25,7 +25,7 @@ function invalidQueryReason(body: SearchBody): string | null {
 export const radonCapability = "read";
 
 export async function POST(request: Request): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "knowledge/search:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "knowledge/search:route", limit: 20, windowMs: 60_000 }, durableRateTier: "B" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
 

--- a/web/app/api/leap/scan/route.ts
+++ b/web/app/api/leap/scan/route.ts
@@ -19,7 +19,7 @@ export const runtime = "nodejs";
 export const radonCapability = "read.spawn";
 
 export async function POST(request: Request): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "leap/scan:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "leap/scan:route", limit: 20, windowMs: 60_000 }, durableRateTier: "B" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
   let body: Record<string, unknown> = {};

--- a/web/app/api/menthorq/[command]/image/route.tsx
+++ b/web/app/api/menthorq/[command]/image/route.tsx
@@ -473,6 +473,7 @@ export async function GET(
 ) {
   const access = await requireRouteAccess(request, {
     rate: { key: "menthorq/image", limit: 20, windowMs: 60_000 },
+    durableRateTier: "B",
   });
   if (!access.ok) return access.response;
   const { command } = await params;

--- a/web/app/api/menthorq/cta/image/route.tsx
+++ b/web/app/api/menthorq/cta/image/route.tsx
@@ -294,7 +294,7 @@ function DataRow({ row }: { row: CtaRow }) {
 export const radonCapability = "read";
 
 export async function GET(request: Request) {
-  const access = await requireRouteAccess(undefined, { rate: { key: "menthorq/cta/image:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "menthorq/cta/image:route", limit: 20, windowMs: 60_000 }, durableRateTier: "B" });
   if (!access.ok) return access.response;
   const { searchParams } = new URL(request.url);
   const section = searchParams.get("section") ?? undefined;

--- a/web/app/api/menthorq/cta/route.ts
+++ b/web/app/api/menthorq/cta/route.ts
@@ -365,7 +365,7 @@ function triggerBackgroundSync(expectedDate: string): void {
 export const radonCapability = "read";
 
 export async function GET(): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "menthorq/cta:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "menthorq/cta:route", limit: 20, windowMs: 60_000 }, durableRateTier: "A" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
   const expectedDate = latestClosedTradingDay();

--- a/web/app/api/menthorq/cta/share/route.ts
+++ b/web/app/api/menthorq/cta/share/route.ts
@@ -10,7 +10,7 @@ export const runtime = "nodejs";
 export const radonCapability = "internal";
 
 export async function POST(request: Request): Promise<Response> {
-  const access = await requireRouteAccess(request, { rate: { key: "share-generator", limit: 10, windowMs: 60_000 } });
+  const access = await requireRouteAccess(request, { rate: { key: "share-generator", limit: 10, windowMs: 60_000 }, durableRateTier: "B" });
   if (!access.ok) return access.response;
   const limit = rateLimit(clientIp(request), { limit: SHARE_CARD_LIMIT, windowMs: SHARE_WINDOW_MS });
   if (!limit.ok) {

--- a/web/app/api/options/chain/route.ts
+++ b/web/app/api/options/chain/route.ts
@@ -7,6 +7,7 @@ import {
   optionsJson,
 } from "../_shared";
 import { boundedTicker, OPTION_EXPIRY_PATTERN } from "@/lib/requestBounds";
+import { buildDemoOptionChain } from "@/lib/demo/fixtures/options";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -14,7 +15,10 @@ export const runtime = "nodejs";
 export const radonCapability = "read";
 
 export async function GET(request: Request): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "options/chain:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, {
+    rate: { key: "options/chain:route", limit: 20, windowMs: 60_000 },
+    durableRateTier: "A",
+  });
   if (!access.ok) return access.response;
   const { searchParams } = new URL(request.url);
   const symbol = boundedTicker(searchParams.get("symbol"));
@@ -25,6 +29,10 @@ export async function GET(request: Request): Promise<Response> {
   }
   if (expiry && !OPTION_EXPIRY_PATTERN.test(expiry)) {
     return optionsJson({ error: "Invalid expiry", code: "BAD_REQUEST" }, 400);
+  }
+
+  if (access.principal.kind === "demo") {
+    return optionsJson({ ...buildDemoOptionChain(symbol, expiry) });
   }
 
   try {

--- a/web/app/api/options/expirations/route.ts
+++ b/web/app/api/options/expirations/route.ts
@@ -7,6 +7,7 @@ import {
   optionsJson,
 } from "../_shared";
 import { boundedTicker } from "@/lib/requestBounds";
+import { buildDemoOptionExpirations } from "@/lib/demo/fixtures/options";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -14,13 +15,20 @@ export const runtime = "nodejs";
 export const radonCapability = "read";
 
 export async function GET(request: Request): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "options/expirations:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, {
+    rate: { key: "options/expirations:route", limit: 20, windowMs: 60_000 },
+    durableRateTier: "A",
+  });
   if (!access.ok) return access.response;
   const { searchParams } = new URL(request.url);
   const symbol = boundedTicker(searchParams.get("symbol"));
 
   if (!symbol) {
     return optionsJson({ error: "Required: symbol", code: "BAD_REQUEST" }, 400);
+  }
+
+  if (access.principal.kind === "demo") {
+    return optionsJson({ ...buildDemoOptionExpirations(symbol) });
   }
 
   try {

--- a/web/app/api/options/exposure/route.ts
+++ b/web/app/api/options/exposure/route.ts
@@ -6,6 +6,8 @@ import {
   optionsErrorResponse,
   optionsJson,
 } from "../_shared";
+import { buildDemoOptionsExposure } from "@/lib/demo/fixtures/options";
+import type { OptionsExposureFrequency } from "@/lib/optionsExposure";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -16,7 +18,10 @@ const FREQUENCIES = new Set(["eod", "intraday"]);
 export const radonCapability = "read";
 
 export async function GET(request: Request): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "options/exposure:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, {
+    rate: { key: "options/exposure:route", limit: 20, windowMs: 60_000 },
+    durableRateTier: "A",
+  });
   if (!access.ok) return access.response;
   const { searchParams } = new URL(request.url);
   const rawSymbol = searchParams.get("symbol");
@@ -31,6 +36,12 @@ export async function GET(request: Request): Promise<Response> {
   }
   if (!FREQUENCIES.has(frequency)) {
     return optionsJson({ error: "Invalid frequency", code: "BAD_REQUEST" }, 400);
+  }
+
+  if (access.principal.kind === "demo") {
+    return optionsJson({
+      ...buildDemoOptionsExposure(symbol, frequency as OptionsExposureFrequency),
+    });
   }
 
   try {

--- a/web/app/api/options/rv-ratio/route.ts
+++ b/web/app/api/options/rv-ratio/route.ts
@@ -79,7 +79,7 @@ function withSessionStaleness(payload: SnapshotPayload): SnapshotPayload {
 export const radonCapability = { GET: "read", POST: "read.spawn" };
 
 export async function GET(request: Request): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "options/rv-ratio:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "options/rv-ratio:route", limit: 20, windowMs: 60_000 }, durableRateTier: "A" });
   if (!access.ok) return access.response;
   const parsed = parseSymbol(request);
   if (parsed.response) return parsed.response;
@@ -96,7 +96,7 @@ export async function GET(request: Request): Promise<Response> {
 }
 
 export async function POST(request: Request): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "options/rv-ratio:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "options/rv-ratio:route", limit: 20, windowMs: 60_000 }, durableRateTier: "B" });
   if (!access.ok) return access.response;
   const parsed = parseSymbol(request);
   if (parsed.response) return parsed.response;

--- a/web/app/api/orders/route.ts
+++ b/web/app/api/orders/route.ts
@@ -4,6 +4,7 @@ import { radonFetch } from "@/lib/radonApi";
 import { readOrdersSnapshotFromDb } from "@/lib/orders/readOrdersFromDb";
 import { invalidateOrdersSnapshotCache } from "@/lib/orders/ordersReadCache";
 import { getRequestId, setNoStoreResponseHeaders } from "@/lib/apiContracts";
+import { buildDemoOrders } from "@/lib/demo/fixtures/orders";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -16,6 +17,19 @@ export async function GET(): Promise<Response> {
   const access = await requireRouteAccess();
   if (!access.ok) return access.response;
   const requestId = getRequestId();
+  if (access.principal.kind === "demo") {
+    const base = await readOrdersSnapshotFromDb().catch(() => ({
+      last_sync: "",
+      open_orders: [],
+      executed_orders: [],
+      open_count: 0,
+      executed_count: 0,
+    }));
+    return setNoStoreResponseHeaders(
+      NextResponse.json(buildDemoOrders(base, new Date())),
+      requestId,
+    );
+  }
   try {
     const data = await readOrdersSnapshotFromDb();
     return setNoStoreResponseHeaders(NextResponse.json(data), requestId);

--- a/web/app/api/paper/place/route.ts
+++ b/web/app/api/paper/place/route.ts
@@ -18,7 +18,7 @@ export const runtime = "nodejs";
 export const radonCapability = "mutate.trading";
 
 export async function POST(request: Request): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "paper/place:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "paper/place:route", limit: 20, windowMs: 60_000 }, durableRateTier: "C" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
   let body: unknown;

--- a/web/app/api/performance/route.ts
+++ b/web/app/api/performance/route.ts
@@ -7,6 +7,7 @@ import { isPerformanceBehindPortfolioSync } from "@/lib/performanceFreshness";
 import { getRequestId, setNoStoreResponseHeaders } from "@/lib/apiContracts";
 import { dbExecute } from "@/lib/dbExecute";
 import { contentTimestampMs, dbFirstRead, type TimestampedRead } from "@/lib/dbFirstRead";
+import { buildDemoPerformance } from "@/lib/demo/fixtures/performance";
 import { getMarketStateFromDate } from "@/lib/serviceHealthWindows";
 // Disable Next.js static caching: this handler reads live disk state
 // (data/*.json, cache files). Without this, the framework freezes the
@@ -159,9 +160,15 @@ async function readPerformanceFromDisk(): Promise<TimestampedRead<Record<string,
 export const radonCapability = { GET: "read", POST: "read.spawn" };
 
 export async function GET(): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "performance:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "performance:route", limit: 20, windowMs: 60_000 }, durableRateTier: "A" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
+  if (access.principal.kind === "demo") {
+    return setNoStoreResponseHeaders(
+      NextResponse.json(buildDemoPerformance(new Date())),
+      requestId,
+    );
+  }
   const cacheTtlMs = getCacheTtlMs();
   const [perfRead, portfolioSnapshot] = await Promise.all([
     // Fresher of DB row and disk JSON — a frozen writer on either side

--- a/web/app/api/portfolio/route.ts
+++ b/web/app/api/portfolio/route.ts
@@ -185,7 +185,7 @@ function unavailablePortfolioResponse(
 export const radonCapability = { GET: "read", POST: "mutate.workspace" };
 
 export async function GET(request?: Request): Promise<Response> {
-  const access = await requireRouteAccess(request, { rate: { key: "portfolio:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(request, { rate: { key: "portfolio:route", limit: 20, windowMs: 60_000 }, durableRateTier: "I" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
   const includeEntryDates = request

--- a/web/app/api/previous-close/route.ts
+++ b/web/app/api/previous-close/route.ts
@@ -268,7 +268,7 @@ async function getPreviousClose(symbol: string): Promise<number | null> {
 export const radonCapability = "read";
 
 export async function POST(req: Request) {
-  const access = await requireRouteAccess(undefined, { rate: { key: "previous-close:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "previous-close:route", limit: 20, windowMs: 60_000 }, durableRateTier: "A" });
   if (!access.ok) return access.response;
   try {
     const { symbols } = await req.json();

--- a/web/app/api/regime/route.ts
+++ b/web/app/api/regime/route.ts
@@ -8,9 +8,10 @@ import { selectPreferredCriCandidate, type CriCacheCandidate } from "@/lib/criCa
 import { backfillRealizedVolHistory, type RegimeHistoryEntry } from "@/lib/regimeHistory";
 import { radonFetch } from "@/lib/radonApi";
 import { createBackgroundScanTrigger } from "@/lib/backgroundScan";
-import { getRequestId, setCacheResponseHeaders } from "@/lib/apiContracts";
+import { getRequestId, setCacheResponseHeaders, setNoStoreResponseHeaders } from "@/lib/apiContracts";
 import { dbExecute } from "@/lib/dbExecute";
 import { cachedRead, invalidateCache } from "@/lib/dbCache";
+import { buildDemoCriFixture } from "@/lib/demo/fixtures/regime";
 // Disable Next.js static caching: this handler reads live disk state
 // (data/*.json, cache files). Without this, the framework freezes the
 // first response and serves stale data until the dev server restarts.
@@ -289,9 +290,12 @@ const triggerBackgroundScan = createBackgroundScanTrigger({ label: "CRI", run: r
 export const radonCapability = { GET: "read", POST: "read.spawn" };
 
 export async function GET(): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "regime:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "regime:route", limit: 20, windowMs: 60_000 }, durableRateTier: "A" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
+  if (access.principal.kind === "demo") {
+    return setNoStoreResponseHeaders(NextResponse.json(buildDemoCriFixture()), requestId);
+  }
   const result = await readLatestCri();
   const data = normalizeCriPayload((result?.data ?? EMPTY_CRI) as Record<string, unknown>);
   const currentMarketOpen = isMarketOpenNow();
@@ -340,8 +344,12 @@ export async function GET(): Promise<Response> {
 }
 
 export async function POST(): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "regime:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "regime:route", limit: 20, windowMs: 60_000 }, durableRateTier: "B" });
   if (!access.ok) return access.response;
+  if (access.principal.kind === "demo") {
+    const requestId = getRequestId();
+    return setNoStoreResponseHeaders(NextResponse.json(buildDemoCriFixture()), requestId);
+  }
   try {
     const rawData = await radonFetch<Record<string, unknown>>("/regime/scan", {
       method: "POST",

--- a/web/app/api/regime/share/route.ts
+++ b/web/app/api/regime/share/route.ts
@@ -10,7 +10,7 @@ export const runtime = "nodejs";
 export const radonCapability = "internal";
 
 export async function POST(request: Request): Promise<Response> {
-  const access = await requireRouteAccess(request, { rate: { key: "share-generator", limit: 10, windowMs: 60_000 } });
+  const access = await requireRouteAccess(request, { rate: { key: "share-generator", limit: 10, windowMs: 60_000 }, durableRateTier: "B" });
   if (!access.ok) return access.response;
   const limit = rateLimit(clientIp(request), { limit: SHARE_CARD_LIMIT, windowMs: SHARE_WINDOW_MS });
   if (!limit.ok) {

--- a/web/app/api/scanner/route.ts
+++ b/web/app/api/scanner/route.ts
@@ -73,7 +73,7 @@ async function readScannerFromDisk(): Promise<TimestampedRead<Record<string, unk
 export const radonCapability = { GET: "read", POST: "read.spawn" };
 
 export async function GET(): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "scanner:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "scanner:route", limit: 20, windowMs: 60_000 }, durableRateTier: "A" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
   // Fresher of DB row and disk JSON. The cache_meta still reflects file
@@ -106,7 +106,7 @@ export async function GET(): Promise<Response> {
 }
 
 export async function POST(): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "scanner:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "scanner:route", limit: 20, windowMs: 60_000 }, durableRateTier: "B" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
   try {

--- a/web/app/api/scanner/strength/scan/route.ts
+++ b/web/app/api/scanner/strength/scan/route.ts
@@ -18,7 +18,7 @@ function cacheMatchesRequest(cached: Record<string, unknown>, ticker: string, pr
 export const radonCapability = "read.spawn";
 
 export async function POST(request: Request): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "scanner/strength/scan:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "scanner/strength/scan:route", limit: 20, windowMs: 60_000 }, durableRateTier: "B" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
   let body: Record<string, unknown> = {};

--- a/web/app/api/scanner/theta/route.ts
+++ b/web/app/api/scanner/theta/route.ts
@@ -11,6 +11,7 @@ import { getRequestId, setNoStoreResponseHeaders } from "@/lib/apiContracts";
 import { radonFetch } from "@/lib/radonApi";
 import { backfillThetaEarningsPayload } from "@/lib/thetaEarningsBackfill";
 import { isCoverageFailedScan, pickUsableScanSnapshot } from "@/lib/scanCoverage";
+import { buildDemoThetaHarvester } from "@/lib/demo/fixtures/thetaHarvester";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -115,9 +116,24 @@ async function fetchEarningsBatch(tickers: string[]): Promise<{
 }
 
 export async function GET(): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "scanner/theta:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "scanner/theta:route", limit: 20, windowMs: 60_000 }, durableRateTier: "A" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
+  if (access.principal.kind === "demo") {
+    const now = new Date();
+    return setNoStoreResponseHeaders(
+      NextResponse.json({
+        ...buildDemoThetaHarvester({ now }),
+        cache_meta: {
+          last_refresh: now.toISOString(),
+          age_seconds: 0,
+          is_stale: false,
+          stale_threshold_seconds: STALE_THRESHOLD_SECONDS,
+        },
+      }),
+      requestId,
+    );
+  }
   const diskCacheMeta = buildCacheMeta(CACHE_PATH);
   // Fresher of the shared Turso snapshot and the host-local disk JSON.
   const result = await cachedRead("scanner:theta", READ_CACHE_TTL_MS, () =>

--- a/web/app/api/scanner/theta/scan/route.ts
+++ b/web/app/api/scanner/theta/scan/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from "next/server";
 import { getRequestId, setNoStoreResponseHeaders } from "@/lib/apiContracts";
 import { radonFetch, RadonApiError } from "@/lib/radonApi";
 import { emptyThetaHarvesterPayload, readThetaHarvesterCache } from "../route";
+import { buildDemoThetaHarvester } from "@/lib/demo/fixtures/thetaHarvester";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -18,7 +19,7 @@ function cacheMatchesRequest(cached: Record<string, unknown>, ticker: string, pr
 export const radonCapability = "read.spawn";
 
 export async function POST(request: Request): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "scanner/theta/scan:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "scanner/theta/scan:route", limit: 20, windowMs: 60_000 }, durableRateTier: "B" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
   let body: Record<string, unknown> = {};
@@ -42,9 +43,10 @@ export async function POST(request: Request): Promise<Response> {
   } else if (typeof body.preset === "string") {
     params.set("preset", body.preset);
   }
-  if (!ticker && typeof body.limit === "number" && Number.isFinite(body.limit) && body.limit > 0) {
-    params.set("limit", String(Math.trunc(body.limit)));
-  }
+  const limit = !ticker && typeof body.limit === "number" && Number.isFinite(body.limit) && body.limit > 0
+    ? Math.trunc(body.limit)
+    : null;
+  if (limit !== null) params.set("limit", String(limit));
 
   // Search parameters (DTE window + minimum per-share credit). FastAPI validates
   // ranges; only forward finite numbers so bad input never reaches the subprocess.
@@ -59,6 +61,24 @@ export async function POST(request: Request): Promise<Response> {
   if (minDte !== null) params.set("min_dte", String(minDte));
   if (maxDte !== null) params.set("max_dte", String(maxDte));
   if (minCredit !== null) params.set("min_credit", String(minCredit));
+
+  if (access.principal.kind === "demo") {
+    return setNoStoreResponseHeaders(
+      NextResponse.json({
+        ...buildDemoThetaHarvester({
+          now: new Date(),
+          ticker: ticker || undefined,
+          preset,
+          limit,
+          minDte,
+          maxDte,
+          minCredit,
+        }),
+        scan_succeeded: true,
+      }),
+      requestId,
+    );
+  }
 
   const path = params.toString()
     ? `/theta-harvester/scan?${params.toString()}`

--- a/web/app/api/short-availability/[ticker]/route.ts
+++ b/web/app/api/short-availability/[ticker]/route.ts
@@ -22,7 +22,7 @@ type Params = { params: Promise<{ ticker: string }> };
 export const radonCapability = "read";
 
 export async function GET(_req: Request, ctx: Params): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "short-availability/[ticker]:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "short-availability/[ticker]:route", limit: 20, windowMs: 60_000 }, durableRateTier: "A" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
   const { ticker: raw } = await ctx.params;

--- a/web/app/api/streaks/route.ts
+++ b/web/app/api/streaks/route.ts
@@ -33,6 +33,7 @@ export const radonCapability = "read.spawn";
 export async function GET(request: Request): Promise<Response> {
   const access = await requireRouteAccess(undefined, {
     rate: { key: "streaks:route", limit: 20, windowMs: 60_000 },
+    durableRateTier: "A",
   });
   if (!access.ok) return access.response;
 

--- a/web/app/api/ticker/info/route.ts
+++ b/web/app/api/ticker/info/route.ts
@@ -241,7 +241,7 @@ const CACHE_TTL_SECONDS = 20;
 export const radonCapability = "read";
 
 export async function GET(request: Request): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "ticker/info:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "ticker/info:route", limit: 20, windowMs: 60_000 }, durableRateTier: "D" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
   const { searchParams } = new URL(request.url);

--- a/web/app/api/ticker/news/route.ts
+++ b/web/app/api/ticker/news/route.ts
@@ -19,7 +19,7 @@ const PROVIDER_TIMEOUT_MS = 3_000;
 export const radonCapability = "read";
 
 export async function GET(request: Request): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "ticker/news:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "ticker/news:route", limit: 20, windowMs: 60_000 }, durableRateTier: "A" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
   const { searchParams } = new URL(request.url);

--- a/web/app/api/ticker/ratings/route.ts
+++ b/web/app/api/ticker/ratings/route.ts
@@ -25,7 +25,7 @@ function coalescedRatings(ticker: string): Promise<Record<string, unknown>> {
 export const radonCapability = "read";
 
 export async function GET(request: Request): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "ticker/ratings:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "ticker/ratings:route", limit: 20, windowMs: 60_000 }, durableRateTier: "A" });
   if (!access.ok) return access.response;
   const { searchParams } = new URL(request.url);
   const ticker = boundedTicker(searchParams.get("ticker"));

--- a/web/app/api/ticker/seasonality/route.ts
+++ b/web/app/api/ticker/seasonality/route.ts
@@ -153,7 +153,7 @@ const STALE_REVALIDATE_SECONDS = 3600;
 export const radonCapability = "read";
 
 export async function GET(request: Request): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "ticker/seasonality:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "ticker/seasonality:route", limit: 20, windowMs: 60_000 }, durableRateTier: "D" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
   const { searchParams } = new URL(request.url);

--- a/web/app/api/trin/route.ts
+++ b/web/app/api/trin/route.ts
@@ -1,10 +1,12 @@
 import { NextResponse } from "next/server";
 import { readFile } from "fs/promises";
 import { join } from "path";
-import { getRequestId, setCacheResponseHeaders } from "@/lib/apiContracts";
+import { getRequestId, setCacheResponseHeaders, setNoStoreResponseHeaders } from "@/lib/apiContracts";
 import { getDb } from "@/lib/db";
 import { contentTimestampMs, dbFirstRead, type TimestampedRead, staleCollapse, isMissingPayload } from "@/lib/dbFirstRead";
 import { MISSING_TRIN } from "@/lib/trin";
+import { requireRouteAccess } from "@/lib/routeAccess";
+import { buildDemoTrinFixture } from "@/lib/demo/fixtures/regime";
 // Disable Next.js static caching: this handler reads live disk state
 // (data/*.json, cache files). Without this, the framework freezes the
 // first response and serves stale data until the dev server restarts.
@@ -43,7 +45,12 @@ async function readTrinFromDisk(): Promise<TimestampedRead<Record<string, unknow
 export const radonCapability = "read";
 
 export async function GET(): Promise<Response> {
+  const access = await requireRouteAccess();
+  if (!access.ok) return access.response;
   const requestId = getRequestId();
+  if (access.principal.kind === "demo") {
+    return setNoStoreResponseHeaders(NextResponse.json(buildDemoTrinFixture()), requestId);
+  }
   const result = await dbFirstRead({
     fromDb: readTrinFromDb,
     fromDisk: readTrinFromDisk,

--- a/web/app/api/vcg/route.ts
+++ b/web/app/api/vcg/route.ts
@@ -6,10 +6,11 @@ import { join } from "path";
 import { isVcgDataStale } from "@/lib/vcgStaleness";
 import { radonFetch } from "@/lib/radonApi";
 import { createBackgroundScanTrigger } from "@/lib/backgroundScan";
-import { getRequestId, setCacheResponseHeaders } from "@/lib/apiContracts";
+import { getRequestId, setCacheResponseHeaders, setNoStoreResponseHeaders } from "@/lib/apiContracts";
 import { getDb } from "@/lib/db";
 import { cachedRead } from "@/lib/dbCache";
 import { contentTimestampMs, dbFirstRead, type TimestampedRead } from "@/lib/dbFirstRead";
+import { buildDemoVcgFixture } from "@/lib/demo/fixtures/regime";
 import { getMarketStateFromDate, isUsTradingDay } from "@/lib/serviceHealthWindows";
 // Disable Next.js static caching: this handler reads live disk state
 // (data/*.json, cache files). Without this, the framework freezes the
@@ -124,9 +125,12 @@ const triggerBackgroundScan = createBackgroundScanTrigger({
 export const radonCapability = "read";
 
 export async function GET(): Promise<Response> {
-  const access = await requireRouteAccess(undefined, { rate: { key: "vcg:route", limit: 20, windowMs: 60_000 } });
+  const access = await requireRouteAccess(undefined, { rate: { key: "vcg:route", limit: 20, windowMs: 60_000 }, durableRateTier: "A" });
   if (!access.ok) return access.response;
   const requestId = getRequestId();
+  if (access.principal.kind === "demo") {
+    return setNoStoreResponseHeaders(NextResponse.json(buildDemoVcgFixture()), requestId);
+  }
   const cached = await readCachedVcg();
   const data = normalizeVcgPayload(cached ?? {});
   const currentMarketOpen = isMarketOpenNow();

--- a/web/app/api/vcg/share/route.ts
+++ b/web/app/api/vcg/share/route.ts
@@ -10,7 +10,7 @@ export const runtime = "nodejs";
 export const radonCapability = "internal";
 
 export async function POST(request: Request): Promise<Response> {
-  const access = await requireRouteAccess(request, { rate: { key: "share-generator", limit: 10, windowMs: 60_000 } });
+  const access = await requireRouteAccess(request, { rate: { key: "share-generator", limit: 10, windowMs: 60_000 }, durableRateTier: "B" });
   if (!access.ok) return access.response;
   const limit = rateLimit(clientIp(request), { limit: SHARE_CARD_LIMIT, windowMs: SHARE_WINDOW_MS });
   if (!limit.ok) {

--- a/web/components/TickerSearch.tsx
+++ b/web/components/TickerSearch.tsx
@@ -14,6 +14,9 @@ import { useWatchlist } from "@/lib/useWatchlist";
 import { useRealtimeAuth } from "@/lib/RealtimeAuthContext";
 import { buildAuthenticatedWebSocketUrl, resolveRealtimeWebSocketUrl } from "@/lib/realtimeSocketAuth";
 import StarToggle from "@/components/StarToggle";
+import { demoSymbolHash } from "@/lib/demo/fixtures/market";
+import { isFuturesRoot } from "@/lib/futuresSymbols";
+import { isIndexSymbol } from "@/lib/indexSymbols";
 
 type SearchResult = {
   conId: number;
@@ -37,12 +40,37 @@ type TickerSearchProps = {
 const MAX_RESULTS = 10;
 const DEBOUNCE_MS = 200;
 const ALLOWED_SEC_TYPES = new Set(["STK", "IND", "FUT"]);
+const DEMO_SEARCH_SYMBOLS = [
+  "AAPL", "AMAT", "AMD", "COIN", "GOOG", "META", "MSFT", "NEM",
+  "NVDA", "QQQ", "SNDK", "SPY", "TSLA", "VIX",
+];
+
+function demoSearchResults(pattern: string): SearchResult[] {
+  const normalized = pattern.trim().toUpperCase();
+  if (!/^[A-Z][A-Z.]{0,9}$/.test(normalized)) return [];
+  const symbols = [
+    normalized,
+    ...DEMO_SEARCH_SYMBOLS.filter((symbol) => symbol !== normalized && symbol.startsWith(normalized)),
+  ].slice(0, MAX_RESULTS);
+  return symbols.map((symbol) => {
+    const secType = isFuturesRoot(symbol) ? "FUT" : isIndexSymbol(symbol) ? "IND" : "STK";
+    return {
+      conId: demoSymbolHash(symbol),
+      symbol,
+      secType,
+      primaryExchange: secType === "FUT" ? "CME" : secType === "IND" ? "CBOE" : "SMART",
+      currency: "USD",
+      ...(secType === "STK" ? { derivativeSecTypes: ["OPT"] } : {}),
+    };
+  });
+}
 
 const TickerSearch = forwardRef<HTMLInputElement, TickerSearchProps>(
   function TickerSearch(
     { onSelect, placeholder = "Search ticker...", className, ariaLabel = "Search ticker", onSearchUnavailable },
     ref,
   ) {
+    const demoMode = process.env.NEXT_PUBLIC_RADON_DEMO === "1";
     const inputRef = useRef<HTMLInputElement>(null);
     const wsRef = useRef<WebSocket | null>(null);
     const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -96,6 +124,7 @@ const TickerSearch = forwardRef<HTMLInputElement, TickerSearchProps>(
     /*  WebSocket lifecycle                                                */
     /* ------------------------------------------------------------------ */
     const connectWs = useCallback(() => {
+      if (demoMode) return;
       if (!mountedRef.current) return;
       if (connectingRef.current) return;
       if (
@@ -204,7 +233,7 @@ const TickerSearch = forwardRef<HTMLInputElement, TickerSearchProps>(
           reconnectTimerRef.current = setTimeout(connectWs, delay);
         }
       }
-    }, [onSearchUnavailable]);
+    }, [demoMode, onSearchUnavailable]);
 
     // Deliberately no eager connect on mount: this component remounts on every
     // App Router navigation (Header lives in the per-page WorkspaceShell, and
@@ -251,6 +280,12 @@ const TickerSearch = forwardRef<HTMLInputElement, TickerSearchProps>(
         activePatternRef.current = pattern.trim().toUpperCase();
 
         debounceRef.current = setTimeout(() => {
+          if (demoMode) {
+            setResults(demoSearchResults(pattern));
+            setLoading(false);
+            pendingPatternRef.current = null;
+            return;
+          }
           const ws = wsRef.current;
           if (ws && ws.readyState === WebSocket.OPEN) {
             ws.send(JSON.stringify({ action: "search", pattern: pattern.trim() }));
@@ -270,7 +305,7 @@ const TickerSearch = forwardRef<HTMLInputElement, TickerSearchProps>(
           }
         }, DEBOUNCE_MS);
       },
-      [connectWs, onSearchUnavailable],
+      [connectWs, demoMode, onSearchUnavailable],
     );
 
     /* ------------------------------------------------------------------ */

--- a/web/components/WorkspaceShell.tsx
+++ b/web/components/WorkspaceShell.tsx
@@ -525,7 +525,7 @@ export default function WorkspaceShell({ section, tickerParam, initialPortfolio 
 
   // R-149: no snapshot at all is a BLACKOUT, and "Awaiting first sample" read
   // as a benign startup state for the rest of the session.
-  const syncLabel = lastSync
+  const syncLabel = isDemoMode ? "Sample snapshot" : lastSync
     ? `Last sample ${new Date(lastSync).toLocaleTimeString([], { hour12: false })}`
     : error
       ? "Sync failed. Reconstruction incomplete."
@@ -580,19 +580,21 @@ export default function WorkspaceShell({ section, tickerParam, initialPortfolio 
           onSyncNow={syncNow}
         >
           {!isOptionsWorkspace ? <div className="sync-controls">
-            <span className={`sync-status ${error || snapshotState === "unknown" ? "sync-error" : syncing ? "sync-active" : ""}`}>
+            <span className={`sync-status ${!isDemoMode && (error || snapshotState === "unknown") ? "sync-error" : syncing ? "sync-active" : ""}`}>
               {syncLabel}
             </span>
-            <button
-              type="button"
-              className="sync-button"
-              onClick={syncNow}
-              disabled={syncing}
-              title={`Sync ${syncTarget} from IB Gateway`}
-            >
-              <RefreshCw size={14} className={syncing ? "spin" : ""} />
-              {syncing ? "Syncing…" : "Sync Now"}
-            </button>
+            {!isDemoMode ? (
+              <button
+                type="button"
+                className="sync-button"
+                onClick={syncNow}
+                disabled={syncing}
+                title={`Sync ${syncTarget} from IB Gateway`}
+              >
+                <RefreshCw size={14} className={syncing ? "spin" : ""} />
+                {syncing ? "Syncing…" : "Sync Now"}
+              </button>
+            ) : null}
           </div> : null}
         </Header>
 

--- a/web/e2e/demo-workstation-data.spec.ts
+++ b/web/e2e/demo-workstation-data.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test, type Page } from "@playwright/test";
+
+test.describe("demo workstation transport", () => {
+  test.skip(process.env.NEXT_PUBLIC_RADON_DEMO !== "1", "demo-only browser contract");
+
+  async function stubShellApis(page: Page): Promise<string[]> {
+    const apiRequests: string[] = [];
+    await page.route("**/api/**", async (route) => {
+      const request = route.request();
+      const url = new URL(request.url());
+      apiRequests.push(`${request.method()} ${url.pathname}`);
+      const now = new Date().toISOString();
+      const body = url.pathname === "/api/portfolio"
+        ? {
+            bankroll: 1_000_000,
+            peak_value: 1_000_000,
+            last_sync: now,
+            total_deployed_pct: 0,
+            total_deployed_dollars: 0,
+            remaining_capacity_pct: 100,
+            position_count: 0,
+            defined_risk_count: 0,
+            undefined_risk_count: 0,
+            avg_kelly_optimal: null,
+            exposure: {},
+            violations: [],
+            positions: [],
+          }
+        : url.pathname === "/api/orders"
+          ? { last_sync: now, open_orders: [], executed_orders: [], open_count: 0, executed_count: 0 }
+          : url.pathname === "/api/blotter"
+            ? { as_of: now, summary: { realized_pnl: 0 }, closed_trades: [], open_trades: [] }
+            : url.pathname === "/api/profile"
+              ? { username: "Demo Operator" }
+              : url.pathname === "/api/watchlist"
+                ? { symbols: [] }
+                : url.pathname === "/api/service-health"
+                  ? { services: [] }
+                  : url.pathname === "/api/flex-token"
+                    ? { ok: true, days_until_expiry: 14 }
+                    : {};
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        headers: { "Cache-Control": "no-store" },
+        body: JSON.stringify(body),
+      });
+    });
+    return apiRequests;
+  }
+
+  test("supplies order-book depth, tape, and local ticker search without broker transport", async ({ page }, testInfo) => {
+    const websocketUrls: string[] = [];
+    page.on("websocket", (socket) => websocketUrls.push(socket.url()));
+    const apiRequests = await stubShellApis(page);
+
+    await page.goto("/NEM?tab=book");
+
+    await expect(page.locator(".book-feed-pill")).toHaveText("SAMPLE SMART DEPTH");
+    await expect(page.locator(".book-montage .book-row")).toHaveCount(10);
+    await expect(page.locator(".book-tape-cell .book-trow")).toHaveCount(8);
+    await expect(page.getByText("No real-time data", { exact: true })).toHaveCount(0);
+
+    const search = page.getByRole("combobox", { name: "Search ticker" });
+    await search.focus();
+    await search.fill("SNDK");
+    await expect(page.getByRole("option", { name: /SNDK/ }).first()).toBeVisible();
+
+    await expect(page.getByRole("button", { name: "Sync now" })).toHaveCount(0);
+    await expect(page.getByText("Sample snapshot", { exact: true })).toBeVisible();
+    await page.screenshot({ path: testInfo.outputPath("demo-order-book.png"), fullPage: true });
+
+    expect(apiRequests.filter((request) => request.endsWith(" /api/ib/ws-ticket"))).toEqual([]);
+    expect(websocketUrls.filter((url) => url.includes(":8765") || /\/ws(?:\?|$)/.test(url))).toEqual([]);
+  });
+});

--- a/web/lib/RealtimePricesContext.tsx
+++ b/web/lib/RealtimePricesContext.tsx
@@ -32,6 +32,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type ReactNode,
@@ -39,6 +40,10 @@ import {
 import { usePrices, type UsePricesReturn } from "./usePrices";
 import { optionKey, type IndexContract, type OptionContract } from "./pricesProtocol";
 import { useRealtimeAuth } from "./RealtimeAuthContext";
+import {
+  buildDemoRealtimeSample,
+  buildDemoSnapshotPrices,
+} from "./demo/demoRealtime";
 
 export type RealtimeSubscriptionRequest = {
   symbols: string[];
@@ -53,6 +58,7 @@ export type RealtimeSubscriptionRequest = {
  *  before it is committed to the wire. Sized to cover the post-navigation gap
  *  where the new shell's portfolio/orders GETs are still in flight. */
 export const SUBSCRIPTION_SHRINK_LINGER_MS = 5_000;
+const DEMO_QUOTE_REFRESH_MS = 60_000;
 
 const EMPTY_REQUEST: RealtimeSubscriptionRequest = {
   symbols: [],
@@ -128,7 +134,9 @@ const requestKey = (r: RealtimeSubscriptionRequest) =>
 
 export function RealtimePricesProvider({ children }: { children: ReactNode }) {
   const getToken = useRealtimeAuth();
+  const demoMode = process.env.NEXT_PUBLIC_RADON_DEMO === "1";
   const [applied, setApplied] = useState<RealtimeSubscriptionRequest>(EMPTY_REQUEST);
+  const [demoClock, setDemoClock] = useState(() => new Date());
   const appliedRef = useRef<RealtimeSubscriptionRequest>(EMPTY_REQUEST);
   const desiredRef = useRef<RealtimeSubscriptionRequest>(EMPTY_REQUEST);
   const shrinkTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -176,15 +184,45 @@ export function RealtimePricesProvider({ children }: { children: ReactNode }) {
     if (shrinkTimerRef.current) clearTimeout(shrinkTimerRef.current);
   }, []);
 
-  const realtime = usePrices({
+  useEffect(() => {
+    if (!demoMode) return;
+    const refresh = () => setDemoClock(new Date());
+    refresh();
+    const interval = setInterval(refresh, DEMO_QUOTE_REFRESH_MS);
+    return () => clearInterval(interval);
+  }, [demoMode]);
+
+  const liveRealtime = usePrices({
     symbols: applied.symbols,
     contracts: applied.contracts,
     indexes: applied.indexes,
+    enabled: !demoMode,
     depthSymbol: applied.depthSymbol,
     depthSymbols: applied.depthSymbols,
     depthExpiry: applied.depthExpiry,
     getToken,
   });
+  const demoSample = useMemo(
+    () => buildDemoRealtimeSample(applied, demoClock),
+    [applied, demoClock],
+  );
+  const demoGetSnapshot = useCallback(
+    async (symbols: string[]) => buildDemoSnapshotPrices(symbols, new Date()),
+    [],
+  );
+  const demoReconnect = useCallback(() => {}, []);
+  const realtime: UsePricesReturn = demoMode
+    ? {
+        ...demoSample,
+        connected: false,
+        ibConnected: false,
+        ibIssue: null,
+        ibStatusMessage: null,
+        error: null,
+        reconnect: demoReconnect,
+        getSnapshot: demoGetSnapshot,
+      }
+    : liveRealtime;
 
   return (
     <RealtimePricesContext.Provider value={{ ...realtime, publishSubscriptions }}>

--- a/web/lib/demo/demoRealtime.ts
+++ b/web/lib/demo/demoRealtime.ts
@@ -1,0 +1,286 @@
+import { isFuturesRoot } from "@/lib/futuresSymbols";
+import {
+  optionKey,
+  parseOptionKey,
+  type DepthBook,
+  type FundamentalsData,
+  type IndexContract,
+  type OptionContract,
+  type PriceData,
+  type Trade,
+} from "@/lib/pricesProtocol";
+import { demoBasePrice, demoSymbolHash, roundDemoPrice } from "./fixtures/market";
+
+export type DemoRealtimeRequest = {
+  symbols: string[];
+  contracts: OptionContract[];
+  indexes: IndexContract[];
+  depthSymbol: string | null;
+  depthSymbols: string[];
+  depthExpiry: string | null;
+};
+
+export type DemoRealtimeSample = {
+  prices: Record<string, PriceData>;
+  fundamentals: Record<string, FundamentalsData>;
+  depths: Record<string, DepthBook>;
+  tape: Record<string, Trade[]>;
+};
+
+function sampleMinute(now: Date): Date {
+  return new Date(Math.floor(now.getTime() / 60_000) * 60_000);
+}
+
+function minuteSeed(symbol: string, now: Date): number {
+  const minute = Math.floor(now.getTime() / 60_000);
+  return demoSymbolHash(`${symbol}:${minute}`);
+}
+
+function instrumentTick(symbol: string, price: number): number {
+  if (isFuturesRoot(symbol)) return symbol === "RTY" ? 0.1 : 0.25;
+  if (price >= 1_000) return 0.25;
+  return 0.01;
+}
+
+function liveUnderlyingPrice(symbol: string, now: Date): number {
+  const base = demoBasePrice(symbol);
+  const drift = ((minuteSeed(symbol, now) % 101) - 50) / 20_000;
+  return roundDemoPrice(base * (1 + drift));
+}
+
+function buildUnderlyingQuote(symbol: string, now: Date): PriceData {
+  const normalized = symbol.trim().toUpperCase();
+  const last = liveUnderlyingPrice(normalized, now);
+  const tick = instrumentTick(normalized, last);
+  const bid = roundDemoPrice(last - tick);
+  const ask = roundDemoPrice(last + tick);
+  const closeDirection = demoSymbolHash(normalized) % 2 === 0 ? 1 : -1;
+  const close = roundDemoPrice(demoBasePrice(normalized) * (1 - closeDirection * 0.004));
+  const fwd = normalized === "VIX" ? roundDemoPrice(last + 0.85) : null;
+
+  return {
+    symbol: normalized,
+    last,
+    lastIsCalculated: false,
+    bid,
+    ask,
+    bidSize: 60 + (demoSymbolHash(`${normalized}:bid`) % 240),
+    askSize: 55 + (demoSymbolHash(`${normalized}:ask`) % 220),
+    volume: 250_000 + (demoSymbolHash(`${normalized}:volume`) % 4_000_000),
+    high: roundDemoPrice(Math.max(last, close) * 1.008),
+    low: roundDemoPrice(Math.min(last, close) * 0.992),
+    open: roundDemoPrice((last + close) / 2),
+    close,
+    week52High: roundDemoPrice(Math.max(last, close) * 1.24),
+    week52Low: roundDemoPrice(Math.min(last, close) * 0.72),
+    avgVolume: 1_500_000 + (demoSymbolHash(`${normalized}:average`) % 8_000_000),
+    delta: null,
+    gamma: null,
+    theta: null,
+    vega: null,
+    impliedVol: null,
+    undPrice: null,
+    ...(fwd == null ? {} : { fwd, fwdCurve: {} }),
+    timestamp: now.toISOString(),
+  };
+}
+
+function daysToExpiry(expiry: string, now: Date): number {
+  const iso = `${expiry.slice(0, 4)}-${expiry.slice(4, 6)}-${expiry.slice(6, 8)}T20:00:00.000Z`;
+  return Math.max(1, (Date.parse(iso) - now.getTime()) / 86_400_000);
+}
+
+function buildOptionQuote(
+  contract: OptionContract,
+  underlying: PriceData,
+  now: Date,
+): PriceData {
+  const key = optionKey(contract);
+  const spot = underlying.last ?? demoBasePrice(contract.symbol);
+  const intrinsic = contract.right === "C"
+    ? Math.max(0, spot - contract.strike)
+    : Math.max(0, contract.strike - spot);
+  const dte = daysToExpiry(contract.expiry, now);
+  const timeValue = Math.max(0.2, spot * 0.018 * Math.sqrt(dte / 30));
+  const distanceDecay = Math.exp(-Math.abs(contract.strike - spot) / Math.max(spot * 0.16, 1));
+  const last = roundDemoPrice(Math.max(0.05, intrinsic + timeValue * distanceDecay));
+  const halfSpread = Math.max(0.01, roundDemoPrice(last * 0.025));
+  const bid = roundDemoPrice(Math.max(0.01, last - halfSpread));
+  const ask = roundDemoPrice(last + halfSpread);
+  const callDelta = Math.max(0.08, Math.min(0.92, 0.5 + (spot - contract.strike) / Math.max(spot * 0.45, 1)));
+  const delta = contract.right === "C" ? callDelta : callDelta - 1;
+
+  return {
+    symbol: key,
+    last,
+    lastIsCalculated: false,
+    bid,
+    ask,
+    bidSize: 10 + (demoSymbolHash(`${key}:bid`) % 90),
+    askSize: 10 + (demoSymbolHash(`${key}:ask`) % 90),
+    volume: 50 + (demoSymbolHash(`${key}:volume`) % 2_500),
+    high: roundDemoPrice(last * 1.12),
+    low: roundDemoPrice(Math.max(0.01, last * 0.88)),
+    open: roundDemoPrice(last * 0.98),
+    close: roundDemoPrice(last * 0.97),
+    week52High: null,
+    week52Low: null,
+    avgVolume: null,
+    delta: Math.round(delta * 10_000) / 10_000,
+    gamma: Math.round((0.01 + distanceDecay * 0.03) * 10_000) / 10_000,
+    theta: -roundDemoPrice(Math.max(0.01, timeValue / Math.max(dte, 1))),
+    vega: roundDemoPrice(spot * 0.0015 * distanceDecay),
+    impliedVol: Math.round((0.22 + (demoSymbolHash(key) % 1_500) / 10_000) * 10_000) / 10_000,
+    undPrice: spot,
+    timestamp: now.toISOString(),
+  };
+}
+
+function buildFundamentals(symbol: string, quote: PriceData, now: Date): FundamentalsData {
+  const seed = demoSymbolHash(symbol);
+  return {
+    symbol,
+    peRatio: Math.round((12 + (seed % 2_800) / 100) * 100) / 100,
+    eps: Math.round((1 + (seed % 1_200) / 100) * 100) / 100,
+    dividendYield: Math.round((seed % 320) / 100) / 100,
+    week52High: quote.week52High,
+    week52Low: quote.week52Low,
+    priceBookRatio: Math.round((1 + (seed % 900) / 100) * 100) / 100,
+    roe: Math.round((8 + (seed % 2_200) / 100) * 100) / 100,
+    revenue: 1_000_000_000 + (seed % 80_000) * 1_000_000,
+    timestamp: now.toISOString(),
+  };
+}
+
+function depthKind(subject: string): DepthBook["kind"] {
+  if (parseOptionKey(subject)) return "option";
+  if (isFuturesRoot(subject)) return "future";
+  return "stock";
+}
+
+function buildDepth(subject: string, quote: PriceData, now: Date): DepthBook {
+  const kind = depthKind(subject);
+  const bid = quote.bid ?? quote.last ?? 0;
+  const ask = quote.ask ?? quote.last ?? 0;
+  const tick = kind === "option" ? 0.01 : instrumentTick(subject, quote.last ?? 0);
+  const exchanges = ["CBOE", "PHLX", "ISE", "ARCA", "EDGX"];
+  const bidLevels = Array.from({ length: 5 }, (_, index) => ({
+    price: roundDemoPrice(Math.max(tick, bid - index * tick)),
+    size: 20 + (demoSymbolHash(`${subject}:bid:${index}`) % 180),
+    marketMaker: kind === "stock" ? `D${index + 1}` : null,
+    exchange: kind === "future" ? null : exchanges[index],
+    ...(kind === "option" ? { nbbo: index === 0 } : {}),
+  }));
+  const askLevels = Array.from({ length: 5 }, (_, index) => ({
+    price: roundDemoPrice(ask + index * tick),
+    size: 20 + (demoSymbolHash(`${subject}:ask:${index}`) % 180),
+    marketMaker: kind === "stock" ? `D${index + 6}` : null,
+    exchange: kind === "future" ? null : exchanges[(index + 2) % exchanges.length],
+    ...(kind === "option" ? { nbbo: index === 0 } : {}),
+  }));
+
+  return {
+    symbol: subject,
+    kind,
+    bid: bidLevels,
+    ask: askLevels,
+    isSmartDepth: kind !== "future",
+    feed: kind === "option"
+      ? "SAMPLE OPRA · PER-EXCHANGE BBO"
+      : kind === "future"
+        ? "SAMPLE CME · GLOBEX DEPTH"
+        : "SAMPLE SMART DEPTH",
+    entitled: true,
+    ...(kind === "option" ? {
+      nbbo: {
+        bestBid: bid,
+        bestAsk: ask,
+        mid: roundDemoPrice((bid + ask) / 2),
+        bidSize: quote.bidSize ?? 0,
+        askSize: quote.askSize ?? 0,
+      },
+    } : {}),
+    timestamp: now.toISOString(),
+  };
+}
+
+function buildTape(subject: string, quote: PriceData, now: Date): Trade[] {
+  const last = quote.last ?? 0;
+  const tick = depthKind(subject) === "option" ? 0.01 : instrumentTick(subject, last);
+  return Array.from({ length: 8 }, (_, index) => {
+    const direction = index % 3 === 0 ? -1 : index % 3 === 1 ? 0 : 1;
+    return {
+      price: roundDemoPrice(Math.max(tick, last + direction * tick)),
+      size: 1 + (demoSymbolHash(`${subject}:trade:${index}`) % 75),
+      exchange: depthKind(subject) === "future" ? null : index % 2 === 0 ? "ARCA" : "FINY",
+      time: String(Math.floor(now.getTime() / 1_000) - (7 - index) * 3),
+    };
+  });
+}
+
+export function buildDemoSnapshotPrices(
+  symbols: string[],
+  now: Date = new Date(),
+): Record<string, PriceData> {
+  const sampledAt = sampleMinute(now);
+  const prices: Record<string, PriceData> = {};
+  for (const rawSymbol of symbols) {
+    const symbol = rawSymbol.trim().toUpperCase();
+    if (!symbol || prices[symbol]) continue;
+    prices[symbol] = buildUnderlyingQuote(symbol, sampledAt);
+  }
+  return prices;
+}
+
+export function buildDemoRealtimeSample(
+  request: DemoRealtimeRequest,
+  now: Date = new Date(),
+): DemoRealtimeSample {
+  const sampledAt = sampleMinute(now);
+  const indexSymbols = request.indexes.map(({ symbol }) => symbol);
+  const contractSymbols = request.contracts.map(({ symbol }) => symbol);
+  const prices = buildDemoSnapshotPrices(
+    [...request.symbols, ...indexSymbols, ...contractSymbols],
+    sampledAt,
+  );
+  const fundamentals: Record<string, FundamentalsData> = {};
+  for (const symbol of [...new Set([...request.symbols, ...contractSymbols])]) {
+    const normalized = symbol.trim().toUpperCase();
+    const quote = prices[normalized];
+    if (quote && !isFuturesRoot(normalized)) {
+      fundamentals[normalized] = buildFundamentals(normalized, quote, sampledAt);
+    }
+  }
+
+  for (const contract of request.contracts) {
+    const normalizedSymbol = contract.symbol.trim().toUpperCase();
+    const underlying = prices[normalizedSymbol] ?? buildUnderlyingQuote(normalizedSymbol, sampledAt);
+    prices[normalizedSymbol] = underlying;
+    prices[optionKey(contract)] = buildOptionQuote(contract, underlying, sampledAt);
+  }
+
+  const requestedDepth = request.depthSymbols.length > 0
+    ? request.depthSymbols
+    : request.depthSymbol
+      ? [request.depthSymbol]
+      : [];
+  const depthSubjects = [...new Set(requestedDepth.map((subject) => subject.trim()).filter(Boolean))].slice(0, 3);
+  const depths: Record<string, DepthBook> = {};
+  const tape: Record<string, Trade[]> = {};
+  for (const subject of depthSubjects) {
+    const parsed = parseOptionKey(subject);
+    let quote = prices[subject];
+    if (!quote && parsed) {
+      const underlying = prices[parsed.symbol]
+        ?? buildUnderlyingQuote(parsed.symbol, sampledAt);
+      prices[parsed.symbol] = underlying;
+      quote = buildOptionQuote(parsed, underlying, sampledAt);
+    }
+    quote ??= buildUnderlyingQuote(subject, sampledAt);
+    prices[subject] = quote;
+    depths[subject] = buildDepth(subject, quote, sampledAt);
+    tape[subject] = buildTape(subject, quote, sampledAt);
+  }
+
+  return { prices, fundamentals, depths, tape };
+}

--- a/web/lib/demo/fixtures/cashFlows.ts
+++ b/web/lib/demo/fixtures/cashFlows.ts
@@ -1,0 +1,69 @@
+import type { CashFlowResponse, CashFlowRow, CashFlowType } from "@/lib/useCashFlows";
+import { marketDateKey, shiftDateKey } from "./time";
+
+type BuildCashFlowsOptions = {
+  now?: Date;
+  days?: number;
+  types?: string;
+};
+
+type CashTemplate = {
+  offsetDays: number;
+  type: CashFlowType;
+  amount: number;
+  description: string;
+  rawType: string;
+};
+
+const CASH_TEMPLATES: CashTemplate[] = [
+  { offsetDays: 5, type: "Deposit", amount: 100_000, description: "Opening cash contribution", rawType: "Deposits/Withdrawals" },
+  { offsetDays: 16, type: "Withdrawal", amount: -12_500, description: "Cash withdrawal", rawType: "Deposits/Withdrawals" },
+  { offsetDays: 26, type: "Dividend", amount: 384.72, description: "Portfolio dividend", rawType: "Dividends" },
+  { offsetDays: 52, type: "Fee", amount: -24.5, description: "Market data fees", rawType: "Fees" },
+];
+
+/** Mirrors the FastAPI days/types query contract using request-time sample rows. */
+export function buildDemoCashFlows(options: BuildCashFlowsOptions = {}): CashFlowResponse {
+  const now = options.now ?? new Date();
+  const days = Number.isFinite(options.days) ? Math.max(1, Math.trunc(options.days ?? 90)) : 90;
+  const today = marketDateKey(now);
+  const fromDate = shiftDateKey(today, -days);
+  const typeFilter = new Set(
+    (options.types ?? "").split(",").map((value) => value.trim()).filter(Boolean),
+  );
+  const syncedAt = now.toISOString();
+  const rows: CashFlowRow[] = CASH_TEMPLATES.map((template) => {
+    const date = shiftDateKey(today, -template.offsetDays);
+    return {
+      id: `DEMO-${date}-${template.type.toUpperCase()}`,
+      date,
+      type: template.type,
+      amount: template.amount,
+      currency: "USD",
+      description: template.description,
+      raw_type: template.rawType,
+      synced_at: syncedAt,
+    };
+  }).filter((row) => row.date >= fromDate && (typeFilter.size === 0 || typeFilter.has(row.type)));
+
+  return {
+    rows,
+    count: rows.length,
+    from_date: fromDate,
+    summary: {
+      deposits: rows.filter((row) => row.type === "Deposit").reduce((sum, row) => sum + row.amount, 0),
+      withdrawals: rows.filter((row) => row.type === "Withdrawal").reduce((sum, row) => sum + row.amount, 0),
+      dividends: rows.filter((row) => row.type === "Dividend").reduce((sum, row) => sum + row.amount, 0),
+      net: rows.reduce((sum, row) => sum + row.amount, 0),
+    },
+    last_synced_at: rows.length > 0 ? syncedAt : null,
+    sync_status: {
+      state: "ok",
+      last_attempt_at: syncedAt,
+      next_attempt_at: null,
+      error_summary: null,
+      is_throttled: false,
+    },
+    db_error: null,
+  };
+}

--- a/web/lib/demo/fixtures/flowAnalysis.ts
+++ b/web/lib/demo/fixtures/flowAnalysis.ts
@@ -1,0 +1,85 @@
+import type { FlowReportData } from "@/lib/useTickerFlowReport";
+import { businessDateKeys } from "./time";
+
+function hashTicker(ticker: string): number {
+  return [...ticker].reduce((hash, char) => (hash * 37 + char.charCodeAt(0)) % 100_003, 23);
+}
+
+function round(value: number, places = 3): number {
+  const scale = 10 ** places;
+  return Math.round(value * scale) / scale;
+}
+
+/** Fresh deterministic market-structure sample for any route-valid ticker. */
+export function buildDemoFlowReport(rawTicker: string, now: Date = new Date()): FlowReportData {
+  const ticker = rawTicker.trim().toUpperCase();
+  const seed = hashTicker(ticker);
+  const bucket = seed % 3;
+  const direction = bucket === 0 ? "BULLISH" : bucket === 1 ? "BEARISH" : "NEUTRAL";
+  const buyRatio = direction === "BULLISH"
+    ? 0.61 + (seed % 7) / 100
+    : direction === "BEARISH"
+      ? 0.33 + (seed % 7) / 100
+      : 0.48 + (seed % 5) / 100;
+  const confidence = direction === "NEUTRAL" ? 58 + seed % 12 : 72 + seed % 17;
+  const dates = businessDateKeys(12, now);
+  const totalVolume = 1_800_000 + (seed % 900_000);
+  const totalPremium = 28_000_000 + (seed % 16_000_000);
+  const numPrints = 135 + seed % 90;
+  const callPremium = direction === "BEARISH" ? 9_800_000 : 17_600_000;
+  const putPremium = direction === "BULLISH" ? 8_200_000 : 15_900_000;
+
+  return {
+    ticker,
+    fetched_at: now.toISOString(),
+    lookback_days: 20,
+    verdict: { direction, confidence },
+    analysis: {
+      signal: `${direction}_FLOW`,
+      score: round((confidence / 100) * (direction === "BEARISH" ? -1 : direction === "NEUTRAL" ? 0.12 : 1)),
+      direction,
+      strength: round(confidence / 100),
+      buy_ratio: round(buyRatio),
+      sustained_days: direction === "NEUTRAL" ? 3 : 8,
+      num_prints: numPrints,
+      options_conflict: false,
+    },
+    dark_pool: {
+      aggregate: {
+        flow_direction: direction,
+        flow_strength: round(confidence / 100),
+        dp_buy_ratio: round(buyRatio),
+        total_volume: totalVolume,
+        total_premium: totalPremium,
+        buy_volume: Math.round(totalVolume * buyRatio),
+        sell_volume: Math.round(totalVolume * (1 - buyRatio)),
+        num_prints: numPrints,
+      },
+      daily: dates.map((date, index) => {
+        const dailyRatio = Math.max(0.05, Math.min(0.95, buyRatio + Math.sin((seed + index) * 0.7) * 0.045));
+        return {
+          date,
+          flow_direction: dailyRatio > 0.55 ? "BULLISH" : dailyRatio < 0.45 ? "BEARISH" : "NEUTRAL",
+          flow_strength: round(Math.abs(dailyRatio - 0.5) * 2),
+          dp_buy_ratio: round(dailyRatio),
+          num_prints: 8 + (seed + index * 7) % 19,
+        };
+      }),
+    },
+    options_flow: {
+      bias: direction,
+      put_call_ratio: round(putPremium / callPremium),
+      call_premium: callPremium,
+      put_premium: putPremium,
+      total_alerts: 28 + seed % 24,
+    },
+    combined_signal: `${direction} / ${confidence}% confidence`,
+    market_status: "Sample data",
+    trading_days_checked: dates,
+    cache_meta: {
+      last_refresh: now.toISOString(),
+      age_seconds: 0,
+      is_stale: false,
+    },
+  };
+}

--- a/web/lib/demo/fixtures/market.ts
+++ b/web/lib/demo/fixtures/market.ts
@@ -1,0 +1,49 @@
+const KNOWN_BASE_PRICES: Readonly<Record<string, number>> = {
+  AAPL: 275,
+  AAOI: 35,
+  AMAT: 430,
+  AMD: 175,
+  COIN: 260,
+  COR1M: 34,
+  CRWD: 380,
+  ES: 6_250,
+  GOOG: 185,
+  GOOGL: 185,
+  IWM: 225,
+  META: 620,
+  MSFT: 450,
+  MSTR: 370,
+  NDX: 23_000,
+  NEM: 85,
+  NQ: 22_500,
+  NVDA: 140,
+  PLTR: 115,
+  QQQ: 525,
+  RTY: 2_450,
+  RUT: 2_450,
+  SPX: 6_250,
+  SPY: 620,
+  TSLA: 340,
+  UBER: 85,
+  VIX: 17.5,
+  VVIX: 96,
+};
+
+export function demoSymbolHash(symbol: string): number {
+  let hash = 2_166_136_261;
+  for (const char of symbol.trim().toUpperCase()) {
+    hash ^= char.charCodeAt(0);
+    hash = Math.imul(hash, 16_777_619);
+  }
+  return hash >>> 0;
+}
+
+/** Stable sample anchor for arbitrary bounded tickers. */
+export function demoBasePrice(symbol: string): number {
+  const normalized = symbol.trim().toUpperCase();
+  return KNOWN_BASE_PRICES[normalized] ?? 25 + (demoSymbolHash(normalized) % 35_000) / 100;
+}
+
+export function roundDemoPrice(value: number): number {
+  return Math.round(value * 100) / 100;
+}

--- a/web/lib/demo/fixtures/options.ts
+++ b/web/lib/demo/fixtures/options.ts
@@ -1,0 +1,194 @@
+import type {
+  OptionsExposureFrequency,
+  OptionsExposureLevel,
+  OptionsExposurePayload,
+} from "@/lib/optionsExposure";
+import { demoBasePrice, demoSymbolHash, roundDemoPrice } from "./market";
+
+export type DemoOptionExpirationsPayload = {
+  symbol: string;
+  expirations: string[];
+};
+
+export type DemoOptionChainPayload = DemoOptionExpirationsPayload & {
+  expiry: string;
+  exchange: "SMART";
+  strikes: number[];
+  multiplier: "100";
+};
+
+const DAY_MS = 86_400_000;
+
+function utcDay(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
+
+function compactDate(date: Date): string {
+  return date.toISOString().slice(0, 10).replaceAll("-", "");
+}
+
+function isoDate(compact: string): string {
+  return `${compact.slice(0, 4)}-${compact.slice(4, 6)}-${compact.slice(6, 8)}`;
+}
+
+/**
+ * A small, rolling calendar prevents the sample chain from expiring while
+ * keeping demo navigation bounded. Four weeklies plus three standard monthly
+ * expiries are enough to exercise every chain control without background fanout.
+ */
+export function buildDemoOptionExpirations(
+  symbol: string,
+  now: Date = new Date(),
+): DemoOptionExpirationsPayload {
+  const weeklies: string[] = [];
+  const monthlies: string[] = [];
+  const cursor = utcDay(now);
+
+  for (let offset = 1; offset <= 140 && (weeklies.length < 4 || monthlies.length < 3); offset += 1) {
+    const candidate = new Date(cursor.getTime() + offset * DAY_MS);
+    if (candidate.getUTCDay() !== 5) continue;
+    const compact = compactDate(candidate);
+    if (weeklies.length < 4) weeklies.push(compact);
+    const dayOfMonth = candidate.getUTCDate();
+    if (dayOfMonth >= 15 && dayOfMonth <= 21 && monthlies.length < 3) {
+      monthlies.push(compact);
+    }
+  }
+
+  return {
+    symbol: symbol.trim().toUpperCase(),
+    expirations: [...new Set([...weeklies, ...monthlies])].sort().slice(0, 7),
+  };
+}
+
+function strikeStep(spot: number): number {
+  if (spot >= 200) return 5;
+  if (spot >= 75) return 2.5;
+  if (spot >= 30) return 1;
+  return 0.5;
+}
+
+function demoStrikes(symbol: string, width = 30): number[] {
+  const spot = demoBasePrice(symbol);
+  const step = strikeStep(spot);
+  const center = Math.round(spot / step) * step;
+  return Array.from(
+    { length: width * 2 + 1 },
+    (_, index) => roundDemoPrice(center + (index - width) * step),
+  ).filter((strike) => strike > 0);
+}
+
+export function buildDemoOptionChain(
+  symbol: string,
+  requestedExpiry?: string | null,
+  now: Date = new Date(),
+): DemoOptionChainPayload {
+  const calendar = buildDemoOptionExpirations(symbol, now);
+  const normalizedExpiry = requestedExpiry?.replaceAll("-", "") ?? calendar.expirations[0];
+  const expirations = calendar.expirations.includes(normalizedExpiry)
+    ? calendar.expirations
+    : [...calendar.expirations, normalizedExpiry].sort();
+
+  return {
+    ...calendar,
+    expirations,
+    expiry: normalizedExpiry,
+    exchange: "SMART",
+    strikes: demoStrikes(calendar.symbol),
+    multiplier: "100",
+  };
+}
+
+function roundedMeasurement(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+export function buildDemoOptionsExposure(
+  symbol: string,
+  frequency: OptionsExposureFrequency,
+  now: Date = new Date(),
+): OptionsExposurePayload {
+  const normalizedSymbol = symbol.trim().toUpperCase();
+  const spot = demoBasePrice(normalizedSymbol);
+  const allStrikes = demoStrikes(normalizedSymbol, 10);
+  const compactExpirations = buildDemoOptionExpirations(normalizedSymbol, now).expirations.slice(0, 3);
+  const today = utcDay(now).getTime();
+  const expirations = compactExpirations.map((compact) => {
+    const expirationDate = isoDate(compact);
+    const expirationMs = Date.parse(`${expirationDate}T00:00:00.000Z`);
+    return {
+      expiration_date: expirationDate,
+      dte: Math.max(1, Math.ceil((expirationMs - today) / DAY_MS)),
+    };
+  });
+  const cells: OptionsExposurePayload["cells"] = {
+    net_gex: [],
+    abs_gex: [],
+    net_dex: [],
+    abs_dex: [],
+    oi_call: [],
+    oi_put: [],
+    strike_idx: [],
+    expiration_idx: [],
+  };
+  const seed = demoSymbolHash(normalizedSymbol);
+  const step = strikeStep(spot);
+
+  for (let expirationIndex = 0; expirationIndex < expirations.length; expirationIndex += 1) {
+    for (let strikeIndex = 0; strikeIndex < allStrikes.length; strikeIndex += 1) {
+      const strike = allStrikes[strikeIndex];
+      const distance = (strike - spot) / step;
+      const decay = 1 / (1 + expirationIndex * 0.35);
+      const callOi = 180 + ((seed + strikeIndex * 47 + expirationIndex * 89) % 620);
+      const putOi = 160 + ((seed + strikeIndex * 71 + expirationIndex * 53) % 680);
+      const gammaShape = Math.exp(-Math.abs(distance) / 5) * decay;
+      const signedGamma = (callOi - putOi) * spot * gammaShape * 32;
+      const absoluteGamma = (callOi + putOi) * spot * gammaShape * 32;
+      const signedDelta = (callOi * 0.55 - putOi * 0.45) * spot * 100 * decay;
+      const absoluteDelta = (callOi * 0.55 + putOi * 0.45) * spot * 100 * decay;
+
+      cells.strike_idx.push(strikeIndex);
+      cells.expiration_idx.push(expirationIndex);
+      cells.net_gex.push(roundedMeasurement(signedGamma));
+      cells.abs_gex.push(roundedMeasurement(absoluteGamma));
+      cells.net_dex.push(roundedMeasurement(signedDelta));
+      cells.abs_dex.push(roundedMeasurement(absoluteDelta));
+      cells.oi_call.push(callOi);
+      cells.oi_put.push(putOi);
+    }
+  }
+
+  const center = Math.round(spot / step) * step;
+  const levels: OptionsExposureLevel[] = [
+    { key: "hvl", label: "HVL", value: center },
+    { key: "call_resistance", label: "Call resistance", value: center + step * 4 },
+    { key: "put_support", label: "Put support", value: center - step * 4 },
+    { key: "call_resistance_0dte", label: "Call resistance 0DTE", value: center + step * 2 },
+    { key: "put_support_0dte", label: "Put support 0DTE", value: center - step * 2 },
+    { key: "max_1d", label: "1D max", value: center + step * 3 },
+    { key: "min_1d", label: "1D min", value: center - step * 3 },
+  ];
+  const timestamp = now.toISOString();
+
+  return {
+    schema_version: 1,
+    symbol: normalizedSymbol,
+    source: "radon_demo_fixture",
+    source_time: timestamp,
+    fetched_at: timestamp,
+    frequency,
+    spot,
+    strikes: allStrikes,
+    expirations,
+    cells,
+    levels,
+    units: {
+      net_gex: "USD per 1% move",
+      abs_gex: "USD per 1% move",
+      net_dex: "USD delta",
+      abs_dex: "USD delta",
+      open_interest: "contracts",
+    },
+    complete: true,
+  };
+}

--- a/web/lib/demo/fixtures/orders.ts
+++ b/web/lib/demo/fixtures/orders.ts
@@ -1,0 +1,75 @@
+import type { OrdersSnapshot } from "@/lib/orders/readOrdersFromDb";
+import type { ExecutedOrder } from "@/lib/types";
+import { compactDate, marketDateKey, nextFridayDateKey } from "./time";
+
+function demoExecutions(now: Date): ExecutedOrder[] {
+  const dayKey = marketDateKey(now).replaceAll("-", "");
+  const optionExpiry = compactDate(nextFridayDateKey(marketDateKey(now), 105));
+  const time = now.toISOString();
+  return [
+    {
+      execId: `DEMO-${dayKey}-STK`,
+      account_id: "DEMO",
+      permId: 91_001,
+      orderId: 51_001,
+      clientId: 0,
+      orderRef: "demo-equity-entry",
+      symbol: "AAPL",
+      contract: { conId: 265_598, symbol: "AAPL", secType: "STK", strike: null, right: null, expiry: null },
+      side: "BOT",
+      quantity: 40,
+      avgPrice: 232.18,
+      commission: 0.35,
+      realizedPNL: 0,
+      time,
+      exchange: "NASDAQ",
+    },
+    {
+      execId: `DEMO-${dayKey}-OPT-C`,
+      account_id: "DEMO",
+      permId: 91_002,
+      orderId: 51_002,
+      clientId: 0,
+      orderRef: "demo-call-entry",
+      symbol: "MSFT",
+      contract: { conId: 901_002, symbol: "MSFT", secType: "OPT", strike: 530, right: "C", expiry: optionExpiry },
+      side: "BOT",
+      quantity: 2,
+      avgPrice: 8.4,
+      commission: 1.3,
+      realizedPNL: 0,
+      time,
+      exchange: "SMART",
+    },
+    {
+      execId: `DEMO-${dayKey}-OPT-P`,
+      account_id: "DEMO",
+      permId: 91_003,
+      orderId: 51_003,
+      clientId: 0,
+      orderRef: "demo-hedge-entry",
+      symbol: "QQQ",
+      contract: { conId: 901_003, symbol: "QQQ", secType: "OPT", strike: 555, right: "P", expiry: optionExpiry },
+      side: "BOT",
+      quantity: 1,
+      avgPrice: 6.15,
+      commission: 0.65,
+      realizedPNL: 0,
+      time,
+      exchange: "SMART",
+    },
+  ];
+}
+
+/** Retains demo working orders while supplying a stable current-session blotter. */
+export function buildDemoOrders(base: OrdersSnapshot, now: Date = new Date()): OrdersSnapshot {
+  const executedOrders = demoExecutions(now);
+  return {
+    ...base,
+    last_sync: now.toISOString(),
+    open_orders: base.open_orders,
+    open_count: base.open_orders.length,
+    executed_orders: executedOrders,
+    executed_count: executedOrders.length,
+  };
+}

--- a/web/lib/demo/fixtures/performance.ts
+++ b/web/lib/demo/fixtures/performance.ts
@@ -1,0 +1,239 @@
+import type {
+  PerformanceData,
+  PerformanceGatedValue,
+  PerformanceSeriesPoint,
+} from "@/lib/types";
+import { businessDateKeys } from "./time";
+
+const SESSION_COUNT = 270;
+
+function round(value: number, places = 6): number {
+  const scale = 10 ** places;
+  return Math.round(value * scale) / scale;
+}
+
+function gated(value: number, n: number, minN: number): PerformanceGatedValue {
+  return { value: round(value), n, min_n: minN, unavailable_reason: null };
+}
+
+function standardDeviation(values: number[]): number {
+  const average = mean(values);
+  return Math.sqrt(
+    values.reduce((sum, value) => sum + (value - average) ** 2, 0) / values.length,
+  );
+}
+
+function mean(values: number[]): number {
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function covariance(left: number[], right: number[]): number {
+  const leftMean = mean(left);
+  const rightMean = mean(right);
+  return left.reduce(
+    (sum, value, index) => sum + (value - leftMean) * (right[index] - rightMean),
+    0,
+  ) / left.length;
+}
+
+function calendarDaysBetween(start: string, end: string): number {
+  return Math.round(
+    (Date.parse(`${end}T12:00:00.000Z`) - Date.parse(`${start}T12:00:00.000Z`)) / 86_400_000,
+  );
+}
+
+/** A request-time sample account curve. No operator NAV, files, or services. */
+export function buildDemoPerformance(now: Date = new Date()): PerformanceData {
+  const dates = businessDateKeys(SESSION_COUNT, now);
+  const starting = 1_000_000;
+  let nav = starting;
+  let benchmarkClose = 585;
+  let highWater = starting;
+  const benchmarkStart = benchmarkClose;
+  let maxDrawdown = 0;
+  let activePeakDate = dates[0];
+  let maxDrawdownPeakDate = dates[0];
+  let maxDrawdownTroughDate = dates[0];
+  const returns: number[] = [];
+  const benchmarkReturns: number[] = [];
+
+  const series: PerformanceSeriesPoint[] = dates.map((date, index) => {
+    const dailyReturn = index === 0
+      ? null
+      : 0.00042 + Math.sin(index * 0.41) * 0.0017 + Math.cos(index * 0.13) * 0.0009;
+    const benchmarkReturn = index === 0
+      ? 0
+      : 0.00034 + Math.sin(index * 0.29) * 0.00145 + Math.cos(index * 0.09) * 0.00075;
+    if (dailyReturn != null) {
+      returns.push(dailyReturn);
+      benchmarkReturns.push(benchmarkReturn);
+      nav *= 1 + dailyReturn;
+      benchmarkClose *= 1 + benchmarkReturn;
+    }
+    if (nav >= highWater) {
+      highWater = nav;
+      activePeakDate = date;
+    }
+    const drawdown = nav / highWater - 1;
+    if (drawdown < maxDrawdown) {
+      maxDrawdown = drawdown;
+      maxDrawdownPeakDate = activePeakDate;
+      maxDrawdownTroughDate = date;
+    }
+    return {
+      date,
+      equity: round(nav, 2),
+      nav: round(nav, 2),
+      daily_return: dailyReturn == null ? null : round(dailyReturn),
+      drawdown: round(drawdown),
+      twr_index: round((nav / starting) * 100, 4),
+      cum_return: round(nav / starting - 1),
+      flow: 0,
+      skipped: false,
+      benchmark_close: round(benchmarkClose, 2),
+      benchmark_return: round(benchmarkReturn),
+    };
+  });
+
+  const periodStart = dates[0];
+  const periodEnd = dates.at(-1) ?? periodStart;
+  const calendarDays = calendarDaysBetween(periodStart, periodEnd);
+  const totalReturn = nav / starting - 1;
+  const annualized = (1 + totalReturn) ** (365 / calendarDays) - 1;
+  const volatility = standardDeviation(returns) * Math.sqrt(252);
+  const downside = returns.filter((value) => value < 0);
+  const downsideDeviation = standardDeviation(downside) * Math.sqrt(252);
+  const riskFreeRate = 0.043;
+  const sharpe = (annualized - riskFreeRate) / volatility;
+  const sortino = (annualized - riskFreeRate) / downsideDeviation;
+  const positiveDays = returns.filter((value) => value > 0).length;
+  const negativeDays = returns.filter((value) => value < 0).length;
+  const benchmarkTotalReturn = benchmarkClose / benchmarkStart - 1;
+  const benchmarkAnnualized = (1 + benchmarkTotalReturn) ** (365 / calendarDays) - 1;
+  const portfolioStdDev = standardDeviation(returns);
+  const benchmarkStdDev = standardDeviation(benchmarkReturns);
+  const returnCovariance = covariance(returns, benchmarkReturns);
+  const correlation = returnCovariance / (portfolioStdDev * benchmarkStdDev);
+  const beta = returnCovariance / benchmarkStdDev ** 2;
+  const trackingError = standardDeviation(
+    returns.map((value, index) => value - benchmarkReturns[index]),
+  ) * Math.sqrt(252);
+  const activeAnnualized = annualized - benchmarkAnnualized;
+  const troughIndex = series.findIndex((point) => point.date === maxDrawdownTroughDate);
+  const recoveryPoint = series.slice(troughIndex + 1).find((point) => point.drawdown === 0);
+  const generatedAt = now.toISOString();
+
+  return {
+    schema_version: 2,
+    status: "ok",
+    generated_at: generatedAt,
+    account_id: "DEMO",
+    nav_source: "sample_data",
+    nav_as_of: periodEnd,
+    nav_sessions_behind: 0,
+    flows_status: "ok",
+    flows_source: "sample_data",
+    calendar_days: calendarDays,
+    counts: {
+      n_nav_observations: series.length,
+      n_subperiods: returns.length,
+      n_returns: returns.length,
+      n_skipped: 0,
+      n_suspect: 0,
+    },
+    twr: {
+      cum_return: round(totalReturn),
+      annualized: gated(annualized, calendarDays, 365),
+      excludes_suspect: true,
+    },
+    mwr: {
+      period_return: gated(totalReturn, returns.length, 2),
+      annualized: gated(annualized, returns.length, 2),
+      multiple_sign_changes: false,
+    },
+    risk: {
+      volatility: gated(volatility, returns.length, 20),
+      sharpe_ratio: gated(sharpe, returns.length, 20),
+      sortino_ratio: gated(sortino, returns.length, 20),
+      max_drawdown: gated(maxDrawdown, returns.length, 2),
+      current_drawdown: gated(series.at(-1)?.drawdown ?? 0, returns.length, 2),
+      var_95: gated(-0.0022, returns.length, 20),
+      cvar_95: gated(-0.0031, returns.length, 20),
+    },
+    distribution: {
+      hit_rate: gated(positiveDays / returns.length, returns.length, 20),
+      best_day: gated(Math.max(...returns), returns.length, 20),
+      worst_day: gated(Math.min(...returns), returns.length, 20),
+    },
+    drawdown_detail: {
+      peak_date: maxDrawdownPeakDate,
+      trough_date: maxDrawdownTroughDate,
+      trough_days: calendarDaysBetween(maxDrawdownPeakDate, maxDrawdownTroughDate),
+      recovery_days: recoveryPoint
+        ? calendarDaysBetween(maxDrawdownTroughDate, recoveryPoint.date)
+        : null,
+      ongoing: !recoveryPoint,
+    },
+    equity: {
+      starting,
+      ending: round(nav, 2),
+      net_external_flows: 0,
+      investment_pnl: round(nav - starting, 2),
+    },
+    benchmark: {
+      symbol: "SPY",
+      n_common: returns.length,
+      coverage: 1,
+      benchmark_return: round(benchmarkTotalReturn),
+      beta: round(beta),
+      alpha_annualized: round(activeAnnualized),
+      correlation: round(correlation),
+      r_squared: round(correlation ** 2),
+      tracking_error: round(trackingError),
+      information_ratio: round(activeAnnualized / trackingError),
+      basis: "sample_data",
+      low_confidence: false,
+    },
+    subperiods: [],
+    as_of: periodEnd,
+    last_sync: generatedAt,
+    period_start: periodStart,
+    period_end: periodEnd,
+    period_label: "Trailing 270 sessions",
+    benchmark_total_return: round(benchmarkTotalReturn),
+    trades_source: "Sample data",
+    price_sources: { stocks: "Sample data", options: "Sample data" },
+    methodology: {
+      curve_type: "twr_modified_dietz_daily",
+      return_basis: "time_weighted",
+      risk_free_rate: riskFreeRate,
+      library_strategy: "sample_curve",
+      risk_free_source: "Sample data",
+      flow_convention: "beginning_of_day",
+      day_count: "ACT/365",
+    },
+    summary: {
+      starting_equity: starting,
+      ending_equity: round(nav, 2),
+      pnl: round(nav - starting, 2),
+      trading_days: returns.length,
+      total_return: round(totalReturn),
+      annualized_return: round(annualized),
+      annualized_volatility: round(volatility),
+      downside_deviation: round(downsideDeviation),
+      sharpe_ratio: round(sharpe),
+      sortino_ratio: round(sortino),
+      max_drawdown: round(maxDrawdown),
+      current_drawdown: series.at(-1)?.drawdown ?? 0,
+      positive_days: positiveDays,
+      negative_days: negativeDays,
+      flat_days: returns.length - positiveDays - negativeDays,
+      hit_rate: round(positiveDays / returns.length),
+      best_day: round(Math.max(...returns)),
+      worst_day: round(Math.min(...returns)),
+    },
+    warnings: [],
+    contracts_missing_history: [],
+    series,
+  };
+}

--- a/web/lib/demo/fixtures/regime.ts
+++ b/web/lib/demo/fixtures/regime.ts
@@ -1,0 +1,589 @@
+import type { BpiIndexSymbol, BpiPayload, BpiResponse, BpiState } from "@/lib/bpi";
+import type { DispersionData, DispersionPoint } from "@/lib/dispersion";
+import { lastCompletedSessionDate, mostRecentSessionDate } from "@/lib/marketSession";
+import type { TrinData, TrinHourlyBar, TrinState } from "@/lib/trin";
+import type { GammaRotationData, GammaRotationHistoryEntry } from "@/lib/useGammaRotation";
+import type { GexBucket, GexData, GexHistoryEntry } from "@/lib/useGex";
+import type { CriData, CriHistoryEntry } from "@/lib/useRegime";
+import type { VcgData, VcgHistoryEntry } from "@/lib/useVcg";
+
+const ET_TIME_ZONE = "America/New_York";
+
+function round(value: number, decimals = 2): number {
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}
+
+function etCalendarDate(now: Date): string {
+  return now.toLocaleDateString("sv", { timeZone: ET_TIME_ZONE });
+}
+
+function isMarketOpenAt(now: Date): boolean {
+  const parts = new Intl.DateTimeFormat("en-US-u-hc-h23", {
+    timeZone: ET_TIME_ZONE,
+    weekday: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(now);
+  const values = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  if (values.weekday === "Sat" || values.weekday === "Sun") return false;
+  const minutes = Number(values.hour) * 60 + Number(values.minute);
+  return minutes >= 9 * 60 + 30 && minutes <= 16 * 60;
+}
+
+function etWallClockTimestamp(sessionDate: string, hour: number, minute: number): string {
+  const probe = new Date(`${sessionDate}T16:00:00.000Z`);
+  const zoneName = new Intl.DateTimeFormat("en-US", {
+    timeZone: ET_TIME_ZONE,
+    timeZoneName: "longOffset",
+  }).formatToParts(probe).find((part) => part.type === "timeZoneName")?.value;
+  const offset = zoneName?.match(/^GMT([+-]\d{2}:\d{2})$/)?.[1] ?? "-05:00";
+  return new Date(
+    `${sessionDate}T${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}:00${offset}`,
+  ).toISOString();
+}
+
+/**
+ * Use request time while it belongs to the expected ET session. Overnight and
+ * weekend requests use that session's close so freshness checks do not mistake
+ * the calendar date for a missing trading session.
+ */
+function currentSessionTimestamp(now: Date, sessionDate = mostRecentSessionDate(now)): string {
+  return etCalendarDate(now) === sessionDate
+    ? now.toISOString()
+    : etWallClockTimestamp(sessionDate, 16, 0);
+}
+
+function sessionDatesEndingAt(count: number, endDate: string): string[] {
+  const dates: string[] = [];
+  const cursor = new Date(`${endDate}T12:00:00.000Z`);
+  while (dates.length < count) {
+    const day = cursor.getUTCDay();
+    if (day !== 0 && day !== 6) dates.unshift(cursor.toISOString().slice(0, 10));
+    cursor.setUTCDate(cursor.getUTCDate() - 1);
+  }
+  return dates;
+}
+
+export function buildDemoCriFixture(now: Date = new Date()): CriData {
+  const date = mostRecentSessionDate(now);
+  const scanTime = currentSessionTimestamp(now, date);
+  const marketOpen = isMarketOpenAt(now);
+  const dates = sessionDatesEndingAt(42, date);
+  const history: CriHistoryEntry[] = dates.map((session, index) => ({
+    date: session,
+    vix: round(17.2 + 1.8 * Math.sin(index / 4)),
+    vvix: round(94 + 8 * Math.cos(index / 5)),
+    spy: round(621 + index * 0.52 + 2.5 * Math.sin(index / 6)),
+    cor1m: round(38 + 7 * Math.sin(index / 7)),
+    realized_vol: round(13.5 + 1.4 * Math.cos(index / 8)),
+    spx_vs_ma_pct: round(1.2 + 0.9 * Math.sin(index / 9)),
+    vix_5d_roc: round(-2.5 + 4 * Math.cos(index / 6)),
+  }));
+  history[history.length - 1] = {
+    date,
+    vix: 18.64,
+    vvix: 97.18,
+    spy: 642.35,
+    cor1m: 42.6,
+    realized_vol: 14.2,
+    spx_vs_ma_pct: 1.17,
+    vix_5d_roc: -3.4,
+  };
+
+  return {
+    scan_time: scanTime,
+    market_open: marketOpen,
+    date,
+    vix: 18.64,
+    vvix: 97.18,
+    spy: 642.35,
+    vix_5d_roc: -3.4,
+    vvix_vix_ratio: 5.21,
+    spx_100d_ma: 634.92,
+    spx_distance_pct: 1.17,
+    cor1m: 42.6,
+    cor1m_previous_close: 41.9,
+    cor1m_5d_change: 2.1,
+    realized_vol: 14.2,
+    cri: {
+      score: 31,
+      level: "ELEVATED",
+      components: { vix: 8, vvix: 9, correlation: 8, momentum: 6 },
+    },
+    cta: {
+      realized_vol: 14.2,
+      exposure_pct: 126,
+      forced_reduction_pct: 0,
+      est_selling_bn: 0,
+    },
+    menthorq_cta: null,
+    crash_trigger: {
+      triggered: false,
+      conditions: {
+        spx_below_100d_ma: false,
+        realized_vol_gt_25: false,
+        cor1m_gt_60: false,
+      },
+      values: { spx_distance_pct: 1.17, realized_vol: 14.2, cor1m: 42.6 },
+    },
+    history,
+    spy_closes: history.slice(-21).map((entry) => entry.spy),
+  };
+}
+
+export function buildDemoVcgFixture(now: Date = new Date()): VcgData {
+  const date = mostRecentSessionDate(now);
+  const dates = sessionDatesEndingAt(42, date);
+  const history: VcgHistoryEntry[] = dates.map((session, index) => ({
+    date: session,
+    residual: round(-0.004 + 0.00018 * index + 0.001 * Math.sin(index / 4), 4),
+    vcg: round(-0.8 + index * 0.035 + 0.25 * Math.sin(index / 5)),
+    vcg_adj: round(-0.7 + index * 0.032 + 0.22 * Math.sin(index / 5)),
+    beta1: -0.0139,
+    beta2: -0.023,
+    vix: round(17.5 + 2 * Math.sin(index / 5)),
+    vvix: round(95 + 9 * Math.cos(index / 6)),
+    credit: round(79.2 + 0.06 * index + 0.3 * Math.cos(index / 7)),
+  }));
+  history[history.length - 1] = {
+    date,
+    residual: 0.0027,
+    vcg: 0.74,
+    vcg_adj: 0.61,
+    beta1: -0.0139,
+    beta2: -0.023,
+    vix: 18.64,
+    vvix: 97.18,
+    credit: 81.73,
+  };
+
+  return {
+    scan_time: currentSessionTimestamp(now, date),
+    market_open: isMarketOpenAt(now),
+    credit_proxy: "HYG",
+    signal: {
+      vcg: 0.74,
+      vcg_adj: 0.61,
+      residual: 0.0027,
+      beta1_vvix: -0.0139,
+      beta2_vix: -0.023,
+      alpha: 0,
+      vix: 18.64,
+      vvix: 97.18,
+      credit_price: 81.73,
+      credit_5d_return_pct: 0.32,
+      ro: 0,
+      edr: 0,
+      tier: null,
+      bounce: 0,
+      vvix_severity: "moderate",
+      sign_ok: true,
+      sign_suppressed: false,
+      pi_panic: 0.08,
+      regime: "DIVERGENCE",
+      interpretation: "WATCH",
+      attribution: {
+        vvix_pct: 54,
+        vix_pct: 46,
+        vvix_component: 0.41,
+        vix_component: 0.33,
+        model_implied: 0.74,
+      },
+    },
+    history,
+  };
+}
+
+export function buildDemoGammaRotationFixture(now: Date = new Date()): GammaRotationData {
+  const date = mostRecentSessionDate(now);
+  const history: GammaRotationHistoryEntry[] = sessionDatesEndingAt(63, date).map((session, index) => {
+    const spyZ = round(0.35 + 1.1 * Math.sin(index / 8));
+    const tltZ = round(-0.2 + 0.9 * Math.cos(index / 9));
+    const spyNetGamma = round(160_000 + 420_000 * Math.sin(index / 7));
+    const tltNetGamma = round(-100_000 + 500_000 * Math.cos(index / 8));
+    const rawSpread = round(spyZ - tltZ, 3);
+    const state = spyNetGamma > 0 && tltNetGamma < 0
+      ? "RISK_ON_DIVERGENCE"
+      : spyNetGamma < 0 && tltNetGamma > 0
+        ? "RISK_OFF_DIVERGENCE"
+        : spyNetGamma > 0 && tltNetGamma > 0
+          ? "DUAL_CUSHION"
+          : "DUAL_WHIP";
+    return {
+      date: session,
+      spy_net_gamma: spyNetGamma,
+      tlt_net_gamma: tltNetGamma,
+      spy_gamma_z: spyZ,
+      tlt_gamma_z: tltZ,
+      grg_z: round(rawSpread * 0.72 + 0.18 * Math.sin(index / 5)),
+      raw_spread: rawSpread,
+      state,
+    };
+  });
+  history[history.length - 4].spy_net_gamma = -566_900;
+  history[history.length - 4].tlt_net_gamma = 2_508_000;
+  history[history.length - 4].state = "RISK_OFF_DIVERGENCE";
+  history[history.length - 1] = {
+    date,
+    spy_net_gamma: -382_900,
+    tlt_net_gamma: 2_600_000,
+    spy_gamma_z: -0.38,
+    tlt_gamma_z: 0.32,
+    grg_z: -0.7,
+    raw_spread: -0.7,
+    state: "RISK_OFF_DIVERGENCE",
+  };
+
+  return {
+    scan_time: currentSessionTimestamp(now, date),
+    market_open: isMarketOpenAt(now),
+    data_date: date,
+    source: "Sample snapshot",
+    storage: "demo",
+    lookback_days: 250,
+    z_window: 63,
+    signal: {
+      state: "RISK_OFF_DIVERGENCE",
+      state_label: "Risk-off divergence",
+      interpretation: "RISK_OFF",
+      tier: 3,
+      top_watch: false,
+      bottom_watch: true,
+      top_score: 1,
+      bottom_score: 4,
+      grg_z: -0.7,
+      raw_spread: -0.7,
+      spy_gamma_z: -0.38,
+      tlt_gamma_z: 0.32,
+      spy_3d_gamma_change: 184_000,
+      tlt_3d_gamma_change: 92_000,
+      summary: "SPY gamma is amplifying equity moves while TLT gamma is cushioning duration.",
+    },
+    assets: {
+      SPY: {
+        ticker: "SPY",
+        spot: 642.35,
+        data_date: date,
+        strike_data_date: date,
+        net_gamma: -382_900,
+        net_gex: -382_900,
+        call_gex: 2_461_000,
+        put_gex: -2_843_900,
+        net_delta: 84_200_000,
+        gamma_z: -0.38,
+        gamma_1d_change: -71_000,
+        gamma_3d_change: 184_000,
+        state: "WHIP",
+        spot_vs_flip_pct: 0.2,
+        levels: {
+          gex_flip: { strike: 641, gamma: 0, distance: -1.35, distance_pct: -0.21 },
+        },
+      },
+      TLT: {
+        ticker: "TLT",
+        spot: 91.48,
+        data_date: date,
+        strike_data_date: date,
+        net_gamma: 2_600_000,
+        net_gex: 2_600_000,
+        call_gex: 3_170_000,
+        put_gex: -570_000,
+        net_delta: 19_400_000,
+        gamma_z: 0.32,
+        gamma_1d_change: 31_000,
+        gamma_3d_change: 92_000,
+        state: "CUSHION",
+        spot_vs_flip_pct: 0.52,
+        levels: {
+          gex_flip: { strike: 91, gamma: 0, distance: -0.48, distance_pct: -0.52 },
+        },
+      },
+    },
+    gates: [
+      { id: "polarity", label: "Polarity", status: "WATCH", copy: "SPY positive and TLT negative identifies the clean risk-on divergence." },
+      { id: "magnitude", label: "Magnitude", status: "WATCH", copy: "Absolute GRG above 2σ means the cross-asset gamma spread is statistically stretched." },
+      { id: "spy_cushion", label: "SPY cushion", status: "FAIL", copy: "Positive SPY gamma means dealer hedging is mechanically dampening equity moves." },
+      { id: "duration_whip", label: "TLT whip", status: "WATCH", copy: "Negative TLT gamma means duration moves are mechanically amplified." },
+      { id: "decay", label: "Decay", status: "WATCH", copy: "A negative 3-session SPY gamma slope marks possible equity cushion decay." },
+      { id: "flip", label: "Flip", status: "PASS", copy: "Spot above the SPY gamma flip keeps the equity cushion valid." },
+    ],
+    history,
+    top_bottom: {
+      top: { active: false, copy: "Top gate is inactive." },
+      bottom: { active: true, copy: "Four of five bottom gates are active." },
+    },
+  };
+}
+
+function gexLevel(strike: number, gamma: number, spot: number) {
+  const distance = round(strike - spot);
+  return { strike, gamma, distance, distance_pct: round((distance / spot) * 100) };
+}
+
+export function buildDemoGexFixture(now: Date = new Date()): GexData {
+  const date = mostRecentSessionDate(now);
+  const spot = 642.35;
+  const strikes = [620, 625, 630, 635, 640, 645, 650, 655, 660];
+  const profile: GexBucket[] = strikes.map((strike, index) => {
+    const callGex = round(1_100 + index * 310 + 420 * Math.sin(index / 2));
+    const putGex = round(-(3_600 - index * 330 + 280 * Math.cos(index / 2)));
+    return {
+      strike,
+      call_gex: callGex,
+      put_gex: putGex,
+      net_gex: round(callGex + putGex),
+      pct_from_spot: round(((strike - spot) / spot) * 100),
+      tag: strike === 640 ? "GEX FLIP" : strike === 660 ? "MAX MAGNET" : null,
+    };
+  });
+  const history: GexHistoryEntry[] = sessionDatesEndingAt(30, date).map((session, index) => ({
+    date: session,
+    net_gex: round(-155_000 + index * 4_100 + 22_000 * Math.sin(index / 4)),
+    net_dex: round(28_000 + 8_000 * Math.cos(index / 5)),
+    gex_flip: round(626 + index * 0.4),
+    spot: round(626 + index * 0.55 + 2 * Math.sin(index / 5)),
+    atm_iv: round(21 - index * 0.08 + Math.sin(index / 4)),
+    vol_pc: round(1.05 + 0.2 * Math.cos(index / 5)),
+    bias: index > 18 ? "CAUTIOUS_BULL" : "NEUTRAL",
+  }));
+  history[history.length - 1] = {
+    date,
+    net_gex: -82_400,
+    net_dex: 34_700,
+    gex_flip: 640,
+    spot,
+    atm_iv: 18.9,
+    vol_pc: 1.18,
+    bias: "CAUTIOUS_BULL",
+  };
+
+  return {
+    scan_time: currentSessionTimestamp(now, date),
+    market_open: isMarketOpenAt(now),
+    ticker: "SPX",
+    spot,
+    close: 640.98,
+    day_change: 1.37,
+    day_change_pct: 0.21,
+    data_date: date,
+    net_gex: -82_400,
+    net_dex: 34_700,
+    atm_iv: 18.9,
+    vol_pc: 1.18,
+    levels: {
+      gex_flip: gexLevel(640, 0, spot),
+      max_magnet: gexLevel(660, profile.find((bucket) => bucket.strike === 660)?.net_gex ?? 0, spot),
+      second_magnet: gexLevel(655, profile.find((bucket) => bucket.strike === 655)?.net_gex ?? 0, spot),
+      max_accelerator: gexLevel(620, profile.find((bucket) => bucket.strike === 620)?.net_gex ?? 0, spot),
+      put_wall: gexLevel(620, profile.find((bucket) => bucket.strike === 620)?.net_gex ?? 0, spot),
+      call_wall: gexLevel(660, profile.find((bucket) => bucket.strike === 660)?.net_gex ?? 0, spot),
+    },
+    profile,
+    expected_range: { low: 632, high: 653, iv_1d: 1.63 },
+    bias: {
+      direction: "CAUTIOUS_BULL",
+      reasons: ["Spot is above the gamma flip", "Net gamma remains negative", "Primary magnet is above spot"],
+      days_above_flip: 3,
+      flip_migration: history.slice(-5).map((entry) => ({ date: entry.date, flip: entry.gex_flip ?? 635 })),
+    },
+    history,
+    iv: { iv30d: 18.9, iv_rank: 36, hv30: 16.7, mq_iv30d: 19.1, mq_iv_rank: "38%", source: "both" },
+    mq: {
+      source_date: date,
+      spot,
+      hvl: 635,
+      call_resistance_all: 655,
+      call_resistance_0dte: 650,
+      put_support_all: 620,
+      put_support_0dte: 630,
+      expected_high: 653,
+      expected_low: 632,
+      distance_to_hvl_pct: "1.16%",
+      iv30d: 19.1,
+      hv30: 16.7,
+      iv_rank: "38%",
+      top_gex_strikes: [635, 645, 650],
+    },
+    source_delta: {
+      flip_vs_hvl: { uw: 640, mq: 635, delta: 5 },
+      put_wall_vs_support_all: { uw: 620, mq: 620, delta: 0 },
+      call_wall_vs_resistance_all: { uw: 660, mq: 655, delta: 5 },
+    },
+  };
+}
+
+export function buildDemoDispersionFixture(now: Date = new Date()): DispersionData {
+  const date = lastCompletedSessionDate(now);
+  const dates = sessionDatesEndingAt(126, date);
+  const series: DispersionPoint[] = dates.map((session, index) => ({
+    date: session,
+    z_vix: round(0.15 + 0.85 * Math.sin(index / 13)),
+    z_stock: round(0.75 + 1.05 * Math.sin(index / 15)),
+    z_sector: round(0.55 + 0.9 * Math.cos(index / 17)),
+    vix: round(17.8 + 3.2 * Math.sin(index / 12)),
+    stock_spread: round(0.061 + 0.013 * Math.sin(index / 15), 4),
+    sector_spread: round(0.021 + 0.006 * Math.cos(index / 17), 4),
+  }));
+  const last: DispersionPoint = {
+    date,
+    z_vix: -0.31,
+    z_stock: 2.38,
+    z_sector: 2.41,
+    vix: 18.64,
+    stock_spread: 0.0712,
+    sector_spread: 0.0241,
+  };
+  series[series.length - 1] = last;
+
+  return {
+    scan_time: now.toISOString(),
+    status: "ok",
+    source: { prices: "stored", vix: "stored" },
+    data_date: date,
+    universe: {
+      index: "SPX",
+      n_constituents: 503,
+      sectors: ["XLK", "XLF", "XLV", "XLY", "XLP", "XLE", "XLI", "XLB", "XLU", "XLRE", "XLC"],
+    },
+    fetch: { ib_ok: 0, yahoo_ok: 0, failed: 0, failed_symbols: [] },
+    count: series.length,
+    current: {
+      ...last,
+      m60_vix: 18.1,
+      m60_stock: 0.064,
+      m60_sector: 0.021,
+      n_stocks: 501,
+      n_sectors: 11,
+      regime: "BELOW THE SURFACE",
+      surface_gap: 2.72,
+    },
+    stats: {
+      base: { start: dates[0], end: date, n: series.length },
+      vix: { mean_60d: 18.1, stdev_60d: 3.9, z_min: -1.4, z_max: 2.8 },
+      stock: { mean_60d: 0.064, stdev_60d: 0.013, z_min: -1.5, z_max: 3.2 },
+      sector: { mean_60d: 0.021, stdev_60d: 0.006, z_min: -1.3, z_max: 2.9 },
+      days_below_surface: 18,
+      last_below_surface_date: date,
+    },
+    series,
+  };
+}
+
+function trinState(value: number): TrinState {
+  if (value <= 0.6) return "in_zone";
+  if (value <= 0.65) return "near_zone";
+  if (value >= 1.5) return "elevated";
+  return "neutral";
+}
+
+export function buildDemoTrinFixture(now: Date = new Date()): TrinData {
+  const date = mostRecentSessionDate(now);
+  const scanTime = currentSessionTimestamp(now, date);
+  const sessions = sessionDatesEndingAt(8, date);
+  const hourly: TrinHourlyBar[] = sessions.flatMap((session, dayIndex) =>
+    Array.from({ length: 7 }, (_, slot) => {
+      const index = dayIndex * 7 + slot;
+      const value = round(0.92 + 0.27 * Math.sin(index / 4));
+      return {
+        ts: `${session}T${String(14 + slot).padStart(2, "0")}:30:00.000Z`,
+        bucket: `${session}T${String(9 + slot).padStart(2, "0")}:30`,
+        trin: value,
+        ma10: index < 9 ? null : round(0.94 + 0.08 * Math.sin(index / 8)),
+      };
+    }),
+  );
+  const latest = hourly[hourly.length - 1];
+  const marketOpen = isMarketOpenAt(now) && etCalendarDate(now) === date;
+  latest.ts = marketOpen ? now.toISOString() : etWallClockTimestamp(date, 15, 55);
+  if (marketOpen) {
+    const parts = new Intl.DateTimeFormat("en-US-u-hc-h23", {
+      timeZone: ET_TIME_ZONE,
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+    }).formatToParts(now);
+    const values = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+    const minutes = Number(values.hour) * 60 + Number(values.minute);
+    const bucketStart = 9 * 60 + 30 + Math.floor((minutes - (9 * 60 + 30)) / 60) * 60;
+    latest.bucket = `${date}T${String(Math.floor(bucketStart / 60)).padStart(2, "0")}:${String(bucketStart % 60).padStart(2, "0")}`;
+  }
+  latest.trin = 0.82;
+  latest.ma10 = 0.91;
+  const daily = sessionDatesEndingAt(30, date).map((session, index) => ({
+    date: session,
+    close: session === date ? latest.trin : round(0.95 + 0.32 * Math.sin(index / 4)),
+  }));
+
+  return {
+    scan_time: scanTime,
+    source: "sample snapshot",
+    current: {
+      ts: latest.ts,
+      session_date: date,
+      trin: latest.trin,
+      ma10: latest.ma10,
+      state: trinState(latest.ma10 ?? latest.trin),
+      adv: 1_742,
+      dec: 1_318,
+      up_vol: 2_180_000_000,
+      down_vol: 1_352_000_000,
+      daily_close: latest.trin,
+      daily_date: date,
+      zone_low: 0.6,
+      zone_near: 0.65,
+      zone_high: 1.5,
+    },
+    hourly,
+    daily,
+  };
+}
+
+const BPI_INDEX_NAMES: Record<BpiIndexSymbol, string> = {
+  NDX: "Nasdaq-100",
+  SPX: "S&P 500",
+  RUT: "Russell 2000",
+};
+
+const BPI_MEMBERS: Record<BpiIndexSymbol, number> = { NDX: 100, SPX: 500, RUT: 1_950 };
+const BPI_PHASE: Record<BpiIndexSymbol, number> = { NDX: 0, SPX: 11, RUT: 23 };
+
+function buildDemoBpiIndex(symbol: BpiIndexSymbol, asOf: string, takenAt: string): BpiPayload {
+  const dates = sessionDatesEndingAt(252, asOf);
+  const phase = BPI_PHASE[symbol];
+  const values = dates.map((_date, index) => round(47 + 21 * Math.sin((2 * Math.PI * (index + phase)) / 84)));
+  const value = values[values.length - 1];
+  const previous = values[values.length - 2];
+  const members = BPI_MEMBERS[symbol];
+  const state: BpiState = value <= 30 ? "OVERSOLD" : value >= 70 ? "OVERBOUGHT" : "NEUTRAL";
+  return {
+    schema_version: 1,
+    index_symbol: symbol,
+    index_name: BPI_INDEX_NAMES[symbol],
+    taken_at: takenAt,
+    as_of_session: asOf,
+    bpi: value,
+    members,
+    bullish: Math.round((value / 100) * members),
+    state,
+    cross_up_30: previous < 30 && value >= 30,
+    thresholds: { oversold: 30, overbought: 70 },
+    history: dates.map((date, index) => ({ date, bpi: values[index] })),
+    sources: { constituents: "sample snapshot", member_close_fetches: { sample_snapshot: members } },
+  };
+}
+
+export function buildDemoBpiFixture(now: Date = new Date()): BpiResponse {
+  const asOf = lastCompletedSessionDate(now);
+  const takenAt = currentSessionTimestamp(now, asOf);
+  const ndx = buildDemoBpiIndex("NDX", asOf, takenAt);
+  return {
+    generated_at: ndx.taken_at,
+    indices: {
+      NDX: ndx,
+      SPX: buildDemoBpiIndex("SPX", asOf, takenAt),
+      RUT: buildDemoBpiIndex("RUT", asOf, takenAt),
+    },
+  };
+}

--- a/web/lib/demo/fixtures/thetaHarvester.ts
+++ b/web/lib/demo/fixtures/thetaHarvester.ts
@@ -1,0 +1,150 @@
+import type { ThetaHarvesterData, ThetaHarvesterResult } from "@/lib/types";
+import { compactDate, marketDateKey, shiftDateKey } from "./time";
+
+type BuildThetaOptions = {
+  now?: Date;
+  ticker?: string;
+  preset?: string;
+  limit?: number | null;
+  minDte?: number | null;
+  maxDte?: number | null;
+  minCredit?: number | null;
+};
+
+const PRESET_TICKERS = ["AAPL", "MSFT", "NVDA", "AMZN"];
+
+function hashTicker(ticker: string): number {
+  return [...ticker].reduce((hash, char) => (hash * 31 + char.charCodeAt(0)) % 10_007, 17);
+}
+
+function round(value: number, places = 2): number {
+  const scale = 10 ** places;
+  return Math.round(value * scale) / scale;
+}
+
+function fridayDte(now: Date, preferred: number, minDte: number, maxDte: number): number | null {
+  const today = marketDateKey(now);
+  const candidates: number[] = [];
+  for (let dte = Math.max(1, minDte); dte <= maxDte; dte += 1) {
+    const date = shiftDateKey(today, dte);
+    if (new Date(`${date}T12:00:00.000Z`).getUTCDay() === 5) candidates.push(dte);
+  }
+  return candidates.sort((left, right) =>
+    Math.abs(left - preferred) - Math.abs(right - preferred) || left - right,
+  )[0] ?? null;
+}
+
+function buildCandidate(ticker: string, dte: number, now: Date): ThetaHarvesterResult {
+  const seed = hashTicker(ticker);
+  const spot = round(95 + (seed % 360) + (seed % 10) / 10);
+  const putStrike = Math.max(5, Math.floor((spot * 0.92) / 5) * 5);
+  const callStrike = Math.ceil((spot * 1.08) / 5) * 5;
+  const expiry = compactDate(shiftDateKey(marketDateKey(now), dte));
+  const iv = round(0.28 + (seed % 8) / 100, 3);
+  const hv20 = round(iv - 0.075, 3);
+  const credit = round(1.85 + (seed % 11) * 0.14);
+
+  return {
+    ticker,
+    score: round(82 + (seed % 14) * 0.7, 1),
+    verdict: "THETA_HARVEST",
+    structure: {
+      expiry,
+      dte,
+      short_put: {
+        symbol: `${ticker}-${expiry}-${putStrike}P`,
+        expiry,
+        strike: putStrike,
+        right: "P",
+        iv,
+        delta: -0.18,
+        theta: -0.09,
+        gamma: 0.004,
+        vega: 0.11,
+        bid: round(credit * 0.52),
+        ask: round(credit * 0.56),
+        volume: 420 + seed % 500,
+        open_interest: 2_400 + seed % 2_000,
+      },
+      short_call: {
+        symbol: `${ticker}-${expiry}-${callStrike}C`,
+        expiry,
+        strike: callStrike,
+        right: "C",
+        iv: round(iv - 0.01, 3),
+        delta: 0.17,
+        theta: -0.085,
+        gamma: 0.0038,
+        vega: 0.105,
+        bid: round(credit * 0.48),
+        ask: round(credit * 0.52),
+        volume: 390 + seed % 450,
+        open_interest: 2_100 + seed % 1_800,
+      },
+      net_delta: -0.01,
+      theta: 0.175,
+      gamma: -0.0078,
+      vega: -0.215,
+      credit,
+    },
+    spot,
+    iv,
+    hv20,
+    hv60: round(iv - 0.055, 3),
+    iv_rv_edge: 7.5,
+    iv_rv_ratio: round(iv / hv20, 2),
+    trend_20d_pct: round(((seed % 9) - 4) * 0.34),
+    range_score: round(0.79 + (seed % 8) / 100, 2),
+    dealer_support: "SUPPORT",
+    net_gex: 1_250_000 + seed * 100,
+    gex_flip: round(spot * 0.96),
+    setup: "Range-bound sample with rich implied volatility and dealer support.",
+    gates: {
+      delta_near_zero: true,
+      iv_rich_vs_rv: true,
+      dealer_support: true,
+      theta_positive: true,
+      range_bound: true,
+    },
+    errors: [],
+    earnings: null,
+  };
+}
+
+/** Complete scan data for the default universe or one validated ticker. */
+export function buildDemoThetaHarvester(options: BuildThetaOptions = {}): ThetaHarvesterData {
+  const now = options.now ?? new Date();
+  const ticker = options.ticker?.trim().toUpperCase() ?? "";
+  const minDte = options.minDte ?? 7;
+  const maxDte = options.maxDte ?? 45;
+  const requested = ticker ? [ticker] : PRESET_TICKERS;
+  const preferredDtes = ticker
+    ? [Math.max(minDte, Math.min(maxDte, 30))]
+    : [21, 28, 35, 42];
+  let results = minDte > maxDte
+    ? []
+    : requested.flatMap((symbol, index) => {
+        const preferred = preferredDtes[index] ?? preferredDtes[0];
+        const dte = fridayDte(now, preferred, minDte, maxDte);
+        return dte == null ? [] : [buildCandidate(symbol, dte, now)];
+      });
+  results = results.filter((result) =>
+    result.structure.dte >= minDte
+    && result.structure.dte <= maxDte
+    && (result.structure.credit ?? 0) >= (options.minCredit ?? 0),
+  );
+  if (!ticker && options.limit != null && Number.isFinite(options.limit) && options.limit > 0) {
+    results = results.slice(0, Math.trunc(options.limit));
+  }
+
+  return {
+    scan_time: now.toISOString(),
+    source: "Sample data",
+    universe: ticker ? "explicit" : `preset:${options.preset ?? "ndx100"}`,
+    requested_tickers: requested,
+    tickers_scanned: requested.length,
+    candidates_found: results.length,
+    theta_harvest_count: results.filter((result) => result.verdict === "THETA_HARVEST").length,
+    results,
+  };
+}

--- a/web/lib/demo/fixtures/time.ts
+++ b/web/lib/demo/fixtures/time.ts
@@ -1,0 +1,48 @@
+import { isUsTradingDay } from "@/lib/serviceHealthWindows";
+
+const MARKET_TIME_ZONE = "America/New_York";
+
+function datePartsInMarketTime(date: Date): { year: number; month: number; day: number } {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: MARKET_TIME_ZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(date);
+  const value = (type: Intl.DateTimeFormatPartTypes): number =>
+    Number(parts.find((part) => part.type === type)?.value ?? 0);
+  return { year: value("year"), month: value("month"), day: value("day") };
+}
+
+export function marketDateKey(date: Date): string {
+  const { year, month, day } = datePartsInMarketTime(date);
+  return `${year.toString().padStart(4, "0")}-${month.toString().padStart(2, "0")}-${day.toString().padStart(2, "0")}`;
+}
+
+export function shiftDateKey(dateKey: string, days: number): string {
+  const [year, month, day] = dateKey.split("-").map(Number);
+  const shifted = new Date(Date.UTC(year, month - 1, day + days, 12));
+  return shifted.toISOString().slice(0, 10);
+}
+
+export function businessDateKeys(count: number, now: Date): string[] {
+  const dates: string[] = [];
+  let cursor = marketDateKey(now);
+  while (dates.length < count) {
+    if (isUsTradingDay(cursor)) dates.push(cursor);
+    cursor = shiftDateKey(cursor, -1);
+  }
+  return dates.reverse();
+}
+
+export function nextFridayDateKey(dateKey: string, minimumDays = 0): string {
+  let cursor = shiftDateKey(dateKey, Math.max(0, Math.trunc(minimumDays)));
+  while (new Date(`${cursor}T12:00:00.000Z`).getUTCDay() !== 5) {
+    cursor = shiftDateKey(cursor, 1);
+  }
+  return cursor;
+}
+
+export function compactDate(dateKey: string): string {
+  return dateKey.replaceAll("-", "");
+}

--- a/web/lib/demo/rateTier.ts
+++ b/web/lib/demo/rateTier.ts
@@ -15,7 +15,9 @@ const AI_PATHS = new Set<string>([
   "/api/ticker/info",
 ]);
 
-// Expensive scans / aggregations / IB-touching exec, regardless of method.
+// Expensive producers / aggregations / IB-touching exec. Cached GETs are
+// ordinary reads; classifying them here made passive panels spend a 10/hour
+// producer allowance before an operator touched a control.
 const EXPENSIVE_PATTERNS: RegExp[] = [
   /^\/api\/(vcg|gex|cri|leap)\/scan$/,
   /^\/api\/regime(\/|$)/,
@@ -55,7 +57,7 @@ export function classifyRateTier(
   if (normalizedMethod === "GET" && pathname === "/api/headlines") return "G";
   if (normalizedMethod === "GET" && PASSIVE_POLL_PATHS.has(pathname)) return "I";
   if (AI_PATHS.has(pathname)) return "D";
-  if (EXPENSIVE_PATTERNS.some((re) => re.test(pathname))) return "B";
+  if (normalizedMethod !== "GET" && EXPENSIVE_PATTERNS.some((re) => re.test(pathname))) return "B";
   if (WRITE_METHODS.has(normalizedMethod)) return "C";
   return "A";
 }

--- a/web/lib/routeAccess.ts
+++ b/web/lib/routeAccess.ts
@@ -21,7 +21,7 @@ export type RoutePrincipal = {
   token?: string;
 };
 
-export type RouteAccessOptions = {
+type RouteAccessCommonOptions = {
   operatorOnly?: boolean;
   /**
    * The route carries its own demo order blockade downstream (paper path or an
@@ -31,9 +31,18 @@ export type RouteAccessOptions = {
    * everywhere else operatorOnly stays fail-closed.
    */
   demoBlockadeRoute?: boolean;
-  rate?: { key: string; limit: number; windowMs: number };
-  durableRateTier?: DemoRateTier;
 };
+
+export type RouteAccessOptions = RouteAccessCommonOptions & (
+  | {
+      rate: { key: string; limit: number; windowMs: number };
+      durableRateTier: DemoRateTier;
+    }
+  | {
+      rate?: never;
+      durableRateTier?: never;
+    }
+);
 
 export type RouteAccessDeps = {
   authFn?: () => Promise<AuthResult>;
@@ -164,10 +173,15 @@ export async function requireRouteAccess(
   // budget above, and backend admission/single-flight controls. Demo traffic
   // additionally consumes its fail-closed cross-instance spend/DOS budget.
   if (options.rate && kind === "demo") {
+    if (!options.durableRateTier) {
+      // TypeScript makes this unreachable for in-repo callers. Keep the
+      // runtime guard for JavaScript or dynamically assembled options so a
+      // new route cannot silently inherit an unrelated quota class.
+      return reject(503, "Rate limit policy unavailable");
+    }
     try {
-      const tier = options.durableRateTier ?? "B";
       const durable = await (deps.durableRateLimitFn ?? demoRateLimit)(
-        tier,
+        options.durableRateTier,
         `route:${options.rate.key}:${userId}`,
       );
       if (!durable.success) {

--- a/web/lib/useChainPrefetch.ts
+++ b/web/lib/useChainPrefetch.ts
@@ -20,6 +20,7 @@ export function useChainPrefetch(
   ticker: string,
   expirations: string[],
   selectedExpiry: string | null,
+  enabled: boolean = process.env.NEXT_PUBLIC_RADON_DEMO !== "1",
 ) {
   const cacheRef = useRef<StrikesCache>(new Map());
   const [prefetchedCount, setPrefetchedCount] = useState(0);
@@ -44,7 +45,7 @@ export function useChainPrefetch(
 
   // Background prefetch of non-selected expirations
   useEffect(() => {
-    if (expirations.length <= 1 || !selectedExpiry) return;
+    if (!enabled || expirations.length <= 1 || !selectedExpiry) return;
 
     // Cancel any in-flight prefetch
     if (abortRef.current) abortRef.current.abort();
@@ -99,7 +100,7 @@ export function useChainPrefetch(
     return () => {
       controller.abort();
     };
-  }, [ticker, expirations, selectedExpiry]);
+  }, [ticker, expirations, selectedExpiry, enabled]);
 
   return {
     cacheStrikes,

--- a/web/lib/useSyncHook.ts
+++ b/web/lib/useSyncHook.ts
@@ -67,6 +67,7 @@ export function useSyncHook<T>(config: UseSyncConfig<T>, active: boolean): UseSy
     showBackgroundError = false,
     loadWhenInactive = true,
   } = config;
+  const isDemoMode = process.env.NEXT_PUBLIC_RADON_DEMO === "1";
 
   const [data, setData] = useState<T | null>(null);
   const [loading, setLoading] = useState(true);
@@ -103,7 +104,7 @@ export function useSyncHook<T>(config: UseSyncConfig<T>, active: boolean): UseSy
    * pick up the recovery. R-230.
    */
   const armRetry = useCallback((json: T) => {
-    if (!active || !shouldRetry?.(json)) {
+    if (isDemoMode || !active || !shouldRetry?.(json)) {
       retryAttemptRef.current = 0;
       return;
     }
@@ -118,7 +119,7 @@ export function useSyncHook<T>(config: UseSyncConfig<T>, active: boolean): UseSy
     retryTimeoutRef.current = setTimeout(() => {
       void requestRef.current(retryMethod, true);
     }, delay);
-  }, [active, shouldRetry, retryIntervalMs, maxRetryDelayMs, maxRetryAttempts, retryMethod]);
+  }, [active, isDemoMode, shouldRetry, retryIntervalMs, maxRetryDelayMs, maxRetryAttempts, retryMethod]);
 
   const executeRequest = useCallback(async (method: RetryMethod, background = false) => {
     // R-106: a wedged endpoint (FastAPI blocked on UW / MenthorQ) used to
@@ -174,9 +175,11 @@ export function useSyncHook<T>(config: UseSyncConfig<T>, active: boolean): UseSy
   requestRef.current = executeRequest;
 
   const triggerSync = useCallback(async () => {
-    const method = hasPost ? "POST" : "GET";
+    // Demo snapshots are read-only. A manual refresh re-reads the deterministic
+    // fixture instead of consuming a producer/mutation quota.
+    const method = hasPost && !isDemoMode ? "POST" : "GET";
     await executeRequest(method, false);
-  }, [executeRequest, hasPost]);
+  }, [executeRequest, hasPost, isDemoMode]);
 
   // Initial fetch — read the cached file once when the hook mounts (unless
   // loadWhenInactive is false and the consumer is inactive). active=false
@@ -218,7 +221,7 @@ export function useSyncHook<T>(config: UseSyncConfig<T>, active: boolean): UseSy
 
         // Auto-sync on first load when the hook is active. GET-only endpoints
         // already hydrated above — do not immediately re-GET the same cache.
-        if (active && !didInitialSync.current) {
+        if (!isDemoMode && active && !didInitialSync.current) {
           didInitialSync.current = true;
           if (hasPost) void triggerSync();
         }
@@ -227,7 +230,7 @@ export function useSyncHook<T>(config: UseSyncConfig<T>, active: boolean): UseSy
         setError(err instanceof Error ? err.message : "Unknown error");
         setLoading(false);
         didInitialRead.current = true;
-        if (active && !didInitialSync.current) {
+        if (!isDemoMode && active && !didInitialSync.current) {
           didInitialSync.current = true;
           if (hasPost) void triggerSync();
         }
@@ -235,7 +238,7 @@ export function useSyncHook<T>(config: UseSyncConfig<T>, active: boolean): UseSy
     };
 
     void init();
-  }, [active, armRetry, clearRetry, endpoint, hasPost, loadWhenInactive, triggerSync, extractTimestamp]);
+  }, [active, armRetry, clearRetry, endpoint, hasPost, isDemoMode, loadWhenInactive, triggerSync, extractTimestamp]);
 
   // If the hook mounted while inactive (with loadWhenInactive), issue the first
   // POST/sync when it later becomes active. When loadWhenInactive is false the
@@ -243,27 +246,29 @@ export function useSyncHook<T>(config: UseSyncConfig<T>, active: boolean): UseSy
   // Re-activation after the first sync (scanner mode, section still mounted)
   // must kick a fresh producer run — didInitialSync used to swallow that.
   useEffect(() => {
+    if (isDemoMode) return;
     const becameActive = active && !previousActiveRef.current;
     previousActiveRef.current = active;
     if (!becameActive || !didInitialRead.current) return;
     didInitialSync.current = true;
     if (hasPost) void triggerSync();
     else void requestRef.current("GET", true);
-  }, [active, hasPost, triggerSync]);
+  }, [active, hasPost, isDemoMode, triggerSync]);
 
   // Pathname change while this hook stays mounted (regime tabs, ticker
   // swaps). Re-read the cache immediately; do not wait for the interval.
   useEffect(() => {
+    if (isDemoMode) return;
     if (!routeKey || routeKey === lastRouteKeyRef.current) return;
     lastRouteKeyRef.current = routeKey;
     if (!didInitialRead.current) return;
     if (!active && !loadWhenInactive) return;
     void requestRef.current("GET", true);
-  }, [routeKey, active, loadWhenInactive]);
+  }, [routeKey, active, isDemoMode, loadWhenInactive]);
 
   // Auto-sync interval (only when active)
   useEffect(() => {
-    if (!active || interval <= 0) {
+    if (isDemoMode || !active || interval <= 0) {
       if (intervalRef.current) {
         clearInterval(intervalRef.current);
         intervalRef.current = null;
@@ -280,7 +285,7 @@ export function useSyncHook<T>(config: UseSyncConfig<T>, active: boolean): UseSy
       if (intervalRef.current) clearInterval(intervalRef.current);
       clearRetry();
     };
-  }, [active, clearRetry, interval, triggerSync]);
+  }, [active, clearRetry, interval, isDemoMode, triggerSync]);
 
   const syncNow = useCallback(() => {
     void triggerSync();

--- a/web/tests/demo-chain-prefetch.test.tsx
+++ b/web/tests/demo-chain-prefetch.test.tsx
@@ -1,0 +1,38 @@
+/** @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+import { useChainPrefetch } from "@/lib/useChainPrefetch";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubEnv("NEXT_PUBLIC_RADON_DEMO", "1");
+  vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ strikes: [100] }))));
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe("demo option-chain prefetch", () => {
+  it("can disable background expiries while retaining the selected-expiry cache API", async () => {
+    const { result } = renderHook(() => useChainPrefetch(
+      "AAPL",
+      ["20260911", "20260918", "20261016"],
+      "20260911",
+    ));
+
+    act(() => result.current.cacheStrikes("20260911", [270, 275, 280]));
+    await act(async () => {
+      vi.advanceTimersByTime(20_000);
+      await Promise.resolve();
+    });
+
+    expect(result.current.getCachedStrikes("20260911")).toEqual([270, 275, 280]);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/web/tests/demo-data-routes.test.ts
+++ b/web/tests/demo-data-routes.test.ts
@@ -1,0 +1,324 @@
+/**
+ * @vitest-environment node
+ *
+ * Demo data must be complete, current, and independent of operator-only
+ * files/services. These tests pin both the fixture math and each route seam.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { buildDemoCashFlows } from "@/lib/demo/fixtures/cashFlows";
+import { buildDemoFlowReport } from "@/lib/demo/fixtures/flowAnalysis";
+import { buildDemoOrders } from "@/lib/demo/fixtures/orders";
+import { buildDemoPerformance } from "@/lib/demo/fixtures/performance";
+import { buildDemoThetaHarvester } from "@/lib/demo/fixtures/thetaHarvester";
+import { filterExecutedToEtToday } from "@/lib/orders/executedToday";
+import { buildPerformanceView } from "@/lib/performanceData";
+import { businessDateKeys, marketDateKey } from "@/lib/demo/fixtures/time";
+
+const mocks = vi.hoisted(() => ({
+  getDb: vi.fn(),
+  radonFetch: vi.fn(),
+  readFile: vi.fn(),
+  readOrders: vi.fn(),
+  requireRouteAccess: vi.fn(),
+  statSync: vi.fn(),
+}));
+
+vi.mock("@/lib/routeAccess", () => ({
+  requireRouteAccess: mocks.requireRouteAccess,
+}));
+
+vi.mock("@/lib/radonApi", () => ({
+  radonFetch: mocks.radonFetch,
+  RadonApiError: class RadonApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+vi.mock("@/lib/orders/readOrdersFromDb", () => ({
+  readOrdersSnapshotFromDb: mocks.readOrders,
+}));
+
+vi.mock("@/lib/db", () => ({
+  getDb: mocks.getDb,
+  resetDb: vi.fn(),
+  syncDb: vi.fn(),
+}));
+
+vi.mock("fs/promises", () => ({
+  readFile: mocks.readFile,
+}));
+
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  return { ...actual, statSync: mocks.statSync };
+});
+
+const NOW = new Date("2026-09-04T18:15:00.000Z");
+
+const OPEN_ORDER = {
+  orderId: 41,
+  permId: 8041,
+  symbol: "SPY",
+  contract: {
+    conId: 756733,
+    symbol: "SPY",
+    secType: "STK",
+    strike: null,
+    right: null,
+    expiry: null,
+  },
+  action: "BUY",
+  orderType: "LMT",
+  totalQuantity: 5,
+  limitPrice: 630,
+  auxPrice: null,
+  status: "Submitted",
+  filled: 0,
+  remaining: 5,
+  avgFillPrice: null,
+  tif: "DAY",
+};
+
+function expectNoStore(response: Response): void {
+  expect(response.headers.get("Cache-Control")?.toLowerCase()).toContain("no-store");
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+  vi.clearAllMocks();
+  mocks.requireRouteAccess.mockResolvedValue({
+    ok: true,
+    principal: { userId: "demo-user", kind: "demo" },
+  });
+  mocks.getDb.mockReturnValue({
+    execute: vi.fn(() => {
+      throw new Error("demo route reached Turso");
+    }),
+  });
+  mocks.readFile.mockRejectedValue(new Error("demo route reached disk"));
+  mocks.statSync.mockImplementation(() => {
+    throw new Error("demo route reached disk metadata");
+  });
+  mocks.radonFetch.mockRejectedValue(new Error("demo route reached upstream"));
+  mocks.readOrders.mockResolvedValue({
+    last_sync: "",
+    open_orders: [OPEN_ORDER],
+    executed_orders: [],
+    open_count: 1,
+    executed_count: 0,
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("production-owned demo fixtures", () => {
+  it("builds a complete, reproducible performance series from an injected clock", () => {
+    const first = buildDemoPerformance(NOW);
+    const second = buildDemoPerformance(NOW);
+
+    expect(first).toEqual(second);
+    expect(first.status).toBe("ok");
+    expect(first.series.length).toBeGreaterThanOrEqual(250);
+    expect(first.counts?.n_nav_observations).toBe(first.series.length);
+    expect(first.nav_as_of).toBe(first.series.at(-1)?.date);
+    expect(first.twr?.cum_return).toBeTypeOf("number");
+    expect(first.risk?.sharpe_ratio.value).toBeTypeOf("number");
+    expect(first.equity?.ending).toBe(first.series.at(-1)?.nav);
+    expect(first.benchmark && typeof first.benchmark !== "string" ? first.benchmark.r_squared : null)
+      .toBeCloseTo((first.benchmark && typeof first.benchmark !== "string" ? first.benchmark.correlation : 0) ** 2, 5);
+    expect(buildPerformanceView(first)).toMatchObject({
+      status: "ok",
+      isInsufficient: false,
+      isStale: false,
+      annualized: { unavailable_reason: null },
+    });
+  });
+
+  it("uses ET dates and skips weekends plus full-closure market holidays", () => {
+    const afterUtcMidnight = new Date("2026-09-05T00:05:00.000Z");
+    const afterLaborDay = new Date("2026-09-08T18:00:00.000Z");
+
+    expect(marketDateKey(afterUtcMidnight)).toBe("2026-09-04");
+    expect(businessDateKeys(2, afterLaborDay)).toEqual(["2026-09-04", "2026-09-08"]);
+    const orders = buildDemoOrders({
+      last_sync: "",
+      open_orders: [],
+      executed_orders: [],
+      open_count: 0,
+      executed_count: 0,
+    }, afterUtcMidnight);
+    expect(orders.executed_orders[0].execId).toContain("20260904");
+    expect(filterExecutedToEtToday(orders.executed_orders, afterUtcMidnight)).toHaveLength(3);
+  });
+
+  it("filters cash flows by lookback and comma-separated transaction type", () => {
+    const all = buildDemoCashFlows({ now: NOW, days: 90, types: "" });
+    const filtered = buildDemoCashFlows({ now: NOW, days: 30, types: "Withdrawal,Dividend" });
+
+    expect(all.rows.length).toBeGreaterThan(filtered.rows.length);
+    expect(filtered.rows.every((row) => row.type === "Withdrawal" || row.type === "Dividend")).toBe(true);
+    expect(filtered.summary?.net).toBe(
+      filtered.rows.reduce((total, row) => total + row.amount, 0),
+    );
+  });
+
+  it("keeps demo executions on the injected clock while preserving open orders", () => {
+    const orders = buildDemoOrders({
+      last_sync: "",
+      open_orders: [OPEN_ORDER],
+      executed_orders: [],
+      open_count: 1,
+      executed_count: 0,
+    }, NOW);
+
+    expect(orders.open_orders).toEqual([OPEN_ORDER]);
+    expect(orders.executed_orders.length).toBeGreaterThan(0);
+    expect(orders.executed_orders.every((order) => order.time === NOW.toISOString())).toBe(true);
+    expect(filterExecutedToEtToday(orders.executed_orders, NOW)).toHaveLength(orders.executed_orders.length);
+    expect(orders.executed_count).toBe(orders.executed_orders.length);
+  });
+
+  it("builds coherent theta candidates and honors ticker scan filters", () => {
+    const data = buildDemoThetaHarvester({
+      now: NOW,
+      ticker: "SNDK",
+      minDte: 20,
+      maxDte: 35,
+      minCredit: 1,
+    });
+
+    expect(data.requested_tickers).toEqual(["SNDK"]);
+    expect(data.results).toHaveLength(1);
+    expect(data.results[0].ticker).toBe("SNDK");
+    expect(data.results[0].structure.dte).toBeGreaterThanOrEqual(20);
+    expect(data.results[0].structure.dte).toBeLessThanOrEqual(35);
+    expect(data.results[0].structure.expiry).toMatch(/^\d{8}$/);
+    const expiry = data.results[0].structure.expiry;
+    expect(new Date(`${expiry.slice(0, 4)}-${expiry.slice(4, 6)}-${expiry.slice(6, 8)}T12:00:00.000Z`).getUTCDay()).toBe(5);
+    expect(data.theta_harvest_count).toBe(1);
+  });
+
+  it("builds a fresh, full report for any valid ticker without randomness", () => {
+    const first = buildDemoFlowReport("SNDK", NOW);
+    const second = buildDemoFlowReport("SNDK", NOW);
+
+    expect(first).toEqual(second);
+    expect(first.ticker).toBe("SNDK");
+    expect(first.fetched_at).toBe(NOW.toISOString());
+    expect(first.verdict).toBeTruthy();
+    expect(first.dark_pool?.daily?.length).toBeGreaterThan(5);
+    expect(first.options_flow?.total_alerts).toBeGreaterThan(0);
+    expect(first.cache_meta).toMatchObject({ age_seconds: 0, is_stale: false });
+  });
+});
+
+describe("demo route seams", () => {
+  it("serves performance before Turso or disk access", async () => {
+    const { GET } = await import("@/app/api/performance/route");
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expectNoStore(response);
+    expect(body.status).toBe("ok");
+    expect(body.series.length).toBeGreaterThan(0);
+    expect(mocks.getDb().execute).not.toHaveBeenCalled();
+    expect(mocks.readFile).not.toHaveBeenCalled();
+  });
+
+  it("merges stable current fills with the demo DB's open orders", async () => {
+    const { GET } = await import("@/app/api/orders/route");
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expectNoStore(response);
+    expect(body.open_orders).toEqual([OPEN_ORDER]);
+    expect(body.executed_orders.length).toBeGreaterThan(0);
+    expect(mocks.readOrders).toHaveBeenCalledTimes(1);
+  });
+
+  it("serves filtered cash flows without FastAPI", async () => {
+    const { GET } = await import("@/app/api/cash-flows/route");
+    const response = await GET(
+      new Request("http://localhost/api/cash-flows?days=30&types=Withdrawal") as never,
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expectNoStore(response);
+    expect(body.rows.length).toBeGreaterThan(0);
+    expect(body.rows.every((row: { type: string }) => row.type === "Withdrawal")).toBe(true);
+    expect(mocks.radonFetch).not.toHaveBeenCalled();
+  });
+
+  it("serves theta GET and POST scans without cache or upstream access", async () => {
+    const { GET } = await import("@/app/api/scanner/theta/route");
+    const getResponse = await GET();
+    const getBody = await getResponse.json();
+    expect(getBody.results.length).toBeGreaterThan(0);
+
+    const { POST } = await import("@/app/api/scanner/theta/scan/route");
+    const postResponse = await POST(new Request("http://localhost/api/scanner/theta/scan", {
+      method: "POST",
+      body: JSON.stringify({ ticker: "SNDK", min_dte: 20, max_dte: 35, min_credit: 1 }),
+    }));
+    const postBody = await postResponse.json();
+
+    expect(postResponse.status).toBe(200);
+    expectNoStore(postResponse);
+    expect(postBody.scan_succeeded).toBe(true);
+    expect(postBody.results[0].ticker).toBe("SNDK");
+    expect(mocks.readFile).not.toHaveBeenCalled();
+    expect(mocks.radonFetch).not.toHaveBeenCalled();
+  });
+
+  it("keeps theta ticker validation ahead of the demo fixture", async () => {
+    const { POST } = await import("@/app/api/scanner/theta/scan/route");
+    const response = await POST(new Request("http://localhost/api/scanner/theta/scan", {
+      method: "POST",
+      body: JSON.stringify({ ticker: "BAD1" }),
+    }));
+
+    expect(response.status).toBe(400);
+    expectNoStore(response);
+  });
+
+  it("serves fresh GET and POST flow reports for arbitrary valid tickers", async () => {
+    const route = await import("@/app/api/flow-analysis/[ticker]/route");
+    const context = { params: Promise.resolve({ ticker: "sndk" }) };
+    const request = new Request("http://localhost/api/flow-analysis/sndk");
+    const getResponse = await route.GET(request, context);
+    const postResponse = await route.POST(request, context);
+    const getBody = await getResponse.json();
+    const postBody = await postResponse.json();
+
+    expect(getBody).toMatchObject({ ticker: "SNDK", fetched_at: NOW.toISOString() });
+    expect(postBody).toMatchObject({ ticker: "SNDK", fetched_at: NOW.toISOString() });
+    expectNoStore(getResponse);
+    expectNoStore(postResponse);
+    expect(mocks.readFile).not.toHaveBeenCalled();
+    expect(mocks.radonFetch).not.toHaveBeenCalled();
+  });
+
+  it("keeps flow ticker validation ahead of the demo fixture", async () => {
+    const { GET } = await import("@/app/api/flow-analysis/[ticker]/route");
+    const response = await GET(
+      new Request("http://localhost/api/flow-analysis/BAD1"),
+      { params: Promise.resolve({ ticker: "BAD1" }) },
+    );
+
+    expect(response.status).toBe(400);
+    expectNoStore(response);
+  });
+});

--- a/web/tests/demo-gate.test.ts
+++ b/web/tests/demo-gate.test.ts
@@ -129,7 +129,7 @@ describe("handleDemoGate", () => {
 
     expect(scanner).toBeNull();
     expect(limiter.mock.calls.at(-1)).toEqual([
-      "B",
+      "A",
       "fresh-demo-user:resource:scanner",
     ]);
   });
@@ -147,8 +147,8 @@ describe("handleDemoGate", () => {
     );
 
     expect(limiter.mock.calls).toEqual([
-      ["B", "user:resource:scanner"],
-      ["B", "user:resource:scanner"],
+      ["A", "user:resource:scanner"],
+      ["A", "user:resource:scanner"],
     ]);
   });
 

--- a/web/tests/demo-options-fixtures.test.ts
+++ b/web/tests/demo-options-fixtures.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildDemoOptionChain,
+  buildDemoOptionExpirations,
+  buildDemoOptionsExposure,
+} from "@/lib/demo/fixtures/options";
+import { isOptionsExposurePayload } from "@/lib/optionsExposure";
+
+const NOW = new Date("2026-09-04T18:00:00.000Z");
+
+describe("demo options fixtures", () => {
+  it("builds a bounded future expiry calendar shared by the chain", () => {
+    const expirations = buildDemoOptionExpirations("amat", NOW);
+
+    expect(expirations.symbol).toBe("AMAT");
+    expect(expirations.expirations.length).toBeGreaterThanOrEqual(4);
+    expect(expirations.expirations.length).toBeLessThanOrEqual(8);
+    expect(expirations.expirations).toEqual([...expirations.expirations].sort());
+    expect(expirations.expirations.every((expiry) => /^\d{8}$/.test(expiry))).toBe(true);
+    expect(expirations.expirations.every((expiry) => expiry > "20260904")).toBe(true);
+
+    const requestedExpiry = expirations.expirations.at(-1)!;
+    const chain = buildDemoOptionChain("amat", requestedExpiry, NOW);
+    expect(chain).toMatchObject({
+      symbol: "AMAT",
+      expiry: requestedExpiry,
+      exchange: "SMART",
+      multiplier: "100",
+    });
+    expect(chain.expirations).toEqual(expirations.expirations);
+    expect(chain.strikes).toContain(400);
+    expect(chain.strikes).toContain(485);
+    expect(chain.strikes).toEqual([...chain.strikes].sort((a, b) => a - b));
+  });
+
+  it("builds a current, schema-valid exposure cube with coherent dimensions", () => {
+    const payload = buildDemoOptionsExposure("aapl", "intraday", NOW);
+
+    expect(isOptionsExposurePayload(payload)).toBe(true);
+    expect(payload.symbol).toBe("AAPL");
+    expect(payload.frequency).toBe("intraday");
+    expect(payload.source_time).toBe(NOW.toISOString());
+    expect(payload.fetched_at).toBe(NOW.toISOString());
+    expect(payload.expirations.every(({ dte }) => dte > 0)).toBe(true);
+    expect(payload.cells.strike_idx).toHaveLength(
+      payload.strikes.length * payload.expirations.length,
+    );
+  });
+});

--- a/web/tests/demo-options-routes.test.ts
+++ b/web/tests/demo-options-routes.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { isOptionsExposurePayload } from "@/lib/optionsExposure";
+
+const mocks = vi.hoisted(() => ({
+  principalKind: "demo" as "demo" | "operator",
+  radonFetch: vi.fn(),
+}));
+
+vi.mock("@/lib/routeAccess", () => ({
+  requireRouteAccess: vi.fn(async () => ({
+    ok: true,
+    principal: { userId: "demo-user", kind: mocks.principalKind },
+  })),
+}));
+
+vi.mock("@/lib/radonApi", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/radonApi")>();
+  return { ...actual, radonFetch: mocks.radonFetch };
+});
+
+describe("demo option routes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.principalKind = "demo";
+    mocks.radonFetch.mockReset();
+    mocks.radonFetch.mockRejectedValue(new Error("FastAPI must not run for demo fixtures"));
+  });
+
+  it("serves expirations and a selected chain without FastAPI", async () => {
+    const { GET: getExpirations } = await import("../app/api/options/expirations/route");
+    const expirationResponse = await getExpirations(
+      new Request("http://localhost/api/options/expirations?symbol=amat"),
+    );
+    const expirations = await expirationResponse.json() as {
+      symbol: string;
+      expirations: string[];
+    };
+
+    expect(expirationResponse.status).toBe(200);
+    expect(expirationResponse.headers.get("Cache-Control")).toContain("no-store");
+    expect(expirations.symbol).toBe("AMAT");
+
+    const expiry = expirations.expirations.at(-1)!;
+    const { GET: getChain } = await import("../app/api/options/chain/route");
+    const chainResponse = await getChain(
+      new Request(`http://localhost/api/options/chain?symbol=AMAT&expiry=${expiry}`),
+    );
+    const chain = await chainResponse.json() as { strikes: number[] };
+
+    expect(chainResponse.status).toBe(200);
+    expect(chainResponse.headers.get("Cache-Control")).toContain("no-store");
+    expect(chain.strikes).toContain(400);
+    expect(chain.strikes).toContain(485);
+    expect(mocks.radonFetch).not.toHaveBeenCalled();
+  });
+
+  it("serves normalized options exposure without FastAPI", async () => {
+    const { GET } = await import("../app/api/options/exposure/route");
+    const response = await GET(
+      new Request("http://localhost/api/options/exposure?symbol=aapl&frequency=intraday"),
+    );
+    const payload: unknown = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toContain("no-store");
+    expect(isOptionsExposurePayload(payload)).toBe(true);
+    expect(payload).toMatchObject({ symbol: "AAPL", frequency: "intraday" });
+    expect(mocks.radonFetch).not.toHaveBeenCalled();
+  });
+
+  it("preserves the non-demo proxy path", async () => {
+    mocks.principalKind = "operator";
+    mocks.radonFetch.mockResolvedValue({ symbol: "AAPL", expirations: ["20261016"] });
+    const { GET } = await import("../app/api/options/expirations/route");
+    const response = await GET(
+      new Request("http://localhost/api/options/expirations?symbol=AAPL"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.radonFetch).toHaveBeenCalledWith(
+      "/options/expirations?symbol=AAPL",
+      { timeout: 50_000 },
+    );
+  });
+});

--- a/web/tests/demo-rate-tier.test.ts
+++ b/web/tests/demo-rate-tier.test.ts
@@ -13,7 +13,14 @@ describe("classifyRateTier", () => {
     expect(classifyRateTier("POST", "/api/gex/scan")).toBe("B");
     expect(classifyRateTier("POST", "/api/leap/scan")).toBe("B");
     expect(classifyRateTier("POST", "/api/pi/exec")).toBe("B");
-    expect(classifyRateTier("GET", "/api/performance/foo")).toBe("B");
+    expect(classifyRateTier("POST", "/api/performance/build")).toBe("B");
+  });
+
+  it("keeps cached measurement reads out of producer quotas", () => {
+    expect(classifyRateTier("GET", "/api/performance")).toBe("A");
+    expect(classifyRateTier("GET", "/api/scanner/theta")).toBe("A");
+    expect(classifyRateTier("GET", "/api/regime")).toBe("A");
+    expect(classifyRateTier("GET", "/api/regime/gex")).toBe("A");
   });
 
   it("writes are tier C", () => {

--- a/web/tests/demo-realtime-prices.test.tsx
+++ b/web/tests/demo-realtime-prices.test.tsx
@@ -1,0 +1,122 @@
+/** @vitest-environment jsdom */
+
+import React, { useEffect } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+
+import {
+  RealtimePricesProvider,
+  useRealtimePrices,
+  type RealtimePricesValue,
+  type RealtimeSubscriptionRequest,
+} from "@/lib/RealtimePricesContext";
+import { buildDemoRealtimeSample } from "@/lib/demo/demoRealtime";
+import { optionKey } from "@/lib/pricesProtocol";
+
+vi.mock("@/lib/RealtimeAuthContext", () => ({
+  useRealtimeAuth: () => async () => "clerk-token",
+}));
+
+const CALL = { symbol: "AAPL", expiry: "20261016", strike: 280, right: "C" as const };
+const REQUEST: RealtimeSubscriptionRequest = {
+  symbols: ["NEM", "ES"],
+  contracts: [CALL],
+  indexes: [{ symbol: "VIX", exchange: "CBOE" }],
+  depthSymbol: "NEM",
+  depthSymbols: [],
+  depthExpiry: null,
+};
+
+let latest: RealtimePricesValue | null = null;
+
+function Probe() {
+  const realtime = useRealtimePrices();
+  latest = realtime;
+  useEffect(() => realtime.publishSubscriptions(REQUEST), [realtime.publishSubscriptions]);
+  return null;
+}
+
+beforeEach(() => {
+  latest = null;
+  vi.stubEnv("NEXT_PUBLIC_RADON_DEMO", "1");
+  vi.stubGlobal("fetch", vi.fn(async () => {
+    throw new Error("demo realtime must not request a WebSocket ticket");
+  }));
+  vi.stubGlobal("WebSocket", vi.fn(() => {
+    throw new Error("demo realtime must not open a WebSocket");
+  }));
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe("demo realtime prices provider", () => {
+  it("is stable for the same symbols and sample minute", () => {
+    const sampleTime = new Date("2026-09-04T18:42:15.000Z");
+
+    expect(buildDemoRealtimeSample(REQUEST, sampleTime)).toEqual(
+      buildDemoRealtimeSample(REQUEST, new Date("2026-09-04T18:42:59.000Z")),
+    );
+  });
+
+  it("publishes coherent local quotes, depth, and tape without network transport", async () => {
+    render(<RealtimePricesProvider><Probe /></RealtimePricesProvider>);
+
+    await waitFor(() => expect(latest?.prices.NEM?.last).toBeTypeOf("number"));
+
+    const value = latest!;
+    const stock = value.prices.NEM;
+    const option = value.prices[optionKey(CALL)];
+    const index = value.prices.VIX;
+    const book = value.depths.NEM;
+
+    expect(stock.bid).toBeLessThan(stock.last!);
+    expect(stock.ask).toBeGreaterThan(stock.last!);
+    expect(option.undPrice).toBe(value.prices.AAPL.last);
+    expect(index.last).toBeGreaterThan(0);
+    expect(book).toMatchObject({ symbol: "NEM", kind: "stock", entitled: true });
+    expect(book.bid[0].price).toBe(stock.bid);
+    expect(book.ask[0].price).toBe(stock.ask);
+    expect(value.tape.NEM.length).toBeGreaterThan(2);
+    expect(value.connected).toBe(false);
+    expect(value.ibConnected).toBe(false);
+    expect(fetch).not.toHaveBeenCalled();
+    expect(WebSocket).not.toHaveBeenCalled();
+
+    await expect(value.getSnapshot(["NEM", "AAPL"])).resolves.toMatchObject({
+      NEM: { symbol: "NEM" },
+      AAPL: { symbol: "AAPL" },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("publishes an option NBBO book when the focused subject is a contract", async () => {
+    function OptionProbe() {
+      const realtime = useRealtimePrices();
+      latest = realtime;
+      useEffect(() => realtime.publishSubscriptions({
+        ...REQUEST,
+        contracts: [],
+        depthSymbol: optionKey(CALL),
+      }), [realtime.publishSubscriptions]);
+      return null;
+    }
+
+    render(<RealtimePricesProvider><OptionProbe /></RealtimePricesProvider>);
+    await waitFor(() => expect(latest?.depths[optionKey(CALL)]?.kind).toBe("option"));
+
+    const book = latest!.depths[optionKey(CALL)];
+    expect(book.nbbo).toMatchObject({
+      bestBid: latest!.prices[optionKey(CALL)].bid,
+      bestAsk: latest!.prices[optionKey(CALL)].ask,
+    });
+    expect(latest!.prices[optionKey(CALL)].undPrice).toBe(latest!.prices.AAPL.last);
+    expect(book.bid[0].nbbo).toBe(true);
+    expect(book.ask[0].nbbo).toBe(true);
+    expect(fetch).not.toHaveBeenCalled();
+    expect(WebSocket).not.toHaveBeenCalled();
+  });
+});

--- a/web/tests/demo-regime-fixtures.test.ts
+++ b/web/tests/demo-regime-fixtures.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+
+import { isBpiPayload } from "@/lib/bpi";
+import { lastCompletedSessionDate, mostRecentSessionDate } from "@/lib/marketSession";
+import { scanTimeToEtDate } from "@/lib/parseScanTime";
+import {
+  buildDemoBpiFixture,
+  buildDemoCriFixture,
+  buildDemoDispersionFixture,
+  buildDemoGammaRotationFixture,
+  buildDemoGexFixture,
+  buildDemoTrinFixture,
+  buildDemoVcgFixture,
+} from "@/lib/demo/fixtures/regime";
+
+describe("deterministic demo regime fixtures", () => {
+  const now = new Date("2031-02-10T18:45:00.000Z");
+  const expectedSession = mostRecentSessionDate(now);
+
+  it("is stable for an injected clock and follows the current ET session", () => {
+    const first = {
+      cri: buildDemoCriFixture(now),
+      vcg: buildDemoVcgFixture(now),
+      gammaRotation: buildDemoGammaRotationFixture(now),
+      gex: buildDemoGexFixture(now),
+      dispersion: buildDemoDispersionFixture(now),
+      trin: buildDemoTrinFixture(now),
+      bpi: buildDemoBpiFixture(now),
+    };
+    const second = {
+      cri: buildDemoCriFixture(now),
+      vcg: buildDemoVcgFixture(now),
+      gammaRotation: buildDemoGammaRotationFixture(now),
+      gex: buildDemoGexFixture(now),
+      dispersion: buildDemoDispersionFixture(now),
+      trin: buildDemoTrinFixture(now),
+      bpi: buildDemoBpiFixture(now),
+    };
+
+    expect(second).toEqual(first);
+    expect(first.cri.date).toBe(expectedSession);
+    expect(scanTimeToEtDate(first.cri.scan_time)).toBe(expectedSession);
+    expect(scanTimeToEtDate(first.vcg.scan_time)).toBe(expectedSession);
+    expect(scanTimeToEtDate(first.gammaRotation.scan_time)).toBe(expectedSession);
+    expect(scanTimeToEtDate(first.gex.scan_time)).toBe(expectedSession);
+    expect(first.dispersion.data_date).toBe(lastCompletedSessionDate(now));
+    expect(first.trin.current?.session_date).toBe(expectedSession);
+  });
+
+  it("contains representative non-empty data for every regime panel", () => {
+    const cri = buildDemoCriFixture(now);
+    const vcg = buildDemoVcgFixture(now);
+    const gammaRotation = buildDemoGammaRotationFixture(now);
+    const gex = buildDemoGexFixture(now);
+    const dispersion = buildDemoDispersionFixture(now);
+    const trin = buildDemoTrinFixture(now);
+    const bpi = buildDemoBpiFixture(now);
+
+    expect(cri.cri?.score).toBeGreaterThan(0);
+    expect(cri.history.length).toBeGreaterThanOrEqual(20);
+    expect(vcg.signal?.vcg_adj).not.toBeNull();
+    expect(vcg.history.length).toBeGreaterThanOrEqual(20);
+    expect(gammaRotation.signal.grg_z).not.toBeNull();
+    expect(gammaRotation.history.length).toBeGreaterThanOrEqual(20);
+    expect(gex.spot).toBeGreaterThan(0);
+    expect(gex.profile.length).toBeGreaterThanOrEqual(5);
+    expect(dispersion.current).not.toBeNull();
+    expect(dispersion.series.length).toBeGreaterThanOrEqual(60);
+    expect(trin.current?.trin).not.toBeNull();
+    expect(trin.hourly.length).toBeGreaterThanOrEqual(20);
+    expect(Object.values(bpi.indices).every(isBpiPayload)).toBe(true);
+  });
+
+  it("keeps each summary coherent with its final series observation", () => {
+    const cri = buildDemoCriFixture(now);
+    const vcg = buildDemoVcgFixture(now);
+    const gammaRotation = buildDemoGammaRotationFixture(now);
+    const gex = buildDemoGexFixture(now);
+    const dispersion = buildDemoDispersionFixture(now);
+    const trin = buildDemoTrinFixture(now);
+
+    expect(cri.history.at(-1)).toMatchObject({ date: cri.date, vix: cri.vix, spy: cri.spy });
+    expect(vcg.history.at(-1)).toMatchObject({ vcg_adj: vcg.signal?.vcg_adj, credit: vcg.signal?.credit_price });
+    expect(gammaRotation.history.at(-1)).toMatchObject({
+      date: gammaRotation.data_date,
+      grg_z: gammaRotation.signal.grg_z,
+      raw_spread: gammaRotation.signal.raw_spread,
+      spy_gamma_z: gammaRotation.signal.spy_gamma_z,
+      tlt_gamma_z: gammaRotation.signal.tlt_gamma_z,
+    });
+    expect(gammaRotation.signal.raw_spread).toBe(
+      (gammaRotation.signal.spy_gamma_z ?? 0) - (gammaRotation.signal.tlt_gamma_z ?? 0),
+    );
+    expect(gammaRotation.signal.spy_3d_gamma_change).toBeGreaterThan(0);
+    expect(gammaRotation.assets.SPY.gamma_3d_change).toBe(
+      gammaRotation.signal.spy_3d_gamma_change,
+    );
+    expect(gammaRotation.history.at(-1)?.state).toBe("RISK_OFF_DIVERGENCE");
+    for (const point of gammaRotation.history) {
+      const spy = point.spy_net_gamma ?? 0;
+      const tlt = point.tlt_net_gamma ?? 0;
+      const expectedState = spy > 0 && tlt < 0
+        ? "RISK_ON_DIVERGENCE"
+        : spy < 0 && tlt > 0
+          ? "RISK_OFF_DIVERGENCE"
+          : spy > 0 && tlt > 0
+            ? "DUAL_CUSHION"
+            : "DUAL_WHIP";
+      expect(point.state).toBe(expectedState);
+    }
+    expect(gex.history.at(-1)).toMatchObject({
+      date: gex.data_date,
+      net_gex: gex.net_gex,
+      spot: gex.spot,
+      gex_flip: gex.levels.gex_flip?.strike,
+    });
+    for (const name of ["max_magnet", "second_magnet", "max_accelerator", "put_wall", "call_wall"] as const) {
+      const level = gex.levels[name];
+      expect(gex.profile.find((bucket) => bucket.strike === level?.strike)?.net_gex).toBe(level?.gamma);
+    }
+    expect(dispersion.current).toMatchObject(dispersion.series.at(-1) ?? {});
+    expect(trin.hourly.at(-1)).toMatchObject({
+      ts: trin.current?.ts,
+      trin: trin.current?.trin,
+      ma10: trin.current?.ma10,
+    });
+    expect(
+      ((trin.current?.adv ?? 0) / (trin.current?.dec ?? 1))
+      / ((trin.current?.up_vol ?? 0) / (trin.current?.down_vol ?? 1)),
+    ).toBeCloseTo(trin.current?.trin ?? 0, 2);
+  });
+});

--- a/web/tests/demo-regime-routes.test.ts
+++ b/web/tests/demo-regime-routes.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { isBpiPayload } from "@/lib/bpi";
+
+const mocks = vi.hoisted(() => ({
+  requireRouteAccess: vi.fn(),
+  dbExecute: vi.fn(),
+  getDb: vi.fn(),
+  readFile: vi.fn(),
+  readdir: vi.fn(),
+  writeFile: vi.fn(),
+  stat: vi.fn(),
+  mkdir: vi.fn(),
+  radonFetch: vi.fn(),
+}));
+
+vi.mock("@/lib/routeAccess", () => ({ requireRouteAccess: mocks.requireRouteAccess }));
+vi.mock("@/lib/dbExecute", () => ({ dbExecute: mocks.dbExecute }));
+vi.mock("@/lib/db", () => ({ getDb: mocks.getDb, resetDb: vi.fn() }));
+vi.mock("@/lib/radonApi", () => ({ radonFetch: mocks.radonFetch }));
+vi.mock("fs/promises", () => ({
+  readFile: mocks.readFile,
+  readdir: mocks.readdir,
+  writeFile: mocks.writeFile,
+  stat: mocks.stat,
+  mkdir: mocks.mkdir,
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  Object.values(mocks).forEach((mock) => mock.mockReset());
+  mocks.requireRouteAccess.mockResolvedValue({
+    ok: true,
+    principal: { userId: "demo-user", kind: "demo" },
+  });
+  mocks.dbExecute.mockRejectedValue(new Error("database must not be reached"));
+  mocks.getDb.mockImplementation(() => { throw new Error("database must not be reached"); });
+  mocks.readFile.mockRejectedValue(new Error("disk must not be reached"));
+  mocks.readdir.mockRejectedValue(new Error("disk must not be reached"));
+  mocks.radonFetch.mockRejectedValue(new Error("FastAPI must not be reached"));
+});
+
+function expectDemoResponse(response: Response): void {
+  expect(response.status).toBe(200);
+  expect(response.headers.get("cache-control")).toContain("no-store");
+}
+
+function expectNoUpstreamWork(): void {
+  expect(mocks.dbExecute).not.toHaveBeenCalled();
+  expect(mocks.getDb).not.toHaveBeenCalled();
+  expect(mocks.readFile).not.toHaveBeenCalled();
+  expect(mocks.readdir).not.toHaveBeenCalled();
+  expect(mocks.writeFile).not.toHaveBeenCalled();
+  expect(mocks.stat).not.toHaveBeenCalled();
+  expect(mocks.mkdir).not.toHaveBeenCalled();
+  expect(mocks.radonFetch).not.toHaveBeenCalled();
+}
+
+describe("demo regime GET routes", () => {
+  it("checks route access before selecting a demo fixture", async () => {
+    const denied = new Response(JSON.stringify({ error: "Forbidden" }), { status: 403 });
+    mocks.requireRouteAccess.mockResolvedValueOnce({ ok: false, response: denied });
+    const { GET } = await import("../app/api/bpi/route");
+
+    const response = await GET();
+
+    expect(response).toBe(denied);
+    expectNoUpstreamWork();
+  });
+
+  it("serves CRI without DB, disk, or FastAPI work", async () => {
+    const { GET } = await import("../app/api/regime/route");
+    const response = await GET();
+    const body = await response.json();
+    expectDemoResponse(response);
+    expect(body.cri.score).toBeGreaterThan(0);
+    expectNoUpstreamWork();
+  });
+
+  it("serves VCG without DB, disk, or background work", async () => {
+    const { GET } = await import("../app/api/vcg/route");
+    const response = await GET();
+    const body = await response.json();
+    expectDemoResponse(response);
+    expect(body.signal.vcg_adj).not.toBeNull();
+    expectNoUpstreamWork();
+  });
+
+  it("serves gamma rotation without DB, disk, or background work", async () => {
+    const { GET } = await import("../app/api/gamma-rotation/route");
+    const response = await GET();
+    const body = await response.json();
+    expectDemoResponse(response);
+    expect(body.signal.grg_z).not.toBeNull();
+    expectNoUpstreamWork();
+  });
+
+  it("serves GEX without DB, disk, or background work", async () => {
+    const { GET } = await import("../app/api/gex/route");
+    const response = await GET();
+    const body = await response.json();
+    expectDemoResponse(response);
+    expect(body.profile.length).toBeGreaterThan(0);
+    expectNoUpstreamWork();
+  });
+
+  it("serves dispersion without DB or disk work", async () => {
+    const { GET } = await import("../app/api/dispersion/route");
+    const response = await GET();
+    const body = await response.json();
+    expectDemoResponse(response);
+    expect(body.current).not.toBeNull();
+    expectNoUpstreamWork();
+  });
+
+  it("serves TRIN without DB or disk work", async () => {
+    const { GET } = await import("../app/api/trin/route");
+    const response = await GET();
+    const body = await response.json();
+    expectDemoResponse(response);
+    expect(body.current.trin).not.toBeNull();
+    expectNoUpstreamWork();
+  });
+
+  it("serves all three BPI indices without DB or disk work", async () => {
+    const { GET } = await import("../app/api/bpi/route");
+    const response = await GET();
+    const body = await response.json();
+    expectDemoResponse(response);
+    expect(Object.values(body.indices).every(isBpiPayload)).toBe(true);
+    expectNoUpstreamWork();
+  });
+});
+
+describe("demo producer routes", () => {
+  it.each([
+    ["CRI", () => import("../app/api/regime/route")],
+    ["gamma rotation", () => import("../app/api/gamma-rotation/route")],
+    ["GEX", () => import("../app/api/gex/route")],
+  ])("serves %s POST from the same fixture without spawning work", async (_label, loadRoute) => {
+    const { POST } = await loadRoute();
+    const response = await POST();
+    expectDemoResponse(response);
+    expectNoUpstreamWork();
+  });
+});

--- a/web/tests/demo-workspace-chrome.test.ts
+++ b/web/tests/demo-workspace-chrome.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("demo workspace sync chrome", () => {
+  it("describes the static sample without offering an IB producer action", () => {
+    const source = readFileSync(
+      resolve(__dirname, "..", "components", "WorkspaceShell.tsx"),
+      "utf8",
+    );
+
+    expect(source).toContain('isDemoMode ? "Sample snapshot"');
+    expect(source).toContain("{!isDemoMode ? (");
+    expect(source).toContain('title={`Sync ${syncTarget} from IB Gateway`}');
+  });
+});

--- a/web/tests/route-access.test.ts
+++ b/web/tests/route-access.test.ts
@@ -87,7 +87,10 @@ describe("requireRouteAccess", () => {
       env: { ALLOWED_USER_IDS: "user-operator" },
       rateLimitFn: () => ({ ok: false, retryAfterSec: 9 }),
     };
-    const result = await requireRouteAccess(request, { rate: { key: "scan", limit: 1, windowMs: 60_000 } }, deps);
+    const result = await requireRouteAccess(request, {
+      rate: { key: "scan", limit: 1, windowMs: 60_000 },
+      durableRateTier: "B",
+    }, deps);
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.response.status).toBe(429);
@@ -105,6 +108,7 @@ describe("requireRouteAccess", () => {
 
     const result = await requireRouteAccess(request, {
       rate: { key: "portfolio:route", limit: 20, windowMs: 60_000 },
+      durableRateTier: "I",
     }, {
       authFn: async () => ({ userId: "operator" }),
       env: { ALLOWED_USER_IDS: "operator" },
@@ -116,7 +120,30 @@ describe("requireRouteAccess", () => {
     expect(durableRateLimitFn).not.toHaveBeenCalled();
   });
 
-  it("keeps active demo traffic inside the default durable tier", async () => {
+  it("fails closed when a dynamically assembled rate policy omits its durable tier", async () => {
+    const now = Date.parse("2026-08-13T12:00:00Z");
+    const result = await requireRouteAccess(request, {
+      rate: { key: "portfolio:route", limit: 20, windowMs: 60_000 },
+    } as unknown as import("@/lib/routeAccess").RouteAccessOptions, {
+      authFn: async () => ({
+        userId: "demo-user",
+        sessionClaims: {
+          metadata: {
+            demoRole: "trial",
+            demoTrialExpiresAt: "2026-08-14T12:00:00Z",
+          },
+        },
+      }),
+      env: { NEXT_PUBLIC_RADON_DEMO: "1" },
+      now,
+      rateLimitFn: () => ({ ok: true, retryAfterSec: 0 }),
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.response.status).toBe(503);
+  });
+
+  it("keeps active demo reads inside their explicitly declared durable tier", async () => {
     const now = Date.parse("2026-08-13T12:00:00Z");
     const durableRateLimitFn = vi.fn(async () => ({
       success: false,
@@ -127,6 +154,7 @@ describe("requireRouteAccess", () => {
 
     const result = await requireRouteAccess(request, {
       rate: { key: "portfolio:route", limit: 20, windowMs: 60_000 },
+      durableRateTier: "I",
     }, {
       authFn: async () => ({
         userId: "demo-user",
@@ -145,7 +173,7 @@ describe("requireRouteAccess", () => {
 
     expect(result.ok).toBe(false);
     expect(durableRateLimitFn).toHaveBeenCalledWith(
-      "B",
+      "I",
       "route:portfolio:route:demo-user",
     );
     if (!result.ok) {

--- a/web/tests/ticker-search-lazy-connect.test.tsx
+++ b/web/tests/ticker-search-lazy-connect.test.tsx
@@ -78,6 +78,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.useRealTimers();
+  vi.unstubAllEnvs();
   vi.unstubAllGlobals();
 });
 
@@ -129,5 +130,22 @@ describe("TickerSearch lazy connect", () => {
     act(() => ws.simulateOpen());
     const searches = ws.sent.map((s) => JSON.parse(s)).filter((m) => m.action === "search");
     expect(searches).toEqual([{ action: "search", pattern: "AAPL" }]);
+  });
+
+  it("resolves demo symbols locally without a ticket, socket, or unavailable alarm", async () => {
+    vi.stubEnv("NEXT_PUBLIC_RADON_DEMO", "1");
+    const onSearchUnavailable = vi.fn();
+    render(<TickerSearch onSelect={vi.fn()} onSearchUnavailable={onSearchUnavailable} />);
+    const input = screen.getByRole("combobox");
+
+    act(() => { fireEvent.focus(input); });
+    act(() => { fireEvent.change(input, { target: { value: "SNDK" } }); });
+    act(() => { vi.advanceTimersByTime(300); });
+    await flush();
+
+    expect(screen.getByText("SNDK")).toBeTruthy();
+    expect(wsInstances).toHaveLength(0);
+    expect(ticketFetches).toBe(0);
+    expect(onSearchUnavailable).not.toHaveBeenCalled();
   });
 });

--- a/web/tests/use-sync-hook-demo.test.tsx
+++ b/web/tests/use-sync-hook-demo.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useSyncHook } from "@/lib/useSyncHook";
+
+type Payload = { scan_time: string; stale: boolean };
+
+function response(): Response {
+  return new Response(JSON.stringify({ scan_time: "2031-02-10T18:45:00.000Z", stale: true }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function methodOf(call: unknown[]): string {
+  return String(((call[1] ?? {}) as RequestInit).method ?? "GET").toUpperCase();
+}
+
+async function flushRequests(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("useSyncHook in the demo deployment", () => {
+  beforeEach(() => {
+    vi.stubEnv("NEXT_PUBLIC_RADON_DEMO", "1");
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("performs one initial GET with no automatic POST, poll, or stale retry", async () => {
+    const fetchMock = vi.fn().mockImplementation(async () => response());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useSyncHook<Payload>({
+      endpoint: "/api/regime",
+      interval: 100,
+      hasPost: true,
+      shouldRetry: (payload) => payload.stale,
+      retryIntervalMs: 50,
+      retryMethod: "POST",
+    }, true));
+
+    await flushRequests();
+    expect(result.current.loading).toBe(false);
+    expect(fetchMock.mock.calls.map(methodOf)).toEqual(["GET"]);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60 * 60_000);
+    });
+    expect(fetchMock.mock.calls.map(methodOf)).toEqual(["GET"]);
+  });
+
+  it("turns manual sync into a single GET", async () => {
+    const fetchMock = vi.fn().mockImplementation(async () => response());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useSyncHook<Payload>({
+      endpoint: "/api/gex",
+      interval: 100,
+      hasPost: true,
+    }, true));
+
+    await flushRequests();
+    act(() => result.current.syncNow());
+    await flushRequests();
+
+    expect(fetchMock.mock.calls.map(methodOf)).toEqual(["GET", "GET"]);
+  });
+});


### PR DESCRIPTION
## Cause

Demo read surfaces depended on absent or stale producer artifacts, demo Turso seed coverage, vendor services, and broker realtime transport. Passive panel mounting also classified cached GETs with producer budgets, so ordinary navigation could exhaust a shared allowance and turn otherwise healthy demo pages into 429 or unavailable states.

## Fix

- Add current, typed request-time sample fixtures for performance, executions, cash flows, option expirations/chains/exposure, theta, flow, CRI, GRG, VCG, dispersion, GEX, TRIN, and BPI.
- Preserve seeded open orders while adding representative current-session executions.
- Generate deterministic minute-bucketed demo quotes, depth, tape, fundamentals, and option marks locally; demo search no longer requests a broker ticket or WebSocket.
- Suppress demo chain prefetch, automatic producer POSTs, retries, and polling; manual refresh performs a bounded GET.
- Require every locally limited route to declare a durable tier, and keep cached GETs out of producer Tier B.
- Document the demo workstation sample contract and transport boundary.

## Verification

- Focused Vitest: 70 passed.
- Dedicated demo Playwright: 1 passed with screenshot inspection.
- Relevant surface Playwright: 30/31 passed; the only failure is the unchanged options-exposure sticky-header geometry baseline after its demo data, controls, and table assertions passed.
- Full Vitest: all 8,322 collected assertions passed; one unrelated REL-148 suite retains its pre-existing cwd-relative web/web collection error.
- TypeScript passed. ESLint passed with 0 errors and 17 existing warnings.
- Next production compile passed. The post-build trace audit retains the existing assistant and orders/place file-count/size failures.