### PR TITLE
Route the deploy preflight compose render through radon-docker-gw

### DIFF
--- a/cloud/CLAUDE.md
+++ b/cloud/CLAUDE.md
@@ -66,6 +66,23 @@ steps. The shim refuses a symlinked or non-root-owned body, and
 `--project-name cloud` is pinned so the `cloud_ib-config` volume — the
 Gateway's Jts settings and 2FA state — survives the move.
 
+`config-check` is `deploy.sh`'s preflight compose render. It takes no
+env-file argument on purpose — a caller-supplied path is the one thing the
+shim refuses — and pins the same `/etc/radon/env` the deploy's
+`ENV_FILE_DEFAULT` resolves to in production. `preflight_env` falls back to a
+direct `docker compose config` only for a dev or test invocation against some
+other env file, where the caller brings its own docker access. Note the
+narrowing: preflight now renders the INSTALLED compose body, not the incoming
+release's. The incoming body is gated at install time instead, by provenance
+(git blob at the deployed commit) plus `compose_body_is_valid`.
+
+**The broker host gets none of this from CI.** `.github/workflows/ci.yml`
+deploys to a single `secrets.VPS_HOST`, and `sync-control-plane` reads
+`/home/radon/radon/.git`, which the broker does not have. Every control-plane
+change reaches it by hand: rsync the `cloud/` tree at the tested SHA to a
+root-owned path there, then run `bootstrap-control-plane.sh` with
+`RADON_BOOTSTRAP_CLOUD_ROOT` pointed at it.
+
 `inspect-running` passes docker's stdout, stderr and exit code through
 untouched: `gateway_state()` tells `missing` from `unknown` by matching
 "No such object" on stderr, and swallowing it wedges the watchdog's restart

--- a/cloud/config/sudoers.d/radon-ops
+++ b/cloud/config/sudoers.d/radon-ops
@@ -29,7 +29,7 @@ radon ALL=(root) NOPASSWD: /usr/bin/docker logs ib-gateway
 # container, with no caller-supplied paths, images, mounts or flags. Each verb
 # is listed in full: a trailing wildcard would hand back the arbitrary argv the
 # shim exists to refuse.
-radon ALL=(root) NOPASSWD: /usr/local/sbin/radon-docker-gw compose-up, /usr/local/sbin/radon-docker-gw compose-down, /usr/local/sbin/radon-docker-gw inspect-running
+radon ALL=(root) NOPASSWD: /usr/local/sbin/radon-docker-gw compose-up, /usr/local/sbin/radon-docker-gw compose-down, /usr/local/sbin/radon-docker-gw inspect-running, /usr/local/sbin/radon-docker-gw config-check
 radon ALL=(root) NOPASSWD: /usr/local/sbin/radon-docker-gw pgrep-jvm, /usr/local/sbin/radon-docker-gw pgrep-java, /usr/local/sbin/radon-docker-gw thread-dump [0-9]*
 radon ALL=(root) NOPASSWD: /usr/local/sbin/radon-docker-gw logs, /usr/local/sbin/radon-docker-gw stats, /usr/local/sbin/radon-docker-gw ps
 

--- a/cloud/scripts/deploy.sh
+++ b/cloud/scripts/deploy.sh
@@ -101,6 +101,7 @@ UNITS_RESTARTED=1
 # Discord vars are intentionally absent — the notification stack uses Pushover.
 readonly ENV_FILE_DEFAULT="$(_default_env_file)"
 readonly APP_RUNTIME_HELPER="${RADON_APP_RUNTIME_HELPER:-/usr/local/sbin/radon-app-runtime}"
+readonly DOCKER_GW="${RADON_DOCKER_GW:-/usr/local/sbin/radon-docker-gw}"
 readonly APP_IMAGE_PREPULL_TIMEOUT="${RADON_APP_IMAGE_PREPULL_TIMEOUT:-600}"
 readonly NEXT_RUNTIME_DROPIN="${RADON_NEXT_RUNTIME_DROPIN:-/etc/systemd/system/radon-nextjs.service.d/runtime-container.conf}"
 readonly SYSTEMCTL="${RADON_SYSTEMCTL:-/usr/bin/systemctl}"
@@ -194,11 +195,25 @@ preflight_env() {
 
   # Do not let Compose print expanded values or secret fragments. A generic
   # failure is enough; operators can inspect the named-key checks above.
-  if ! (
+  #
+  # radon is not in group `docker` (that group is root-equivalent), so the
+  # render goes through the root shim, which pins the same canonical env file
+  # this deploy defaults to. The direct call remains for a dev or test
+  # invocation against some other env file, where the caller has its own
+  # docker access.
+  local compose_check_ok=0
+  if [[ -x "$DOCKER_GW" && "$env_file" == "$ENV_FILE_DEFAULT" ]]; then
+    if sudo -n "$DOCKER_GW" config-check >/dev/null 2>&1; then
+      compose_check_ok=1
+    fi
+  elif (
     cd "$CLOUD_DIR"
     RADON_COMPOSE_ENV_FILE="$env_file" \
       docker compose --env-file "$env_file" config --quiet >/dev/null 2>&1
   ); then
+    compose_check_ok=1
+  fi
+  if (( compose_check_ok == 0 )); then
     log_error "[preflight] FAIL: docker compose config validation failed"
     return 1
   fi

--- a/cloud/scripts/radon-docker-gw.sh
+++ b/cloud/scripts/radon-docker-gw.sh
@@ -34,7 +34,7 @@ else
 fi
 
 usage() {
-  echo "usage: radon-docker-gw {compose-up|compose-down|inspect-running|pgrep-jvm|pgrep-java|thread-dump <pid>|logs|stats|ps}" >&2
+  echo "usage: radon-docker-gw {compose-up|compose-down|config-check|inspect-running|pgrep-jvm|pgrep-java|thread-dump <pid>|logs|stats|ps}" >&2
   exit 64
 }
 
@@ -82,6 +82,15 @@ main() {
     compose-down)
       (( $# == 0 )) || usage
       compose down
+      ;;
+    # deploy.sh's preflight render check. Takes no env-file argument: a
+    # caller-supplied path is the one thing this shim exists to refuse, and in
+    # production the deploy's own ENV_FILE_DEFAULT is this same /etc/radon/env.
+    # Output is suppressed by the caller so a failure never prints expanded
+    # secret fragments.
+    config-check)
+      (( $# == 0 )) || usage
+      compose config --quiet
       ;;
     # stdout, stderr and the exit code pass through untouched: gateway_state()
     # reads the exit code and matches "No such object" on stderr to tell

--- a/cloud/tests/test_docker_gw_shim.py
+++ b/cloud/tests/test_docker_gw_shim.py
@@ -23,6 +23,7 @@ OPS_SUDOERS = CLOUD / "config" / "sudoers.d" / "radon-ops"
 VERBS = (
     "compose-up",
     "compose-down",
+    "config-check",
     "inspect-running",
     "pgrep-jvm",
     "pgrep-java",
@@ -97,6 +98,16 @@ def test_compose_pins_file_project_and_env(box) -> None:
     assert f"-f {box.compose_file}" in line
     assert "--project-name cloud" in line
     assert line.endswith("up -d")
+
+
+def test_config_check_renders_the_pinned_body_and_env(box) -> None:
+    """deploy.sh's preflight render, without a caller-supplied env path."""
+    assert box.run("config-check").returncode == 0
+    line = box.log.read_text(encoding="utf-8").strip()
+    assert f"-f {box.compose_file}" in line
+    assert line.endswith("config --quiet")
+
+    assert box.run("config-check", "/tmp/somewhere.env").returncode == 64
 
 
 def test_compose_down_is_the_only_other_lifecycle_verb(box) -> None:
@@ -184,3 +195,9 @@ def test_sudoers_lists_each_verb_without_a_wildcard() -> None:
         assert f"/usr/local/sbin/radon-docker-gw {verb}" in text
     assert "/usr/local/sbin/radon-docker-gw *" not in text
     assert "radon ALL=(root) NOPASSWD: /usr/bin/docker compose" not in text
+
+
+def test_deploy_preflight_prefers_the_shim_over_group_docker() -> None:
+    deploy = (CLOUD / "scripts" / "deploy.sh").read_text(encoding="utf-8")
+    assert "$DOCKER_GW\" config-check" in deploy or '"$DOCKER_GW" config-check' in deploy
+    assert 'sudo -n "$DOCKER_GW" config-check' in deploy

--- a/web/tests/iv-spread-api.test.ts
+++ b/web/tests/iv-spread-api.test.ts
@@ -270,8 +270,17 @@ describe("GET /api/iv-spread — absent and stale data are 200, never 4xx", () =
 });
 
 describe("GET /api/iv-spread — degradation passes through untransformed", () => {
+  // Freshness for a stale_source payload rides the DATA age (as_of), pinned to
+  // T22:15:00Z against a 48h budget, so a hardcoded as_of degrades to `missing`
+  // the moment wall-clock drifts past it -- this went red on main at 22:15Z.
+  // Anchor it to yesterday so the fixture stays inside the budget at any hour.
   it("passes a stale_source payload through verbatim", async () => {
-    await insertSnapshot(buildPayload({ status: "stale_source" }));
+    const yesterday = new Date(Date.now() - 24 * 60 * 60_000)
+      .toISOString()
+      .slice(0, 10);
+    await insertSnapshot(
+      buildPayload({ status: "stale_source", as_of: yesterday }),
+    );
 
     const { GET } = await import("../app/api/iv-spread/route");
     const body = await (await GET()).json();


### PR DESCRIPTION
Follow-up to #292. The last thing on the app host that still needed radon's group `docker` membership.

## Why

`preflight_env` (`cloud/scripts/deploy.sh:196-200`) ran `docker compose --env-file <env> config --quiet` directly, as `radon`. Removing the group membership would have failed every deploy at preflight — which is why I stopped short of running `gpasswd -d radon docker` after #292 deployed.

## Change

- `radon-docker-gw config-check` — renders the pinned compose body against the pinned `/etc/radon/env`. **No env-file argument**: a caller-supplied path is the one thing the shim exists to refuse, and in production the deploy's own `ENV_FILE_DEFAULT` resolves to that same file (`deploy.sh:_default_env_file`).
- `preflight_env` uses the shim when it is installed *and* the env file is the canonical one; otherwise it falls back to the direct call, for a dev or test invocation against some other env file where the caller has its own docker access.
- Output stays suppressed on both paths, so a failure never prints expanded secret fragments.
- One more sudoers verb, listed in full, no wildcard.

## Narrowing, stated plainly

Preflight now renders the **installed** compose body, not the incoming release's. If a release adds a compose variable the env file lacks, preflight no longer catches it. The incoming body is gated at install time instead: git-blob provenance at the deployed commit (#291) plus `compose_body_is_valid` (#292), and a genuinely unrenderable body fails the Gateway start loudly.

## Tests

`cloud/tests/test_docker_gw_shim.py`: `config-check` is in the parametrized verb sweep; renders `-f <pinned body> … config --quiet`; rejects a supplied env path with 64; preflight asserted to prefer the shim.

`cloud/tests`: 1719 passed, 7 skipped, 5 pre-existing local failures (caddy not on PATH; CI installs it). The four deploy suites (`test_deploy_resilience`, `test_monorepo_cutover`, `test_deploy_and_setup`, `test_deploy_corrections`): 209 passed, 4 skipped.

## Also documented

The broker host receives no control-plane change from CI: `ci.yml` deploys to a single `secrets.VPS_HOST`, and `sync-control-plane` reads `/home/radon/radon/.git`, which the broker does not have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXaiDhMkTcXjJmyT14Z4Eg