### PR TITLE
Copy agent prompt + developer recipes (issue 295)

### DIFF
--- a/site/app/convex-options-from-dark-pool-flow/page.tsx
+++ b/site/app/convex-options-from-dark-pool-flow/page.tsx
@@ -4,6 +4,7 @@ import { RevealOnScroll } from "@/components/atoms/RevealOnScroll";
 import { ScrollProgress } from "@/components/atoms/ScrollProgress";
 import { SectionHeading } from "@/components/atoms/SectionHeading";
 import { SectionRule } from "@/components/atoms/SectionRule";
+import { CopyAgentPromptBar } from "@/components/molecules/CopyAgentPromptBar";
 import { PlateFrame } from "@/components/molecules/PlateFrame";
 import { EditorialFooter } from "@/components/sections/EditorialFooter";
 import { EditorialHeader } from "@/components/sections/EditorialHeader";
@@ -128,6 +129,7 @@ export default function ConvexOptionsFromDarkPoolFlowPage() {
               publishes the working procedure: seven milestones run in order,
               with a stop on failure at any gate.
             </RevealOnScroll>
+            <CopyAgentPromptBar capabilityId="flow" />
           </div>
         </section>
 
@@ -158,6 +160,13 @@ export default function ConvexOptionsFromDarkPoolFlowPage() {
                 remains visible is a different thing from a gate that quietly
                 disappears.
               </p>
+              <CopyAgentPromptBar capabilityId="gates" />
+              <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                <CopyAgentPromptBar capabilityId="gate-01" className="" />
+                <CopyAgentPromptBar capabilityId="gate-02" className="" />
+                <CopyAgentPromptBar capabilityId="gate-03" className="" />
+                <CopyAgentPromptBar capabilityId="gate-04" className="" />
+              </div>
             </RevealOnScroll>
             <RevealOnScroll>
               <PlateFrame

--- a/site/app/crash-risk-index/page.tsx
+++ b/site/app/crash-risk-index/page.tsx
@@ -6,6 +6,7 @@ import { RevealOnScroll } from "@/components/atoms/RevealOnScroll";
 import { ScrollProgress } from "@/components/atoms/ScrollProgress";
 import { SectionHeading } from "@/components/atoms/SectionHeading";
 import { SectionRule } from "@/components/atoms/SectionRule";
+import { CopyAgentPromptBar } from "@/components/molecules/CopyAgentPromptBar";
 import { PlateFrame } from "@/components/molecules/PlateFrame";
 import { EditorialFooter } from "@/components/sections/EditorialFooter";
 import { EditorialHeader } from "@/components/sections/EditorialHeader";
@@ -118,6 +119,7 @@ export default function CrashRiskIndexPage() {
               average. The inputs, the weights, and the thresholds are
               published here in full.
             </RevealOnScroll>
+            <CopyAgentPromptBar capabilityId="cri" />
           </div>
         </section>
 

--- a/site/app/defined-risk-options-structures/page.tsx
+++ b/site/app/defined-risk-options-structures/page.tsx
@@ -6,6 +6,7 @@ import { ScrollProgress } from "@/components/atoms/ScrollProgress";
 import { SectionHeading } from "@/components/atoms/SectionHeading";
 import { SectionRule } from "@/components/atoms/SectionRule";
 import { SignalPill } from "@/components/atoms/SignalPill";
+import { CopyAgentPromptBar } from "@/components/molecules/CopyAgentPromptBar";
 import { PlateFrame } from "@/components/molecules/PlateFrame";
 import { EditorialFooter } from "@/components/sections/EditorialFooter";
 import { EditorialHeader } from "@/components/sections/EditorialHeader";
@@ -200,6 +201,7 @@ export default function DefinedRiskOptionsStructuresPage() {
               {catalogCounts.conditional} are conditional: defined or undefined
               depending on how strikes and tenors are set.
             </RevealOnScroll>
+            <CopyAgentPromptBar capabilityId="structures" />
           </div>
         </section>
 

--- a/site/app/developers/recipes/page.tsx
+++ b/site/app/developers/recipes/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next";
+import { DeveloperRecipeGrid } from "@/components/molecules/DeveloperRecipeGrid";
+import { AgentDocument } from "@/components/sections/AgentDocument";
+import { recipesMetadata, recipesPage } from "@/lib/developer-pages";
+
+export const metadata: Metadata = recipesMetadata;
+
+export default function DeveloperRecipesPage() {
+  return <AgentDocument page={recipesPage} afterIntro={<DeveloperRecipeGrid />} />;
+}

--- a/site/app/fractional-kelly-position-sizing/page.tsx
+++ b/site/app/fractional-kelly-position-sizing/page.tsx
@@ -5,6 +5,7 @@ import { RevealOnScroll } from "@/components/atoms/RevealOnScroll";
 import { ScrollProgress } from "@/components/atoms/ScrollProgress";
 import { SectionHeading } from "@/components/atoms/SectionHeading";
 import { SectionRule } from "@/components/atoms/SectionRule";
+import { CopyAgentPromptBar } from "@/components/molecules/CopyAgentPromptBar";
 import { PlateFrame } from "@/components/molecules/PlateFrame";
 import { EditorialFooter } from "@/components/sections/EditorialFooter";
 import { EditorialHeader } from "@/components/sections/EditorialHeader";
@@ -76,6 +77,7 @@ export default function FractionalKellyPositionSizingPage() {
               maximum loss and the signal&apos;s odds, then hard-capped at 2.5%
               of bankroll per position. The cap is a ceiling, not a target.
             </RevealOnScroll>
+            <CopyAgentPromptBar capabilityId="kelly" />
           </div>
         </section>
 

--- a/site/app/interactive-brokers-dark-pool-terminal/page.tsx
+++ b/site/app/interactive-brokers-dark-pool-terminal/page.tsx
@@ -5,6 +5,7 @@ import { RevealOnScroll } from "@/components/atoms/RevealOnScroll";
 import { ScrollProgress } from "@/components/atoms/ScrollProgress";
 import { SectionHeading } from "@/components/atoms/SectionHeading";
 import { SectionRule } from "@/components/atoms/SectionRule";
+import { CopyAgentPromptBar } from "@/components/molecules/CopyAgentPromptBar";
 import { PlateFrame } from "@/components/molecules/PlateFrame";
 import { EditorialFooter } from "@/components/sections/EditorialFooter";
 import { EditorialHeader } from "@/components/sections/EditorialHeader";
@@ -79,6 +80,7 @@ export default function InteractiveBrokersDarkPoolTerminalPage() {
               Unusual Whales supplies the off-exchange prints, because IB does
               not publish a public dark pool print feed.
             </RevealOnScroll>
+            <CopyAgentPromptBar capabilityId="ib-terminal" />
           </div>
         </section>
 

--- a/site/app/unusual-whales-interactive-brokers/page.tsx
+++ b/site/app/unusual-whales-interactive-brokers/page.tsx
@@ -5,6 +5,7 @@ import { ScrollProgress } from "@/components/atoms/ScrollProgress";
 import { SectionHeading } from "@/components/atoms/SectionHeading";
 import { SectionRule } from "@/components/atoms/SectionRule";
 import { MilestoneRow } from "@/components/molecules/MilestoneRow";
+import { CopyAgentPromptBar } from "@/components/molecules/CopyAgentPromptBar";
 import { PlateFrame } from "@/components/molecules/PlateFrame";
 import { EditorialFooter } from "@/components/sections/EditorialFooter";
 import { EditorialHeader } from "@/components/sections/EditorialHeader";
@@ -123,6 +124,7 @@ export default function UnusualWhalesInteractiveBrokersPage() {
               </a>
               .
             </RevealOnScroll>
+            <CopyAgentPromptBar capabilityId="uw-ib" />
           </div>
         </section>
 

--- a/site/components/molecules/CopyAgentPrompt.tsx
+++ b/site/components/molecules/CopyAgentPrompt.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useId, useState } from "react";
+import {
+  formatAgentPrompt,
+  writeClipboard,
+  type AgentPrompt,
+} from "@/lib/agent-prompts";
+
+interface Props {
+  prompt: AgentPrompt;
+  showView?: boolean;
+}
+
+const focusRing =
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus/60 focus-visible:ring-offset-2 focus-visible:ring-offset-canvas";
+
+const buttonClass = `inline-block rounded-[4px] border border-grid px-[13px] py-[7px] font-mono text-[11px] tracking-[0.04em] text-primary transition-colors hover:border-signal-deep hover:text-signal-deep ${focusRing}`;
+
+export function CopyAgentPrompt({ prompt, showView = true }: Props) {
+  const markdown = formatAgentPrompt(prompt);
+  const titleId = useId();
+  const [status, setStatus] = useState<"idle" | "copied" | "failed">("idle");
+  const [open, setOpen] = useState(false);
+
+  async function copy() {
+    setStatus(await writeClipboard(markdown));
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+      <button type="button" className={buttonClass} onClick={() => void copy()}>
+        Copy agent prompt
+      </button>
+      {showView ? (
+        <button
+          type="button"
+          className={`font-mono text-[11px] tracking-[0.04em] text-secondary underline decoration-grid underline-offset-4 transition-colors hover:text-signal-deep ${focusRing}`}
+          onClick={() => setOpen(true)}
+        >
+          View prompt
+        </button>
+      ) : null}
+      <span
+        role="status"
+        aria-live="polite"
+        className="font-mono text-[11px] uppercase tracking-[0.08em] text-signal-deep"
+      >
+        {status === "copied" ? "Copied" : status === "failed" ? "Copy failed" : ""}
+      </span>
+      {open ? (
+        <div
+          className="fixed inset-0 z-[70] flex items-center justify-center bg-canvas/80 p-6"
+          role="presentation"
+          onClick={() => setOpen(false)}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={titleId}
+            className="max-h-[80vh] w-full max-w-[760px] overflow-auto rounded-[4px] border border-grid bg-figure-bg p-6"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="mb-4 flex items-start justify-between gap-4">
+              <h2
+                id={titleId}
+                className="font-serif text-[1.24rem] font-medium text-primary"
+              >
+                Agent prompt
+              </h2>
+              <button
+                type="button"
+                className={buttonClass}
+                onClick={() => setOpen(false)}
+              >
+                Close
+              </button>
+            </div>
+            <pre className="whitespace-pre-wrap font-mono text-[12px] leading-[1.55] text-secondary">
+              {markdown}
+            </pre>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/site/components/molecules/CopyAgentPromptBar.tsx
+++ b/site/components/molecules/CopyAgentPromptBar.tsx
@@ -1,0 +1,18 @@
+import { CopyAgentPrompt } from "@/components/molecules/CopyAgentPrompt";
+import { getCapabilityPrompt } from "@/lib/agent-prompts";
+
+interface Props {
+  capabilityId: string;
+  className?: string;
+}
+
+export function CopyAgentPromptBar({
+  capabilityId,
+  className = "mt-7",
+}: Props) {
+  return (
+    <div className={className}>
+      <CopyAgentPrompt prompt={getCapabilityPrompt(capabilityId)} />
+    </div>
+  );
+}

--- a/site/components/molecules/DeveloperRecipeGrid.tsx
+++ b/site/components/molecules/DeveloperRecipeGrid.tsx
@@ -1,0 +1,20 @@
+import { CopyAgentPrompt } from "@/components/molecules/CopyAgentPrompt";
+import { developerRecipes } from "@/lib/agent-prompts";
+
+export function DeveloperRecipeGrid() {
+  return (
+    <div className="mt-11 grid gap-4">
+      {developerRecipes.map((recipe) => (
+        <article
+          key={recipe.id}
+          className="rounded-[4px] border border-grid bg-figure-bg p-[22px]"
+        >
+          <h3 className="mb-4 font-serif text-[1.24rem] font-medium text-primary">
+            {recipe.title}
+          </h3>
+          <CopyAgentPrompt prompt={recipe.prompt} />
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/site/components/molecules/GateCard.tsx
+++ b/site/components/molecules/GateCard.tsx
@@ -1,12 +1,18 @@
+import { CopyAgentPrompt } from "@/components/molecules/CopyAgentPrompt";
+import { getCapabilityPrompt } from "@/lib/agent-prompts";
 import type { Gate } from "@/lib/editorial-content";
 
 type GateCardProps = {
   gate: Gate;
+  capabilityId?: string;
 };
 
-export function GateCard({ gate }: GateCardProps) {
+export function GateCard({ gate, capabilityId }: GateCardProps) {
   return (
-    <div className={["gate", gate.disabled ? "gate-disabled" : ""].filter(Boolean).join(" ")}>
+    <div
+      id={capabilityId}
+      className={["gate", gate.disabled ? "gate-disabled" : ""].filter(Boolean).join(" ")}
+    >
       <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-signal-deep">
         {gate.no}
       </span>
@@ -15,6 +21,11 @@ export function GateCard({ gate }: GateCardProps) {
       </h3>
       <p className="mb-3 text-[0.95rem] leading-[1.46] text-secondary">{gate.body}</p>
       <span className="gate-rule">{gate.rule}</span>
+      {capabilityId ? (
+        <div className="mt-4">
+          <CopyAgentPrompt prompt={getCapabilityPrompt(capabilityId)} />
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/site/components/organisms/RegimeModelCard.tsx
+++ b/site/components/organisms/RegimeModelCard.tsx
@@ -1,4 +1,6 @@
 import type { ReactNode } from "react";
+import { CopyAgentPrompt } from "@/components/molecules/CopyAgentPrompt";
+import { getCapabilityPrompt } from "@/lib/agent-prompts";
 import type { RegimeModel } from "@/lib/editorial-content";
 
 // Each model carries a hand-built mini-figure (not a screenshot). Colors come
@@ -87,7 +89,13 @@ type RegimeModelCardProps = {
   model: RegimeModel;
 };
 
+const regimeCapability: Record<string, string> = {
+  CRI: "cri",
+  GEX: "gex",
+};
+
 export function RegimeModelCard({ model }: RegimeModelCardProps) {
+  const capabilityId = regimeCapability[model.code];
   return (
     <div className="flex flex-col rounded-[4px] border border-grid bg-figure-bg p-[22px]">
       <div className="mb-1 flex items-baseline justify-between gap-3">
@@ -107,6 +115,11 @@ export function RegimeModelCard({ model }: RegimeModelCardProps) {
       <div className="mt-auto border-t border-hairline-soft pt-[14px] fig-svg">
         {miniFigures[model.code]}
       </div>
+      {capabilityId ? (
+        <div className="mt-4">
+          <CopyAgentPrompt prompt={getCapabilityPrompt(capabilityId)} />
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/site/components/sections/AgentDocument.tsx
+++ b/site/components/sections/AgentDocument.tsx
@@ -1,10 +1,17 @@
+import type { ReactNode } from "react";
 import { LegalDocument } from "@/components/sections/LegalDocument";
 import {
   agentPageStructuredData,
   type AgentPage,
 } from "@/lib/developer-pages";
 
-export function AgentDocument({ page }: { page: AgentPage }) {
+export function AgentDocument({
+  page,
+  afterIntro,
+}: {
+  page: AgentPage;
+  afterIntro?: ReactNode;
+}) {
   return (
     <>
       <LegalDocument
@@ -15,6 +22,7 @@ export function AgentDocument({ page }: { page: AgentPage }) {
         dateLabel="Updated"
         intro={page.intro}
         sections={page.sections}
+        afterIntro={afterIntro}
       />
       <script
         type="application/ld+json"

--- a/site/components/sections/ConvexitySection.tsx
+++ b/site/components/sections/ConvexitySection.tsx
@@ -1,5 +1,6 @@
 import { RevealOnScroll } from "@/components/atoms/RevealOnScroll";
 import { SectionHeading } from "@/components/atoms/SectionHeading";
+import { CopyAgentPromptBar } from "@/components/molecules/CopyAgentPromptBar";
 import { GateCard } from "@/components/molecules/GateCard";
 import { gates } from "@/lib/editorial-content";
 
@@ -26,11 +27,16 @@ export function ConvexitySection() {
             </a>
             .
           </p>
+          <CopyAgentPromptBar capabilityId="gates" />
         </RevealOnScroll>
 
         <RevealOnScroll className="gates">
-          {gates.map((gate) => (
-            <GateCard key={gate.no} gate={gate} />
+          {gates.map((gate, index) => (
+            <GateCard
+              key={gate.no}
+              gate={gate}
+              capabilityId={`gate-0${index + 1}`}
+            />
           ))}
         </RevealOnScroll>
       </div>

--- a/site/components/sections/FlowThesisSection.tsx
+++ b/site/components/sections/FlowThesisSection.tsx
@@ -1,5 +1,6 @@
 import { RevealOnScroll } from "@/components/atoms/RevealOnScroll";
 import { SectionHeading } from "@/components/atoms/SectionHeading";
+import { CopyAgentPromptBar } from "@/components/molecules/CopyAgentPromptBar";
 import { PlateFrame } from "@/components/molecules/PlateFrame";
 import { ScannerTable } from "@/components/organisms/ScannerTable";
 import { flowArgumentSteps } from "@/lib/editorial-content";
@@ -45,6 +46,8 @@ export function FlowThesisSection() {
                 </div>
               ))}
             </div>
+
+            <CopyAgentPromptBar capabilityId="flow" className="mt-5" />
 
             <p className="mt-5 text-[1.02rem] leading-[1.55] text-secondary">
               The wiring from Unusual Whales prints to Interactive Brokers

--- a/site/components/sections/LegalDocument.tsx
+++ b/site/components/sections/LegalDocument.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import type { ReactNode } from "react";
 import { EditorialEyebrow } from "@/components/atoms/EditorialEyebrow";
 import { EditorialFooter } from "@/components/sections/EditorialFooter";
 import { EditorialHeader } from "@/components/sections/EditorialHeader";
@@ -17,6 +18,7 @@ interface LegalDocumentProps {
   dateLabel?: string;
   intro: string;
   sections: LegalSection[];
+  afterIntro?: ReactNode;
 }
 
 const focusRing =
@@ -51,6 +53,7 @@ export function LegalDocument({
   dateLabel = "Effective",
   intro,
   sections,
+  afterIntro,
 }: LegalDocumentProps) {
   return (
     <div className="min-h-screen bg-canvas font-serif text-[17.5px] leading-[1.62] text-primary">
@@ -81,6 +84,8 @@ export function LegalDocument({
             <p className="max-w-[66ch] text-[1.12rem] leading-[1.55] text-secondary">
               {intro}
             </p>
+
+            {afterIntro}
 
             <nav
               aria-label="Contents"

--- a/site/e2e/agent-prompt-recipes.spec.ts
+++ b/site/e2e/agent-prompt-recipes.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "../../web/node_modules/@playwright/test";
+
+test.describe("Copy agent prompt and developer recipes", () => {
+  test("shows Copy agent prompt on a dossier and seven recipe cards", async ({
+    page,
+  }) => {
+    await page.goto("/crash-risk-index");
+    const dossierCopy = page.getByRole("button", { name: "Copy agent prompt" });
+    await expect(dossierCopy.first()).toBeVisible();
+    await dossierCopy.first().click();
+    await expect(page.getByRole("status")).toHaveText(/Copied|Copy failed/);
+
+    await page.getByRole("button", { name: "View prompt" }).first().click();
+    await expect(page.getByRole("dialog", { name: "Agent prompt" })).toBeVisible();
+    await expect(page.getByRole("dialog")).toContainText("# Radon Terminal - Crash Risk Index");
+    await page.getByRole("button", { name: "Close" }).click();
+
+    await page.goto("/developers");
+    await expect(page.getByRole("heading", { name: "Agent prompt payload" })).toBeVisible();
+    await expect(page.getByText("Field order is stable")).toBeVisible();
+
+    await page.goto("/developers/recipes");
+    await expect(
+      page.getByRole("heading", { name: "Radon Terminal developer recipes" }),
+    ).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Score flow for TICKER" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Evaluate gates for a structure" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Read CRI regime" })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Read GEX walls and magnets for TICKER" }),
+    ).toBeVisible();
+    await expect(page.getByRole("heading", { name: "List convex structures" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Size with fractional Kelly" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "What is Radon / when to use" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Copy agent prompt" })).toHaveCount(7);
+  });
+});

--- a/site/e2e/agent-prompt-recipes.spec.ts
+++ b/site/e2e/agent-prompt-recipes.spec.ts
@@ -3,7 +3,9 @@ import { expect, test } from "../../web/node_modules/@playwright/test";
 test.describe("Copy agent prompt and developer recipes", () => {
   test("shows Copy agent prompt on a dossier and seven recipe cards", async ({
     page,
+    context,
   }) => {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
     await page.goto("/crash-risk-index");
     const dossierCopy = page.getByRole("button", { name: "Copy agent prompt" });
     await expect(dossierCopy.first()).toBeVisible();

--- a/site/e2e/agent-prompt-recipes.spec.ts
+++ b/site/e2e/agent-prompt-recipes.spec.ts
@@ -15,6 +15,7 @@ test.describe("Copy agent prompt and developer recipes", () => {
     await page.getByRole("button", { name: "View prompt" }).first().click();
     await expect(page.getByRole("dialog", { name: "Agent prompt" })).toBeVisible();
     await expect(page.getByRole("dialog")).toContainText("# Radon Terminal - Crash Risk Index");
+    await expect(page.getByRole("dialog")).toContainText("## Hard nos");
     await page.getByRole("button", { name: "Close" }).click();
 
     await page.goto("/developers");

--- a/site/lib/agent-prompts.test.ts
+++ b/site/lib/agent-prompts.test.ts
@@ -159,6 +159,7 @@ describe("writeClipboard", () => {
 
   it("reports failed when the clipboard is missing or throws", async () => {
     vi.stubGlobal("navigator", {});
+    vi.stubGlobal("document", undefined);
     await expect(writeClipboard("payload")).resolves.toBe("failed");
     vi.stubGlobal("navigator", {
       clipboard: {
@@ -166,5 +167,27 @@ describe("writeClipboard", () => {
       },
     });
     await expect(writeClipboard("payload")).resolves.toBe("failed");
+  });
+
+  it("falls back to a textarea copy when the clipboard API is missing", async () => {
+    const execCommand = vi.fn().mockReturnValue(true);
+    const area = {
+      value: "",
+      setAttribute: vi.fn(),
+      style: { position: "", left: "" },
+      select: vi.fn(),
+    };
+    vi.stubGlobal("navigator", {});
+    vi.stubGlobal("document", {
+      createElement: vi.fn(() => area),
+      body: {
+        appendChild: vi.fn(),
+        removeChild: vi.fn(),
+      },
+      execCommand,
+    });
+    await expect(writeClipboard("payload")).resolves.toBe("copied");
+    expect(area.value).toBe("payload");
+    expect(execCommand).toHaveBeenCalledWith("copy");
   });
 });

--- a/site/lib/agent-prompts.test.ts
+++ b/site/lib/agent-prompts.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  AGENT_PROMPT_SECTION_HEADINGS,
+  SHARED_HARD_NOS,
+  capabilityPrompts,
+  developerRecipes,
+  formatAgentPrompt,
+  getCapabilityPrompt,
+  writeClipboard,
+} from "./agent-prompts";
+import { HOSTED_MCP_URL } from "./developer-pages";
+import { DEMO_APP_URL, siteUrl } from "./seo";
+
+const REQUIRED_CAPABILITIES = [
+  "flow",
+  "gates",
+  "gate-01",
+  "gate-02",
+  "gate-03",
+  "gate-04",
+  "cri",
+  "gex",
+  "structures",
+  "kelly",
+  "ib-terminal",
+  "uw-ib",
+] as const;
+
+const REQUIRED_RECIPE_TITLES = [
+  "Score flow for TICKER",
+  "Evaluate gates for a structure",
+  "Read CRI regime",
+  "Read GEX walls and magnets for TICKER",
+  "List convex structures",
+  "Size with fractional Kelly",
+  "What is Radon / when to use",
+];
+
+function headings(markdown: string): string[] {
+  return markdown.split("\n").filter((line) => line.startsWith("#"));
+}
+
+describe("agent prompt payload", () => {
+  it("keeps a stable markdown field order", () => {
+    const markdown = formatAgentPrompt(getCapabilityPrompt("flow"));
+    expect(headings(markdown)).toEqual([
+      "# Radon Terminal - Flow scorer",
+      ...AGENT_PROMPT_SECTION_HEADINGS.map((heading) => `## ${heading}`),
+    ]);
+    expect(markdown.startsWith("# Radon Terminal - Flow scorer\n")).toBe(true);
+  });
+
+  it("ships the shared hard nos before capability-specific nos", () => {
+    const markdown = formatAgentPrompt(getCapabilityPrompt("flow"));
+    const hardNos = markdown.split("## Hard nos\n")[1].split("\n## ")[0];
+    const bullets = hardNos
+      .split("\n")
+      .filter((line) => line.startsWith("- "));
+    expect(bullets.slice(0, SHARED_HARD_NOS.length)).toEqual(
+      SHARED_HARD_NOS.map((item) => `- ${item}`),
+    );
+    expect(bullets.length).toBeGreaterThan(SHARED_HARD_NOS.length);
+  });
+
+  it("covers every listed dossier and gate surface", () => {
+    expect(Object.keys(capabilityPrompts)).toEqual([...REQUIRED_CAPABILITIES]);
+    for (const id of REQUIRED_CAPABILITIES) {
+      const markdown = formatAgentPrompt(getCapabilityPrompt(id));
+      expect(markdown).toContain(`1. Read ${siteUrl}/llms.txt`);
+      expect(markdown).toMatch(
+        /2\. Fetch https:\/\/radon\.run\/\S* with Accept: text\/markdown \(or \.md\)/,
+      );
+      expect(markdown).toContain("3. Demo: ");
+      expect(markdown).toContain("4. MCP: ");
+      expect(markdown).toContain(DEMO_APP_URL);
+    }
+  });
+
+  it("reuses published when-to-use language and refuses broker behavior", () => {
+    const flow = formatAgentPrompt(getCapabilityPrompt("flow"));
+    expect(flow).toContain("dark-pool");
+    expect(flow).toContain("accumulation or distribution");
+    expect(flow).toContain("does not place, route, or broker an order");
+
+    const gates = formatAgentPrompt(getCapabilityPrompt("gates"));
+    expect(gates).toContain("gain at least 2x loss");
+    expect(gates).toContain("stops on the first failure");
+
+    const gate04 = formatAgentPrompt(getCapabilityPrompt("gate-04"));
+    expect(gate04).toContain("Disabled by operator policy");
+
+    const kelly = formatAgentPrompt(getCapabilityPrompt("kelly"));
+    expect(kelly).toContain("2.5%");
+    expect(kelly).toContain("ceiling, not a target");
+  });
+
+  it("points GEX and CRI at existing demo routes and hosted MCP reads", () => {
+    const cri = formatAgentPrompt(getCapabilityPrompt("cri"));
+    expect(cri).toContain(`${DEMO_APP_URL}/regime/cri`);
+    expect(cri).toContain("demo_regime");
+    expect(cri).toContain(HOSTED_MCP_URL);
+
+    const gex = formatAgentPrompt(getCapabilityPrompt("gex"));
+    expect(gex).toContain(`${DEMO_APP_URL}/regime/gex`);
+    expect(gex).toContain("demo_gex");
+    expect(gex).toContain("walls");
+    expect(gex).toContain("magnets");
+  });
+});
+
+describe("developer recipes", () => {
+  it("ships seven one-paste cards with the canonical payload shape", () => {
+    expect(developerRecipes).toHaveLength(7);
+    expect(developerRecipes.map((recipe) => recipe.title)).toEqual(
+      REQUIRED_RECIPE_TITLES,
+    );
+    for (const recipe of developerRecipes) {
+      const markdown = formatAgentPrompt(recipe.prompt);
+      expect(headings(markdown).slice(1)).toEqual(
+        AGENT_PROMPT_SECTION_HEADINGS.map((heading) => `## ${heading}`),
+      );
+      expect(markdown).toContain("Not a broker; no Robinhood routing");
+      expect(markdown).toContain("does not place, route, or broker an order");
+      expect(markdown).not.toMatch(/[–—]/);
+    }
+  });
+
+  it("keeps ticker and structure placeholders in the matching recipes", () => {
+    const flow = formatAgentPrompt(
+      developerRecipes.find((recipe) => recipe.id === "score-flow")!.prompt,
+    );
+    expect(flow).toContain("TICKER");
+    expect(flow).toContain(`${DEMO_APP_URL}/flow-analysis/TICKER`);
+
+    const gates = formatAgentPrompt(
+      developerRecipes.find((recipe) => recipe.id === "evaluate-gates")!.prompt,
+    );
+    expect(gates).toContain("STRUCTURE_ID");
+
+    const kelly = formatAgentPrompt(
+      developerRecipes.find((recipe) => recipe.id === "size-kelly")!.prompt,
+    );
+    expect(kelly).toContain("MAX_GAIN");
+    expect(kelly).toContain("MAX_LOSS");
+  });
+});
+
+describe("writeClipboard", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reports copied when the clipboard write succeeds", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    await expect(writeClipboard("payload")).resolves.toBe("copied");
+    expect(writeText).toHaveBeenCalledWith("payload");
+  });
+
+  it("reports failed when the clipboard is missing or throws", async () => {
+    vi.stubGlobal("navigator", {});
+    await expect(writeClipboard("payload")).resolves.toBe("failed");
+    vi.stubGlobal("navigator", {
+      clipboard: {
+        writeText: vi.fn().mockRejectedValue(new Error("denied")),
+      },
+    });
+    await expect(writeClipboard("payload")).resolves.toBe("failed");
+  });
+});

--- a/site/lib/agent-prompts.ts
+++ b/site/lib/agent-prompts.ts
@@ -62,14 +62,36 @@ export function formatAgentPrompt(prompt: AgentPrompt): string {
   ].join("\n");
 }
 
+function writeClipboardFallback(text: string): boolean {
+  if (typeof document === "undefined") return false;
+  const area = document.createElement("textarea");
+  area.value = text;
+  area.setAttribute("readonly", "");
+  area.style.position = "fixed";
+  area.style.left = "-9999px";
+  document.body.appendChild(area);
+  area.select();
+  try {
+    return document.execCommand("copy");
+  } finally {
+    document.body.removeChild(area);
+  }
+}
+
 export async function writeClipboard(
   text: string,
 ): Promise<"copied" | "failed"> {
   try {
     const clipboard = globalThis.navigator?.clipboard;
-    if (!clipboard?.writeText) return "failed";
-    await clipboard.writeText(text);
-    return "copied";
+    if (clipboard?.writeText) {
+      await clipboard.writeText(text);
+      return "copied";
+    }
+  } catch {
+    // fall through to the textarea path
+  }
+  try {
+    return writeClipboardFallback(text) ? "copied" : "failed";
   } catch {
     return "failed";
   }

--- a/site/lib/agent-prompts.ts
+++ b/site/lib/agent-prompts.ts
@@ -1,0 +1,436 @@
+import { HOSTED_MCP_URL } from "./developer-pages";
+import { DEMO_APP_URL, SITE_NAME, siteUrl } from "./seo";
+
+export const AGENT_PROMPT_SECTION_HEADINGS = [
+  "When to use",
+  "Hard nos",
+  "How to call",
+  "Parameters / constraints",
+  "Definition of done for the agent",
+] as const;
+
+export const SHARED_HARD_NOS = [
+  "Not a broker; no Robinhood routing",
+  "No undefined-risk / naked shorts as default path",
+  "Live execution requires Interactive Brokers + operator rails",
+] as const;
+
+const MCP_NOT_PUBLIC = "not public yet; use markdown + demo";
+const MCP_DOCS = `hosted Streamable HTTP at ${HOSTED_MCP_URL}: radon_docs (no token)`;
+const MCP_CRI = `hosted Streamable HTTP at ${HOSTED_MCP_URL}: demo_regime (demo Clerk token) or radon_docs (no token)`;
+const MCP_GEX = `hosted Streamable HTTP at ${HOSTED_MCP_URL}: demo_gex (demo Clerk token) or radon_docs (no token)`;
+
+export type AgentPrompt = {
+  capability: string;
+  whenToUse: string;
+  hardNos: string[];
+  canonicalUrl: string;
+  demoUrl: string;
+  mcp: string;
+  parameters: string[];
+  definitionOfDone: string[];
+};
+
+export type DeveloperRecipe = {
+  id: string;
+  title: string;
+  prompt: AgentPrompt;
+};
+
+export function formatAgentPrompt(prompt: AgentPrompt): string {
+  return [
+    `# ${SITE_NAME} - ${prompt.capability}`,
+    "",
+    "## When to use",
+    prompt.whenToUse,
+    "",
+    "## Hard nos",
+    ...[...SHARED_HARD_NOS, ...prompt.hardNos].map((item) => `- ${item}`),
+    "",
+    "## How to call",
+    `1. Read ${siteUrl}/llms.txt`,
+    `2. Fetch ${prompt.canonicalUrl} with Accept: text/markdown (or .md)`,
+    `3. Demo: ${prompt.demoUrl}`,
+    `4. MCP: ${prompt.mcp}`,
+    "",
+    "## Parameters / constraints",
+    ...prompt.parameters.map((item) => `- ${item}`),
+    "",
+    "## Definition of done for the agent",
+    ...prompt.definitionOfDone.map((item) => `- ${item}`),
+    "",
+  ].join("\n");
+}
+
+export async function writeClipboard(
+  text: string,
+): Promise<"copied" | "failed"> {
+  try {
+    const clipboard = globalThis.navigator?.clipboard;
+    if (!clipboard?.writeText) return "failed";
+    await clipboard.writeText(text);
+    return "copied";
+  } catch {
+    return "failed";
+  }
+}
+
+const DONE_NO_ORDER =
+  "The turn explains the read and stops. It does not place, route, or broker an order.";
+
+export const capabilityPrompts: Record<string, AgentPrompt> = {
+  flow: {
+    capability: "Flow scorer",
+    whenToUse:
+      "Score Unusual Whales dark-pool or OTC prints for accumulation or distribution that has not moved the lit price.",
+    hardNos: [
+      "Do not invent Yahoo as the primary print source. Interactive Brokers first, Unusual Whales second.",
+    ],
+    canonicalUrl: `${siteUrl}/convex-options-from-dark-pool-flow`,
+    demoUrl: `${DEMO_APP_URL}/flow-analysis`,
+    mcp: MCP_NOT_PUBLIC,
+    parameters: [
+      "Off-exchange and OTC prints, sweeps, and options flow from Unusual Whales, reconciled against the Interactive Brokers realtime tape.",
+      "Volume is venue-weighted and normalized to a rolling z-score; directional pressure comes from print-side and size clustering.",
+      "A threshold-crossing flow score that precedes the lit move, with the lead window measured per ticker.",
+    ],
+    definitionOfDone: [
+      "Reports accumulation, distribution, or below-threshold, plus the lead window when one exists.",
+      DONE_NO_ORDER,
+    ],
+  },
+  gates: {
+    capability: "Gate stack",
+    whenToUse:
+      "Force a candidate through four sequential gates before a contract exists. A failure at any gate stops the trade and names the gate.",
+    hardNos: [
+      "Do not skip a failed gate or award partial credit for clearing three of four.",
+      "Gate 04 is disabled by operator policy; do not treat it as active.",
+    ],
+    canonicalUrl: `${siteUrl}/convex-options-from-dark-pool-flow`,
+    demoUrl: DEMO_APP_URL,
+    mcp: MCP_NOT_PUBLIC,
+    parameters: [
+      "Gate 01 Convexity: defined-risk only, gain at least 2x loss, capped loss known at submit.",
+      "Gate 02 Edge: a specific dark-pool or OTC signal that has not yet moved the lit price.",
+      "Gate 03 Risk: fractional Kelly with a hard ceiling of 2.5% of bankroll per position.",
+      "Gate 04 Naked shorts: historically blocked undefined-risk shorts; disabled 2026-04-30, logic preserved.",
+    ],
+    definitionOfDone: [
+      "Names each gate pass or fail in order and stops on the first failure.",
+      DONE_NO_ORDER,
+    ],
+  },
+  "gate-01": {
+    capability: "Gate 01 Convexity",
+    whenToUse:
+      "Check whether the payoff is asymmetric before any other gate runs. Defined-risk structures only, with capped loss known at submit.",
+    hardNos: [
+      "Do not admit undefined-risk or naked shorts as the default path.",
+    ],
+    canonicalUrl: `${siteUrl}/convex-options-from-dark-pool-flow`,
+    demoUrl: `${DEMO_APP_URL}/options`,
+    mcp: MCP_NOT_PUBLIC,
+    parameters: [
+      "Rule: gain ≥ 2 × loss.",
+      "Defined-risk structures only. The capped loss is known before the order is submitted.",
+    ],
+    definitionOfDone: [
+      "States max gain, max loss, and whether gain is at least 2x loss.",
+      DONE_NO_ORDER,
+    ],
+  },
+  "gate-02": {
+    capability: "Gate 02 Edge",
+    whenToUse:
+      "Confirm a specific, data-backed dark-pool or OTC signal that has not yet moved the lit price.",
+    hardNos: [
+      "Seasonality, analyst ratings, and news are context, not this gate.",
+    ],
+    canonicalUrl: `${siteUrl}/convex-options-from-dark-pool-flow`,
+    demoUrl: `${DEMO_APP_URL}/flow-analysis`,
+    mcp: MCP_NOT_PUBLIC,
+    parameters: [
+      "Rule: signal precedes price.",
+      "The print stream nominates candidates; a score that misses its threshold is discarded.",
+    ],
+    definitionOfDone: [
+      "Names the print or flow evidence and whether it still leads the lit move.",
+      DONE_NO_ORDER,
+    ],
+  },
+  "gate-03": {
+    capability: "Gate 03 Risk",
+    whenToUse:
+      "Size the position with fractional Kelly and refuse anything above the hard per-position ceiling.",
+    hardNos: [
+      "Do not override the 2.5% bankroll cap. The cap is a ceiling, not a target.",
+    ],
+    canonicalUrl: `${siteUrl}/fractional-kelly-position-sizing`,
+    demoUrl: DEMO_APP_URL,
+    mcp: MCP_NOT_PUBLIC,
+    parameters: [
+      "Rule: ≤ 2.5% bankroll.",
+      "Quarter-Kelly from max gain over max loss and the signal odds, then min(that, 2.5%).",
+    ],
+    definitionOfDone: [
+      "Reports the Kelly fraction, the cap, and the binding size.",
+      DONE_NO_ORDER,
+    ],
+  },
+  "gate-04": {
+    capability: "Gate 04 Naked shorts",
+    whenToUse:
+      "Read the published no-naked-shorts rule. Disabled by operator policy on 2026-04-30. The blocking logic is preserved for re-enable.",
+    hardNos: [
+      "Do not re-enable the gate or treat undefined-risk shorts as the default path.",
+    ],
+    canonicalUrl: `${siteUrl}/convex-options-from-dark-pool-flow`,
+    demoUrl: DEMO_APP_URL,
+    mcp: MCP_NOT_PUBLIC,
+    parameters: [
+      "Rule: no naked shorts.",
+      "Disabled by operator policy; logic preserved. Re-enable is a documented operator path, not an agent action.",
+    ],
+    definitionOfDone: [
+      "States that Gate 04 is disabled and that undefined-risk shorts stay off the default path.",
+      DONE_NO_ORDER,
+    ],
+  },
+  cri: {
+    capability: "Crash Risk Index",
+    whenToUse:
+      "Read CRI, the tail-risk regime that forces systematic selling, and pair it with GEX, VCG-R, or GRG when the job is corroboration.",
+    hardNos: [
+      "Do not use CRI as a SpotGamma-style levels dashboard or as a standalone trade.",
+    ],
+    canonicalUrl: `${siteUrl}/crash-risk-index`,
+    demoUrl: `${DEMO_APP_URL}/regime/cri`,
+    mcp: MCP_CRI,
+    parameters: [
+      "Four components, each scored 0 to 25: VIX level and rate of change, VVIX and its ratio to VIX, COR1M implied correlation, and SPX distance from its 100-day average.",
+      "Published weights and thresholds. The scores sum to a 0 to 100 crash regime read.",
+    ],
+    definitionOfDone: [
+      "Reports the 0 to 100 CRI read, the published band, and the four component scores when present.",
+      DONE_NO_ORDER,
+    ],
+  },
+  gex: {
+    capability: "GEX walls and magnets",
+    whenToUse:
+      "Read dealer gamma (GEX) as walls and magnets, then pair it with CRI, VCG-R, or GRG. Walls set resistance; magnets set gravity.",
+    hardNos: [
+      "Do not treat GEX levels as a trade by themselves or as a SpotGamma-style dashboard substitute.",
+    ],
+    canonicalUrl: `${siteUrl}/`,
+    demoUrl: `${DEMO_APP_URL}/regime/gex`,
+    mcp: MCP_GEX,
+    parameters: [
+      "Aggregate dealer gamma by strike. Positive gamma pins and dampens; negative gamma amplifies.",
+      "Surfaces walls (resistance) and magnets (gravity) as price levels for targets and structure.",
+    ],
+    definitionOfDone: [
+      "Names walls and magnets for the requested ticker and the directional bias when present.",
+      DONE_NO_ORDER,
+    ],
+  },
+  structures: {
+    capability: "Structure catalog",
+    whenToUse:
+      "Choose a defined-risk options structure with gain at least 2x loss. The catalog is a risk policy, not a menu.",
+    hardNos: [
+      "Do not recommend undefined-risk or naked shorts as the default path.",
+    ],
+    canonicalUrl: `${siteUrl}/defined-risk-options-structures`,
+    demoUrl: `${DEMO_APP_URL}/options`,
+    mcp: MCP_NOT_PUBLIC,
+    parameters: [
+      "Filter on defined-risk, guard ALLOW, and gain at least 2x loss.",
+      "Gate 04 is disabled; catalog guard decisions still describe the preserved no-naked-shorts logic.",
+    ],
+    definitionOfDone: [
+      "Lists matching catalog entries with risk verdict and guard decision.",
+      DONE_NO_ORDER,
+    ],
+  },
+  kelly: {
+    capability: "Fractional Kelly sizer",
+    whenToUse:
+      "Size a defined-risk structure with fractional Kelly, hard-capped at 2.5% of bankroll per position.",
+    hardNos: [
+      "Do not override the 2.5% cap. The cap is a ceiling, not a target.",
+    ],
+    canonicalUrl: `${siteUrl}/fractional-kelly-position-sizing`,
+    demoUrl: DEMO_APP_URL,
+    mcp: MCP_NOT_PUBLIC,
+    parameters: [
+      "Signal odds b = max gain / max loss on the chosen defined-risk structure.",
+      "Quarter-Kelly, then min(that fraction, 2.5% of bankroll). If Kelly is smaller, take the smaller number.",
+    ],
+    definitionOfDone: [
+      "Reports b, quarter-Kelly, the 2.5% cap, and which number binds.",
+      DONE_NO_ORDER,
+    ],
+  },
+  "ib-terminal": {
+    capability: "Interactive Brokers dark pool terminal",
+    whenToUse:
+      "Explain the seven-milestone path from a print to an Interactive Brokers combo order. IB supplies tape, account state, and execution; Unusual Whales supplies the prints.",
+    hardNos: [
+      "There is no public order-placement API and no anonymous FastAPI /docs.",
+    ],
+    canonicalUrl: `${siteUrl}/interactive-brokers-dark-pool-terminal`,
+    demoUrl: DEMO_APP_URL,
+    mcp: MCP_NOT_PUBLIC,
+    parameters: [
+      "Interactive Brokers first for realtime data; Unusual Whales second for dark-pool prints and sweeps.",
+      "Live routing stays on the operator terminal behind Clerk.",
+    ],
+    definitionOfDone: [
+      "Explains the IB jobs (tape, account, execution, journal) without inventing a public order API.",
+      DONE_NO_ORDER,
+    ],
+  },
+  "uw-ib": {
+    capability: "Unusual Whales to Interactive Brokers",
+    whenToUse:
+      "Walk the disciplined pipeline from an Unusual Whales print to an Interactive Brokers defined-risk combo.",
+    hardNos: [
+      "An alert is a read, not a route. Do not treat Unusual Whales as a broker.",
+    ],
+    canonicalUrl: `${siteUrl}/unusual-whales-interactive-brokers`,
+    demoUrl: DEMO_APP_URL,
+    mcp: MCP_NOT_PUBLIC,
+    parameters: [
+      "Prints and options flow drive the flow score; open-interest changes are required confirmation; seasonality never gates a trade.",
+      "Four sequential gates and fractional Kelly sit between the read and any IB combo.",
+    ],
+    definitionOfDone: [
+      "Names ingest surfaces and the stages a print passes through, then stops before routing.",
+      DONE_NO_ORDER,
+    ],
+  },
+};
+
+export function getCapabilityPrompt(id: string): AgentPrompt {
+  const prompt = capabilityPrompts[id];
+  if (!prompt) {
+    throw new Error(`Unknown agent capability: ${id}`);
+  }
+  return prompt;
+}
+
+export const developerRecipes: DeveloperRecipe[] = [
+  {
+    id: "score-flow",
+    title: "Score flow for TICKER",
+    prompt: {
+      ...capabilityPrompts.flow,
+      whenToUse: `Score Unusual Whales dark-pool or OTC prints on TICKER for accumulation or distribution that has not moved the lit price.`,
+      demoUrl: `${DEMO_APP_URL}/flow-analysis/TICKER`,
+      parameters: [
+        "Replace TICKER with the symbol under review.",
+        ...capabilityPrompts.flow.parameters,
+      ],
+      definitionOfDone: [
+        "Reports the TICKER flow score, accumulation or distribution or below-threshold, and the lead window when one exists.",
+        DONE_NO_ORDER,
+      ],
+    },
+  },
+  {
+    id: "evaluate-gates",
+    title: "Evaluate gates for a structure",
+    prompt: {
+      ...capabilityPrompts.gates,
+      whenToUse:
+        "Evaluate STRUCTURE_ID through the four sequential gates. A failure at any gate stops the trade and names the gate.",
+      parameters: [
+        "Replace STRUCTURE_ID with a catalog name such as Long Call or Bull Call Spread.",
+        ...capabilityPrompts.gates.parameters,
+      ],
+      definitionOfDone: [
+        "Names STRUCTURE_ID and each gate pass or fail in order, and stops on the first failure.",
+        DONE_NO_ORDER,
+      ],
+    },
+  },
+  {
+    id: "read-cri",
+    title: "Read CRI regime",
+    prompt: capabilityPrompts.cri,
+  },
+  {
+    id: "read-gex",
+    title: "Read GEX walls and magnets for TICKER",
+    prompt: {
+      ...capabilityPrompts.gex,
+      whenToUse:
+        "Read dealer gamma (GEX) walls and magnets for TICKER, then pair the levels with CRI, VCG-R, or GRG.",
+      demoUrl: `${DEMO_APP_URL}/regime/gex`,
+      parameters: [
+        "Replace TICKER with the symbol whose dealer-gamma surface you need.",
+        ...capabilityPrompts.gex.parameters,
+      ],
+      definitionOfDone: [
+        "Names walls and magnets for TICKER and the directional bias when present.",
+        DONE_NO_ORDER,
+      ],
+    },
+  },
+  {
+    id: "list-structures",
+    title: "List convex structures",
+    prompt: {
+      ...capabilityPrompts.structures,
+      whenToUse:
+        "List catalog entries that clear the defined-risk convexity gate (gain at least 2x loss, guard ALLOW).",
+      parameters: [
+        "Optional filter: family id (vertical, butterfly, condor) or STRUCTURE_ID.",
+        ...capabilityPrompts.structures.parameters,
+      ],
+    },
+  },
+  {
+    id: "size-kelly",
+    title: "Size with fractional Kelly",
+    prompt: {
+      ...capabilityPrompts.kelly,
+      whenToUse:
+        "Size a defined-risk structure from MAX_GAIN and MAX_LOSS with fractional Kelly, hard-capped at 2.5% of bankroll.",
+      parameters: [
+        "Replace MAX_GAIN and MAX_LOSS with the structure's dollar extremes. Signal odds b = MAX_GAIN / MAX_LOSS.",
+        "Quarter-Kelly, then min(that fraction, 2.5% of bankroll). If Kelly is smaller, take the smaller number.",
+      ],
+      definitionOfDone: [
+        "Reports b from MAX_GAIN / MAX_LOSS, quarter-Kelly, the 2.5% cap, and which number binds.",
+        DONE_NO_ORDER,
+      ],
+    },
+  },
+  {
+    id: "bootstrap",
+    title: "What is Radon / when to use",
+    prompt: {
+      capability: "When to use",
+      whenToUse:
+        "Reach for Radon Terminal when the job is scoring Unusual Whales dark-pool or OTC prints; reading GEX walls and magnets; reading CRI, VCG-R, or GRG regimes; choosing a defined-risk options structure with gain at least 2x loss; or sizing with fractional Kelly hard-capped at 2.5% of bankroll.",
+      hardNos: [
+        "Do not treat Radon as a broker, a Robinhood integration, a public order API, or an order-routing MCP.",
+        "Do not invent Yahoo as the primary data source. Interactive Brokers first, Unusual Whales second, Yahoo last.",
+      ],
+      canonicalUrl: `${siteUrl}/agent-instructions`,
+      demoUrl: DEMO_APP_URL,
+      mcp: MCP_DOCS,
+      parameters: [
+        "Start at llms.txt, then fetch the matching URL with Accept: text/markdown or the .md suffix.",
+        "The working product surface without brokerage credentials is the free demo.",
+      ],
+      definitionOfDone: [
+        "Explains when Radon is the right tool, how to call it, and the hard nos.",
+        DONE_NO_ORDER,
+      ],
+    },
+  },
+];

--- a/site/lib/developer-pages.test.ts
+++ b/site/lib/developer-pages.test.ts
@@ -23,6 +23,7 @@ describe("developer resource pages", () => {
   it("publishes predictable developer URLs", () => {
     expect(agentPages.map((page) => page.slug)).toEqual([
       "developers",
+      "developers/recipes",
       "developers/openapi",
       "developers/auth",
       "developers/mcp",
@@ -30,10 +31,19 @@ describe("developer resource pages", () => {
       "agent-instructions",
     ]);
     expect(developersPage.heading).toBe("Radon Terminal developer resources");
+    expect(developersPage.sections.map((section) => section.id)).toContain(
+      "agent-prompt-payload",
+    );
+    expect(pageToMarkdown(developersPage)).toContain(
+      "Field order is stable: title, When to use, Hard nos, How to call, Parameters / constraints, Definition of done for the agent.",
+    );
     expect(openapiPage.heading).toBe("Radon Terminal OpenAPI spec");
     expect(authPage.heading).toBe("Radon Terminal auth docs");
     expect(mcpPage.heading).toBe("Radon Terminal MCP server");
     expect(webhooksPage.heading).toBe("Radon Terminal webhooks");
+    expect(agentPages.find((page) => page.slug === "developers/recipes")?.heading).toBe(
+      "Radon Terminal developer recipes",
+    );
   });
 
   it("keeps MCP and webhook copy honest", () => {

--- a/site/lib/developer-pages.ts
+++ b/site/lib/developer-pages.ts
@@ -7,7 +7,7 @@ import {
   siteUrl,
 } from "./seo";
 
-export const AGENT_SURFACES_LAST_MODIFIED = "2026-09-02";
+export const AGENT_SURFACES_LAST_MODIFIED = "2026-09-05";
 
 // The hosted Streamable HTTP MCP endpoint (issue #232 chunk 1). Served by a
 // dedicated process behind the app.radon.run edge; mcp.radon.run does not
@@ -76,6 +76,7 @@ export const developersPage: AgentPage = {
         `OpenAPI at ${siteUrl}/openapi.json describes the public radon.run developer surface.`,
         `Sitemap at ${siteUrl}/sitemap.xml lists every public HTML URL.`,
         `Agent instructions at ${siteUrl}/agent-instructions name the jobs Radon is right for and how an agent should call it.`,
+        `Developer recipes at ${siteUrl}/developers/recipes are one-paste agent prompts for Flow, Gates, CRI, GEX, the structure catalog, and fractional Kelly.`,
       ],
     },
     {
@@ -86,6 +87,17 @@ export const developersPage: AgentPage = {
         `Radon Terminal auth docs: ${siteUrl}/developers/auth.`,
         `Radon Terminal MCP server: ${siteUrl}/developers/mcp.`,
         `Radon Terminal webhooks: ${siteUrl}/developers/webhooks.`,
+        `Radon Terminal developer recipes: ${siteUrl}/developers/recipes.`,
+      ],
+    },
+    {
+      id: "agent-prompt-payload",
+      heading: "Agent prompt payload",
+      paragraphs: [
+        "Copy agent prompt on dossier and gate surfaces, and the recipe cards below, copy the same plain-markdown shape. Field order is stable: title, When to use, Hard nos, How to call, Parameters / constraints, Definition of done for the agent.",
+        "Hard nos always start with: not a broker and no Robinhood routing; no undefined-risk or naked shorts as the default path; live execution requires Interactive Brokers and operator rails. Then capability-specific nos.",
+        "How to call is always: read llms.txt; fetch the canonical URL with Accept: text/markdown or the .md suffix; open the demo deep link when one exists; use hosted MCP tools when they are public, otherwise markdown plus demo.",
+        "These prompts are free. They are not a public order API.",
       ],
     },
     {
@@ -132,7 +144,7 @@ export const openapiPage: AgentPage = {
       id: "covers",
       heading: "What it covers",
       paragraphs: [
-        "GET /llms.txt, GET /openapi.json, GET /sitemap.xml, GET /robots.txt, GET /agent-instructions, GET /developers and the named auth, MCP, and webhook docs.",
+        "GET /llms.txt, GET /openapi.json, GET /sitemap.xml, GET /robots.txt, GET /agent-instructions, GET /developers, GET /developers/recipes, and the named auth, MCP, and webhook docs.",
         "HTML pages accept content negotiation: send Accept: text/markdown for the markdown representation of the same URL.",
       ],
     },
@@ -268,6 +280,39 @@ export const webhooksPage: AgentPage = {
   ],
 };
 
+export const recipesPage: AgentPage = {
+  slug: "developers/recipes",
+  navLabel: "Recipes",
+  title: "Radon Terminal developer recipes",
+  heading: "Radon Terminal developer recipes",
+  description:
+    "Seven one-paste Radon Terminal agent prompts: score flow, evaluate gates, read CRI and GEX, list convex structures, size with fractional Kelly, and bootstrap from llms.txt.",
+  eyebrow: "Developers · Recipes",
+  intro:
+    "Each card is one agent turn. Copy the prompt, replace TICKER or STRUCTURE_ID or MAX_GAIN and MAX_LOSS, and paste it into a coding agent. The payload shape is documented on the developer index.",
+  lastModified: AGENT_SURFACES_LAST_MODIFIED,
+  sections: [
+    {
+      id: "how",
+      heading: "How to use a recipe",
+      paragraphs: [
+        "Copy agent prompt puts the canonical markdown on the clipboard. View prompt shows the same text without copying.",
+        "Fetch the canonical URL in the prompt with Accept: text/markdown, or open the matching .md suffix. The free demo is the working UI without brokerage credentials.",
+        "The hosted MCP is read-only. Recipes that name demo_regime or demo_gex need a demo Clerk token. Everything else says not public yet; use markdown plus demo.",
+      ],
+    },
+    {
+      id: "placeholders",
+      heading: "Placeholders",
+      paragraphs: [
+        "TICKER is an equity or index symbol such as NVDA.",
+        "STRUCTURE_ID is a catalog name such as Long Call or Bull Call Spread.",
+        "MAX_GAIN and MAX_LOSS are the structure's dollar extremes for fractional Kelly.",
+      ],
+    },
+  ],
+};
+
 export const agentInstructionsPage: AgentPage = {
   slug: "agent-instructions",
   navLabel: "Agent instructions",
@@ -316,6 +361,7 @@ export const agentInstructionsPage: AgentPage = {
 
 export const agentPages: AgentPage[] = [
   developersPage,
+  recipesPage,
   openapiPage,
   authPage,
   mcpPage,
@@ -324,6 +370,7 @@ export const agentPages: AgentPage[] = [
 ];
 
 export const developersMetadata = pageMetadata(developersPage);
+export const recipesMetadata = pageMetadata(recipesPage);
 export const openapiMetadata = pageMetadata(openapiPage);
 export const authMetadata = pageMetadata(authPage);
 export const mcpMetadata = pageMetadata(mcpPage);

--- a/site/lib/llms-txt.test.ts
+++ b/site/lib/llms-txt.test.ts
@@ -28,6 +28,8 @@ describe("llms.txt agent index", () => {
     expect(llmsTxt).toContain("Radon Terminal auth docs");
     expect(llmsTxt).toContain("Radon Terminal MCP server");
     expect(llmsTxt).toContain("Radon Terminal webhooks");
+    expect(llmsTxt).toContain(`${siteUrl}/developers/recipes`);
+    expect(llmsTxt).toContain("Radon Terminal developer recipes");
   });
 
   it("keeps H2 sections as file lists", () => {

--- a/site/lib/markdown-pages.test.ts
+++ b/site/lib/markdown-pages.test.ts
@@ -27,6 +27,10 @@ describe("markdown page registry", () => {
       expect(body).toContain(`# ${page.heading}`);
       expect(body).toContain("Radon");
     }
+    const recipes = lookupMarkdown("/developers/recipes");
+    expect(recipes).toContain("Score flow for TICKER");
+    expect(recipes).toContain("## When to use");
+    expect(recipes).toContain("## Hard nos");
   });
 
   it("returns HTTP 404 markdown with sitemap and llms recovery links", () => {

--- a/site/lib/markdown-pages.ts
+++ b/site/lib/markdown-pages.ts
@@ -1,7 +1,9 @@
 import { clusterPages } from "./cluster-pages";
+import { developerRecipes, formatAgentPrompt } from "./agent-prompts";
 import {
   agentPages,
   pageToMarkdown,
+  recipesPage,
 } from "./developer-pages";
 import {
   DEMO_URL,
@@ -132,6 +134,20 @@ for (const page of clusterPages) {
 for (const page of agentPages) {
   pages.set(`/${page.slug}`, pageToMarkdown(page));
 }
+
+pages.set(
+  `/${recipesPage.slug}`,
+  joinBlocks([
+    pageToMarkdown(recipesPage).trim(),
+    "## Recipes",
+    developerRecipes
+      .map(
+        (recipe) =>
+          `### ${recipe.title}\n\n${formatAgentPrompt(recipe.prompt).trim()}`,
+      )
+      .join("\n\n"),
+  ]),
+);
 
 export const MARKDOWN_PATHS = [...pages.keys()].sort();
 

--- a/site/lib/openapi.test.ts
+++ b/site/lib/openapi.test.ts
@@ -22,6 +22,7 @@ describe("public OpenAPI document", () => {
       "/llms.txt",
       "/openapi.json",
       "/developers",
+      "/developers/recipes",
       "/developers/openapi",
       "/developers/auth",
       "/developers/mcp",

--- a/site/lib/openapi.ts
+++ b/site/lib/openapi.ts
@@ -31,7 +31,13 @@ const documentedPaths = [
     path: "/developers",
     summary: "Radon Terminal developer resources",
     description:
-      "Index of OpenAPI, auth docs, MCP server, and webhook status. Accept: text/markdown supported.",
+      "Index of OpenAPI, auth docs, MCP server, webhook status, and agent-prompt payload shape. Accept: text/markdown supported.",
+  },
+  {
+    path: "/developers/recipes",
+    summary: "Radon Terminal developer recipes",
+    description:
+      "Seven one-paste agent prompts for Flow, Gates, CRI, GEX, structures, Kelly, and llms.txt bootstrap.",
   },
   {
     path: "/developers/openapi",

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,25 @@
+# Task: Agent distribution pattern (issue 295) [IN PROGRESS]
+
+Copy Agent Prompt on dossiers/gates plus 5-7 developer recipe cards.
+
+## Dependency graph
+
+- T1 depends_on: [] - Payload builder, capability registry, and 7 recipes (red/green).
+- T2 depends_on: [T1] - Copy agent prompt control + View prompt modal.
+- T3 depends_on: [T2] - Wire buttons on dossiers, homepage flow/gates/CRI/GEX.
+- T4 depends_on: [T1] - /developers/recipes, payload-shape doc, llms.txt, sitemap.
+- T5 depends_on: [T3, T4] - Site lib tests, Playwright, screenshots, PR for #295.
+
+## Checklist
+
+- [x] T1 Canonical payload + recipes
+- [x] T2 Copy control
+- [x] T3 Dossier/gate wiring
+- [x] T4 Discovery
+- [ ] T5 Verify and open PR
+
+---
+
 # Task: Make every demo workstation surface deterministic (2026-09-04) [DONE]
 
 Restore representative demo data across performance, orders, instruments,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -16,7 +16,13 @@ Copy Agent Prompt on dossiers/gates plus 5-7 developer recipe cards.
 - [x] T2 Copy control
 - [x] T3 Dossier/gate wiring
 - [x] T4 Discovery
-- [ ] T5 Verify and open PR
+- [x] T5 Verify and open PR
+
+## Review
+
+- Copy agent prompt is on all six dossiers, homepage Flow, the gate stack, Gates 01-04, and CRI/GEX cards.
+- Seven recipe cards live at /developers/recipes and are linked from developers, llms.txt, sitemap, and OpenAPI.
+- Verification: site lib 98 passed; focused 26 passed; Playwright agent-prompt-recipes 1 passed.
 
 ---
 

--- a/web/tests/iv-spread-api.test.ts
+++ b/web/tests/iv-spread-api.test.ts
@@ -271,17 +271,25 @@ describe("GET /api/iv-spread — absent and stale data are 200, never 4xx", () =
 
 describe("GET /api/iv-spread — degradation passes through untransformed", () => {
   it("passes a stale_source payload through verbatim", async () => {
-    // as_of must stay inside the 48h data-age budget. A frozen 2026-09-02
-    // date collapses to missing once "today" is more than two sessions later.
-    const asOf = new Date(Date.now() - 12 * 3_600_000)
-      .toISOString()
-      .slice(0, 10);
-    await insertSnapshot(buildPayload({ status: "stale_source", as_of: asOf }));
+    // Pin Date. A frozen 2026-09-02 as_of collapsed to missing two sessions
+    // later; 12h-ago on this noon clock is still the same YYYY-MM-DD and
+    // pins to T22:15Z in the future. 30h-ago matches the hour-sweep budget.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      const now = new Date(Date.UTC(2026, 8, 5, 12, 0, 0));
+      vi.setSystemTime(now);
+      const asOf = new Date(now.getTime() - 30 * 3_600_000)
+        .toISOString()
+        .slice(0, 10);
+      await insertSnapshot(buildPayload({ status: "stale_source", as_of: asOf }));
 
-    const { GET } = await import("../app/api/iv-spread/route");
-    const body = await (await GET()).json();
-    expect(body.status).toBe("stale_source");
-    expect(body.current.spread).toBeCloseTo(5.481468, 6);
+      const { GET } = await import("../app/api/iv-spread/route");
+      const body = await (await GET()).json();
+      expect(body.status).toBe("stale_source");
+      expect(body.current.spread).toBeCloseTo(5.481468, 6);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("keeps a null z_score / regime and an excluded session intact", async () => {

--- a/web/tests/iv-spread-api.test.ts
+++ b/web/tests/iv-spread-api.test.ts
@@ -271,7 +271,12 @@ describe("GET /api/iv-spread — absent and stale data are 200, never 4xx", () =
 
 describe("GET /api/iv-spread — degradation passes through untransformed", () => {
   it("passes a stale_source payload through verbatim", async () => {
-    await insertSnapshot(buildPayload({ status: "stale_source" }));
+    // as_of must stay inside the 48h data-age budget. A frozen 2026-09-02
+    // date collapses to missing once "today" is more than two sessions later.
+    const asOf = new Date(Date.now() - 12 * 3_600_000)
+      .toISOString()
+      .slice(0, 10);
+    await insertSnapshot(buildPayload({ status: "stale_source", as_of: asOf }));
 
     const { GET } = await import("../app/api/iv-spread/route");
     const body = await (await GET()).json();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements [#295](https://github.com/joemccann/radon/issues/295). Joe authorized merge this turn.

Successor of #298. Merge this PR; close #298 as superseded after merge.

## Summary

Every public Radon capability is one clipboard prompt. Unit of value is a capability (Flow, Gates, CRI, GEX, Structure catalog, Kelly), not a CSS kit.

## Part A — Copy agent prompt

- Shared markdown payload with stable field order: When to use, Hard nos, How to call, Parameters / constraints, Definition of done for the agent.
- Shared hard nos: not a broker / no Robinhood routing; no undefined-risk or naked shorts as the default path; live execution needs IB + operator rails.
- Button label `Copy agent prompt` plus toast and optional `View prompt` modal.
- Wired on all six dossiers, homepage Flow, the gate stack and Gates 01-04, and CRI / GEX regime cards.

## Part B — Developer recipes

Seven one-paste cards at `/developers/recipes`:

1. Score flow for TICKER
2. Evaluate gates for a structure
3. Read CRI regime
4. Read GEX walls and magnets for TICKER
5. List convex structures
6. Size with fractional Kelly
7. What is Radon / when to use

## Part C — Discovery

- Payload shape documented once on `/developers`.
- Recipes linked from the developer index, `llms.txt`, sitemap, and public OpenAPI.
- Markdown negotiation kept (`Accept: text/markdown` / `.md`), including full recipe bodies.

## Out of scope

- UI pack C (PR #296, already on main; GateCard keeps MarkerAccent plus Copy Agent Prompt)
- Paywalled prompts, public order API, Pro Studio
- P1 demo dual-mode, P3 skills pack, MCP expansion (#232)

## Conflict resolution vs main `43c786fd`

- `site/components/molecules/GateCard.tsx` — keep pack C `MarkerAccent` and #295 `CopyAgentPrompt` / `capabilityId`
- `web/tests/iv-spread-api.test.ts` — take main's yesterday `as_of` fixture
- `tasks/todo.md` — keep both #295 and pack C task sections

## Verification

- Focused Vitest after merge: 6 files, 45 passed (agent-prompts, developer-pages, markdown-pages, libraries-fx, iv-spread-api, libraries-fx-pack).
- Prior head `7a7a4d26` CI was green (Vitest 8/8, coverage ratchets, pytest matrix, perimeter smoke, Playwright P0).

- [x] Red/green TDD (failing test, then fix)
- [x] Staged only the files this change owns (no `git add -A`)
- [x] Owner doc updated, or the commit message has `docs-skip: <reason>`
- [x] Screenshots of button + recipes live on #298
- [x] Previous `main` deploy finished before this push

Fixes #295

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6396bc0c-6968-4442-b74c-96e75e4eea14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6396bc0c-6968-4442-b74c-96e75e4eea14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

