### PR TITLE
CI Performance 2026-09-05: e2e apt provisioning: the unbounded apt-get fetch hit a degraded Ubuntu mirror on both 2026-09-05 main runs (319s and 448s vs the 5-8s norm), tripling the e2e job wall with no retry or timeout defense (CIP-007).

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -722,7 +722,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # The Playwright image ships without unzip, which setup-bun needs to
       # extract its release archive (first-run failure 2026-08-08).
-      - run: apt-get update -qq && apt-get install -y -qq unzip
+      # Bounded: a degraded Ubuntu mirror ran this 5-8s step for 319-448s on
+      # 2026-09-05 (CIP-007). Retries + HTTP timeout + a step cap fail fast.
+      - run: >-
+          apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=15 update -qq
+          && apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=15 install -y -qq unzip
+        timeout-minutes: 3
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.3.14"

--- a/CI_PERFORMANCE_LOG.md
+++ b/CI_PERFORMANCE_LOG.md
@@ -869,3 +869,75 @@ the 86-88s deploy floor (CIP-004) with the gateway-wait p95 tail (CIP-006).
 - Outcome: `VALIDATING` (implemented, awaiting post-merge samples).
 - Residual bottleneck: python/web gate co-wall ~100-110s, then the 86-88s
   deploy floor (CIP-004) with the gateway-wait p95 tail (CIP-006).
