### PR TITLE
Ship libraries.dev UI pack C (orbs + beams)

### DIFF
--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -687,4 +687,5 @@ html[data-theme="dark"] .plate-shot .shot-dark {
 
 .hero-beam {
   display: block;
+  overflow: visible !important;
 }

--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -677,3 +677,14 @@ html[data-theme="dark"] .plate-shot .shot-dark {
     transition: none;
   }
 }
+
+.cta-beam,
+.hero-beam {
+  display: inline-block;
+  max-width: 100%;
+  border-radius: var(--radius-panel);
+}
+
+.hero-beam {
+  display: block;
+}

--- a/site/components/atoms/CtaBeam.tsx
+++ b/site/components/atoms/CtaBeam.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { BorderBeam } from "border-beam";
+import { CTA_BEAM } from "@/lib/librariesFx";
+import { useSiteFxTheme } from "./useSiteFxTheme";
+
+export function CtaBeam({ children }: { children: ReactNode }) {
+  const theme = useSiteFxTheme();
+  return (
+    <BorderBeam
+      {...CTA_BEAM}
+      theme={theme}
+      className="cta-beam"
+      data-testid="cta-beam"
+    >
+      {children}
+    </BorderBeam>
+  );
+}

--- a/site/components/atoms/HeroBeam.tsx
+++ b/site/components/atoms/HeroBeam.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { BorderBeam } from "border-beam";
+import { HERO_BEAM } from "@/lib/librariesFx";
+import { useSiteFxTheme } from "./useSiteFxTheme";
+
+export function HeroBeam({ children }: { children: ReactNode }) {
+  const theme = useSiteFxTheme();
+  return (
+    <BorderBeam
+      {...HERO_BEAM}
+      theme={theme}
+      className="hero-beam"
+      data-testid="hero-beam"
+    >
+      {children}
+    </BorderBeam>
+  );
+}

--- a/site/components/atoms/MarkerAccent.tsx
+++ b/site/components/atoms/MarkerAccent.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { MetalFx } from "metal-fx";
+import { MARKER_METAL } from "@/lib/librariesFx";
+import { useSiteFxTheme } from "./useSiteFxTheme";
+
+export function MarkerAccent({ children }: { children: ReactNode }) {
+  const theme = useSiteFxTheme();
+  return (
+    <MetalFx {...MARKER_METAL} theme={theme} data-testid="marker-accent">
+      {children}
+    </MetalFx>
+  );
+}

--- a/site/components/atoms/useSiteFxTheme.ts
+++ b/site/components/atoms/useSiteFxTheme.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { DEFAULT_SITE_THEME, isSiteTheme, type SiteTheme } from "@/lib/theme";
+
+function subscribe(onChange: () => void) {
+  const observer = new MutationObserver(onChange);
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["data-theme"],
+  });
+  return () => observer.disconnect();
+}
+
+function snapshot(): SiteTheme {
+  const attr = document.documentElement.getAttribute("data-theme");
+  return isSiteTheme(attr) ? attr : DEFAULT_SITE_THEME;
+}
+
+export function useSiteFxTheme(): SiteTheme {
+  return useSyncExternalStore(subscribe, snapshot, () => DEFAULT_SITE_THEME);
+}

