### PR TITLE
Preflight must try both compose-render paths, not deadlock on one

### DIFF
--- a/cloud/scripts/deploy.sh
+++ b/cloud/scripts/deploy.sh
@@ -201,11 +201,17 @@ preflight_env() {
   # this deploy defaults to. The direct call remains for a dev or test
   # invocation against some other env file, where the caller has its own
   # docker access.
+  # Try BOTH paths and fail only when neither renders. Preferring one and
+  # stopping there deadlocks the deploy: this file arrives from the new release
+  # before refresh-control-plane installs the sudoers verb that permits the shim
+  # call, so `sudo -n` is refused, preflight aborts, and the promote that would
+  # have installed the verb never runs. The same applies in reverse once radon
+  # leaves group `docker` and the direct call is the one that cannot work.
+  # A genuinely unrenderable compose body still fails both.
   local compose_check_ok=0
-  if [[ -x "$DOCKER_GW" && "$env_file" == "$ENV_FILE_DEFAULT" ]]; then
-    if sudo -n "$DOCKER_GW" config-check >/dev/null 2>&1; then
-      compose_check_ok=1
-    fi
+  if [[ -x "$DOCKER_GW" && "$env_file" == "$ENV_FILE_DEFAULT" ]] \
+    && sudo -n "$DOCKER_GW" config-check >/dev/null 2>&1; then
+    compose_check_ok=1
   elif (
     cd "$CLOUD_DIR"
     RADON_COMPOSE_ENV_FILE="$env_file" \

--- a/cloud/tests/test_docker_gw_shim.py
+++ b/cloud/tests/test_docker_gw_shim.py
@@ -197,7 +197,30 @@ def test_sudoers_lists_each_verb_without_a_wildcard() -> None:
     assert "radon ALL=(root) NOPASSWD: /usr/bin/docker compose" not in text
 
 
-def test_deploy_preflight_prefers_the_shim_over_group_docker() -> None:
+def _preflight_body() -> str:
     deploy = (CLOUD / "scripts" / "deploy.sh").read_text(encoding="utf-8")
-    assert "$DOCKER_GW\" config-check" in deploy or '"$DOCKER_GW" config-check' in deploy
-    assert 'sudo -n "$DOCKER_GW" config-check' in deploy
+    start = deploy.index("preflight_env() {")
+    return deploy[start : deploy.index("\n}", start)]
+
+
+def test_deploy_preflight_prefers_the_shim_over_group_docker() -> None:
+    assert 'sudo -n "$DOCKER_GW" config-check' in _preflight_body()
+
+
+def test_deploy_preflight_falls_back_instead_of_deadlocking() -> None:
+    """Preferring one path and stopping there strands the deploy.
+
+    deploy.sh arrives from the new release BEFORE refresh-control-plane
+    installs the sudoers verb that permits the shim call, so `sudo -n` is
+    refused; if that were the only path, preflight would abort and the promote
+    that installs the verb would never run. It has to fall through to the
+    direct render, and only fail when neither works.
+    """
+    body = _preflight_body()
+    shim_at = body.index('sudo -n "$DOCKER_GW" config-check')
+    direct_at = body.index("docker compose --env-file")
+    fail_at = body.index("compose config validation failed")
+
+    assert shim_at < direct_at < fail_at, "direct render must sit between them"
+    assert "elif (" in body, "the direct render must be an elif fallback"
+    assert body.count("compose_check_ok=1") == 2


### PR DESCRIPTION
Hotfix. **Production deploys are currently blocked** — main is red at `b9c026e8`.

## What I broke

#297 made `preflight_env` prefer `sudo -n radon-docker-gw config-check`, falling back to the direct render only when the shim was absent or the env file was non-canonical. On the app host both conditions are satisfied, so the deploy took the shim path — and `sudo -n` was refused, because the sudoers verb permitting `config-check` ships in that same release and is installed by `refresh-control-plane` **after** promote.

That is a deadlock, not a flake: preflight aborts before promote, so the verb that would make preflight pass can never be installed. Every subsequent deploy fails identically.

Evidence, run 33933705972:
```
[WARN]  [preflight] privileged control-plane config/sudoers.d/radon-ops differs
        from the installed manifest; refresh-control-plane-privileged will apply
        it after promote
[env-check] ok (39 contract keys)
[ERROR] [preflight] FAIL: docker compose config validation failed
[ERROR] Aborting deploy: env preflight failed.
```
The warning line names the exact cause: the sudoers file was still the old one.

## Fix

Attempt both paths; fail only when neither renders. The same reasoning holds in reverse — once `radon` leaves group `docker`, the direct call is the one that cannot work and the shim carries it. A genuinely unrenderable compose body still fails both, so the check is not weakened.

This unblocks itself: with the fallback, preflight tries the shim (refused, verb not yet installed), falls through to the direct render (radon is still in group `docker`), passes, and the promote then installs the verb.

## Regression

`test_deploy_preflight_falls_back_instead_of_deadlocking` pins the ordering — shim attempt, then the direct render as an `elif`, then the failure — and asserts two `compose_check_ok=1` assignments, so a future edit cannot collapse it back to a single path.

`cloud/tests/test_docker_gw_shim.py`: 27 passed. `test_deploy_resilience` + `test_monorepo_cutover` + `test_deploy_and_setup` + `test_deploy_corrections`: 209 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXaiDhMkTcXjJmyT14Z4Eg