### PR TITLE
fix(web): stack /regime/cri charts to match other regime pages

### DIFF
--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -12,7 +12,7 @@ Stack CRI charts full width to match sibling regime pages. Leave Correlation Ris
 
 - [x] T1 Failing contracts
 - [x] T2 Layout + hover
-- [ ] T3 Verify and open PR
+- [x] T3 Verify and open PR
 
 ---
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,21 @@
+# Task: /regime/cri chart layout + scatter hover [IN PROGRESS]
+
+Stack CRI charts full width to match sibling regime pages. Leave Correlation Risk Premium unchanged.
+
+## Dependency graph
+
+- T1 depends_on: [] - Failing layout/hover contracts for history, quadrants, divergence.
+- T2 depends_on: [T1] - Full-width stack + quadrant scatter tooltips.
+- T3 depends_on: [T2] - Focused Vitest + Playwright, screenshots, PR against main. Do not merge.
+
+## Checklist
+
+- [x] T1 Failing contracts
+- [x] T2 Layout + hover
+- [ ] T3 Verify and open PR
+
+---
+
 # Task: Agent distribution pattern (issue 295) [IN PROGRESS]
 
 Copy Agent Prompt on dossiers/gates plus 5-7 developer recipe cards.

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -11449,7 +11449,7 @@ body[data-mobile="true"] .vol-cone-analysis .vol-cone-analysis-metrics {
 
 .regime-history-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: 1fr;
   gap: 16px;
   align-items: start;
 }
