### PR TITLE
fix(web): coalesce partial fills into one updating toast

### DIFF
--- a/web/components/WorkspaceShell.tsx
+++ b/web/components/WorkspaceShell.tsx
@@ -74,7 +74,7 @@ export default function WorkspaceShell({ section, tickerParam, initialPortfolio 
     && activeSection !== "watchlist"
     && activeSection !== "admin"
     && activeSection !== "workflow";
-  const { toasts, exitingIds, addToast, dismissToast } = useToast();
+  const { toasts, exitingIds, addToast, upsertToast, dismissToast } = useToast();
   const marketState = useMarketHours();
   const isMarketActive = marketState !== MarketState.CLOSED;
   // CME Globex session gate for the header ES/NQ/RTY futures strip — runs ~23h,
@@ -427,7 +427,7 @@ export default function WorkspaceShell({ section, tickerParam, initialPortfolio 
     if (isDemoMode) return;
     portfolioSyncNow();
   }, [isDemoMode, portfolioSyncNow]);
-  useFillToasts(orders, addToast, onNewFills);
+  useFillToasts(orders, upsertToast, onNewFills);
 
   const syncing = isOrdersPage ? ordersSyncing : portfolioSyncing;
   const error = isOrdersPage ? ordersError : portfolioError;

--- a/web/lib/fillToasts.ts
+++ b/web/lib/fillToasts.ts
@@ -114,6 +114,60 @@ export function loadSeen(storage: SeenStorage): Set<string> {
   }
 }
 
+/**
+ * Toast identity for a fill. IB reports one execution per partial fill of the
+ * same order, so grouping on the order collapses a fill sequence onto a single
+ * toast that updates in place. Rows carrying neither id fall back to the
+ * instrument + side, the tightest grouping still available.
+ */
+export function fillGroupKey(fill: ExecutedOrder): string {
+  if (typeof fill.orderId === "number") return `order:${fill.orderId}`;
+  if (typeof fill.permId === "number") return `perm:${fill.permId}`;
+  const instrument = fill.contract?.conId ?? fill.contract?.symbol ?? fill.symbol;
+  return `inst:${instrument}:${fill.side}`;
+}
+
+/**
+ * Running total for one group: quantity summed, price share-weighted. A fill
+ * with an unusable price contributes quantity only, so the average stays the
+ * mean of the prices actually reported.
+ */
+export function mergeFill(running: ExecutedOrder | null, fill: ExecutedOrder): ExecutedOrder {
+  if (running == null) return fill;
+  const runningQty = usableQuantity(running);
+  const fillQty = usableQuantity(fill);
+  return {
+    ...fill,
+    quantity: runningQty + fillQty,
+    avgPrice: weightedAvgPrice(running, runningQty, fill, fillQty),
+  };
+}
+
+function usableQuantity(fill: ExecutedOrder): number {
+  return typeof fill.quantity === "number" && Number.isFinite(fill.quantity) ? fill.quantity : 0;
+}
+
+function usablePrice(fill: ExecutedOrder): number | null {
+  return typeof fill.avgPrice === "number" && Number.isFinite(fill.avgPrice) ? fill.avgPrice : null;
+}
+
+function weightedAvgPrice(
+  running: ExecutedOrder,
+  runningQty: number,
+  fill: ExecutedOrder,
+  fillQty: number,
+): number | null {
+  const priced: Array<[number, number]> = [];
+  const runningPrice = usablePrice(running);
+  const fillPrice = usablePrice(fill);
+  if (runningPrice != null) priced.push([runningPrice, runningQty]);
+  if (fillPrice != null) priced.push([fillPrice, fillQty]);
+  if (priced.length === 0) return null;
+  const shares = priced.reduce((total, [, qty]) => total + qty, 0);
+  if (shares <= 0) return priced[priced.length - 1][0];
+  return priced.reduce((total, [price, qty]) => total + price * qty, 0) / shares;
+}
+
 /** Persist the seen set, bounded to the newest MAX_SEEN_KEYS entries. */
 export function saveSeen(storage: SeenStorage, seen: Set<string>): void {
   try {

--- a/web/lib/useFillToasts.ts
+++ b/web/lib/useFillToasts.ts
@@ -4,10 +4,13 @@ import { useEffect, useRef } from "react";
 import type { OrdersData } from "./types";
 import type { ToastType } from "./useToast";
 import { shouldMarkDemoSignup } from "./demo/demoSignup";
+import type { ExecutedOrder } from "./types";
 import {
   diffNewFills,
   execKey,
+  fillGroupKey,
   formatFillToast,
+  mergeFill,
   hasSeenBaseline,
   loadSeen,
   primeSeen,
@@ -41,11 +44,14 @@ function safeSessionStorage(): SeenStorage | null {
  */
 export function useFillToasts(
   orders: OrdersData | null,
-  addToast: (type: ToastType, message: string, duration?: number) => string,
+  upsertToast: (key: string, type: ToastType, message: string, duration?: number) => string,
   onNewFills?: () => void,
 ): void {
   const primedRef = useRef(false);
   const seenRef = useRef<Set<string>>(new Set());
+  // Running total per order, so a partial-fill sequence rewrites one toast
+  // instead of stacking one per execution.
+  const groupsRef = useRef<Map<string, ExecutedOrder>>(new Map());
   // Read through a ref so a caller passing an inline closure cannot re-run the
   // diff effect (and re-fire the producer sync) on every render.
   const onNewFillsRef = useRef(onNewFills);
@@ -75,7 +81,10 @@ export function useFillToasts(
     const fresh = diffNewFills(seenRef.current, executed);
     if (fresh.length === 0) return;
     for (const fill of fresh) {
-      addToast("success", formatFillToast(fill), 0);
+      const group = fillGroupKey(fill);
+      const running = mergeFill(groupsRef.current.get(group) ?? null, fill);
+      groupsRef.current.set(group, running);
+      upsertToast(group, "success", formatFillToast(running), 0);
       const key = execKey(fill);
       if (key) seenRef.current.add(key);
     }
@@ -84,5 +93,5 @@ export function useFillToasts(
     // Without this the positions table waited on its own producer timer and
     // rendered pre-fill state underneath a FILLED toast.
     onNewFillsRef.current?.();
-  }, [orders, addToast]);
+  }, [orders, upsertToast]);
 }

--- a/web/lib/useToast.ts
+++ b/web/lib/useToast.ts
@@ -10,6 +10,8 @@ export type Toast = {
   message: string;
   /** auto-dismiss delay in ms (default 5000, 0 = manual) */
   duration?: number;
+  /** coalescing identity — a later upsert with the same key updates in place */
+  key?: string;
 };
 
 let nextId = 0;
@@ -20,6 +22,16 @@ export function useToast() {
   const [toasts, setToasts] = useState<Toast[]>([]);
   const [exitingIds, setExitingIds] = useState<Set<string>>(new Set());
   const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  // Live toast id per coalescing key. An entry is dropped the moment its toast
+  // starts leaving, so the next upsert opens a fresh toast instead of writing
+  // into one the operator already dismissed.
+  const keyedIdsRef = useRef<Map<string, string>>(new Map());
+
+  const forgetKey = useCallback((id: string) => {
+    for (const [key, keyedId] of keyedIdsRef.current) {
+      if (keyedId === id) keyedIdsRef.current.delete(key);
+    }
+  }, []);
 
   const removeToast = useCallback((id: string) => {
     const timer = timersRef.current.get(id);
@@ -27,10 +39,12 @@ export function useToast() {
       clearTimeout(timer);
       timersRef.current.delete(id);
     }
+    forgetKey(id);
     setToasts((prev) => prev.filter((t) => t.id !== id));
-  }, []);
+  }, [forgetKey]);
 
   const dismissToast = useCallback((id: string) => {
+    forgetKey(id);
     setExitingIds((prev) => new Set(prev).add(id));
     setTimeout(() => {
       setToasts((prev) => prev.filter((t) => t.id !== id));
@@ -40,27 +54,51 @@ export function useToast() {
         return n;
       });
     }, EXIT_MS);
-  }, []);
+  }, [forgetKey]);
 