+
+### 2026-09-05 - audit - branch `ci-performance/2026-09-05`
+
+- Audited range: `2b936ebc..391aaaea` (118 commits: PRs #272-#301). Runner
+  state: dedicated clone verified, stale lock reclaimed, tree clean at
+  `391aaaea`.
+- CI/deploy surface delta: `ci.yml` (CIP-005 stage 2 shard globs via PR
+  #272; e2e job gained a second `bun run build` with
+  `NEXT_PUBLIC_RADON_DEMO=1` plus `demo-workstation-data.spec.ts` via
+  PR #293), `app-images.yml` (`load: true` + hardened Playwright smoke on
+  the python image), python image gained Playwright Chromium (PR #285).
+- Samples (mixed warm, deploy-clean `main` successes, workflow createdAt ->
+  Deploy-to-VPS completedAt, 16 runs 33890263669..33938475254):
+  231 234 236 243 244 244 244 252 254 260 262 263 271 287 306 319 —
+  **p50 253s, p95 ~316s**. Push-to-production is UNCHANGED by the delta;
+  Deploy job wall 72-96s (CIP-004 floor intact). Queue delay negligible on
+  all 16.
+- Failed/cancelled runs (33934165998, 33933705972, 33932478962,
+  33929247644, 33911589496, 33892597609, 33892580953, 33892167740,
+  33891258539) excluded from performance windows; counted for reliability
+  only.
+- **New bottleneck evidence — e2e container apt tail.** The
+  `Playwright P0-financial smoke` job runs
+  `apt-get update -qq && apt-get install -y -qq unzip`
+  (`.github/workflows/ci.yml:725`, needed because
+  `mcr.microsoft.com/playwright:v1.58.2-jammy` ships without unzip and
+  setup-bun requires it). Step norm is 5-8s (runs 33890263669: 5s,
+  33917247042: 8s, 33934337009: 7s) but both 2026-09-05 successes hit a
+  degraded mirror: **319s in 33938475254 and 448s in 33935134766**, tripling
+  the job (130s norm -> 463/594s run wall). Off the deploy critical path
+  (job is non-gating for deploy) but it inflates PR time-to-green (the
+  deliver phase's watch clock) and runner minutes by up to ~7.5 min/run
+  with no retry/timeout defense.
+- Demo rebuild cost inside the same job measured at 22s build + 5s spec —
+  real but minor; the 09-05 wall explosions are apt, not the demo build.
+- CIP-005 stage 2 post-merge shard walls so far (2 mixed samples):
+  scripts-npsz 91s (was 119s, on target), scripts-gh 91s, scripts-rs
+  103s/108s — **rs is above the 85s revert-trigger line**; 3 more samples
+  needed before invoking it. Outcome stays `VALIDATING`
+  (`INSUFFICIENT_SAMPLE` for acceptance).
+
+#### CIP-007 - remove the unbounded apt-get network dependency from the e2e job (selected)
+
+- Hypothesis: provisioning unzip via apt with no timeout/retry exposes every
+  e2e run to Ubuntu-mirror latency; bounding or eliminating the network
+  fetch caps a measured 319-448s tail back to <10s.
+- Options for remediate, smallest first: (a) add
+  `-o Acquire::Retries=3 -o Acquire::http::Timeout=15` and a step
+  `timeout-minutes`; (b) eliminate apt entirely by extracting bun without
+  unzip (hermetic); either preserves the pinned setup-bun action and all
+  gates.
+- Expected: ~0s on the p50 (step norm already 5-8s), up to ~440s off the
+  tail per affected run; runner-minute reduction on degraded days;
+  confidence high (step-level timestamps), effort low, risk low
+  (provisioning-only, no test or gate change).
+- Validation: step duration across the next five mixed runs; no e2e spec
+  count change.
+
+#### CIP-008 - demo workstation rebuild serialized in e2e (ranked second)
+
+- 27s serialized per e2e run (`ci.yml:764-776`). Candidate: reuse
+  `web/.next/cache` between the two builds or split into a parallel job.
+  Deferred below CIP-007 tonight: small, and off the deploy path.
+
+#### CIP-004 / CIP-006 - unchanged evidence, remain DEFERRED
+
+- Deploy floor 72-96s and gateway-wait tail unchanged across the 16-run
+  window.
+
+Outcome for tonight: audit `DONE`; CIP-007 handed to remediate (with
+CIP-008 behind it). Residual bottleneck for the production clock stays the
+python/web gate co-wall then the deploy floor (CIP-004).

--- a/CI_PERFORMANCE_LOG.md
+++ b/CI_PERFORMANCE_LOG.md
@@ -941,3 +941,40 @@ the 86-88s deploy floor (CIP-004) with the gateway-wait p95 tail (CIP-006).
 Outcome for tonight: audit `DONE`; CIP-007 handed to remediate (with
 CIP-008 behind it). Residual bottleneck for the production clock stays the
 python/web gate co-wall then the deploy floor (CIP-004).
+
+### 2026-09-05 - remediate - branch `ci-performance/2026-09-05`
+
+- **CIP-007 IMPLEMENTED** (commit `1bb2cfa2`). Both apt-get invocations in
+  the e2e job's unzip provisioning step now carry `Acquire::Retries=3` and
+  `Acquire::http::Timeout=15`, and the step is capped at
+  `timeout-minutes: 3`. A degraded mirror now fails fast (~90s worst case
+  with retries) instead of running 319-448s inside the job's 25-minute
+  budget.
+- Changed files: `.github/workflows/ci.yml` (e2e-financial-smoke apt step),
+  `scripts/tests/test_ci_gate_integrity.py`
+  (`test_e2e_apt_provisioning_is_bounded`, added first).
+- Red/green: new contract test FAILED against the unbounded step
+  (`Acquire::Retries` assertion), green after the `ci.yml` edit. Full
+  workflow contract set: 79 passed in 9.23s
+  (`test_ci_gate_integrity` + `test_ci_deploy_concurrency` +
+  `test_path_filter`). YAML parse clean.
+- Safety: provisioning-only; no test, spec, gate, `needs` edge, coverage,
+  provenance, health, stability-window or rollback surface touched.
+  setup-bun pin unchanged. Runner minutes strictly reduced on degraded
+  days, unchanged otherwise.
+- Expected: ~0s p50 effect (step norm 5-8s); caps the measured 319-448s
+  tail; up to ~7.5 runner-min/run saved on degraded days.
+- Revert trigger: the apt step failing on a healthy mirror in any of the
+  next five `main` runs.
+- Validation: step duration + conclusion across the next five mixed runs;
+  spec count unchanged (21 e2e specs).
+- Outcome: `VALIDATING`.
+- **CIP-008 DEFERRED** with rationale: `web/.next/cache` is already shared
+  between the two builds (same workspace, cache survives the rebuild), so
+  the 22s is post-cache demo-boundary compile; a parallel-job split would
+  duplicate checkout + bun install + build (~60s+ runner time) to save 27s
+  off a non-gating job. No safe material change tonight.
+- CIP-005 stage 2 remains `VALIDATING` (rs shard 103/108s vs 85s trigger;
+  needs 3 more post-merge samples). CIP-004 / CIP-006 unchanged, DEFERRED.
+- Residual bottleneck: python/web gate co-wall ~100-110s, then the 86-88s
+  deploy floor (CIP-004).

--- a/scripts/tests/test_ci_gate_integrity.py
+++ b/scripts/tests/test_ci_gate_integrity.py
@@ -208,3 +208,28 @@ def test_removing_a_gate_from_an_if_expression_alone_fails_the_check() -> None:
             offenders[name] = missing
     # ... but the expression-level check catches it.
     assert offenders.get("stage-release") == ["web-coverage"], offenders
+
+
+def test_e2e_apt_provisioning_is_bounded() -> None:
+    """The e2e container's apt-get step must not hang on a degraded mirror.
+
+    2026-09-05: the unbounded ``apt-get update && apt-get install unzip``
+    step (norm 5-8s) hit a degraded Ubuntu mirror twice, running 319s and
+    448s and tripling the job wall (CIP-007). Every apt invocation in the
+    step must carry a retry cap and an HTTP timeout, and the step itself
+    must carry a ``timeout-minutes`` bound so a dead mirror fails fast
+    instead of eating the job's 25-minute budget.
+    """
+    job = _workflow()["jobs"]["e2e-financial-smoke"]
+    apt_steps = [
+        step
+        for step in job["steps"]
+        if "apt-get" in str(step.get("run", ""))
+    ]
+    assert apt_steps, "the e2e job no longer provisions via apt-get; retire this test"
+    for step in apt_steps:
+        run = step["run"]
+        for invocation in re.findall(r"apt-get[^&|;]*", run):
+            assert "Acquire::Retries=" in invocation, invocation
+            assert "Acquire::http::Timeout=" in invocation, invocation
+        assert step.get("timeout-minutes"), step


### PR DESCRIPTION
## Issue discovered

- **e2e apt provisioning**: the unbounded apt-get fetch hit a degraded Ubuntu mirror on both 2026-09-05 main runs (319s and 448s vs the 5-8s norm), tripling the e2e job wall with no retry or timeout defense (CIP-007).

## What was done to fix it

- **e2e apt provisioning**: both apt-get invocations now carry Acquire::Retries=3 and Acquire::http::Timeout=15 and the step is capped at timeout-minutes: 3; contract test test_e2e_apt_provisioning_is_bounded added red-first (79 workflow contract tests green). CIP-008 (27s demo rebuild) deferred: .next cache already shared, a parallel job costs more runner time than it saves.

## Next

Fixed with green deployment