@@ -11583,7 +11583,7 @@ body[data-mobile="true"] .vol-cone-analysis .vol-cone-analysis-metrics {
 
 .regime-relationship-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: 1fr;
   gap: 16px;
   align-items: start;
   padding: 16px;

--- a/web/components/RegimePanel.tsx
+++ b/web/components/RegimePanel.tsx
@@ -834,7 +834,7 @@ export default function RegimePanel({
         </>
       )}
 
-      {/* ── Row 5: 20-Session History Charts (side by side) ── */}
+      {/* ── Row 5: 20-Session History Charts (full-width stack) ── */}
 
       {data?.history && data.history.length > 0 && (() => {
         const vixVvixSeries: [ChartSeries, ChartSeries] = [

--- a/web/components/RegimeRelationshipView.tsx
+++ b/web/components/RegimeRelationshipView.tsx
@@ -88,6 +88,26 @@ export function resolveRelationshipTickCount(innerWidth: number): number {
   return Math.max(4, Math.min(7, Math.floor(innerWidth / 110)));
 }
 
+export function nearestRegimeScatterIndex(
+  points: ReadonlyArray<{ x: number; y: number }>,
+  pointerX: number,
+  pointerY: number,
+): number {
+  if (points.length === 0) return 0;
+  let best = 0;
+  let bestDist = Number.POSITIVE_INFINITY;
+  for (let index = 0; index < points.length; index += 1) {
+    const dx = points[index].x - pointerX;
+    const dy = points[index].y - pointerY;
+    const dist = dx * dx + dy * dy;
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = index;
+    }
+  }
+  return best;
+}
+
 function spreadStateColor(state: string): string {
   if (state === "Fear Premium") return "var(--positive)";
   if (state === "Realized Lead") return "var(--negative)";
@@ -144,6 +164,7 @@ type ZScoreHoverState = {
 };
 
 type SpreadHoverState = ZScoreHoverState;
+type QuadrantHoverState = ZScoreHoverState;
 
 type BrushDragMode = "left" | "right" | "window";
 
@@ -161,10 +182,12 @@ export default function RegimeRelationshipView({
 }: RegimeRelationshipViewProps) {
   const zScoreSvgRef = useRef<SVGSVGElement>(null);
   const spreadSvgRef = useRef<SVGSVGElement>(null);
+  const quadrantSvgRef = useRef<SVGSVGElement>(null);
   const brushRef = useRef<HTMLDivElement>(null);
   const dragStateRef = useRef<BrushDragState | null>(null);
   const [zScoreHover, setZScoreHover] = useState<ZScoreHoverState | null>(null);
   const [spreadHover, setSpreadHover] = useState<SpreadHoverState | null>(null);
+  const [quadrantHover, setQuadrantHover] = useState<QuadrantHoverState | null>(null);
   const entries = useMemo(
     () => buildRegimeRelationshipEntries(history, liveValues),
     [history, liveValues],
@@ -351,6 +374,14 @@ export default function RegimeRelationshipView({
   const spreadTooltipTop = spreadHover
     ? Math.max(12, Math.min(spreadHover.y - 54, spreadHover.height - 96))
     : 0;
+  const quadrantTooltipSideStyle = quadrantHover
+    ? quadrantHover.x > quadrantHover.width / 2
+      ? { right: quadrantHover.width - quadrantHover.x + 12 }
+      : { left: quadrantHover.x + 12 }
+    : {};
+  const quadrantTooltipTop = quadrantHover
+    ? Math.max(12, Math.min(quadrantHover.y - 54, quadrantHover.height - 96))
+    : 0;
 
   // Brush window dimensions as percentages of the brush track.
   const totalSpan = Math.max(entries.length - 1, 1);
@@ -415,6 +446,36 @@ export default function RegimeRelationshipView({
 
   function handleSpreadHover(event: ReactMouseEvent<HTMLElement | SVGRectElement>) {
     updateSpreadHover(event.clientX, event.clientY);
+  }
+
+  function updateQuadrantHover(clientX: number, clientY: number) {
+    const svgRect = quadrantSvgRef.current?.getBoundingClientRect();
+    if (!svgRect || entries.length === 0) return;
+
+    const pointerX = clientX - svgRect.left;
+    const pointerY = clientY - svgRect.top;
+    const chartX = (pointerX / svgRect.width) * CHART_WIDTH;
+    const chartY = (pointerY / svgRect.height) * CHART_HEIGHT;
+    const innerX = chartX - MARGIN.left;
+    const innerY = chartY - MARGIN.top;
+    const points = entries.map((entry) => ({
+      x: scatterXScale(entry.realizedVol),
+      y: scatterYScale(entry.cor1m),
+    }));
+    const index = nearestRegimeScatterIndex(points, innerX, innerY);
+
+    setQuadrantHover({
+      entry: entries[index],
+      index,
+      x: pointerX,
+      y: pointerY,
+      width: svgRect.width,
+      height: svgRect.height,
+    });
+  }
+
+  function handleQuadrantHover(event: ReactMouseEvent<HTMLElement | SVGRectElement>) {
+    updateQuadrantHover(event.clientX, event.clientY);
   }
 
   function applyPreset(slug: RangePresetSlug) {
@@ -751,7 +812,7 @@ export default function RegimeRelationshipView({
           </div>
         </section>
 
-        <section className="regime-relationship-panel" data-testid="regime-quadrant-card">
+        <section className="regime-relationship-panel regime-relationship-panel-wide" data-testid="regime-quadrant-card">
           <div className="regime-relationship-panel-head">
             <div>
               <div className="regime-panel-title">REGIME QUADRANTS</div>
@@ -771,108 +832,177 @@ export default function RegimeRelationshipView({
             </div>
           </div>
 
-          <svg
-            className="regime-relationship-chart"
-            data-testid="regime-quadrant-chart"
-            viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
-            role="img"
-            aria-label="RVOL versus COR1M regime quadrant"
+          <div
+            className="regime-relationship-chart-shell"
+            data-testid="regime-quadrant-chart-shell"
+            onPointerMove={handleQuadrantHover}
+            onMouseMove={handleQuadrantHover}
+            onPointerLeave={() => setQuadrantHover(null)}
+            onMouseLeave={() => setQuadrantHover(null)}
           >
-            <g transform={`translate(${MARGIN.left},${MARGIN.top})`}>
-              {scatterXScale.ticks(4).map((tick) => (
-                <g key={`scatter-x-${tick}`}>
-                  <line
-                    x1={scatterXScale(tick)}
-                    x2={scatterXScale(tick)}
-                    y1={0}
-                    y2={innerHeight}
-                    className="regime-relationship-grid-line"
-                  />
-                  <text
-                    x={scatterXScale(tick)}
-                    y={innerHeight + 20}
-                    textAnchor="middle"
-                    className="regime-relationship-axis-label"
-                  >
-                    {tick.toFixed(1)}
-                  </text>
-                </g>
-              ))}
-              {scatterYScale.ticks(4).map((tick) => (
-                <g key={`scatter-y-${tick}`}>
-                  <line
-                    x1={0}
-                    x2={innerWidth}
-                    y1={scatterYScale(tick)}
-                    y2={scatterYScale(tick)}
-                    className="regime-relationship-grid-line"
-                  />
-                  <text
-                    x={-10}
-                    y={scatterYScale(tick) + 4}
-                    textAnchor="end"
-                    className="regime-relationship-axis-label"
-                  >
-                    {tick.toFixed(1)}
-                  </text>
-                </g>
-              ))}
+            <svg
+              ref={quadrantSvgRef}
+              className="regime-relationship-chart"
+              data-testid="regime-quadrant-chart"
+              viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+              role="img"
+              aria-label="RVOL versus COR1M regime quadrant"
+            >
+              <g transform={`translate(${MARGIN.left},${MARGIN.top})`}>
+                {scatterXScale.ticks(4).map((tick) => (
+                  <g key={`scatter-x-${tick}`}>
+                    <line
+                      x1={scatterXScale(tick)}
+                      x2={scatterXScale(tick)}
+                      y1={0}
+                      y2={innerHeight}
+                      className="regime-relationship-grid-line"
+                    />
+                    <text
+                      x={scatterXScale(tick)}
+                      y={innerHeight + 20}
+                      textAnchor="middle"
+                      className="regime-relationship-axis-label"
+                    >
+                      {tick.toFixed(1)}
+                    </text>
+                  </g>
+                ))}
+                {scatterYScale.ticks(4).map((tick) => (
+                  <g key={`scatter-y-${tick}`}>
+                    <line
+                      x1={0}
+                      x2={innerWidth}
+                      y1={scatterYScale(tick)}
+                      y2={scatterYScale(tick)}
+                      className="regime-relationship-grid-line"
+                    />
+                    <text
+                      x={-10}
+                      y={scatterYScale(tick) + 4}
+                      textAnchor="end"
+                      className="regime-relationship-axis-label"
+                    >
+                      {tick.toFixed(1)}
+                    </text>
+                  </g>
+                ))}
 
-              <line
-                x1={scatterXScale(realizedMean)}
-                x2={scatterXScale(realizedMean)}
-                y1={0}
-                y2={innerHeight}
-                className="regime-relationship-baseline"
-              />
-              <line
-                x1={0}
-                x2={innerWidth}
-                y1={scatterYScale(cor1mMean)}
-                y2={scatterYScale(cor1mMean)}
-                className="regime-relationship-baseline"
-              />
+                <line
+                  x1={scatterXScale(realizedMean)}
+                  x2={scatterXScale(realizedMean)}
+                  y1={0}
+                  y2={innerHeight}
+                  className="regime-relationship-baseline"
+                />
+                <line
+                  x1={0}
+                  x2={innerWidth}
+                  y1={scatterYScale(cor1mMean)}
+                  y2={scatterYScale(cor1mMean)}
+                  className="regime-relationship-baseline"
+                />
 
-              <text x={10} y={18} className="regime-relationship-quadrant-label">Fragile Calm</text>
-              <text x={innerWidth - 10} y={18} textAnchor="end" className="regime-relationship-quadrant-label">Systemic Panic</text>
-              <text x={10} y={innerHeight - 10} className="regime-relationship-quadrant-label">Goldilocks</text>
-              <text x={innerWidth - 10} y={innerHeight - 10} textAnchor="end" className="regime-relationship-quadrant-label">Stock Picker&apos;s</text>
+                <text x={10} y={18} className="regime-relationship-quadrant-label">Fragile Calm</text>
+                <text x={innerWidth - 10} y={18} textAnchor="end" className="regime-relationship-quadrant-label">Systemic Panic</text>
+                <text x={10} y={innerHeight - 10} className="regime-relationship-quadrant-label">Goldilocks</text>
+                <text x={innerWidth - 10} y={innerHeight - 10} textAnchor="end" className="regime-relationship-quadrant-label">Stock Picker&apos;s</text>
 
-              {entries.map((entry, index) => {
-                const isLatest = index === entries.length - 1;
-                return (
+                {entries.map((entry, index) => {
+                  const isLatest = index === entries.length - 1;
+                  return (
+                    <circle
+                      key={`scatter-point-${entry.date}`}
+                      data-testid={`regime-quadrant-point-${entry.date}`}
+                      cx={scatterXScale(entry.realizedVol)}
+                      cy={scatterYScale(entry.cor1m)}
+                      r={isLatest ? 6 : 3.5}
+                      fill={isLatest ? latestQuadrantColor : "var(--signal-core)"}
+                      opacity={isLatest ? 1 : 0.18 + (index / entries.length) * 0.45}
+                      stroke={isLatest ? latestQuadrantColor : "none"}
+                      className={isLatest ? "regime-relationship-marker" : undefined}
+                    />
+                  );
+                })}
+
+                {quadrantHover && (
                   <circle
-                    key={`scatter-point-${entry.date}`}
-                    cx={scatterXScale(entry.realizedVol)}
-                    cy={scatterYScale(entry.cor1m)}
-                    r={isLatest ? 6 : 3.5}
-                    fill={isLatest ? latestQuadrantColor : "var(--signal-core)"}
-                    opacity={isLatest ? 1 : 0.18 + (index / entries.length) * 0.45}
-                    stroke={isLatest ? latestQuadrantColor : "none"}
-                    className={isLatest ? "regime-relationship-marker" : undefined}
+                    cx={scatterXScale(quadrantHover.entry.realizedVol)}
+                    cy={scatterYScale(quadrantHover.entry.cor1m)}
+                    r={7}
+                    fill={quadrantTone(quadrantHover.entry.quadrant)}
+                    stroke={quadrantTone(quadrantHover.entry.quadrant)}
+                    className="regime-relationship-hover-marker"
                   />
-                );
-              })}
+                )}
 
-              <text
-                x={innerWidth / 2}
-                y={innerHeight + 30}
-                textAnchor="middle"
-                className="regime-relationship-axis-title"
+                <text
+                  x={innerWidth / 2}
+                  y={innerHeight + 30}
+                  textAnchor="middle"
+                  className="regime-relationship-axis-title"
+                >
+                  RVOL
+                </text>
+                <text
+                  x={-innerHeight / 2}
+                  y={-30}
+                  textAnchor="middle"
+                  transform="rotate(-90)"
+                  className="regime-relationship-axis-title"
+                >
+                  COR1M
+                </text>
+
+                <rect
+                  x={0}
+                  y={0}
+                  width={innerWidth}
+                  height={innerHeight}
+                  fill="transparent"
+                  pointerEvents="all"
+                  className="regime-relationship-chart-overlay"
+                  data-testid="regime-quadrant-chart-overlay"
+                  onPointerMove={handleQuadrantHover}
+                />
+              </g>
+            </svg>
+
+            {quadrantHover && (
+              <div
+                className="chart-tooltip regime-relationship-chart-tooltip"
+                data-testid="regime-quadrant-hover-tooltip"
+                style={{
+                  top: `${quadrantTooltipTop}px`,
+                  ...quadrantTooltipSideStyle,
+                }}
               >
-                RVOL
-              </text>
-              <text
-                x={-innerHeight / 2}
-                y={-30}
-                textAnchor="middle"
-                transform="rotate(-90)"
-                className="regime-relationship-axis-title"
-              >
-                COR1M
-              </text>
-            </g>
-          </svg>
+                <div className="chart-tooltip-date" data-testid="regime-quadrant-hover-date">
+                  {formatDateLabel(quadrantHover.entry.date)}
+                </div>
+                <div className="chart-tooltip-row">
+                  <span className="chart-tooltip-label">Quadrant</span>
+                  <span className="chart-tooltip-value">{quadrantHover.entry.quadrant}</span>
+                </div>
+                <div className="chart-tooltip-row">
+                  <span className="chart-tooltip-label">RVOL</span>
+                  <span className="chart-tooltip-value">{quadrantHover.entry.realizedVol.toFixed(2)}</span>
+                </div>
+                <div className="chart-tooltip-row">
+                  <span className="chart-tooltip-label">COR1M</span>
+                  <span className="chart-tooltip-value">{quadrantHover.entry.cor1m.toFixed(2)}</span>
+                </div>
+                <div className="chart-tooltip-row">
+                  <span className="chart-tooltip-label">RVOL z</span>
+                  <span className="chart-tooltip-value">{fmtSigned(quadrantHover.entry.realizedVolZ)}σ</span>
+                </div>
+                <div className="chart-tooltip-row">
+                  <span className="chart-tooltip-label">COR1M z</span>
+                  <span className="chart-tooltip-value">{fmtSigned(quadrantHover.entry.cor1mZ)}σ</span>
+                </div>
+              </div>
+            )}
+          </div>
 
           <div className="regime-state-key" data-testid="regime-state-key">
             <div className="regime-panel-title">STATE KEY</div>
@@ -905,7 +1035,7 @@ export default function RegimeRelationshipView({
           </div>
         </section>
 
-        <section className="regime-relationship-panel" data-testid="regime-zscore-card">
+        <section className="regime-relationship-panel regime-relationship-panel-wide" data-testid="regime-zscore-card">
           <div className="regime-relationship-panel-head">
             <div>
               <div className="regime-panel-title">

--- a/web/e2e/regime-history-responsive.spec.ts
+++ b/web/e2e/regime-history-responsive.spec.ts
@@ -116,7 +116,7 @@ async function setupMocks(page: import("@playwright/test").Page) {
 }
 
 test.describe("/regime page — responsive history chart stack", () => {
-  test("keeps the charts side by side on wide screens", async ({ page }) => {
+  test("stacks the charts full width on wide screens", async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 1400 });
     await setupMocks(page);
     await page.goto("/regime");
@@ -131,8 +131,9 @@ test.describe("/regime page — responsive history chart stack", () => {
 
     expect(firstBox).not.toBeNull();
     expect(secondBox).not.toBeNull();
-    expect(Math.abs((firstBox?.y ?? 0) - (secondBox?.y ?? 0))).toBeLessThan(20);
-    expect((secondBox?.x ?? 0)).toBeGreaterThan((firstBox?.x ?? 0) + 40);
+    expect((secondBox?.y ?? 0)).toBeGreaterThan((firstBox?.y ?? 0) + (firstBox?.height ?? 0) - 20);
+    expect(Math.abs((firstBox?.x ?? 0) - (secondBox?.x ?? 0))).toBeLessThan(20);
+    expect(Math.abs((firstBox?.width ?? 0) - (secondBox?.width ?? 0))).toBeLessThan(24);
   });
 
   test("stacks the charts vertically on narrow screens", async ({ page }) => {

--- a/web/e2e/regime-history-tooltip.spec.ts
+++ b/web/e2e/regime-history-tooltip.spec.ts
@@ -136,8 +136,8 @@ test.describe("/regime page — 20-session history tooltip", () => {
 
     const tooltip = page.locator('[data-testid="regime-history-tooltip-bubble"]');
     await expect(tooltip).toBeVisible();
-    await expect(tooltip).toContainText("Left chart tracks VIX and VVIX across the last 20 trading sessions");
-    await expect(tooltip).toContainText("Right chart compares realized volatility with COR1M over the same window");
+    await expect(tooltip).toContainText("The VIX / VVIX chart tracks VIX and VVIX across the last 20 trading sessions");
+    await expect(tooltip).toContainText("The realized vol / COR1M chart compares realized volatility with COR1M over the same window");
     await expect(tooltip).toContainText("VIX");
     await expect(tooltip).toContainText("VVIX");
     await expect(tooltip).toContainText("realized volatility");

--- a/web/e2e/regime-relationship-view.spec.ts
+++ b/web/e2e/regime-relationship-view.spec.ts
@@ -233,4 +233,61 @@ test.describe("/regime page — RVOL/COR1M relationship view", () => {
     await expect(tooltip).toContainText("COR1M z-score");
     await expect(tooltip).toContainText("Divergence");
   });
+
+  test("shows a hover readout for the regime quadrant scatter", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 1800 });
+    await setupMocks(page);
+    await page.goto("/regime");
+
+    const chartShell = page.locator('[data-testid="regime-quadrant-chart-shell"]');
+    await expect(chartShell).toBeVisible();
+
+    const shellBox = await chartShell.boundingBox();
+    expect(shellBox).not.toBeNull();
+    if (!shellBox) {
+      throw new Error("Expected quadrant chart shell to have a bounding box");
+    }
+
+    await chartShell.dispatchEvent("mousemove", {
+      bubbles: true,
+      clientX: shellBox.x + shellBox.width * 0.62,
+      clientY: shellBox.y + shellBox.height * 0.42,
+    });
+
+    const tooltip = page.locator('[data-testid="regime-quadrant-hover-tooltip"]');
+    await expect(tooltip).toBeVisible();
+    await expect(tooltip.locator('[data-testid="regime-quadrant-hover-date"]')).toContainText("Mar");
+    await expect(tooltip).toContainText("Quadrant");
+    await expect(tooltip).toContainText("RVOL");
+    await expect(tooltip).toContainText("COR1M");
+  });
+
+  test("stacks relationship charts full width except the already-wide premium panel", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 1800 });
+    await setupMocks(page);
+    await page.goto("/regime");
+
+    const spread = page.locator('[data-testid="regime-spread-card"]');
+    const quadrant = page.locator('[data-testid="regime-quadrant-card"]');
+    const zscore = page.locator('[data-testid="regime-zscore-card"]');
+    await expect(spread).toBeVisible();
+    await expect(quadrant).toBeVisible();
+    await expect(zscore).toBeVisible();
+
+    const [spreadBox, quadrantBox, zscoreBox] = await Promise.all([
+      spread.boundingBox(),
+      quadrant.boundingBox(),
+      zscore.boundingBox(),
+    ]);
+
+    expect(spreadBox).not.toBeNull();
+    expect(quadrantBox).not.toBeNull();
+    expect(zscoreBox).not.toBeNull();
+    expect((quadrantBox?.y ?? 0)).toBeGreaterThan((spreadBox?.y ?? 0) + (spreadBox?.height ?? 0) - 24);
+    expect((zscoreBox?.y ?? 0)).toBeGreaterThan((quadrantBox?.y ?? 0) + (quadrantBox?.height ?? 0) - 24);
+    expect(Math.abs((spreadBox?.x ?? 0) - (quadrantBox?.x ?? 0))).toBeLessThan(20);
+    expect(Math.abs((quadrantBox?.x ?? 0) - (zscoreBox?.x ?? 0))).toBeLessThan(20);
+    expect(Math.abs((spreadBox?.width ?? 0) - (quadrantBox?.width ?? 0))).toBeLessThan(24);
+    expect(Math.abs((quadrantBox?.width ?? 0) - (zscoreBox?.width ?? 0))).toBeLessThan(24);
+  });
 });

--- a/web/e2e/regime-relationship-view.spec.ts
+++ b/web/e2e/regime-relationship-view.spec.ts
@@ -220,10 +220,8 @@ test.describe("/regime page — RVOL/COR1M relationship view", () => {
       throw new Error("Expected z-score chart shell to have a bounding box");
     }
 
-    await chartShell.dispatchEvent("mousemove", {
-      bubbles: true,
-      clientX: shellBox.x + shellBox.width * 0.74,
-      clientY: shellBox.y + shellBox.height * 0.5,
+    await chartShell.hover({
+      position: { x: shellBox.width * 0.74, y: shellBox.height * 0.5 },
     });
 
     const tooltip = page.locator('[data-testid="regime-zscore-hover-tooltip"]');
@@ -248,15 +246,13 @@ test.describe("/regime page — RVOL/COR1M relationship view", () => {
       throw new Error("Expected quadrant chart shell to have a bounding box");
     }
 
-    await chartShell.dispatchEvent("mousemove", {
-      bubbles: true,
-      clientX: shellBox.x + shellBox.width * 0.62,
-      clientY: shellBox.y + shellBox.height * 0.42,
+    await chartShell.hover({
+      position: { x: shellBox.width * 0.62, y: shellBox.height * 0.42 },
     });
 
     const tooltip = page.locator('[data-testid="regime-quadrant-hover-tooltip"]');
     await expect(tooltip).toBeVisible();
-    await expect(tooltip.locator('[data-testid="regime-quadrant-hover-date"]')).toContainText("Mar");
+    await expect(tooltip.locator('[data-testid="regime-quadrant-hover-date"]')).toHaveText(/Feb|Mar/);
     await expect(tooltip).toContainText("Quadrant");
     await expect(tooltip).toContainText("RVOL");
     await expect(tooltip).toContainText("COR1M");

--- a/web/lib/sectionTooltips.ts
+++ b/web/lib/sectionTooltips.ts
@@ -105,8 +105,8 @@ export const SECTION_TOOLTIPS: Record<string, string> = {
     "and COR1M > 60 (panic herding). All three must fire to trigger.",
 
   "20-SESSION HISTORY":
-    "Left chart tracks VIX and VVIX across the last 20 trading sessions so you can see whether volatility and vol-of-vol are expanding together or cooling off. " +
-    "Right chart compares realized volatility with COR1M over the same window to show whether actual market turbulence is being joined by tighter stock-to-stock correlation. " +
+    "The VIX / VVIX chart tracks VIX and VVIX across the last 20 trading sessions so you can see whether volatility and vol-of-vol are expanding together or cooling off. " +
+    "The realized vol / COR1M chart compares realized volatility with COR1M over the same window to show whether actual market turbulence is being joined by tighter stock-to-stock correlation. " +
     "The latest point is the most recent session in view, and each point shows that session's reading.",
 
   "RELATIONSHIP VIEW":

--- a/web/tests/regime-cri-chart-layout.test.ts
+++ b/web/tests/regime-cri-chart-layout.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { fileURLToPath } from "url";
+import { nearestRegimeScatterIndex } from "../components/RegimeRelationshipView";
+
+const TEST_DIR = fileURLToPath(new URL(".", import.meta.url));
+const PANEL_PATH = join(TEST_DIR, "../components/RegimePanel.tsx");
+const VIEW_PATH = join(TEST_DIR, "../components/RegimeRelationshipView.tsx");
+const CSS_PATH = join(TEST_DIR, "../app/globals.css");
+const panelSource = readFileSync(PANEL_PATH, "utf-8");
+const viewSource = readFileSync(VIEW_PATH, "utf-8");
+const cssSource = readFileSync(CSS_PATH, "utf-8");
+
+function cssRule(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = cssSource.match(new RegExp(`${escaped}\\s*\\{([\\s\\S]*?)\\n\\}`));
+  if (!match) {
+    throw new Error(`Missing CSS rule for ${selector}`);
+  }
+  return match[1];
+}
+
+describe("CRI chart layout — full-width stack", () => {
+  it("stacks the analytical history charts in a single column", () => {
+    expect(panelSource).toContain('className="regime-history-grid"');
+    expect(panelSource).toContain('data-testid="regime-history-grid"');
+    expect(cssRule(".regime-history-grid")).toMatch(/grid-template-columns:\s*1fr/);
+    expect(cssRule(".regime-history-grid")).not.toMatch(/repeat\(2/);
+  });
+
+  it("keeps Correlation Risk Premium on its existing wide panel contract", () => {
+    expect(viewSource).toContain('data-testid="regime-spread-card"');
+    expect(viewSource).toContain("CORRELATION RISK PREMIUM");
+    expect(viewSource).toContain("regime-relationship-panel-wide");
+    expect(viewSource).toContain('data-testid="regime-spread-range-chips"');
+    expect(viewSource).toContain('data-testid="regime-spread-brush"');
+  });
+
+  it("makes regime quadrants and normalized divergence full-width panels", () => {
+    const quadrantOpen = viewSource.slice(
+      Math.max(0, viewSource.indexOf('data-testid="regime-quadrant-card"') - 220),
+      viewSource.indexOf('data-testid="regime-quadrant-card"') + 40,
+    );
+    const zscoreOpen = viewSource.slice(
+      Math.max(0, viewSource.indexOf('data-testid="regime-zscore-card"') - 220),
+      viewSource.indexOf('data-testid="regime-zscore-card"') + 40,
+    );
+    expect(quadrantOpen).toContain("regime-relationship-panel-wide");
+    expect(zscoreOpen).toContain("regime-relationship-panel-wide");
+    expect(cssRule(".regime-relationship-grid")).toMatch(/grid-template-columns:\s*1fr/);
+  });
+});
+
+describe("CRI quadrant scatter hover", () => {
+  it("exposes hover shell, overlay, and tooltip hooks on the quadrant scatter", () => {
+    expect(viewSource).toContain('data-testid="regime-quadrant-chart-shell"');
+    expect(viewSource).toContain('data-testid="regime-quadrant-chart-overlay"');
+    expect(viewSource).toContain('data-testid="regime-quadrant-hover-tooltip"');
+    expect(viewSource).toContain('data-testid="regime-quadrant-hover-date"');
+    expect(viewSource).toContain("Quadrant");
+    expect(viewSource).toContain("RVOL");
+    expect(viewSource).toContain("COR1M");
+  });
+
+  it("picks the nearest scatter point in plot space", () => {
+    const points = [
+      { x: 10, y: 10 },
+      { x: 80, y: 40 },
+      { x: 120, y: 90 },
+    ];
+    expect(nearestRegimeScatterIndex(points, 12, 8)).toBe(0);
+    expect(nearestRegimeScatterIndex(points, 78, 42)).toBe(1);
+    expect(nearestRegimeScatterIndex(points, 200, 200)).toBe(2);
+  });
+});

--- a/web/tests/regime-history-responsive.test.ts
+++ b/web/tests/regime-history-responsive.test.ts
@@ -16,8 +16,9 @@ describe("RegimePanel — responsive history chart layout", () => {
     expect(panelSource).not.toContain('<div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "16px" }}>'); 
   });
 
-  it("collapses the history grid to a single column below the narrow-screen breakpoint", () => {
-    expect(cssSource).toMatch(/\.regime-history-grid\s*\{[\s\S]*grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\)/);
-    expect(cssSource).toMatch(/@media\s*\(max-width:\s*960px\)\s*\{[\s\S]*\.regime-history-grid\s*\{[\s\S]*grid-template-columns:\s*1fr;/);
+  it("keeps the history grid as a single full-width column at every breakpoint", () => {
+    const historyGridRule = cssSource.match(/\.regime-history-grid\s*\{([^}]+)\}/)?.[1] ?? "";
+    expect(historyGridRule).toMatch(/grid-template-columns:\s*1fr/);
+    expect(historyGridRule).not.toMatch(/repeat\(2/);
   });
 });

--- a/web/tests/regime-history-tooltip.test.ts
+++ b/web/tests/regime-history-tooltip.test.ts
@@ -32,8 +32,10 @@ describe("Regime history tooltip copy", () => {
     const copy = SECTION_TOOLTIPS["20-SESSION HISTORY"];
 
     expect(copy).toMatch(/20 trading sessions/i);
-    expect(copy).toMatch(/Left chart/i);
-    expect(copy).toMatch(/Right chart/i);
+    expect(copy).toMatch(/VIX \/ VVIX chart/i);
+    expect(copy).toMatch(/realized vol \/ COR1M chart/i);
+    expect(copy).not.toMatch(/Left chart/i);
+    expect(copy).not.toMatch(/Right chart/i);
     expect(copy).toMatch(/VIX/i);
     expect(copy).toMatch(/VVIX/i);
     expect(copy).toMatch(/realized vol/i);

--- a/web/tests/regime-relationship-tooltips.test.ts
+++ b/web/tests/regime-relationship-tooltips.test.ts
@@ -48,6 +48,12 @@ describe("Regime relationship state tooltips", () => {
     expect(source).toContain('data-testid="regime-zscore-hover-date"');
   });
 
+  it("renders hover telemetry hooks for the regime quadrant scatter", () => {
+    expect(source).toContain('data-testid="regime-quadrant-chart-overlay"');
+    expect(source).toContain('data-testid="regime-quadrant-hover-tooltip"');
+    expect(source).toContain('data-testid="regime-quadrant-hover-date"');
+  });
+
   it("colors the latest quadrant marker from the classified quadrant instead of a hardcoded warning tone", () => {
     expect(source).toContain('const latestQuadrantColor = quadrantTone(latest.quadrant);');
     expect(source).toContain('fill={isLatest ? latestQuadrantColor : "var(--signal-core)"}');

--- a/web/tests/regime-relationship-zoom.test.tsx
+++ b/web/tests/regime-relationship-zoom.test.tsx
@@ -248,3 +248,37 @@ describe("Correlation Risk Premium brush + hover", () => {
     expect(widthVal).toBeLessThan(15);
   });
 });
+
+describe("Regime quadrants scatter hover", () => {
+  it("shows date, quadrant, and series values for the nearest hovered point", () => {
+    const history = buildHistory(40);
+    render(
+      React.createElement(RegimeRelationshipView, {
+        history,
+      }),
+    );
+
+    const overlay = screen.getByTestId("regime-quadrant-chart-overlay");
+    overlay.getBoundingClientRect = () => ({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 760,
+      bottom: 240,
+      width: 760,
+      height: 240,
+      toJSON: () => ({}),
+    });
+
+    fireEvent.pointerMove(overlay, { clientX: 400, clientY: 100 });
+
+    const tooltip = screen.getByTestId("regime-quadrant-hover-tooltip");
+    expect(tooltip).toBeTruthy();
+    expect(screen.getByTestId("regime-quadrant-hover-date")).toBeTruthy();
+    expect(tooltip.textContent ?? "").toMatch(/Quadrant/i);
+    expect(tooltip.textContent ?? "").toMatch(/RVOL/i);
+    expect(tooltip.textContent ?? "").toMatch(/COR1M/i);
+    expect(tooltip.textContent ?? "").toMatch(/(Goldilocks|Fragile Calm|Stock Picker|Systemic Panic)/i);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- [x] Red/green TDD (failing test, then fix)
- [x] Staged only the files this change owns (no `git add -A`)
- [x] Owner doc updated, or the commit message has `docs-skip: <reason>`
- [x] Previous `main` deploy finished before this push

## Problem

`/regime/cri` rendered several charts in two-column grids with weaker interactivity than the rest of `/regime`. Correlation Risk Premium was already correct.

## What changed

- **20-session history (VIX/VVIX + RVOL/COR1M):** stacked full width. Same `CriHistoryChart` family, tooltips, axes, and theme.
- **REGIME QUADRANTS:** still a scatter, now full width. Dots hover with date, quadrant, RVOL, COR1M, and z-scores.
- **NORMALIZED DIVERGENCE:** full width. Existing hover readout kept.
- **Correlation Risk Premium:** unchanged (range chips, brush, tooltip, height).

## Before / after

- Before: history charts sat side by side; quadrants and divergence shared a 2-column row; scatter had no point tooltip.
- After: those charts stack full width; scatter hover matches the other relationship tooltips.

![Stacked full-width VIX/VVIX and RVOL/COR1M history charts](https://cursor.com/artifacts/c/art-a98cf2a1-ff86-4732-ab7c-2a879fb38d5f)
![Stacked Correlation Risk Premium, regime quadrants, and normalized divergence](https://cursor.com/artifacts/c/art-493f6170-b297-4461-b80d-31ae8d99fd3b)
![Regime quadrants scatter with hover tooltip](https://cursor.com/artifacts/c/art-40cd8c53-b8a3-4bd0-9c41-8f3adb19e5cb)

## Out of scope

- No Correlation Risk Premium redesign
- No other regime tab product logic
- Do not merge

## Verification

- Focused Vitest: 31 passed (`regime-cri-chart-layout`, history responsive/tooltip, relationship tooltips/zoom/axis)
- Playwright: 10/10 (`regime-history-responsive`, `regime-history-tooltip`, `regime-relationship-view`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1178a34c-d378-4bbd-99fc-c1d2970650ea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1178a34c-d378-4bbd-99fc-c1d2970650ea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