-  const addToast = useCallback(
-    (type: ToastType, message: string, duration = 5000) => {
-      const id = `toast-${++nextId}`;
-      const toast: Toast = { id, type, message, duration };
-
-      setToasts((prev) => [...prev, toast]);
-
-      if (duration > 0) {
-        const timer = setTimeout(() => {
-          timersRef.current.delete(id);
-          dismissToast(id);
-        }, duration);
-        timersRef.current.set(id, timer);
-      }
-
-      return id;
+  const scheduleDismiss = useCallback(
+    (id: string, duration: number) => {
+      const existing = timersRef.current.get(id);
+      if (existing) clearTimeout(existing);
+      timersRef.current.delete(id);
+      if (duration <= 0) return;
+      const timer = setTimeout(() => {
+        timersRef.current.delete(id);
+        dismissToast(id);
+      }, duration);
+      timersRef.current.set(id, timer);
     },
     [dismissToast],
   );
 
-  return { toasts, exitingIds, addToast, dismissToast, removeToast };
+  const addToast = useCallback(
+    (type: ToastType, message: string, duration = 5000, key?: string) => {
+      const id = `toast-${++nextId}`;
+      setToasts((prev) => [...prev, { id, type, message, duration, key }]);
+      if (key) keyedIdsRef.current.set(key, id);
+      scheduleDismiss(id, duration);
+      return id;
+    },
+    [scheduleDismiss],
+  );
+
+  /**
+   * Raise a toast for `key`, or rewrite the one already on screen for it. A
+   * sequence of partial fills for one order therefore reads as a single toast
+   * whose quantity and price climb, not as a stack of near-identical rows.
+   */
+  const upsertToast = useCallback(
+    (key: string, type: ToastType, message: string, duration = 5000) => {
+      const liveId = keyedIdsRef.current.get(key);
+      if (!liveId) return addToast(type, message, duration, key);
+      setToasts((prev) =>
+        prev.map((t) => (t.id === liveId ? { ...t, type, message, duration } : t)),
+      );
+      scheduleDismiss(liveId, duration);
+      return liveId;
+    },
+    [addToast, scheduleDismiss],
+  );
+
+  return { toasts, exitingIds, addToast, upsertToast, dismissToast, removeToast };
 }

--- a/web/tests/fill-toasts-hook.test.tsx
+++ b/web/tests/fill-toasts-hook.test.tsx
@@ -61,9 +61,9 @@ const BASELINE = [
 
 type HookProps = { orders: OrdersData | null };
 
-function mountHook(addToast: ReturnType<typeof vi.fn>, initialOrders: OrdersData | null = null) {
+function mountHook(upsertToast: ReturnType<typeof vi.fn>, initialOrders: OrdersData | null = null) {
   return renderHook(
-    ({ orders }: HookProps) => useFillToasts(orders, addToast as never),
+    ({ orders }: HookProps) => useFillToasts(orders, upsertToast as never),
     { initialProps: { orders: initialOrders } },
   );
 }
@@ -78,27 +78,27 @@ describe("useFillToasts", () => {
   });
 
   it("does not toast the first non-null payload (baseline snapshot)", () => {
-    const addToast = vi.fn();
-    const { rerender } = mountHook(addToast);
+    const upsertToast = vi.fn();
+    const { rerender } = mountHook(upsertToast);
     rerender({ orders: makeOrders(BASELINE) });
-    expect(addToast).not.toHaveBeenCalled();
+    expect(upsertToast).not.toHaveBeenCalled();
   });
 
   it("toasts exactly once for a new fill, persistent (duration 0)", () => {
-    const addToast = vi.fn();
-    const { rerender } = mountHook(addToast);
+    const upsertToast = vi.fn();
+    const { rerender } = mountHook(upsertToast);
     rerender({ orders: makeOrders(BASELINE) });
 
     const newFill = makeFill({ execId: "b.9.01" });
     rerender({ orders: makeOrders([...BASELINE, newFill]) });
 
-    expect(addToast).toHaveBeenCalledTimes(1);
-    expect(addToast).toHaveBeenCalledWith("success", "FILLED · SELL 25x EWY $175C @ $4.55", 0);
+    expect(upsertToast).toHaveBeenCalledTimes(1);
+    expect(upsertToast).toHaveBeenCalledWith(expect.any(String), "success", "FILLED · SELL 25x EWY $175C @ $4.55", 0);
   });
 
   it("does not re-toast on rerender with identical data", () => {
-    const addToast = vi.fn();
-    const { rerender } = mountHook(addToast);
+    const upsertToast = vi.fn();
+    const { rerender } = mountHook(upsertToast);
     rerender({ orders: makeOrders(BASELINE) });
 
     const withNew = [...BASELINE, makeFill({ execId: "b.9.01" })];
@@ -106,61 +106,91 @@ describe("useFillToasts", () => {
     rerender({ orders: makeOrders(withNew) });
     rerender({ orders: makeOrders(withNew) });
 
-    expect(addToast).toHaveBeenCalledTimes(1);
+    expect(upsertToast).toHaveBeenCalledTimes(1);
   });
 
   it("does not re-toast a seen fill after unmount + remount (sessionStorage survival)", () => {
-    const addToast = vi.fn();
-    const first = mountHook(addToast);
+    const upsertToast = vi.fn();
+    const first = mountHook(upsertToast);
     first.rerender({ orders: makeOrders(BASELINE) });
     const newFill = makeFill({ execId: "b.9.01" });
     first.rerender({ orders: makeOrders([...BASELINE, newFill]) });
-    expect(addToast).toHaveBeenCalledTimes(1);
+    expect(upsertToast).toHaveBeenCalledTimes(1);
     first.unmount();
 
-    const addToast2 = vi.fn();
-    const second = mountHook(addToast2);
+    const upsertToast2 = vi.fn();
+    const second = mountHook(upsertToast2);
     second.rerender({ orders: makeOrders([...BASELINE, newFill]) });
-    expect(addToast2).not.toHaveBeenCalled();
+    expect(upsertToast2).not.toHaveBeenCalled();
   });
 
   it("toasts a fill that landed while unmounted (route-nav does not swallow fills)", () => {
-    const addToast = vi.fn();
-    const first = mountHook(addToast);
+    const upsertToast = vi.fn();
+    const first = mountHook(upsertToast);
     first.rerender({ orders: makeOrders(BASELINE) });
-    expect(addToast).not.toHaveBeenCalled();
+    expect(upsertToast).not.toHaveBeenCalled();
     first.unmount();
 
     // Fill executes during navigation; the remounted hook's FIRST payload
     // already contains it. A re-prime would silently absorb it.
     const midNavFill = makeFill({ execId: "c.7.01" });
-    const addToast2 = vi.fn();
-    const second = mountHook(addToast2);
+    const upsertToast2 = vi.fn();
+    const second = mountHook(upsertToast2);
     second.rerender({ orders: makeOrders([...BASELINE, midNavFill]) });
 
-    expect(addToast2).toHaveBeenCalledTimes(1);
-    expect(addToast2).toHaveBeenCalledWith("success", "FILLED · SELL 25x EWY $175C @ $4.55", 0);
+    expect(upsertToast2).toHaveBeenCalledTimes(1);
+    expect(upsertToast2).toHaveBeenCalledWith(expect.any(String), "success", "FILLED · SELL 25x EWY $175C @ $4.55", 0);
   });
 
   it("does not re-toast seen fills after orders transitions to null and back", () => {
-    const addToast = vi.fn();
-    const { rerender } = mountHook(addToast);
+    const upsertToast = vi.fn();
+    const { rerender } = mountHook(upsertToast);
     rerender({ orders: makeOrders(BASELINE) });
     const withNew = [...BASELINE, makeFill({ execId: "b.9.01" })];
     rerender({ orders: makeOrders(withNew) });
-    expect(addToast).toHaveBeenCalledTimes(1);
+    expect(upsertToast).toHaveBeenCalledTimes(1);
 
     rerender({ orders: null });
     rerender({ orders: makeOrders(withNew) });
-    expect(addToast).toHaveBeenCalledTimes(1);
+    expect(upsertToast).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces partial fills of one order into a single accumulating toast", () => {
+    const upsertToast = vi.fn();
+    const { rerender } = mountHook(upsertToast);
+    rerender({ orders: makeOrders(BASELINE) });
+
+    const first = makeFill({ execId: "p.1.01", orderId: 77, quantity: 10, avgPrice: 4.5 });
+    rerender({ orders: makeOrders([...BASELINE, first]) });
+    const second = makeFill({ execId: "p.2.01", orderId: 77, quantity: 15, avgPrice: 4.6 });
+    rerender({ orders: makeOrders([...BASELINE, first, second]) });
+
+    expect(upsertToast).toHaveBeenCalledTimes(2);
+    const [firstKey] = upsertToast.mock.calls[0] as [string];
+    const [secondKey, , message] = upsertToast.mock.calls[1] as [string, string, string];
+    expect(secondKey).toBe(firstKey);
+    expect(message).toBe("FILLED · SELL 25x EWY $175C @ $4.56");
+  });
+
+  it("keeps separate orders on separate toasts", () => {
+    const upsertToast = vi.fn();
+    const { rerender } = mountHook(upsertToast);
+    rerender({ orders: makeOrders(BASELINE) });
+
+    const a = makeFill({ execId: "q.1.01", orderId: 11 });
+    const b = makeFill({ execId: "q.2.01", orderId: 12 });
+    rerender({ orders: makeOrders([...BASELINE, a, b]) });
+
+    const keys = upsertToast.mock.calls.map((call) => call[0] as string);
+    expect(new Set(keys).size).toBe(2);
   });
 
   it("never toasts in demo mode", () => {
     vi.stubEnv("NEXT_PUBLIC_RADON_DEMO", "1");
-    const addToast = vi.fn();
-    const { rerender } = mountHook(addToast);
+    const upsertToast = vi.fn();
+    const { rerender } = mountHook(upsertToast);
     rerender({ orders: makeOrders(BASELINE) });
     rerender({ orders: makeOrders([...BASELINE, makeFill({ execId: "b.9.01" })]) });
-    expect(addToast).not.toHaveBeenCalled();
+    expect(upsertToast).not.toHaveBeenCalled();
   });
 });

--- a/web/tests/fill-toasts.test.ts
+++ b/web/tests/fill-toasts.test.ts
@@ -13,8 +13,10 @@ import {
   SEEN_STORAGE_KEY,
   diffNewFills,
   execKey,
+  fillGroupKey,
   formatFillToast,
   loadSeen,
+  mergeFill,
   primeSeen,
   saveSeen,
 } from "../lib/fillToasts";
@@ -195,5 +197,59 @@ describe("loadSeen / saveSeen", () => {
     const storage = new FakeStorage();
     storage.setItem(SEEN_STORAGE_KEY, JSON.stringify({ nope: true }));
     expect(loadSeen(storage).size).toBe(0);
+  });
+});
+
+describe("fillGroupKey", () => {
+  it("groups partial fills of one order together", () => {
+    expect(fillGroupKey(makeFill({ execId: "a.1.01", orderId: 42 }))).toBe(
+      fillGroupKey(makeFill({ execId: "a.2.01", orderId: 42 })),
+    );
+  });
+
+  it("separates distinct orders", () => {
+    expect(fillGroupKey(makeFill({ orderId: 42 }))).not.toBe(
+      fillGroupKey(makeFill({ orderId: 43 })),
+    );
+  });
+
+  it("falls back to instrument and side when the row carries no order id", () => {
+    expect(fillGroupKey(makeFill())).toBe(fillGroupKey(makeFill({ execId: "z.9.01" })));
+    expect(fillGroupKey(makeFill())).not.toBe(fillGroupKey(makeFill({ side: "BOT" })));
+  });
+});
+
+describe("mergeFill", () => {
+  it("returns the fill unchanged when nothing is running yet", () => {
+    const fill = makeFill({ quantity: 10, avgPrice: 4.5 });
+    expect(mergeFill(null, fill)).toBe(fill);
+  });
+
+  it("sums quantity and share-weights the price", () => {
+    const merged = mergeFill(
+      makeFill({ quantity: 10, avgPrice: 4.5 }),
+      makeFill({ quantity: 15, avgPrice: 4.6 }),
+    );
+    expect(merged.quantity).toBe(25);
+    expect(merged.avgPrice).toBeCloseTo(4.56, 10);
+    expect(formatFillToast(merged)).toBe("FILLED · SELL 25x EWY $175C @ $4.56");
+  });
+
+  it("keeps the reported price when the other side has none", () => {
+    const merged = mergeFill(
+      makeFill({ quantity: 10, avgPrice: null }),
+      makeFill({ quantity: 5, avgPrice: 4.2 }),
+    );
+    expect(merged.quantity).toBe(15);
+    expect(merged.avgPrice).toBeCloseTo(4.2, 10);
+  });
+
+  it("yields a null price when neither fill reports one", () => {
+    const merged = mergeFill(
+      makeFill({ quantity: 10, avgPrice: null }),
+      makeFill({ quantity: 5, avgPrice: null }),
+    );
+    expect(merged.avgPrice).toBeNull();
+    expect(formatFillToast(merged)).toBe("FILLED · SELL 15x EWY $175C");
   });
 });

--- a/web/tests/iv-spread-api.test.ts
+++ b/web/tests/iv-spread-api.test.ts
@@ -271,7 +271,12 @@ describe("GET /api/iv-spread — absent and stale data are 200, never 4xx", () =
 
 describe("GET /api/iv-spread — degradation passes through untransformed", () => {
   it("passes a stale_source payload through verbatim", async () => {
-    await insertSnapshot(buildPayload({ status: "stale_source" }));
+    // A stale_source payload's freshness rides `as_of`, not `scan_time`, so
+    // this fixture must be window-relative: the hardcoded default rotted out
+    // of the 48h budget two days after it was written and collapsed the
+    // response to the missing shape.
+    const today = new Date().toISOString().slice(0, 10);
+    await insertSnapshot(buildPayload({ status: "stale_source", as_of: today }));
 
     const { GET } = await import("../app/api/iv-spread/route");
     const body = await (await GET()).json();

--- a/web/tests/use-toast-upsert.test.tsx
+++ b/web/tests/use-toast-upsert.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Keyed toast coalescing (web/lib/useToast.ts).
+ *
+ * Covers: one toast per key with in-place message updates, independence
+ * between keys, auto-dismiss timer restart on update, and a dismissed toast
+ * not being resurrected by a later update for the same key.
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useToast } from "../lib/useToast";
+
+describe("useToast upsertToast", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("updates the existing toast for a key instead of stacking a new one", () => {
+    const { result } = renderHook(() => useToast());
+
+    act(() => {
+      result.current.upsertToast("order:77", "success", "FILLED · SELL 10x EWY $175C @ $4.50", 0);
+    });
+    act(() => {
+      result.current.upsertToast("order:77", "success", "FILLED · SELL 25x EWY $175C @ $4.56", 0);
+    });
+
+    expect(result.current.toasts).toHaveLength(1);
+    expect(result.current.toasts[0].message).toBe("FILLED · SELL 25x EWY $175C @ $4.56");
+  });
+
+  it("keeps a stable id across updates so the toast does not re-animate", () => {
+    const { result } = renderHook(() => useToast());
+
+    let firstId = "";
+    act(() => {
+      firstId = result.current.upsertToast("order:77", "success", "one", 0);
+    });
+    let secondId = "";
+    act(() => {
+      secondId = result.current.upsertToast("order:77", "success", "two", 0);
+    });
+
+    expect(secondId).toBe(firstId);
+  });
+
+  it("keeps separate keys on separate toasts", () => {
+    const { result } = renderHook(() => useToast());
+
+    act(() => {
+      result.current.upsertToast("order:11", "success", "one", 0);
+      result.current.upsertToast("order:12", "success", "two", 0);
+    });
+
+    expect(result.current.toasts.map((t) => t.message)).toEqual(["one", "two"]);
+  });
+
+  it("restarts the auto-dismiss timer on update", () => {
+    const { result } = renderHook(() => useToast());
+
+    act(() => {
+      result.current.upsertToast("order:77", "success", "one", 5000);
+    });
+    act(() => {
+      vi.advanceTimersByTime(4000);
+      result.current.upsertToast("order:77", "success", "two", 5000);
+    });
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+
+    expect(result.current.toasts).toHaveLength(1);
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current.toasts).toHaveLength(0);
+  });
+
+  it("opens a fresh toast after the operator dismissed the previous one", () => {
+    const { result } = renderHook(() => useToast());
+
+    act(() => {
+      result.current.upsertToast("order:77", "success", "one", 0);
+    });
+    act(() => {
+      result.current.dismissToast(result.current.toasts[0].id);
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current.toasts).toHaveLength(0);
+
+    act(() => {
+      result.current.upsertToast("order:77", "success", "two", 0);
+    });
+    expect(result.current.toasts.map((t) => t.message)).toEqual(["two"]);
+  });
+});


### PR DESCRIPTION
## Problem

A partially-filled order arrives from IB as one execution row per tranche, and each row raised its own persistent `FILLED` toast. A single order therefore stacked a column of near-identical toasts the operator had to dismiss one by one.

## Change

- **Keyed toasts** (`web/lib/useToast.ts`). `upsertToast(key, type, message, duration)` rewrites the toast already on screen for that key instead of appending: stable id (no re-animation), restarted auto-dismiss timer. The key is dropped the moment its toast starts leaving, so a dismissed toast is never resurrected by a later update.
- **Per-order grouping** (`web/lib/fillToasts.ts`). `fillGroupKey` keys on `orderId`, then `permId`, falling back to instrument + side. `mergeFill` keeps the running total: quantity summed, price share-weighted, a priceless tranche contributing quantity only.
- **`useFillToasts`** holds one running aggregate per group and upserts, so one order shows one toast whose quantity and average price climb as the tranches land.

## Verification

- `8282 passed, 0 failed` (full `web/tests` suite)
- `tsc --noEmit` clean, ESLint clean (pre-commit gate)
- New coverage: `web/tests/use-toast-upsert.test.tsx` (keyed upsert semantics, timer restart, dismissed-then-reopened), coalescing cases in `fill-toasts-hook.test.tsx`, `fillGroupKey` / `mergeFill` units in `fill-toasts.test.ts`
- Not verified live in the browser: reproducing needs a real partial-fill sequence during RTH

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7HW9QiKZ2DuuURj8LGVHq