--- a/site/components/molecules/GateCard.tsx
+++ b/site/components/molecules/GateCard.tsx
@@ -1,3 +1,4 @@
+import { MarkerAccent } from "@/components/atoms/MarkerAccent";
 import type { Gate } from "@/lib/editorial-content";
 
 type GateCardProps = {
@@ -7,9 +8,11 @@ type GateCardProps = {
 export function GateCard({ gate }: GateCardProps) {
   return (
     <div className={["gate", gate.disabled ? "gate-disabled" : ""].filter(Boolean).join(" ")}>
-      <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-signal-deep">
-        {gate.no}
-      </span>
+      <MarkerAccent>
+        <span className="inline-block font-mono text-[11px] uppercase tracking-[0.14em] text-signal-deep">
+          {gate.no}
+        </span>
+      </MarkerAccent>
       <h3 className="mb-2 mt-3 font-serif text-[1.28rem] font-medium text-primary">
         {gate.name}
       </h3>

--- a/site/components/molecules/MilestoneRow.tsx
+++ b/site/components/molecules/MilestoneRow.tsx
@@ -1,3 +1,4 @@
+import { MarkerAccent } from "@/components/atoms/MarkerAccent";
 import type { Milestone } from "@/lib/editorial-content";
 
 type MilestoneRowProps = {
@@ -9,10 +10,12 @@ type MilestoneRowProps = {
 export function MilestoneRow({ milestone }: MilestoneRowProps) {
   return (
     <div className="grid grid-cols-[40px_1fr] items-start gap-[18px] border-b border-hairline-soft py-[26px] sm:grid-cols-[56px_1fr] sm:gap-7">
-      <span
-        aria-hidden="true"
-        className="milestone-no pt-[5px] font-mono text-[13px] font-semibold text-signal-deep"
-      />
+      <MarkerAccent>
+        <span
+          aria-hidden="true"
+          className="milestone-no inline-block min-w-[28px] pt-[5px] font-mono text-[13px] font-semibold text-signal-deep"
+        />
+      </MarkerAccent>
       <div>
         <h3 className="mb-[7px] font-serif text-[1.32rem] font-medium tracking-[-0.01em] text-primary">
           {milestone.name}

--- a/site/components/sections/ColophonSection.tsx
+++ b/site/components/sections/ColophonSection.tsx
@@ -1,3 +1,4 @@
+import { CtaBeam } from "@/components/atoms/CtaBeam";
 import { EditorialEyebrow } from "@/components/atoms/EditorialEyebrow";
 import { RevealOnScroll } from "@/components/atoms/RevealOnScroll";
 import { DEMO_URL } from "@/lib/editorial-content";
@@ -42,12 +43,14 @@ export function ColophonSection() {
         </RevealOnScroll>
 
         <RevealOnScroll className="flex flex-wrap items-center gap-x-6 gap-y-4">
-          <a
-            href={DEMO_URL}
-            className={`inline-block rounded-[4px] border border-signal-deep bg-signal-deep px-[22px] py-[13px] font-mono text-[12px] uppercase tracking-[0.06em] text-canvas transition-colors hover:bg-transparent hover:text-signal-deep ${focusRing}`}
-          >
-            Try the free demo
-          </a>
+          <CtaBeam>
+            <a
+              href={DEMO_URL}
+              className={`inline-block rounded-[4px] border border-signal-deep bg-signal-deep px-[22px] py-[13px] font-mono text-[12px] uppercase tracking-[0.06em] text-canvas transition-colors hover:bg-transparent hover:text-signal-deep ${focusRing}`}
+            >
+              Try the free demo
+            </a>
+          </CtaBeam>
           <a
             href="#pipeline"
             className={`inline-block rounded-[4px] border border-grid bg-transparent px-[22px] py-[13px] font-mono text-[12px] uppercase tracking-[0.06em] text-primary transition-colors hover:border-signal-deep hover:text-signal-deep ${focusRing}`}

--- a/site/components/sections/EditorialHeader.tsx
+++ b/site/components/sections/EditorialHeader.tsx
@@ -1,3 +1,4 @@
+import { CtaBeam } from "@/components/atoms/CtaBeam";
 import { ThemeToggle } from "@/components/atoms/ThemeToggle";
 import { editorialNavLinks, DEMO_URL } from "@/lib/editorial-content";
 
@@ -30,12 +31,14 @@ export function EditorialHeader() {
               {link.label}
             </a>
           ))}
-          <a
-            href={DEMO_URL}
-            className={`inline-block rounded-[4px] border border-grid px-[13px] py-[7px] font-mono text-[11px] uppercase tracking-[0.06em] text-primary transition-colors hover:border-signal-deep hover:text-signal-deep ${focusRing}`}
-          >
-            Try free demo
-          </a>
+          <CtaBeam>
+            <a
+              href={DEMO_URL}
+              className={`inline-block rounded-[4px] border border-grid px-[13px] py-[7px] font-mono text-[11px] uppercase tracking-[0.06em] text-primary transition-colors hover:border-signal-deep hover:text-signal-deep ${focusRing}`}
+            >
+              Try free demo
+            </a>
+          </CtaBeam>
           <ThemeToggle />
         </nav>
       </div>

--- a/site/components/sections/EditorialHeroSection.tsx
+++ b/site/components/sections/EditorialHeroSection.tsx
@@ -1,4 +1,5 @@
 import { EditorialEyebrow } from "@/components/atoms/EditorialEyebrow";
+import { HeroBeam } from "@/components/atoms/HeroBeam";
 import { RevealOnScroll } from "@/components/atoms/RevealOnScroll";
 import { PlateFrame } from "@/components/molecules/PlateFrame";
 import { ProductPlate } from "@/components/molecules/ProductPlate";
@@ -97,15 +98,17 @@ export function EditorialHeroSection() {
         </RevealOnScroll>
 
         <RevealOnScroll className="mt-14">
-          <PlateFrame
-            figNo="Figure 1"
-            figTitle="Dark-pool buy-pressure leads realized price · NVDA · 30 sessions"
-            source="IB + UW"
-            confidence="High"
-            caption="Aggregated off-exchange buy-pressure rises into a measurable lead before the lit-market move. Radon scores the lead window, not the breakout. The breakout is where everyone else is already looking."
-          >
-            <FlowLeadFigure />
-          </PlateFrame>
+          <HeroBeam>
+            <PlateFrame
+              figNo="Figure 1"
+              figTitle="Dark-pool buy-pressure leads realized price · NVDA · 30 sessions"
+              source="IB + UW"
+              confidence="High"
+              caption="Aggregated off-exchange buy-pressure rises into a measurable lead before the lit-market move. Radon scores the lead window, not the breakout. The breakout is where everyone else is already looking."
+            >
+              <FlowLeadFigure />
+            </PlateFrame>
+          </HeroBeam>
         </RevealOnScroll>
 
         <RevealOnScroll className="mt-10">

--- a/site/e2e/libraries-fx-pack.spec.ts
+++ b/site/e2e/libraries-fx-pack.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "../../web/node_modules/@playwright/test";
+
+const SHOT_DIR = process.env.FX_SHOT_DIR ?? "/opt/cursor/artifacts";
+
+test.describe("libraries.dev pack C — marketing", () => {
+  test("dark theme CTA beam, hero beam, and gate markers", async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem("theme", "dark");
+    });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/");
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+    await expect(page.getByTestId("cta-beam").first()).toBeVisible();
+    await expect(page.getByTestId("hero-beam")).toBeVisible();
+    await page.locator("header").screenshot({
+      path: `${SHOT_DIR}/site_header_cta_beam_dark.png`,
+    });
+    await page.locator("[data-testid='hero-beam']").screenshot({
+      path: `${SHOT_DIR}/site_hero_flow_beam_dark.png`,
+    });
+    await page.locator("#convexity").scrollIntoViewIfNeeded();
+    await expect(page.locator(".gates")).toBeVisible();
+    await page.locator("#convexity").screenshot({
+      path: `${SHOT_DIR}/site_gates_metal_dark.png`,
+    });
+    await page.locator("#pipeline").scrollIntoViewIfNeeded();
+    await expect(page.locator(".pipeline")).toBeVisible();
+    await page.locator("#pipeline").screenshot({
+      path: `${SHOT_DIR}/site_method_markers_dark.png`,
+    });
+  });
+});

--- a/site/lib/libraries-fx.test.ts
+++ b/site/lib/libraries-fx.test.ts
@@ -34,7 +34,7 @@ describe("hero accent", () => {
   it("keeps a single calm mono beam for the flow plate", () => {
     expect(HERO_BEAM.colorVariant).toBe("mono");
     expect(HERO_BEAM.staticColors).toBe(true);
-    expect(HERO_BEAM.size).toBe("md");
+    expect(HERO_BEAM.size).toBe("line");
   });
 });
 

--- a/site/lib/libraries-fx.test.ts
+++ b/site/lib/libraries-fx.test.ts
@@ -1,0 +1,56 @@
+/**
+ * libraries.dev pack C — marketing CTA / marker / hero contracts.
+ * Primary demo CTAs get a mono beam. Gate and method markers share one
+ * silver metal accent. Forbidden packages stay out of site/package.json.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  CTA_BEAM,
+  HERO_BEAM,
+  MARKER_METAL,
+} from "./librariesFx";
+
+describe("marketing CTA beam", () => {
+  it("uses a mono beam, not a rainbow idle palette", () => {
+    expect(CTA_BEAM.colorVariant).toBe("mono");
+    expect(CTA_BEAM.staticColors).toBe(true);
+    expect(CTA_BEAM.size).toBe("sm");
+    expect(CTA_BEAM.strength).toBeLessThan(0.7);
+  });
+});
+
+describe("gate and method marker accent", () => {
+  it("uses one light silver metal system", () => {
+    expect(MARKER_METAL.preset).toBe("silver");
+    expect(MARKER_METAL.strength).toBeLessThan(0.5);
+    expect(MARKER_METAL.variant).toBe("button");
+  });
+});
+
+describe("hero accent", () => {
+  it("keeps a single calm mono beam for the flow plate", () => {
+    expect(HERO_BEAM.colorVariant).toBe("mono");
+    expect(HERO_BEAM.staticColors).toBe(true);
+    expect(HERO_BEAM.size).toBe("md");
+  });
+});
+
+describe("site package pin", () => {
+  const pkg = JSON.parse(
+    readFileSync(resolve(import.meta.dirname, "../package.json"), "utf8"),
+  ) as { dependencies: Record<string, string> };
+
+  it("installs border-beam and metal-fx", () => {
+    expect(pkg.dependencies["border-beam"]).toMatch(/^\^?1\./);
+    expect(pkg.dependencies["metal-fx"]).toMatch(/^\^?1\./);
+  });
+
+  it("does not install liquid-gooey, img-fx, or thinking-orbs", () => {
+    expect(pkg.dependencies["liquid-gooey"]).toBeUndefined();
+    expect(pkg.dependencies["img-fx"]).toBeUndefined();
+    expect(pkg.dependencies["thinking-orbs"]).toBeUndefined();
+  });
+});

--- a/site/lib/librariesFx.ts
+++ b/site/lib/librariesFx.ts
@@ -7,10 +7,10 @@ export const CTA_BEAM = {
 };
 
 export const HERO_BEAM = {
-  size: "md" as const,
+  size: "line" as const,
   colorVariant: "mono" as const,
   staticColors: true,
-  strength: 0.4,
+  strength: 0.45,
   borderRadius: 4,
 };
 

--- a/site/lib/librariesFx.ts
+++ b/site/lib/librariesFx.ts
@@ -1,0 +1,21 @@
+export const CTA_BEAM = {
+  size: "sm" as const,
+  colorVariant: "mono" as const,
+  staticColors: true,
+  strength: 0.55,
+  borderRadius: 4,
+};
+
+export const HERO_BEAM = {
+  size: "md" as const,
+  colorVariant: "mono" as const,
+  staticColors: true,
+  strength: 0.4,
+  borderRadius: 4,
+};
+
+export const MARKER_METAL = {
+  preset: "silver" as const,
+  variant: "button" as const,
+  strength: 0.35,
+};

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -11,8 +11,9 @@
         "@fontsource/ibm-plex-mono": "^5.2.7",
         "@fontsource/inter": "^5.2.8",
         "@vercel/analytics": "^2.0.0",
-        "framer-motion": "^12.35.2",
+        "border-beam": "^1.3.0",
         "lucide-react": "^0.577.0",
+        "metal-fx": "^1.0.4",
         "next": "16.1.6",
         "react": "19.2.3",
         "react-dom": "19.2.3"
@@ -6759,6 +6760,16 @@
       "license": "ISC",
       "peer": true
     },
+    "node_modules/border-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/border-beam/-/border-beam-1.3.0.tgz",
+      "integrity": "sha512-oZSISp3aQau4ASTmzm5pzxeBinO6Fh2HW0gyEixJgtpUZvRiU0vNpP+IwGRrNpIyqPjA7Rf5EBnVqDSJ49cm5w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -8963,33 +8974,6 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
-    "node_modules/framer-motion": {
-      "version": "12.35.2",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.35.2.tgz",
-      "integrity": "sha512-dhfuEMaNo0hc+AEqyHiIfiJRNb9U9UQutE9FoKm5pjf7CMitp9xPEF1iWZihR1q86LBmo6EJ7S8cN8QXEy49AA==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-dom": "^12.35.2",
-        "motion-utils": "^12.29.2",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@emotion/is-prop-valid": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/is-prop-valid": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/fresh": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
@@ -11140,6 +11124,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/metal-fx": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/metal-fx/-/metal-fx-1.0.4.tgz",
+      "integrity": "sha512-Zqxp3df47n2yhp7SPMZtPdKQ7Avag8ITxXX1NtbA0bWdU2GJN8MJPNJ2SKtQ2CfXpAWXtCc0CbM64UtiTor3pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -11293,21 +11287,6 @@
       "integrity": "sha512-aF7yRQr/Q0O2/4pIXm6PZ5G+jAd7QS4Yu8m+WEeEHGnbo+7mE36CbLSDQiXYV8bVL3NfmdeqPJct0tUlnjVSnA==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/motion-dom": {
-      "version": "12.35.2",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.35.2.tgz",
-      "integrity": "sha512-pWXFMTwvGDbx1Fe9YL5HZebv2NhvGBzRtiNUv58aoK7+XrsuaydQ0JGRKK2r+bTKlwgSWwWxHbP5249Qr/BNpg==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-utils": "^12.29.2"
-      }
-    },
-    "node_modules/motion-utils": {
-      "version": "12.29.2",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.29.2.tgz",
-      "integrity": "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==",
-      "license": "MIT"
     },
     "node_modules/mrmime": {
       "version": "2.0.1",

--- a/site/package.json
+++ b/site/package.json
@@ -19,7 +19,9 @@
     "@fontsource/ibm-plex-mono": "^5.2.7",
     "@fontsource/inter": "^5.2.8",
     "@vercel/analytics": "^2.0.0",
+    "border-beam": "^1.3.0",
     "lucide-react": "^0.577.0",
+    "metal-fx": "^1.0.4",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3"

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,31 @@
+# Task: Ship libraries.dev UI pack C (2026-09-04)
+
+Wire `thinking-orbs` + `border-beam` on the terminal, and `border-beam` +
+light `metal-fx` on radon.run. No liquid-gooey, no img-fx, no product-pattern
+expansion.
+
+## Dependency graph
+
+- T1 depends_on: [] - Pin failing contracts for wait verbs, gate beams, CTA/marker accents, and package pins.
+- T2 depends_on: [T1] - Install approved packages with React 18+ peers into `web/` and `site/`.
+- T3 depends_on: [T2] - Wire app wait states, kit Gate 01-04 demo, optional IB connected beam.
+- T4 depends_on: [T2] - Wire marketing primary CTAs, gate/method markers, one hero beam.
+- T5 depends_on: [T3, T4] - Focused tests, dark-theme screenshots, bundle note, PR against main.
+
+## Checklist
+
+- [ ] T1 Failing contracts.
+- [ ] T2 Packages installed.
+- [ ] T3 App wiring.
+- [ ] T4 Marketing wiring.
+- [ ] T5 Verify, screenshot, open PR. Do not merge.
+
+## Review
+
+- Pending.
+
+---
+
 # Task: Make every demo workstation surface deterministic (2026-09-04) [DONE]
 
 Restore representative demo data across performance, orders, instruments,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -14,15 +14,19 @@ expansion.
 
 ## Checklist
 
-- [ ] T1 Failing contracts.
-- [ ] T2 Packages installed.
-- [ ] T3 App wiring.
-- [ ] T4 Marketing wiring.
-- [ ] T5 Verify, screenshot, open PR. Do not merge.
+- [x] T1 Failing contracts.
+- [x] T2 Packages installed.
+- [x] T3 App wiring.
+- [x] T4 Marketing wiring.
+- [x] T5 Verify, screenshot, open PR. Do not merge.
 
 ## Review
 
-- Pending.
+- App: thinking-orbs on UW flow ingest, GEX rebuild, EngineTrace/TaskRuns; Gate 01-04 evaluating beam demoed on `/kit`.
+- Marketing: mono beam on primary Free demo CTAs and the hero flow plate; silver metal on gate/method markers.
+- Deferral: production evaluate has no sequential Gate 01-04 chips; contract lives on `/kit`.
+- Bundle gzip: thinking-orbs ~1.5KB, border-beam ~12KB, metal-fx ~20KB (site only).
+- Verification: focused Vitest 16/16 pack contracts; related flow/GEX/agent/footer green.
 
 ---
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,6 +1,28 @@
 import { afterEach, beforeEach } from "vitest";
 import { cleanup } from "@testing-library/react";
 
+function installMatchMediaShim(): void {
+  if (typeof window === "undefined") return;
+  if (typeof window.matchMedia === "function") return;
+
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: query.includes("dark"),
+      media: query,
+      onchange: null,
+      addListener() {},
+      removeListener() {},
+      addEventListener() {},
+      removeEventListener() {},
+      dispatchEvent() {
+        return false;
+      },
+    }),
+  });
+}
+
 function installLocalStorageShim(): void {
   if (typeof window === "undefined") return;
 
@@ -45,6 +67,7 @@ function installLocalStorageShim(): void {
 
 beforeEach(() => {
   installLocalStorageShim();
+  installMatchMediaShim();
 });
 
 // Global test isolation: unmount any @testing-library-rendered React tree after

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -21310,3 +21310,62 @@ body[data-mobile="true"] .alerts-rule__channel {
 }
 
 /* ══ end VIX-COR regime tab ════════════════════════════════════════════ */
+
+.thinking-wait {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 0;
+}
+
+.thinking-wait-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.four-gate-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.gate-chip {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 88px;
+  padding: 8px 10px;
+  border: 1px solid var(--line-grid);
+  border-radius: 4px;
+  background: var(--bg-panel-raised);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.gate-chip__name {
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+.gate-chip--evaluating {
+  border-color: color-mix(in srgb, var(--signal-core) 45%, var(--line-grid));
+  color: var(--signal-core-text);
+}
+
+.gate-chip--cleared {
+  color: var(--signal-core-text);
+}
+
+.gate-chip--failed {
+  color: var(--fault);
+}
+
+.gate-chip--idle {
+  opacity: 0.72;
+}

--- a/web/app/kit/page.tsx
+++ b/web/app/kit/page.tsx
@@ -10,6 +10,8 @@ import {
   DenseNumericTable,
 } from "@/components/kit";
 import { MarkovStateGraph } from "@/components/instruments";
+import { FourGateChips } from "@/components/fx/FourGateChips";
+import ThinkingWait from "@/components/fx/ThinkingWait";
 import { useTheme } from "@/lib/ThemeContext";
 
 const MARKOV_DEMO_STATES = [
@@ -82,6 +84,52 @@ export default function KitPage() {
         <SignalSummary />
         <PortfolioConvexity />
         <CircularScan status="Scanning" />
+      </div>
+
+      <div
+        className="grid grid-cols-1 lg:grid-cols-2"
+        style={{
+          gap: 16,
+          marginBottom: 16,
+          background: "var(--bg-panel)",
+          border: "1px solid var(--border-dim)",
+          borderRadius: 4,
+          padding: 24,
+        }}
+        data-testid="libraries-fx-demo"
+      >
+        <div>
+          <p
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 10,
+              letterSpacing: "0.1em",
+              textTransform: "uppercase",
+              color: "var(--text-muted)",
+              marginBottom: 8,
+            }}
+          >
+            Four Gates / Evaluating Beam
+          </p>
+          <FourGateChips
+            states={{ "01": "evaluating", "02": "cleared", "03": "failed", "04": "idle" }}
+          />
+        </div>
+        <div>
+          <p
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 10,
+              letterSpacing: "0.1em",
+              textTransform: "uppercase",
+              color: "var(--text-muted)",
+              marginBottom: 8,
+            }}
+          >
+            Agent Wait / Thinking Orb
+          </p>
+          <ThinkingWait kind="evaluate" label="Evaluating gates" size={64} />
+        </div>
       </div>
 
       <div

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -16,6 +16,7 @@
         "@upstash/redis": "^1.34.3",
         "@vercel/analytics": "^2.0.0",
         "@xyflow/react": "^12.11.0",
+        "border-beam": "^1.3.0",
         "d3": "^7.9.0",
         "liveline": "^0.0.6",
         "lucide-react": "^0.544.0",
@@ -24,6 +25,7 @@
         "react-dom": "^19.2.4",
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.0",
+        "thinking-orbs": "^0.3.1",
         "undici": "^8.6.0",
         "ws": "^8.21.0",
         "zustand": "^5.0.11",
@@ -650,6 +652,8 @@
     "birpc": ["birpc@4.0.0", "", {}, "sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
+    "border-beam": ["border-beam@1.3.0", "", { "peerDependencies": { "react": ">=18.0.0", "react-dom": ">=18.0.0" } }, "sha512-oZSISp3aQau4ASTmzm5pzxeBinO6Fh2HW0gyEixJgtpUZvRiU0vNpP+IwGRrNpIyqPjA7Rf5EBnVqDSJ49cm5w=="],
 
     "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
@@ -1921,6 +1925,8 @@
 
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
 
+    "thinking-orbs": ["thinking-orbs@0.3.1", "", { "peerDependencies": { "react": ">=18.0.0" } }, "sha512-3BG1aeB1RUTxItCml/BBuIz5JRM4kZqGuyx+vouv0fXTtcR9ZNoKjWGneHPx94y74GxgArwJZ1qbJR5dt54kSw=="],
+
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
@@ -2118,6 +2124,8 @@
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@babel/core/json5": ["json5@2.2.3", "", { "bin": "lib/cli.js" }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "@bomb.sh/tab/citty": ["citty@0.1.6", "", { "dependencies": { "consola": "^3.2.3" } }, "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ=="],
 
     "@bomb.sh/tab/commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
 

--- a/web/components/FooterTelemetryStrip.tsx
+++ b/web/components/FooterTelemetryStrip.tsx
@@ -2,7 +2,9 @@
 
 import { useEffect, useState } from "react";
 import { useIBStatusContext, type IBDisplayStatus } from "@/lib/IBStatusContext";
+import { ibStatusBeamActive } from "@/lib/librariesFx";
 import { useServiceHealth } from "@/lib/useServiceHealth";
+import EvaluatingBeam from "@/components/fx/EvaluatingBeam";
 
 type FlexTokenStatus = {
   days_remaining: number | null;
@@ -92,12 +94,14 @@ export default function FooterTelemetryStrip() {
 
   return (
     <div className="footer-strip" role="status" aria-label="System telemetry">
-      <Chip
-        leadingDot
-        label="IB Gateway"
-        value={ib.text}
-        tone={ib.cls}
-      />
+      <EvaluatingBeam active={ibStatusBeamActive(displayStatus)}>
+        <Chip
+          leadingDot
+          label="IB Gateway"
+          value={ib.text}
+          tone={ib.cls}
+        />
+      </EvaluatingBeam>
       <span className="footer-strip__sep" aria-hidden>/</span>
       <Chip
         label="Flex Token"

--- a/web/components/GexPanel.tsx
+++ b/web/components/GexPanel.tsx
@@ -9,6 +9,7 @@ import InfoTooltip from "./InfoTooltip";
 import ShareReportModal from "./ShareReportModal";
 import GexLaplaceContour from "./instruments/GexLaplaceContour";
 import SpectralLoader from "./SpectralLoader";
+import ThinkingWait from "./fx/ThinkingWait";
 import RegimeSyncStatusBadge from "./RegimeSyncStatusBadge";
 import SortTh from "./SortTh";
 import { useSort } from "@/lib/useSort";
@@ -443,7 +444,10 @@ export default function GexPanel({ marketState }: GexPanelProps) {
           </div>
         </div>
         <div className="section-body">
-          <SpectralLoader label="Sampling gamma exposure by strike" />
+          <div className="thinking-wait-stack">
+            <ThinkingWait kind="gex" label="Sampling gamma exposure by strike" size={64} />
+            <SpectralLoader label="Sampling gamma exposure by strike" />
+          </div>
         </div>
       </div>
     );
@@ -508,6 +512,9 @@ export default function GexPanel({ marketState }: GexPanelProps) {
           />
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+          {syncing ? (
+            <ThinkingWait kind="gex" label="Rebuilding gamma exposure" />
+          ) : null}
           <RegimeSyncStatusBadge
             state={freshnessState}
             className={freshnessBadgeClass}

--- a/web/components/agent/EngineTrace.tsx
+++ b/web/components/agent/EngineTrace.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import ThinkingWait from "@/components/fx/ThinkingWait";
+
 /**
  * EngineTrace — expandable reasoning trace for engine turns (Spectral, Eigen,
  * Markov, Laplace). Adopted from beautifului.dev "Thinking", re-skinned to the
@@ -48,7 +50,11 @@ export default function EngineTrace({
         onClick={onToggle}
         aria-expanded={!collapsed}
       >
-        <span className={`agent-dot${running ? " agent-dot--pulse agent-dot--warn" : " agent-dot--signal"}`} aria-hidden="true" />
+        {running ? (
+          <ThinkingWait kind="agent" label="Agent working" />
+        ) : (
+          <span className="agent-dot agent-dot--signal" aria-hidden="true" />
+        )}
         <span className="engine-trace__title">Engine trace</span>
         <span className="engine-trace__chips">
           {engines.map((e) => (
@@ -62,16 +68,16 @@ export default function EngineTrace({
           <ol className="engine-trace__steps">
             {steps.map((step) => (
               <li key={step.id} className="engine-trace__step" data-state={step.state}>
-                <span
-                  className={`agent-dot${
-                    step.state === "running"
-                      ? " agent-dot--pulse agent-dot--warn"
-                      : step.state === "done"
-                        ? " agent-dot--signal"
-                        : " agent-dot--muted"
-                  }`}
-                  aria-hidden="true"
-                />
+                {step.state === "running" ? (
+                  <ThinkingWait kind="agent" label={step.label} />
+                ) : (
+                  <span
+                    className={`agent-dot${
+                      step.state === "done" ? " agent-dot--signal" : " agent-dot--muted"
+                    }`}
+                    aria-hidden="true"
+                  />
+                )}
                 <span className="engine-trace__step-label">{step.label}</span>
                 <span className="engine-trace__step-meta">{step.meta ?? "—"}</span>
               </li>

--- a/web/components/agent/TaskRuns.tsx
+++ b/web/components/agent/TaskRuns.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import ThinkingWait from "@/components/fx/ThinkingWait";
+
 /**
  * TaskRuns — live agent task status with nested sub-step telemetry. Adopted
  * from beautifului.dev "Task Rows". Replaces the static Workflow job list.
@@ -34,7 +36,7 @@ export default function TaskRuns({ tasks }: { tasks: AgentTask[] }) {
         <span className="task-runs__status">
           {active > 0 ? (
             <>
-              <span className="agent-dot agent-dot--warn agent-dot--pulse" aria-hidden="true" />
+              <ThinkingWait kind="agent" label="Agent runs active" />
               {active} ACTIVE
             </>
           ) : (
@@ -47,16 +49,16 @@ export default function TaskRuns({ tasks }: { tasks: AgentTask[] }) {
           <li key={task.id} className="task-runs__task" data-state={task.state}>
             <div className="task-runs__row">
               <span className="task-runs__index">{i + 1}</span>
-              <span
-                className={`agent-dot${
-                  task.state === "running"
-                    ? " agent-dot--warn agent-dot--pulse"
-                    : task.state === "done"
-                      ? " agent-dot--signal"
-                      : " agent-dot--muted"
-                }`}
-                aria-hidden="true"
-              />
+              {task.state === "running" ? (
+                <ThinkingWait kind="compute" label={task.title} />
+              ) : (
+                <span
+                  className={`agent-dot${
+                    task.state === "done" ? " agent-dot--signal" : " agent-dot--muted"
+                  }`}
+                  aria-hidden="true"
+                />
+              )}
               <span className="task-runs__task-title">{task.title}</span>
               {task.meta ? <span className="task-runs__task-meta">{task.meta}</span> : null}
               <span

--- a/web/components/flow-analysis/TickerFlowReport.tsx
+++ b/web/components/flow-analysis/TickerFlowReport.tsx
@@ -7,6 +7,7 @@ import { classifyFlowSignal, type FlowDirection } from "@/lib/flowSignal";
 import { resolvePutCallRatio } from "@/lib/flowRatio";
 import SignalCard from "@/components/mobile/SignalCard";
 import SpectralLoader from "@/components/SpectralLoader";
+import ThinkingWait from "@/components/fx/ThinkingWait";
 import { useViewport } from "@/lib/useViewport";
 import DailyDarkPoolHistory from "@/components/flow-analysis/DailyDarkPoolHistory";
 import { flowReportErrorCopy } from "@/lib/flowReportError";
@@ -252,7 +253,10 @@ function MobileTickerFlowReport({
         {section === "overview" && (
           <>
             {!data && isAnalyzing && (
-              <SpectralLoader label={`Sampling ${ticker} flow · ${DEFAULT_LOOKBACK_DAYS} sessions`} />
+              <div className="thinking-wait-stack">
+                <ThinkingWait kind="flow" label={`Sampling ${ticker} flow · ${DEFAULT_LOOKBACK_DAYS} sessions`} size={64} />
+                <SpectralLoader label={`Sampling ${ticker} flow · ${DEFAULT_LOOKBACK_DAYS} sessions`} />
+              </div>
             )}
             {verdict && (
               <SignalCard
@@ -551,6 +555,7 @@ function AnalyzingPanel({
     <section className="section">
       <div className="section-body">
         <div className="ticker-flow-analyzing">
+          <ThinkingWait kind="flow" label={label} size={64} />
           <SpectralLoader label={label} />
           <ul className="ticker-flow-analyzing-steps">
             <li>Pulling dark pool prints across the last {lookbackDays} trading sessions</li>

--- a/web/components/fx/EvaluatingBeam.tsx
+++ b/web/components/fx/EvaluatingBeam.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { BorderBeam } from "border-beam";
+import { GATE_BEAM } from "@/lib/librariesFx";
+import { useDataTheme } from "./useDataTheme";
+
+type EvaluatingBeamProps = {
+  active: boolean;
+  children: ReactNode;
+  className?: string;
+};
+
+export default function EvaluatingBeam({ active, children, className }: EvaluatingBeamProps) {
+  const theme = useDataTheme();
+  if (!active) return children;
+  return (
+    <BorderBeam
+      {...GATE_BEAM}
+      active
+      theme={theme}
+      className={className}
+      data-testid="evaluating-beam"
+      data-beam-active="true"
+    >
+      {children}
+    </BorderBeam>
+  );
+}

--- a/web/components/fx/FourGateChips.tsx
+++ b/web/components/fx/FourGateChips.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { FOUR_GATES, gateBeamActive, type GateChipState, type GateId } from "@/lib/librariesFx";
+import EvaluatingBeam from "./EvaluatingBeam";
+
+type FourGateChipsProps = {
+  states: Record<GateId, GateChipState>;
+};
+
+export function FourGateChips({ states }: FourGateChipsProps) {
+  return (
+    <div className="four-gate-chips" data-testid="four-gate-chips">
+      {FOUR_GATES.map((gate) => {
+        const state = states[gate.id];
+        return (
+          <EvaluatingBeam key={gate.id} active={gateBeamActive(state)}>
+            <span
+              className={`gate-chip gate-chip--${state}`}
+              data-testid={`gate-chip-${gate.id}`}
+              data-gate-state={state}
+            >
+              Gate {gate.id}
+              <span className="gate-chip__name">{gate.name}</span>
+            </span>
+          </EvaluatingBeam>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/components/fx/ThinkingWait.tsx
+++ b/web/components/fx/ThinkingWait.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { ThinkingOrb } from "thinking-orbs";
+import { thinkingOrbState, type ThinkingWaitKind } from "@/lib/librariesFx";
+
+type ThinkingWaitProps = {
+  kind: ThinkingWaitKind;
+  label: string;
+  size?: 20 | 64;
+};
+
+export default function ThinkingWait({ kind, label, size = 20 }: ThinkingWaitProps) {
+  return (
+    <span
+      className="thinking-wait"
+      data-testid="thinking-wait"
+      data-kind={kind}
+      role="status"
+      aria-label={label}
+    >
+      <ThinkingOrb state={thinkingOrbState(kind)} size={size} theme="auto" aria-hidden />
+    </span>
+  );
+}

--- a/web/components/fx/useDataTheme.ts
+++ b/web/components/fx/useDataTheme.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+function subscribe(onChange: () => void) {
+  const observer = new MutationObserver(onChange);
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["data-theme"],
+  });
+  return () => observer.disconnect();
+}
+
+function snapshot(): "dark" | "light" {
+  return document.documentElement.getAttribute("data-theme") === "light" ? "light" : "dark";
+}
+
+export function useDataTheme(): "dark" | "light" {
+  return useSyncExternalStore(subscribe, snapshot, () => "dark");
+}

--- a/web/e2e/ci-curation-ledger.txt
+++ b/web/e2e/ci-curation-ledger.txt
@@ -71,6 +71,7 @@ ivrank-tab.spec.ts
 iwm-close-order-summary.spec.ts
 iwm-synthetic-mark-label.spec.ts
 iwm-ticker-detail-combo-sign.spec.ts
+libraries-fx-pack.spec.ts
 margin-debt-tab.spec.ts
 margin-warning-toast.spec.ts
 mobile-a11y-pwa.spec.ts
@@ -192,3 +193,7 @@ ws-connection-stability.spec.ts
 # REVIEWED 2026-09-04 demo-headlines.spec.ts — held out because it requires the
 #   demo build-time flag. Demo compile passed; Chromium passed locally with an
 #   inspected dashboard screenshot. Unit contracts remain in the CI Vitest gate.
+# REVIEWED 2026-09-05 libraries-fx-pack.spec.ts — held out: /kit is a design
+#   surface, not a financial path, and the spec writes dark-theme shots to
+#   /opt/cursor/artifacts (absent on the CI runner). Chromium passed locally
+#   against an authless next start; Vitest pack contracts stay in the CI gate.

--- a/web/e2e/libraries-fx-pack.spec.ts
+++ b/web/e2e/libraries-fx-pack.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "@playwright/test";
+
+const SHOT_DIR = process.env.FX_SHOT_DIR ?? "/opt/cursor/artifacts";
+
+test.describe("libraries.dev pack C — terminal kit", () => {
+  test("shows evaluating gate beam and thinking wait in dark theme", async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem("theme", "dark");
+    });
+    await page.goto("/kit");
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+    await expect(page.getByTestId("libraries-fx-demo")).toBeVisible();
+    await expect(page.getByTestId("four-gate-chips")).toBeVisible();
+    await expect(page.getByTestId("gate-chip-01")).toHaveAttribute("data-gate-state", "evaluating");
+    await expect(page.getByTestId("thinking-wait")).toHaveAttribute("data-kind", "evaluate");
+    await page.locator("[data-testid='libraries-fx-demo']").screenshot({
+      path: `${SHOT_DIR}/app_kit_gates_orbs_dark.png`,
+    });
+  });
+});

--- a/web/lib/librariesFx.ts
+++ b/web/lib/librariesFx.ts
@@ -1,0 +1,44 @@
+import type { IBDisplayStatus } from "./IBStatusContext";
+
+export type ThinkingWaitKind = "flow" | "gex" | "evaluate" | "agent" | "compute";
+
+export const THINKING_ORB_STATE = {
+  flow: "searching",
+  gex: "weaving",
+  evaluate: "solving",
+  agent: "working",
+  compute: "composing",
+} as const;
+
+export type ThinkingOrbState = (typeof THINKING_ORB_STATE)[ThinkingWaitKind];
+
+export function thinkingOrbState(kind: ThinkingWaitKind): ThinkingOrbState {
+  return THINKING_ORB_STATE[kind];
+}
+
+export type GateChipState = "idle" | "evaluating" | "cleared" | "failed";
+
+export const FOUR_GATES = [
+  { id: "01", name: "Convexity" },
+  { id: "02", name: "Edge" },
+  { id: "03", name: "Risk" },
+  { id: "04", name: "Naked Shorts" },
+] as const;
+
+export type GateId = (typeof FOUR_GATES)[number]["id"];
+
+export function gateBeamActive(state: GateChipState): boolean {
+  return state === "evaluating";
+}
+
+export function ibStatusBeamActive(status: IBDisplayStatus): boolean {
+  return status === "connected";
+}
+
+export const GATE_BEAM = {
+  size: "sm" as const,
+  colorVariant: "mono" as const,
+  staticColors: true,
+  strength: 0.55,
+  borderRadius: 4,
+};

--- a/web/package.json
+++ b/web/package.json
@@ -34,6 +34,7 @@
     "@upstash/redis": "^1.34.3",
     "@vercel/analytics": "^2.0.0",
     "@xyflow/react": "^12.11.0",
+    "border-beam": "^1.3.0",
     "d3": "^7.9.0",
     "liveline": "^0.0.6",
     "lucide-react": "^0.544.0",
@@ -42,6 +43,7 @@
     "react-dom": "^19.2.4",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.0",
+    "thinking-orbs": "^0.3.1",
     "undici": "^8.6.0",
     "ws": "^8.21.0",
     "zustand": "^5.0.11"

--- a/web/tests/libraries-fx-pack.test.ts
+++ b/web/tests/libraries-fx-pack.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @vitest-environment node
+ *
+ * libraries.dev pack C — brand-safe contracts for thinking-orbs + border-beam.
+ * Beams stay off when a gate is idle, cleared, or failed. Orb verbs map to
+ * existing wait states only. Forbidden packages stay out of web/package.json.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  FOUR_GATES,
+  gateBeamActive,
+  ibStatusBeamActive,
+  thinkingOrbState,
+} from "../lib/librariesFx";
+
+describe("thinking-orbs wait mapping", () => {
+  it("maps existing async waits onto distinct orb verbs", () => {
+    expect(thinkingOrbState("flow")).toBe("searching");
+    expect(thinkingOrbState("gex")).toBe("weaving");
+    expect(thinkingOrbState("evaluate")).toBe("solving");
+    expect(thinkingOrbState("agent")).toBe("working");
+    expect(thinkingOrbState("compute")).toBe("composing");
+  });
+});
+
+describe("Gate 01-04 beam contract", () => {
+  it("exposes the four sequential gates", () => {
+    expect(FOUR_GATES.map((gate) => gate.id)).toEqual(["01", "02", "03", "04"]);
+  });
+
+  it("beams only while a gate is evaluating", () => {
+    expect(gateBeamActive("evaluating")).toBe(true);
+    expect(gateBeamActive("idle")).toBe(false);
+    expect(gateBeamActive("cleared")).toBe(false);
+    expect(gateBeamActive("failed")).toBe(false);
+  });
+});
+
+describe("IB status beam", () => {
+  it("beams only the live connected control", () => {
+    expect(ibStatusBeamActive("connected")).toBe(true);
+    expect(ibStatusBeamActive("demo")).toBe(false);
+    expect(ibStatusBeamActive("relay_offline")).toBe(false);
+    expect(ibStatusBeamActive("awaiting_2fa")).toBe(false);
+  });
+});
+
+describe("web package pin", () => {
+  const pkg = JSON.parse(
+    readFileSync(resolve(import.meta.dirname, "../package.json"), "utf8"),
+  ) as { dependencies: Record<string, string> };
+
+  it("installs thinking-orbs and border-beam", () => {
+    expect(pkg.dependencies["thinking-orbs"]).toMatch(/^\^?0\./);
+    expect(pkg.dependencies["border-beam"]).toMatch(/^\^?1\./);
+  });
+
+  it("does not install liquid-gooey or img-fx", () => {
+    expect(pkg.dependencies["liquid-gooey"]).toBeUndefined();
+    expect(pkg.dependencies["img-fx"]).toBeUndefined();
+  });
+});

--- a/web/tests/libraries-fx-surfaces.test.tsx
+++ b/web/tests/libraries-fx-surfaces.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Surface pins for pack C: thinking wait on existing flow/GEX/agent waits,
+ * Gate 01-04 beam only while evaluating, IB beam only when connected.
+ */
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("thinking-orbs", () => ({
+  ThinkingOrb: (props: { state: string; size?: number }) => (
+    <canvas data-testid="thinking-orb" data-state={props.state} data-size={String(props.size ?? 20)} />
+  ),
+}));
+
+vi.mock("border-beam", () => ({
+  BorderBeam: ({
+    children,
+    active,
+  }: {
+    children: React.ReactNode;
+    active?: boolean;
+  }) => (
+    <div data-testid="evaluating-beam" data-beam-active={active === false ? "false" : "true"}>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock("@/lib/useTickerFlowReport", () => ({
+  useTickerFlowReport: () => ({
+    data: null,
+    status: "scanning",
+    error: null,
+    refresh: () => {},
+  }),
+}));
+
+vi.mock("@/lib/useViewport", () => ({
+  useViewport: () => ({ isMobile: false, isTablet: false, hasMounted: true }),
+}));
+
+const mockUseGex = vi.fn();
+vi.mock("@/lib/useGex", () => ({
+  useGex: () => mockUseGex(),
+}));
+
+vi.mock("@/lib/useMarketHours", () => ({
+  MarketState: { OPEN: "OPEN", CLOSED: "CLOSED", EXTENDED: "EXTENDED" },
+}));
+
+afterEach(cleanup);
+
+describe("FourGateChips", () => {
+  it("beams only the evaluating gate", async () => {
+    const { FourGateChips } = await import("../components/fx/FourGateChips");
+    render(
+      <FourGateChips
+        states={{ "01": "evaluating", "02": "cleared", "03": "failed", "04": "idle" }}
+      />,
+    );
+
+    expect(screen.getByTestId("gate-chip-01").getAttribute("data-gate-state")).toBe("evaluating");
+    expect(screen.getByTestId("gate-chip-01").closest("[data-beam-active]")?.getAttribute("data-beam-active")).toBe("true");
+    expect(screen.getByTestId("gate-chip-02").closest("[data-beam-active]")).toBeNull();
+    expect(screen.getByTestId("gate-chip-03").closest("[data-beam-active]")).toBeNull();
+    expect(screen.getByTestId("gate-chip-04").closest("[data-beam-active]")).toBeNull();
+  });
+});
+
+describe("existing wait states", () => {
+  it("shows a thinking wait on UW flow ingest", async () => {
+    const TickerFlowReport = (await import("../components/flow-analysis/TickerFlowReport")).default;
+    const { container } = render(<TickerFlowReport ticker="NVDA" />);
+    const wait = container.querySelector('[data-testid="thinking-wait"]');
+    expect(wait).not.toBeNull();
+    expect(wait?.getAttribute("data-kind")).toBe("flow");
+    expect(container.querySelector(".spectral-loader")).not.toBeNull();
+  });
+
+  it("shows a thinking wait on GEX rebuild", async () => {
+    mockUseGex.mockReturnValue({
+      data: null,
+      loading: true,
+      error: null,
+      lastSync: null,
+      syncing: false,
+      syncNow: vi.fn(),
+    });
+    const GexPanel = (await import("../components/GexPanel")).default;
+    const { container } = render(<GexPanel />);
+    const wait = container.querySelector('[data-testid="thinking-wait"]');
+    expect(wait).not.toBeNull();
+    expect(wait?.getAttribute("data-kind")).toBe("gex");
+    expect(container.textContent).toContain("Sampling gamma exposure by strike");
+  });
+
+  it("shows a thinking wait on a running engine-trace step", async () => {
+    const EngineTrace = (await import("../components/agent/EngineTrace")).default;
+    const { container } = render(
+      <EngineTrace
+        steps={[{ id: "phase-route", label: "Routing request", state: "running" }]}
+      />,
+    );
+    const wait = container.querySelector('[data-testid="thinking-wait"]');
+    expect(wait).not.toBeNull();
+    expect(wait?.getAttribute("data-kind")).toBe("agent");
+  });
+});
+
+describe("IB connected beam", () => {
+  it("wraps the IB chip only when connected", async () => {
+    vi.resetModules();
+    vi.doMock("@/lib/IBStatusContext", () => ({
+      useIBStatusContext: () => ({ displayStatus: "connected" }),
+    }));
+    vi.doMock("@/lib/useServiceHealth", () => ({
+      useServiceHealth: () => ({ data: null, loading: false, error: null }),
+    }));
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+    const { default: FooterTelemetryStrip } = await import("../components/FooterTelemetryStrip");
+    render(<FooterTelemetryStrip />);
+    const ib = screen.getByText("IB Gateway").closest("[data-testid='evaluating-beam']");
+    expect(ib?.getAttribute("data-beam-active")).toBe("true");
+    vi.unstubAllGlobals();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- [x] Red/green TDD (failing test, then fix)
- [x] Staged only the files this change owns (no `git add -A`)
- [x] Owner doc updated, or the commit message has `docs-skip: <reason>`
- [x] Previous `main` deploy finished before this push

## What
libraries.dev pack C on Radon terminal + radon.run.

**App (`web/`)**
- `thinking-orbs@0.3.1` + `border-beam@1.3.0` (React 18+ peers)
- Thinking wait on existing UW flow ingest, GEX rebuild, and agent/MCP traces
- Gate 01-04 chips on `/kit`: beam only while evaluating; cleared/failed/idle stay calm
- Optional mono beam on the existing IB Gateway footer chip when connected

**Marketing (`site/`)**
- Mono `border-beam` on primary Free demo CTAs (header + colophon)
- Light silver `metal-fx@1.0.4` on Gate / Method milestone markers
- One hero line-beam around the Flow lead plate

## Hard no (held)
- No `liquid-gooey` or `img-fx`
- No effects in scanner/data tables
- No Pro Studio, copy rewrites, or product-pattern work

## Deferral
Production evaluate has no sequential Gate 01-04 chip UI. The evaluating-beam contract is demoed on `/kit`. Agent `run_evaluate` still gets a thinking orb via EngineTrace.

## Bundle
gzip of published ESM:
- `thinking-orbs` ~1.5 KB
- `border-beam` ~12 KB
- `metal-fx` ~20 KB (marketing only)

## Rebase / conflicts (2026-09-05)
Rebased onto `main` twice (`4f4fdc74`, then `b9c026e8` after #297 landed). One conflicted file both times:

- `web/tests/iv-spread-api.test.ts` — stale_source `as_of` fixture. Both sides window-relativized it. Kept `main` (`d6de38c3`, yesterday / 24h-back). File now matches `main`. Not pack C.

Do not merge. Joe is reviewing.

## Verify
Focused: pack C + iv-spread 27/27, site contracts 5/5. `libraries-fx-pack.spec.ts` held out on the CI ledger. Do not merge.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff7da21a-206b-4c69-962b-8e17c98a8cdf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff7da21a-206b-4c69-962b-8e17c98a8cdf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

