### PR TITLE
Testing 2026-09-06: two dead money-path gates (submit-on-dead-feed, replace-atop-working-order) plus 22 test-quality fixes (T-462…T-485)

### DIFF
--- a/TEST_AUDIT.md
+++ b/TEST_AUDIT.md
@@ -9256,6 +9256,7 @@ Delta findings continue the T-### numbering in dated `## Delta audit` sections.
 - Audited through: `391aaaea` on 2026-09-05 — 22 new findings (T-440…T-461: 8 P1, 14 P2) over 118 commits / 395 files, base `2b936ebc`. Saturday run. pytest **11669 passed / 0 failed** (1642s under sibling-loop contention); vitest first read 13 failed + 34 files failed at import — ALL the delta's new `thinking-orbs` dep missing from this clone's node_modules; after `bun install` the failed set re-ran **322 passed / 0 failed** (environment fixed, repo untouched; `site/` needed npm — bun kept failing on the `next` tarball). cloud **33 failed** / 1692 passed on darwin, strict subset of 2026-09-04: zero NEW, four GONE (incl. T-439's red) — **baseline 37 → 33**. Post-gate tree clean ×3 (T-275); secret-name sweep clean (T-381). Delta-touched determinism 3× NOT run (154 touched test files collapses into full gates, 2026-08-16 rule). Shard-glob union clean (441/441 single-shard, T-122 holds); 40 of 42 new test files CI-reachable, the two `site/e2e` specs are not (T-447). `deploy.needs`/`if` byte-identical; thresholds unmoved; 3 new conditional skips with reasons; no `.only`/`xfail`. CI green on `main` at this HEAD (20 success / 5 skipped). `main` still has no `required_status_checks` (T-222, fifth audit running).
 
 - Audited through: `be64e1fc` on 2026-09-05 (**second pass**, same day, same clone) — 23 new findings (T-462…T-484: 2 P0, 10 P1, 11 P2) over 61 commits / 107 files / +5789-172, base `391aaaea` (the first pass's HEAD). Saturday run. The range CONTAINS the first pass's own remediation (T-440…T-461) and the reliability loop's REL-232…REL-247, re-triaged as ordinary delta per the 2026-08-22 rule. Gates serial round 1 BEFORE the fan-out, no sibling loop, load 3-6: pytest **11762 passed / 1 skipped / 0 failed** (1730s); vitest 39 files failed at IMPORT on ONE environment cause (`thinking-orbs` + `border-beam` declared at `web/package.json:37,46` but absent from this clone's node_modules — the first pass's lesson recurring after a tree reset), and the same 39 files re-ran **323 passed / 0 failed** once installed, repo untouched; cloud **5 failed / 1785 passed**, all in `test_caddy_edge_timeouts.py` with `caddy` ABSENT. The cloud baseline reads 5, not the recorded 33, because this run's gate PATH resolves `bash` to homebrew 5.3.9 instead of `/bin/bash` 3.2 — filed as T-484, and it means every previously recorded darwin baseline was a PATH artifact. Post-gate tree clean x3 (T-275). Zero new code skips/`.only`/`xfail` in the delta. `deploy:` block byte-identical base->HEAD (14 jobs, both coverage ratchets retained); no gate config touched, no threshold moved. Shard-glob union clean (449/449 matched exactly once, T-122 holds); all 27 new test files CI-reachable. CI green on `main` at this HEAD. `main` still has no `required_status_checks` (T-222, sixth audit running). Delta-touched determinism 3x NOT run: 47 touched test files across four roots collapses into full gates (2026-08-16 rule).
+- Audited through: `7a7ca4ae` on 2026-09-06 — **1 new finding** (T-485, P2) over 6 commits / 5 files / +715−1, base `be64e1fc`. Sunday run, no sibling loop, load 2.5. The range is almost entirely the loops' own ledgers plus CIP-007 (one bounded apt step in `ci.yml` + an honest contract test, `9 passed` ×3). Gates: pytest **11763 passed / 0 failed** (1841s); vitest **8925 passed / 0 failed** but exit 1 on one unhandled `EnvironmentTeardownError` — the 2026-09-02 observation recurring UNCONTENDED, promoted to T-485; cloud **33 failed / 1757 passed** with `/bin/bash` 3.2 resolved and caddy PRESENT — sorted FAILED list byte-identical to the 2026-09-05 first-pass 33-list (zero new, zero gone), confirming T-484 from the other direction (caddy's 5 reds gone by installing caddy, the bash-class 33 back with bash 3.2). Post-gate tree clean (T-275); secret sweep vacuously clean (T-381); no new skips/`.only`/`xfail`; `deploy:` untouched; no threshold moved. CI green on `main` at this HEAD (`4dcbfdd2` run cancelled as superseded, not failed). `main` still has no `required_status_checks` (T-222, seventh audit running).
 
 ## Remediation 2026-08-29 — PR #140
 
@@ -9928,3 +9929,84 @@ identical, or the difference must be an explicit skip rather than a failure.
   files across all four collection roots, which per the 2026-08-16 rule
   collapses into full-gate runs. Saying so rather than pretending it
   happened.
+
+## Delta audit 2026-09-06
+
+Range `be64e1fc..7a7ca4ae`: 6 commits / 5 files / +715−1. Sunday run
+(weekend-false-red class LIVE; all gates green, none observed). The range is
+almost entirely the loops' own output: the 2026-09-05 second-pass audit merge
+(#308: `TEST_AUDIT.md` + this skill's lessons) and the ci-performance loop's
+CIP-007 (#302: `CI_PERFORMANCE_LOG.md`, one bounded apt-get step in
+`ci.yml:725-730`, and `scripts/tests/test_ci_gate_integrity.py:213-235`, a
+new contract test). No fan-out was launched — the lead read the entire
+non-ledger delta directly (two files).
+
+1 new finding: **1 P2** (T-485).
+
+### Delta review
+
+- **CIP-007 (`ci.yml` e2e apt step):** the change adds `Acquire::Retries=3`,
+  `Acquire::http::Timeout=15` and `timeout-minutes: 3` — a bounding, not a
+  gate weakening. Its contract test
+  `test_e2e_apt_provisioning_is_bounded` asserts every `apt-get` invocation
+  in the step carries both options plus the step bound, and self-retires
+  with a named message if the step disappears. Honest by inspection and
+  green 3×3 (`9 passed` ×3, 0.9 s each). `scripts/tests` is CI-reachable
+  (existing file, already in a shard). No finding.
+- **Gate drift:** the only `ci.yml` change is the apt step above; no test
+  invocation, shard glob, `deploy.needs`/`if`, coverage threshold or
+  exclusion changed (diff inspected directly). No new skip/`.only`/`xfail`
+  anywhere in the delta.
+
+### Findings
+
+### T-485 — P2 — vitest full-gate exit-1 on `EnvironmentTeardownError` with 0 failed tests is NOT load-class: it recurred uncontended
+
+The 2026-09-02 observation (note 1, `TEST_AUDIT.md:8339-8347`) recorded
+`EnvironmentTeardownError: Closing rpc while "onUserConsoleLog" was pending`
+attributed to `web/tests/regime-dead-feed-degraded.test.ts` and classed it
+as load (load 33, reliability loop concurrent). This run reproduced it
+byte-identically at load ~2.5 with NO sibling loop and an otherwise idle
+host: vitest exit 1 with **901 files / 8925 passed / 0 failed**, and the
+file `5 passed` ×3 in isolation. Two uncorrelated occurrences at opposite
+load profiles make this a real teardown race in the file (it logs to
+console from an async path still in flight at environment teardown —
+`[mktnews] ring restore/persist failed: turso unreachable` lines bracket
+the error), not contention noise. The hazard is unchanged from the
+observation but now demonstrated: any gate keyed on vitest's EXIT CODE
+(this loop's wrapper, a CI shard) reds a round in which every test passed.
+
+### Backlog rows
+
+| ID | Sev | Acceptance criteria |
+|---|---|---|
+| T-485 | P2 | Make `regime-dead-feed-degraded.test.ts` drain or silence its async console writers before teardown (await the in-flight persist/restore rejections, or stub the console path). Red: reproduce the unhandled rejection deterministically (e.g. resolve the pending log after teardown in a harness) or cite two gate logs; green: full-file run clean AND the unhandled-error count 0 across 3 full-suite runs. Never key the fix on widening the wrapper's exit-code read. |
+
+### Standing sweeps
+
+- **Gates (serial, detached, before everything else; load 2.5, no sibling
+  loop — `ps` checked):** pytest **11763 passed / 1 skipped / 0 failed**
+  (1841 s); vitest **8925 passed / 0 failed** across 901 files, exit 1 on
+  T-485's unhandled teardown error only; cloud **33 failed / 1757 passed /
+  7 skipped** (383 s).
+- **Cloud attribution (T-484 rule applied):** resolved `bash --version` =
+  `/bin/bash` **3.2.57** (homebrew bash absent today), `command -v caddy` =
+  `/opt/homebrew/bin/caddy` (**present** — installed since yesterday's
+  second pass). The 33 FAILED lines are 14× `test_bootstrap_control_plane.py`
+  + 19× `test_ib_gateway_control.py` (both bash≥4 classes), **zero** caddy
+  reds, and the sorted list is byte-identical to the 2026-09-05 first-pass
+  33-list (`comm` empty). T-484 confirmed from the other direction: caddy's
+  5 reds vanished by installing caddy, the bash-class 33 returned with
+  `/bin/bash`. Zero new, zero gone vs the comparable-PATH list.
+- **Delta-touched determinism 3×:** the delta touches ONE test file
+  (`test_ci_gate_integrity.py`) — `9 passed` ×3.
+- **Post-gate tree:** `git status --porcelain` empty after all three gates
+  (T-275 sweep clean).
+- **Secrets (T-381):** no wrapper-exported secrets in this manual shell;
+  sweep vacuously clean (weaker evidence than under the wrapper).
+- **Branch protection (T-222, seventh consecutive audit):** `main` still
+  returns no `required_status_checks`.
+- **CI at HEAD:** success on `main` at `7a7ca4ae` (the `4dcbfdd2` run was
+  cancelled as superseded mid-merge, not a failure).
+- **Open-PR pre-check (2026-08-27 rule):** 4 open PRs, none overlapping
+  T-485.

--- a/TEST_LOG.md
+++ b/TEST_LOG.md
@@ -663,3 +663,40 @@ Closing gates ×3 (serial, detached script; reliability loop's cycle concurrent,
 | T-442 | DONE | (this commit) | New `web/tests/modify-partial-fill-wire.test.tsx`: OrderActionsProvider + ModifyOrderModal with stubbed fetch — asserts POST `/api/orders/modify` full URL + payload `{orderId:7, permId:7007, newQuantity:516}` and zero requests while the gate is closed. Red: wire-level newQuantity drop in OrderActionsContext → 1 failed / 11 passed while the existing prop-level test stayed GREEN (the finding); reverted. Existing test kept. Green: 4 files 18 passed landed. |
 | T-459 | DONE | (this commit) | New `web/tests/fill-driven-portfolio-refresh-wire.test.tsx`: real usePortfolio + real useFillToasts through WorkspaceShell's callback shape — POST `/api/portfolio` observed on a new execId, none on baseline/demo. Red: stale-ref mutation of useFillToasts → 1 failed / 5 passed; GREEN at HEAD (no live hook defect), mutation reverted. |
 | T-448 | DONE | (this commit) | ci.yml e2e-financial-smoke reordered: trace-upload now precedes the `NEXT_PUBLIC_RADON_DEMO=1` rebuild + demo spec, so retried prod-bundle steps are no longer poisoned; load-bearing-order + non-gating comments added at the step. New guard `scripts/tests/test_ci_demo_build_order.py` (red 2/2 against the old order). Green: 158 passed across all ci.yml guard suites landed. Promotion into `deploy.needs` left to the operator. |
+
+## Remediation 2026-09-06 (testing/2026-09-06)
+
+Backlog entered this run with 23 un-DONE findings from the 2026-09-05 second-pass
+audit (T-462…T-484: 2 P0, 10 P1, 11 P2) plus this cycle's T-485; all 24 are DONE.
+Two waves of ≤6 worktree subagents; every landing re-verified scoped in the main
+clone; T-463/T-472/T-473 sourced fixes only where a correct test failed against a
+real defect.
+
+| Task | Status | Commits | Evidence |
+|---|---|---|---|
+| T-462 | DONE | `50d6554b` | Source fix: `feedConnected` supplied from `useRealtimePrices().connected` at all 4 owner surfaces; new wire test `quote-gate-feed-wiring.test.tsx` red at HEAD (`1 failed`, gate open), green post-fix, re-reds on call-site mutation. Blast radius 22 files 115 passed. |
+| T-463 | DONE | `eee6d688` | New replace-path test: `Submitted/filled:0` snapshot behind structured-202 cancel → 502 `REPLACE_PARTIAL`, `place.assert_not_awaited()`. Red on `return True` mutation at server.py:3191. File 20 passed landed. |
+| T-464 | DONE | `b87943b8` | `workspace-shell-fill-wire.test.tsx` renders real WorkspaceShell; exactly one POST /api/portfolio on new execId; red on dropping `onNewFills` at :430. |
+| T-465 | DONE | `f38c3b9c` | `hasToastKey` unit + shell R-642 tests; red on `return true` mutation. 25 passed scoped. |
+| T-466 | DONE | `f70aa6fb` | Greps replaced with behavioural GETs (real `requireRouteAccess` recording wrapper, options by value, exhausted budget → 429, no upstream). Red via dead-object mutation both grep literals intact. 10 passed. |
+| T-467 | DONE | `84066e8e` | Digest pipeline executed against temp trees; empty tree now fails the build (`[ -s ]` guard, `xargs -r`, in-layer digest-shape + not-empty-digest consumer). Red: empty tree exited 0 at HEAD. 5 passed ×2. |
+| T-468 | DONE | `85727387` | `git_repo` fixture pins `GIT_CONFIG_GLOBAL/SYSTEM=/dev/null`, hooksPath/gpgsign off. Red: hostile hooksPath errored TestCli. 29 passed under hostile config. |
+| T-469 | DONE | `62bcf17c` | `%cs` → `%as`; red via amend with committer date advanced. File 6 passed. |
+| T-470 | DONE | `e199403b` | `RadonApiError(429)` tests on gex/regime/gamma-rotation: exact 429, `scan_succeeded:false`, no cached body. Red on both mutations (502 hardcode, `>=500`→`true`). 11 passed. |
+| T-471 | DONE | `8cc0e6ee` | Blended-basis fixture breaks the tautology (red `difference is 3000` under sum mutation); `col1 === "---"` NaN guard proven. 5 passed ×2. |
+| T-472 | DONE | `ca573484` | Wire tests: price-only submit carries no `newQuantity`; quantity submit under advanced fills → 0 wire calls + reseed + `.modify-fill-race` alert. Mutation-red both ways. |
+| T-473 | DONE | `ca9e3e72` | Real defect: display read live `filledQuantity(order)` while math read frozen snapshot. Red at HEAD (`'100 of 1000 filled'` vs `984x`). Fix: snapshot-derived display + `.modify-order-fill-stale` flag. 36 passed across 5 modal files. |
+| T-474 | DONE | `7064a8b9` | Retry-budget test now executes `run_portfolio_refresh.sh` with PATH-shim stubs; measured curl count + wall clock vs `TimeoutStartSec`; mirror test deleted. Red on loop-bound mutation (144s vs 120). |
+| T-475 | DONE | `132e8a4c` | Isolation invariant: trailing contiguous demo pair, both steps carry `NEXT_PUBLIC_RADON_DEMO:"1"`, no `failure()`+playwright re-run. Red: env dropped from spec step passed old tests, fails new. 3 passed. |
+| T-476 | DONE | `e087b2c1` | Both shell-body greps deleted; executed counterparts (POISONS matrix, sandbox refusal) already cover the arms. 62 passed both cloud files. |
+| T-477 | DONE | `840718c4` | Red: leaked `mockRadonFetch` called 2×. `mockReset()` in regime beforeEach + fixture date pinned to `mostRecentSessionDate()`. 41 passed. |
+| T-478 | DONE | `c1e7c5fb` | Red: `{mtimeMs:0}` leak into next test. Per-test `mockStat` reset + window-relative re-stamp in both files. 54 passed ×2. |
+| T-479 | DONE | `1cd02569` | testids added (OrderConfirmSummary, PositionTab/Table cells); 6 querySelector sites + `statValue()`/`cellUnder()` converted. Red: class rename → `within(null)` throw; post-fix rename invisible (35/35). |
+| T-480 | DONE | `2c2faef6` | Six real-timer 20ms sleeps → fake timers + `advanceTimersByTimeAsync`; armed-gate mutation still red. 12 passed ×2. |
+| T-481 | DONE | `b55e5d8b` | `_loop_harness.py` shared helper; sibling-test exec_module removed; simulated rename now inert. 89 passed. |
+| T-482 | DONE | `c2e8af42` | playwright-config test: `RADON_AUTHLESS_TEST=1` forces `pk_test_` key even under ambient `pk_live_`. Red with pin removed. 2 passed. |
+| T-483 | DONE | `5c2149ff` | Backoff tick covered: +60s no third fetch, +120s exactly three. Red on dropping `2**failures`. 4 passed ×2. |
+| T-484 | DONE | `108d0be4` | `_bash_toolchain.py` resolves bash ≥ 4 once; bootstrap + ib-gateway suites invoke through it and skip named when absent. Full cloud/tests byte-identical under both PATH orders: `1718 passed, 77 skipped, 0 failed` ×2 (was 33 vs 5). |
+| T-485 | DONE | `281e31a0` | hub.test.js store-down test captures stderr and asserts both failure lines fired before return — no pending `onUserConsoleLog` at teardown. Red: two gate logs (2026-09-02, 2026-09-06). Combined hub+regime ×3: unhandled-error count 0. |
+
+Closing 3× gate counts appended below after the runs.

--- a/cloud/tests/_bash_toolchain.py
+++ b/cloud/tests/_bash_toolchain.py
@@ -1,0 +1,53 @@
+"""T-484: pin which bash the control-plane suites execute.
+
+The darwin cloud "baseline" swung 33 -> 5 failures purely on whether
+/opt/homebrew/bin preceded /bin on PATH, because these suites shell out to
+scripts using bash>=4 features (mapfile, exec {fd}<>) while /bin/bash on
+macOS is 3.2. Resolve a bash >= 4 explicitly once; suites that need it skip
+with a named reason when none exists, so the recorded baseline is identical
+regardless of PATH order.
+"""
+
+import os
+import shutil
+import subprocess
+
+import pytest
+
+
+def _resolve_modern_bash():
+    seen = []
+    candidates = [
+        shutil.which("bash"),
+        "/opt/homebrew/bin/bash",
+        "/usr/local/bin/bash",
+        "/bin/bash",
+    ]
+    for candidate in candidates:
+        if not candidate or candidate in seen or not os.path.exists(candidate):
+            continue
+        seen.append(candidate)
+        try:
+            probe = subprocess.run(
+                [candidate, "-c", 'echo "${BASH_VERSINFO[0]}"'],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+        major = probe.stdout.strip()
+        if probe.returncode == 0 and major.isdigit() and int(major) >= 4:
+            return candidate
+    return None
+
+
+MODERN_BASH = _resolve_modern_bash()
+
+requires_modern_bash = pytest.mark.skipif(
+    MODERN_BASH is None,
+    reason=(
+        "no bash >= 4 on this host (scripts use mapfile / exec {fd}<>); "
+        "install one (e.g. brew install bash) to run this suite"
+    ),
+)

--- a/cloud/tests/conftest.py
+++ b/cloud/tests/conftest.py
@@ -1,8 +1,15 @@
 """Shared fixtures for radon-cloud test suite."""
 
 import pathlib
+import sys
 
 import pytest
+
+# T-484: make sibling test helpers (_bash_toolchain) importable regardless of
+# pytest's rootdir-driven sys.path handling.
+_HERE = str(pathlib.Path(__file__).resolve().parent)
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 

--- a/cloud/tests/test_bootstrap_control_plane.py
+++ b/cloud/tests/test_bootstrap_control_plane.py
@@ -14,6 +14,11 @@ from pathlib import Path
 
 import pytest
 
+from _bash_toolchain import MODERN_BASH, requires_modern_bash
+
+# T-484: bootstrap-control-plane.sh uses exec {fd}<> (bash >= 4.1); which bash
+# resolves must not depend on the invoking shell's PATH order.
+pytestmark = requires_modern_bash
 
 CLOUD_ROOT = Path(__file__).resolve().parents[1]
 BOOTSTRAP = CLOUD_ROOT / "scripts" / "bootstrap-control-plane.sh"
@@ -220,7 +225,7 @@ class Sandbox:
 
     def run(self, **env_overrides: str) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
-            [str(BOOTSTRAP)],
+            [str(MODERN_BASH), str(BOOTSTRAP)],
             env={**self.env, **env_overrides},
             capture_output=True,
             text=True,
@@ -359,7 +364,7 @@ def _run_root_control_plane_verifier(sandbox: Sandbox) -> subprocess.CompletedPr
     sha256sum = shutil.which("sha256sum")
     assert true_bin and rm_bin and sha256sum
     return subprocess.run(
-        ["bash", str(ROOT_HELPER), "verify-control-plane"],
+        [str(MODERN_BASH), str(ROOT_HELPER), "verify-control-plane"],
         env={
             **os.environ,
             "RADON_DEPLOY_HELPER_TEST_MODE": "1",
@@ -393,7 +398,7 @@ def test_non_root_is_refused_before_lock_or_install(tmp_path: Path) -> None:
     env.pop("RADON_BOOTSTRAP_ALLOW_NONROOT")
 
     result = subprocess.run(
-        [str(BOOTSTRAP)],
+        [str(MODERN_BASH), str(BOOTSTRAP)],
         env={**env, "RADON_BOOTSTRAP_TEST_EUID": "1000"},
         capture_output=True,
         text=True,

--- a/cloud/tests/test_ib_gateway_control.py
+++ b/cloud/tests/test_ib_gateway_control.py
@@ -10,6 +10,10 @@ import time
 
 import pytest
 
+from _bash_toolchain import MODERN_BASH, requires_modern_bash
+
+# T-484: operator-radon.sh uses mapfile (bash >= 4); pin which bash runs it.
+pytestmark = requires_modern_bash
 
 CLOUD_ROOT = Path(__file__).resolve().parents[1]
 # Monorepo: cloud/ lives inside radon/. Legacy: cloud repo is a sibling of radon/.
@@ -88,7 +92,7 @@ exit 2
 
 def _run_control(env: dict[str, str], *args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        [str(CONTROL), *args],
+        [str(MODERN_BASH), str(CONTROL), *args],
         env=env,
         text=True,
         capture_output=True,
@@ -1032,7 +1036,7 @@ set -eu
     )
 
     result = subprocess.run(
-        ["bash", "-c", command],
+        [str(MODERN_BASH), "-c", command],
         env=env,
         text=True,
         capture_output=True,
@@ -1096,7 +1100,7 @@ def test_setup_never_replaces_live_helper_with_invalid_candidate(
     )
 
     result = subprocess.run(
-        ["bash", "-c", command], env=env, text=True,
+        [str(MODERN_BASH), "-c", command], env=env, text=True,
         capture_output=True, check=False,
     )
 

--- a/cloud/tests/test_rel234_compose_gate.py
+++ b/cloud/tests/test_rel234_compose_gate.py
@@ -91,17 +91,6 @@ def test_the_three_copies_are_byte_identical() -> None:
     assert helper == _function_text(SETUP)
 
 
-def test_bootstrap_compose_arm_calls_the_shared_function() -> None:
-    text = BOOTSTRAP.read_text(encoding="utf-8")
-    # Strip comments so a comment naming the call cannot satisfy this.
-    code = "\n".join(
-        line for line in text.splitlines() if not line.lstrip().startswith("#")
-    )
-    arm = code[code.index("compose)") :]
-    arm = arm[: arm.index(";;")]
-    assert "compose_body_is_valid" in arm
-
-
 def test_bootstrap_defines_the_gate_before_its_top_level_call() -> None:
     """Bash resolves a function at call time; bootstrap's staging loop runs at
     top level, so a definition placed after it is 'command not found' and the

--- a/cloud/tests/test_rel242_preflight_and_drift.py
+++ b/cloud/tests/test_rel242_preflight_and_drift.py
@@ -21,7 +21,6 @@ surfaces they do not own.
 
 from __future__ import annotations
 
-import re
 import subprocess
 import sys
 from pathlib import Path
@@ -33,23 +32,8 @@ from test_drift_audit import da  # noqa: E402
 
 CLOUD_ROOT = Path(__file__).resolve().parents[1]
 DEPLOY = CLOUD_ROOT / "scripts" / "deploy.sh"
-HELPER = CLOUD_ROOT / "scripts" / "deploy-root-helper.sh"
 
 SHIM_FALLBACK_MARKER = "shim refused (exit 78), direct render covered"
-
-
-def _strip_comments(text: str) -> str:
-    return "\n".join(
-        line for line in text.splitlines() if not line.lstrip().startswith("#")
-    )
-
-
-def _function_body(script: str, name: str) -> str:
-    match = re.search(
-        rf"^{name}\(\)\s*\{{\s*\n(.+?)\n\}}\s*$", script, re.MULTILINE | re.DOTALL
-    )
-    assert match, f"{name}() missing"
-    return match.group(1)
 
 
 def _write_executable(path: Path, body: str) -> None:
@@ -140,18 +124,6 @@ def test_shim_refusal_without_direct_cover_still_fails_preflight(tmp_path: Path)
 
 
 # --- R-648 residual: refresh path renders the incoming staged body ----------
-
-
-def test_refresh_install_file_validates_staged_compose_body() -> None:
-    """Pin: the ib-gateway-compose arm runs the shared validator (deny-list +
-    `docker compose config -q` render) against the staged candidate."""
-    body = _strip_comments(_function_body(HELPER.read_text(encoding="utf-8"), "refresh_install_file"))
-    arm = body.split("*/ib-gateway-compose.yml)", 1)[1].split(";;", 1)[0]
-    assert 'compose_body_is_valid "$candidate"' in arm
-    validator = _strip_comments(
-        _function_body(HELPER.read_text(encoding="utf-8"), "compose_body_is_valid")
-    )
-    assert "docker compose" in validator and "config --quiet" in validator
 
 
 def test_refresh_refuses_an_invalid_staged_compose_body(tmp_path: Path) -> None:

--- a/docker/app/Dockerfile.python
+++ b/docker/app/Dockerfile.python
@@ -22,9 +22,16 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 # R-665: record what the unverified `playwright install` actually fetched.
 # The digest lives next to the browsers and is computed in the same layer,
 # so two images can be compared and an audit can pin the browser build.
+# T-467: an empty/missing browser tree must FAIL the build, never record the
+# empty-stream sha256 (e3b0c442...); the grep below is the digest's in-image
+# consumer — the build aborts unless a real 64-hex non-empty digest landed.
 RUN python -m playwright install --with-deps --only-shell chromium \
-    && find /ms-playwright -type f -print0 | sort -z | xargs -0 sha256sum \
-       | sha256sum | cut -d' ' -f1 > /ms-playwright/.browsers.sha256 \
+    && find /ms-playwright -type f -print0 | sort -z | xargs -0 -r sha256sum > /tmp/.browser-hashes \
+    && [ -s /tmp/.browser-hashes ] \
+    && sha256sum /tmp/.browser-hashes | cut -d' ' -f1 > /ms-playwright/.browsers.sha256 \
+    && rm /tmp/.browser-hashes \
+    && grep -qE '^[0-9a-f]{64}$' /ms-playwright/.browsers.sha256 \
+    && ! grep -q e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 /ms-playwright/.browsers.sha256 \
     && echo "playwright browsers digest: $(cat /ms-playwright/.browsers.sha256)" \
     && chmod -R a+rX /ms-playwright \
     && rm -rf /var/lib/apt/lists/*

--- a/scripts/api/tests/test_order_replace_state_machine.py
+++ b/scripts/api/tests/test_order_replace_state_machine.py
@@ -428,6 +428,55 @@ def test_replace_refuses_structured_202_when_broker_shows_partial_fill(
     assert detail["cancelled"] == []
 
 
+def test_replace_refuses_structured_202_when_broker_shows_order_still_working(
+    trusted_client, monkeypatch
+):
+    """T-463: the status-string arm of _cancel_confirmed_at_broker.
+
+    Broker snapshot shows Submitted with zero filled behind a structured-202
+    cancel error — still-working, not confirmed-cancelled. Replace must abort
+    with REPLACE_PARTIAL and never place the replacement.
+    """
+    from unittest.mock import AsyncMock
+
+    from scripts.api import server
+
+    monkeypatch.setattr(server, "orders_whatif", AsyncMock(return_value={"status": "ok"}))
+    monkeypatch.setattr(
+        server,
+        "orders_cancel",
+        AsyncMock(side_effect=HTTPException(
+            status_code=502,
+            detail={
+                "ib_error_code": 202,
+                "message": "IB error 202: Order Canceled - reason:",
+            },
+        )),
+    )
+    monkeypatch.setattr(
+        server,
+        "_find_working_order",
+        AsyncMock(return_value={"orderId": 10, "status": "Submitted", "filled": 0}),
+    )
+    place = AsyncMock(return_value={"status": "ok", "orderId": 1})
+    monkeypatch.setattr(server, "_orders_place_after_rate_reservation", place)
+    server._order_rate_timestamps.clear()
+
+    try:
+        response = trusted_client.post("/orders/replace", json={
+            "cancelOrders": [{"orderId": 10}],
+            "replaceOrder": _replacement(),
+        })
+    finally:
+        server._order_rate_timestamps.clear()
+
+    assert response.status_code == 502
+    place.assert_not_awaited()
+    detail = response.json()["detail"]
+    assert detail["code"] == "REPLACE_PARTIAL"
+    assert detail["cancelled"] == []
+
+
 def test_replace_does_not_place_when_cancel_reports_order_still_submitted(
     trusted_client, monkeypatch
 ):

--- a/scripts/mktnews/hub.test.js
+++ b/scripts/mktnews/hub.test.js
@@ -350,19 +350,38 @@ describe("createHeadlinesHub", () => {
   });
 
   it("still boots and fans out when the store is down", async () => {
-    const hub = await boot({
-      store: {
-        load: async () => {
-          throw new Error("turso unreachable");
+    // T-485: the restore/persist failure paths write to process.stderr from
+    // async continuations. Under vitest that write becomes a pending
+    // onUserConsoleLog rpc message which can still be in flight when a later
+    // file's environment tears down (EnvironmentTeardownError with 0 failed
+    // tests — gate logs 2026-09-02 and 2026-09-06). Capture stderr here so
+    // the writes never reach the interceptor, and assert both failure lines
+    // actually fired before the test returns, so nothing is left in flight.
+    const stderrLines = [];
+    const realWrite = process.stderr.write;
+    process.stderr.write = (chunk, ...rest) => {
+      stderrLines.push(String(chunk));
+      return typeof rest[rest.length - 1] === "function" ? rest[rest.length - 1]() ?? true : true;
+    };
+    try {
+      const hub = await boot({
+        store: {
+          load: async () => {
+            throw new Error("turso unreachable");
+          },
+          put: async () => {
+            throw new Error("turso unreachable");
+          },
         },
-        put: async () => {
-          throw new Error("turso unreachable");
-        },
-      },
-    });
-    expect(hub.ingest(parseFrame(JSON.stringify(FLASH)))).toBe(true);
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(hub.ring.map((row) => row.id)).toEqual(["h1"]);
+      });
+      expect(hub.ingest(parseFrame(JSON.stringify(FLASH)))).toBe(true);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(hub.ring.map((row) => row.id)).toEqual(["h1"]);
+      expect(stderrLines).toContain("[mktnews] ring restore failed: turso unreachable\n");
+      expect(stderrLines).toContain("[mktnews] ring persist failed: turso unreachable\n");
+    } finally {
+      process.stderr.write = realWrite;
+    }
   });
 
   it("caps the ring", async () => {

--- a/scripts/tests/_loop_harness.py
+++ b/scripts/tests/_loop_harness.py
@@ -1,0 +1,166 @@
+"""Shared harness for the nightly-loop wrapper tests (T-481).
+
+LADDER/LOOPS/the stub sandbox live here so test_weekend_model_ladder.py
+and test_loop_session_limit.py both import a non-test module instead of
+one test file exec_module-ing the other.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+BASH = shutil.which("bash") or "/bin/bash"
+
+# Every nightly loop wrapper. A loop missing here keeps the 2026-09-01
+# failure mode.
+LOOPS = {
+    "reliability": REPO / "scripts" / "reliability_weekend.sh",
+    "testing": REPO / "scripts" / "testing_weekend.sh",
+    "ci-performance": REPO / "scripts" / "ci_performance_nightly.sh",
+    "documentation": REPO / "scripts" / "documentation_nightly.sh",
+    "security": REPO / "scripts" / "security_nightly.sh",
+}
+
+# Best first. The top rung is the operator's own default; the next is the same
+# family one tier down, which is what 2026-09-01 needed and never got.
+LADDER = [
+    "claude-fable-5[1m]",
+    "claude-opus-5[1m]",
+    "claude-opus-5",
+    "claude-sonnet-5",
+]
+
+QUOTA_LINE = (
+    "You're out of usage credits. Switch to another model, or manage usage "
+    "credits at claude.ai/settings/usage?from=cc_cli_limit_message, to continue."
+)
+RATE_LIMIT_LINE = "Request rejected (429)"
+CAPACITY_LINE = "API Error: Repeated 529 Overloaded errors"
+# Claude Code tool-skip categories. Official docs say retry the SAME model.
+# Bare `overloaded` / `rate.limit` in is_quota_exhausted treated these as a
+# dead rung and walked the ladder, including on timeout 124 whose log merely
+# mentioned rate limits.
+TOOL_SKIP_OVERLOADED = "Claude Code skipped a tool (overloaded)"
+TOOL_SKIP_RATE_LIMITED = "Claude Code skipped a tool (rate-limited)"
+CASUAL_RATE_LIMITS = "the 500 mentioned rate limits in a timeout log"
+# The security wrapper refuses to call a phase OK without this; harmless noise
+# for the other four.
+COMPLETION = "SECURITY-NIGHTLY PHASE COMPLETE: audit"
+
+MARKERS = (
+    ".radon-weekend-runner",
+    ".radon-security-runner",
+    ".radon-reliability-runner",
+    ".radon-testing-runner",
+    ".radon-ci-performance-runner",
+    ".radon-documentation-runner",
+)
+
+
+def _clone(tmp_path: Path, wrapper: Path) -> Path:
+    repo = tmp_path / "clone"
+    (repo / "scripts").mkdir(parents=True)
+    shutil.copy2(wrapper, repo / "scripts" / wrapper.name)
+    (repo / "scripts" / wrapper.name).chmod(0o755)
+    for helper in ("weekend_notify.py", "weekend_redact.py"):
+        (repo / "scripts" / helper).write_text("# stub\n", encoding="utf-8")
+    for marker in MARKERS:
+        (repo / marker).write_text("", encoding="utf-8")
+    return repo
+
+
+def _stub_bin(
+    tmp_path: Path,
+    models_log: Path,
+    exhausted: Path,
+    gh_log: Path,
+    exhausted_line: str = QUOTA_LINE,
+) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    # What the agent's OWN nested `claude` calls would inherit. The wrapper's
+    # `--model` binds only the outer process; the security skill's Stage 4
+    # Claude Security scan is a separate `claude` invocation and reads this.
+    env_models = tmp_path / "env_models.txt"
+    stubs = {
+        "gh": (
+            "#!/bin/sh\n"
+            f'printf "%s\\n" "$*" >> "{gh_log}"\n'
+            'if [ "$1 $2" = "issue list" ]; then echo 4242; fi\n'
+            "exit 0\n"
+        ),
+        # Records the model it was handed, then behaves like a real agent whose
+        # quota for that model is (or is not) gone.
+        "claude": (
+            "#!/bin/bash\n"
+            'model=""\n'
+            "while [ $# -gt 0 ]; do\n"
+            '  if [ "$1" = "--model" ]; then model="$2"; shift 2; continue; fi\n'
+            "  shift\n"
+            "done\n"
+            f'printf "%s\\n" "$model" >> "{models_log}"\n'
+            f'printf "%s\\n" "${{RADON_WEEKEND_MODEL:-<unset>}}" >> "{env_models}"\n'
+            f'if grep -qxF -- "$model" "{exhausted}"; then\n'
+            f"  echo \"{exhausted_line}\"\n"
+            "  exit 1\n"
+            "fi\n"
+            f'echo "{COMPLETION}"\n'
+            "exit 0\n"
+        ),
+        "timeout": (
+            "#!/bin/bash\n"
+            "while [ $# -gt 0 ]; do\n"
+            '  case "$1" in\n'
+            "    -k|--kill-after) shift 2 ;;\n"
+            "    *) shift; break ;;\n"
+            "  esac\n"
+            "done\n"
+            'exec "$@"\n'
+        ),
+        "git": '#!/bin/sh\n# REL-188: the wrapper calls a phase OK only on commit evidence, so the\n# stub reports a fresh HEAD and a current committer date.\ncase "$*" in\n  *"rev-parse HEAD"*) date +%s%N; exit 0 ;;\n  *"--format=%ct"*) date +%s; exit 0 ;;\nesac\nexit 0\n',
+        "python3": "#!/bin/sh\nexit 0\n",
+    }
+    for name, body in stubs.items():
+        exe = bin_dir / name
+        exe.write_text(body, encoding="utf-8")
+        exe.chmod(0o755)
+    return bin_dir
+
+
+def _run(
+    tmp_path: Path,
+    loop: str,
+    phase: str,
+    exhausted_models,
+    ladder: str | None = None,
+    exhausted_line: str = QUOTA_LINE,
+):
+    wrapper = LOOPS[loop]
+    models_log = tmp_path / "models.txt"
+    gh_log = tmp_path / "gh.log"
+    exhausted = tmp_path / "exhausted.txt"
+    exhausted.write_text("".join(f"{m}\n" for m in exhausted_models), encoding="utf-8")
+    bin_dir = _stub_bin(
+        tmp_path, models_log, exhausted, gh_log, exhausted_line=exhausted_line
+    )
+    repo = _clone(tmp_path, wrapper)
+    env = {
+        "PATH": f"{bin_dir}:/usr/bin:/bin",
+        "HOME": str(tmp_path / "home"),
+        "RADON_WEEKEND_REPO": str(repo),
+    }
+    if ladder is not None:
+        env["RADON_WEEKEND_MODEL_LADDER"] = ladder
+    proc = subprocess.run(
+        [BASH, str(repo / "scripts" / wrapper.name), phase],
+        cwd=repo, env=env, capture_output=True, text=True, timeout=180,
+    )
+    models = (
+        models_log.read_text(encoding="utf-8").splitlines()
+        if models_log.exists() else []
+    )
+    calls = gh_log.read_text(encoding="utf-8") if gh_log.exists() else ""
+    return proc, models, calls

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -9,6 +9,9 @@ import pytest
 SCRIPTS_DIR = Path(__file__).parent.parent
 sys.path.insert(0, str(SCRIPTS_DIR))
 sys.path.insert(0, str(SCRIPTS_DIR / "trade_blotter"))
+# scripts/tests itself, so test modules can import shared non-test helpers
+# (e.g. _loop_harness) instead of exec_module-ing sibling test files (T-481).
+sys.path.insert(0, str(SCRIPTS_DIR / "tests"))
 
 # Captured before any test can patch it, so `real_orphan_confirm_interval`
 # hands back the production value rather than the zeroed one.

--- a/scripts/tests/test_ci_demo_build_order.py
+++ b/scripts/tests/test_ci_demo_build_order.py
@@ -1,10 +1,13 @@
-"""T-448 (P2) — demo rebuild must be the LAST work in e2e-financial-smoke.
+"""T-448 / T-475 (P2) — demo bundle ISOLATION in e2e-financial-smoke.
 
 The job builds the prod bundle, runs the curated prod specs, then rebuilds
 with NEXT_PUBLIC_RADON_DEMO=1 for demo-workstation-data.spec.ts. The second
-build overwrites web/.next, so any step (or retry) that executes after it
-runs against the demo bundle. Pin the safe order: prod build < prod specs <
-trace upload < demo build < demo spec, with the demo spec as the final step.
+build overwrites web/.next, so any step (or failure()-gated retry) executing
+after it runs against the demo bundle. The invariant is isolation, not mere
+ordering: the demo build and demo spec must be the trailing contiguous pair,
+BOTH must carry NEXT_PUBLIC_RADON_DEMO=1, and no step may combine failure()
+semantics with a `playwright test` re-run (which would replay prod specs
+against whichever bundle last landed in web/.next).
 """
 
 from pathlib import Path
@@ -14,9 +17,11 @@ import yaml
 REPO = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO / ".github" / "workflows" / "ci.yml"
 
+DEMO_SPEC = "demo-workstation-data.spec.ts"
 
-def _steps():
-    workflow = yaml.safe_load(WORKFLOW.read_text())
+
+def _steps(path=WORKFLOW):
+    workflow = yaml.safe_load(Path(path).read_text())
     return workflow["jobs"]["e2e-financial-smoke"]["steps"]
 
 
@@ -27,39 +32,61 @@ def _index(steps, predicate, label):
     raise AssertionError(f"no step matching {label} in e2e-financial-smoke")
 
 
-def test_demo_build_comes_after_trace_upload():
-    steps = _steps()
-    trace = _index(
-        steps, lambda s: "upload-artifact" in str(s.get("uses", "")), "trace upload"
-    )
-    demo_build = _index(
+def _demo_build_index(steps):
+    return _index(
         steps,
-        lambda s: "build" in str(s.get("run", ""))
-        and s.get("env", {}).get("NEXT_PUBLIC_RADON_DEMO") == "1",
-        "demo build",
-    )
-    assert demo_build > trace, (
-        "the NEXT_PUBLIC_RADON_DEMO=1 rebuild overwrites web/.next; it must run "
-        "AFTER the trace-upload step so retried prod-bundle steps are not "
-        f"poisoned (demo build at index {demo_build}, trace upload at {trace})"
+        lambda s: "run build" in str(s.get("run", ""))
+        and DEMO_SPEC not in str(s.get("run", "")),
+        "demo build (a `run build` step distinct from the demo spec step)",
     )
 
 
-def test_demo_spec_is_the_final_step_and_follows_demo_build():
+def _demo_spec_index(steps):
+    return _index(
+        steps, lambda s: DEMO_SPEC in str(s.get("run", "")), "demo spec"
+    )
+
+
+def test_demo_build_and_spec_are_the_trailing_contiguous_pair():
     steps = _steps()
-    demo_build = _index(
-        steps,
-        lambda s: "build" in str(s.get("run", ""))
-        and s.get("env", {}).get("NEXT_PUBLIC_RADON_DEMO") == "1",
-        "demo build",
-    )
-    demo_spec = _index(
-        steps,
-        lambda s: "demo-workstation-data.spec.ts" in str(s.get("run", "")),
-        "demo spec",
-    )
-    assert demo_spec == demo_build + 1, "demo spec must immediately follow demo build"
+    demo_spec = _demo_spec_index(steps)
     assert demo_spec == len(steps) - 1, (
         "the demo spec must be the LAST step of e2e-financial-smoke; anything "
         "after it would execute against the demo bundle"
     )
+    demo_build = demo_spec - 1
+    assert "run build" in str(steps[demo_build].get("run", "")), (
+        "the step immediately before the demo spec must be the demo rebuild; "
+        "any step between them runs against an ambiguous bundle"
+    )
+
+
+def test_both_demo_steps_carry_the_demo_env_flag():
+    steps = _steps()
+    demo_spec = _demo_spec_index(steps)
+    demo_build = demo_spec - 1
+    for label, idx in (("demo build", demo_build), ("demo spec", demo_spec)):
+        env = steps[idx].get("env") or {}
+        assert env.get("NEXT_PUBLIC_RADON_DEMO") == "1", (
+            f"the {label} step (index {idx}) must set NEXT_PUBLIC_RADON_DEMO "
+            '"1"; without it the step silently runs against the prod bundle '
+            "and the demo spec asserts nothing about demo mode"
+        )
+
+
+def test_no_step_combines_failure_with_a_playwright_rerun():
+    steps = _steps()
+    for i, step in enumerate(steps):
+        cond = str(step.get("if", ""))
+        run = str(step.get("run", ""))
+        assert not ("failure()" in cond and "playwright test" in run), (
+            f"step {i} ({step.get('name')}) re-runs `playwright test` under "
+            "failure(); a failure()-gated re-run after the demo rebuild would "
+            "replay specs against the demo bundle in web/.next"
+        )
+        if "continue-on-error" in step:
+            assert "playwright test" not in run, (
+                f"step {i} ({step.get('name')}) marks a `playwright test` run "
+                "continue-on-error, inviting a later re-invocation against a "
+                "swapped bundle"
+            )

--- a/scripts/tests/test_dockerfile_playwright_digest.py
+++ b/scripts/tests/test_dockerfile_playwright_digest.py
@@ -3,11 +3,77 @@ what was fetched. The build must compute and record a digest of the installed
 browser tree so any two images (or an audit) can compare what actually landed.
 Filesystem pin — no docker build required."""
 
+import subprocess
 from pathlib import Path
 
 DOCKERFILE = (
     Path(__file__).resolve().parents[2] / "docker" / "app" / "Dockerfile.python"
 )
+
+# sha256 of the empty stream — what the pipeline must NEVER record.
+EMPTY_STREAM_SHA256 = (
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+)
+
+
+def _digest_pipeline() -> str:
+    """Extract the digest-producing shell fragment from the install RUN layer:
+    every &&-joined command after the playwright install, up to and including
+    the one that writes .browsers.sha256."""
+    source = DOCKERFILE.read_text()
+    install_layer = next(
+        chunk
+        for chunk in source.split("RUN ")
+        if chunk.startswith("python -m playwright install")
+    )
+    flat = install_layer.replace("\\\n", " ")
+    segments = [s.strip() for s in flat.split("&&")]
+    start = 1  # segment 0 is the install itself
+    end = next(
+        i for i, s in enumerate(segments) if ".browsers.sha256" in s and ">" in s
+    )
+    return " && ".join(segments[start : end + 1])
+
+
+def _run_pipeline(tree: Path) -> subprocess.CompletedProcess:
+    script = _digest_pipeline().replace("/ms-playwright", str(tree))
+    return subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True
+    )
+
+
+def test_populated_tree_yields_non_empty_digest(tmp_path):
+    tree = tmp_path / "browsers"
+    (tree / "chromium").mkdir(parents=True)
+    (tree / "chromium" / "shell").write_bytes(b"fake browser bytes")
+    result = _run_pipeline(tree)
+    assert result.returncode == 0, result.stderr
+    digest = (tree / ".browsers.sha256").read_text().strip()
+    assert len(digest) == 64 and digest != EMPTY_STREAM_SHA256
+
+
+def test_empty_tree_fails_instead_of_recording_empty_digest(tmp_path):
+    tree = tmp_path / "browsers"
+    tree.mkdir()
+    result = _run_pipeline(tree)
+    assert result.returncode != 0, (
+        "an empty browser tree must fail the build, not record the "
+        f"empty-stream digest: {result.stdout!r}"
+    )
+    digest_file = tree / ".browsers.sha256"
+    if digest_file.exists():
+        assert digest_file.read_text().strip() != EMPTY_STREAM_SHA256
+
+
+def test_digest_has_an_in_image_consumer():
+    """Nothing else in the repo reads .browsers.sha256, so the build itself
+    must consume it: assert the recorded digest is 64 hex chars and not the
+    empty-stream sha256, failing the image build otherwise."""
+    source = DOCKERFILE.read_text()
+    assert EMPTY_STREAM_SHA256 in source, (
+        "the build must reject the empty-stream digest explicitly"
+    )
+    assert "grep -qE" in source and "[0-9a-f]{64}" in source
 
 
 def test_build_records_browser_tree_digest():

--- a/scripts/tests/test_e2e_ci_curation.py
+++ b/scripts/tests/test_e2e_ci_curation.py
@@ -216,8 +216,10 @@ def test_a_changed_heldout_spec_carries_a_dated_ledger_annotation() -> None:
     annotations = _annotations()
     problems = []
     for spec in heldout_changed:
+        # T-469: %as (author date) is stable across rebase/amend/cherry-pick;
+        # %cs is rewritten to "now" and re-reds a correctly-stamped spec.
         changed_on = _git(
-            "log", "-1", "--format=%cs", base + "..HEAD", "--", "web/e2e/" + spec
+            "log", "-1", "--format=%as", base + "..HEAD", "--", "web/e2e/" + spec
         )
         stamped = annotations.get(spec)
         if stamped is None:

--- a/scripts/tests/test_loop_session_limit.py
+++ b/scripts/tests/test_loop_session_limit.py
@@ -17,21 +17,9 @@ cap so the operator does not re-fire into it.
 
 from __future__ import annotations
 
-import importlib.util
-import sys
-from pathlib import Path
-
 import pytest
 
-_LADDER_TEST = Path(__file__).with_name("test_weekend_model_ladder.py")
-_spec = importlib.util.spec_from_file_location("_weekend_model_ladder", _LADDER_TEST)
-_ladder_mod = importlib.util.module_from_spec(_spec)
-sys.modules[_spec.name] = _ladder_mod
-_spec.loader.exec_module(_ladder_mod)
-
-LADDER = _ladder_mod.LADDER
-LOOPS = _ladder_mod.LOOPS
-_run = _ladder_mod._run
+from _loop_harness import LADDER, LOOPS, _run
 
 SESSION_LIMIT_LINE = "You've hit your session limit · resets 5am (America/Los_Angeles)"
 WEEKLY_LIMIT_LINE = "You've hit your weekly limit · resets Monday"

--- a/scripts/tests/test_nightly_green_base.py
+++ b/scripts/tests/test_nightly_green_base.py
@@ -7,6 +7,7 @@ being unreachable keeps the current tip rather than failing the run.
 from __future__ import annotations
 
 import json
+import os
 import stat
 import subprocess
 import sys
@@ -62,8 +63,20 @@ class TestCli:
     def git_repo(self, tmp_path):
         d = tmp_path / "repo"
         d.mkdir()
-        run = lambda *a: subprocess.run(["git", "-C", str(d), *a], check=True,
-                                        capture_output=True, text=True)
+        # T-468: never inherit the operator's global/system git config — a
+        # host core.hooksPath pre-commit (gitleaks, tsc) would run inside the
+        # fixture and error every commit for reasons unrelated to the SUT.
+        env = {
+            **os.environ,
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+            "GIT_TERMINAL_PROMPT": "0",
+        }
+        run = lambda *a: subprocess.run(
+            ["git", "-C", str(d), "-c", "core.hooksPath=/dev/null",
+             "-c", "commit.gpgsign=false", *a],
+            check=True, capture_output=True, text=True, env=env,
+        )
         run("init", "-q")
         run("config", "user.email", "t@t")
         run("config", "user.name", "t")

--- a/scripts/tests/test_rel198_ladder_signals.py
+++ b/scripts/tests/test_rel198_ladder_signals.py
@@ -89,7 +89,7 @@ class TestQuoteInACrashIsNotQuota:
         deep in its transcript (not in the CLI's final lines) is a crash,
         not quota exhaustion."""
         sys.path.insert(0, str(SCRIPTS / "tests"))
-        from test_weekend_model_ladder import _clone, _stub_bin
+        from _loop_harness import _clone, _stub_bin
 
         wrapper = LOOPS["reliability"]
         models_log = tmp_path / "models.txt"

--- a/scripts/tests/test_rel241_retry_budget.py
+++ b/scripts/tests/test_rel241_retry_budget.py
@@ -4,11 +4,20 @@ systemd unit's TimeoutStartSec with margin.
 Worst case is a sustained 502: every curl runs to its -m timeout and every
 retry sleeps the full delay. If that wall time meets or exceeds
 TimeoutStartSec, systemd kills the oneshot as Result=timeout — a failed unit
-and a watchdog page for the exact condition the retries absorb. Constants
-are parsed from the script and unit file so drift in either re-fails this.
+and a watchdog page for the exact condition the retries absorb.
+
+T-474: the previous test regex-scraped constants and re-modelled the loop
+shape (`attempts = retries + 1`) in Python, so a changed loop bound with
+unchanged constants still passed. This version EXECUTES the real script with
+PATH-shimmed `curl`/`sleep` stubs that log every invocation and force a
+sustained 502, then measures the curl count and simulated wall clock from
+the logs. A loop-bound change now changes the measurement and re-fails.
 """
 
+import os
 import re
+import stat
+import subprocess
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -19,42 +28,108 @@ UNIT = REPO_ROOT / "cloud" / "services" / "radon-portfolio-sync.service"
 MARGIN_SECS = 10
 
 
-def _script_code_lines() -> list[str]:
-    # Strip comment lines first: the retry comment block quotes code-like
-    # text (502/503, exit 7) and must not feed the constant parse.
-    return [
-        line
-        for line in SCRIPT.read_text().splitlines()
-        if not line.lstrip().startswith("#")
-    ]
-
-
-def _script_constants() -> tuple[int, int, int]:
-    code = "\n".join(_script_code_lines())
-    curl_timeout = int(re.search(r"curl\s[^\n]*-m\s+(\d+)", code).group(1))
-    retries = int(
-        re.search(r"RADON_PORTFOLIO_REFRESH_RETRIES:-(\d+)", code).group(1)
-    )
-    delay = int(
-        re.search(
-            r"RADON_PORTFOLIO_REFRESH_RETRY_DELAY_SECS:-(\d+)", code
-        ).group(1)
-    )
-    return curl_timeout, retries, delay
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 
 def _timeout_start_sec() -> int:
     match = re.search(r"^TimeoutStartSec=(\d+)$", UNIT.read_text(), re.M)
+    assert match, f"TimeoutStartSec not found in {UNIT}"
     return int(match.group(1))
 
 
-def test_worst_case_retry_wall_time_fits_timeout_start_sec_with_margin():
-    curl_timeout, retries, delay = _script_constants()
-    attempts = retries + 1
-    worst_case = attempts * curl_timeout + retries * delay
+def _documented_retries() -> int:
+    """The script's shipped retry default — used only to cross-check the
+    MEASURED curl count against the documented budget, never to model the
+    loop shape."""
+    code = "\n".join(
+        line
+        for line in SCRIPT.read_text().splitlines()
+        if not line.lstrip().startswith("#")
+    )
+    return int(re.search(r"RADON_PORTFOLIO_REFRESH_RETRIES:-(\d+)", code).group(1))
+
+
+def _run_script_under_sustained_502(tmp_path: Path) -> tuple[int, list[int], list[int]]:
+    """Execute the real wrapper with curl/sleep stubs. Returns (exit code,
+    per-curl -m timeouts, per-sleep delays), each list one entry per real
+    invocation the script made."""
+    shim = tmp_path / "bin"
+    shim.mkdir()
+    curl_log = tmp_path / "curl.log"
+    sleep_log = tmp_path / "sleep.log"
+
+    # Trading-gate python: pass resolve_python's `-c` probe, answer the
+    # IS_TRADING heredoc with "yes" so the retry loop is reached.
+    _write_executable(
+        shim / "python-stub",
+        '#!/bin/bash\nif [ "${1:-}" = "-c" ]; then exit 0; fi\ncat >/dev/null\necho yes\n',
+    )
+    # curl: log the -m timeout it was given, emit the -w http_code as a
+    # sustained 502, exit 22 (curl -f on a 5xx) — retryable per the script.
+    _write_executable(
+        shim / "curl",
+        "#!/bin/bash\n"
+        'm=""\n'
+        'while [ "$#" -gt 0 ]; do\n'
+        '  if [ "$1" = "-m" ]; then m="$2"; shift; fi\n'
+        "  shift\n"
+        "done\n"
+        f'echo "$m" >> "{curl_log}"\n'
+        "printf '502'\n"
+        "exit 22\n",
+    )
+    # sleep: log the requested delay, return instantly.
+    _write_executable(
+        shim / "sleep",
+        f'#!/bin/bash\necho "$1" >> "{sleep_log}"\nexit 0\n',
+    )
+
+    env = {
+        **os.environ,
+        "PATH": f"{shim}:{os.environ['PATH']}",
+        "RADON_PYTHON_BIN": str(shim / "python-stub"),
+    }
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+        check=False,
+    )
+    curls = [int(x) for x in curl_log.read_text().split()] if curl_log.exists() else []
+    sleeps = (
+        [int(x) for x in sleep_log.read_text().split()] if sleep_log.exists() else []
+    )
+    return result.returncode, curls, sleeps
+
+
+def test_measured_retry_wall_time_fits_timeout_start_sec_with_margin(tmp_path):
+    returncode, curls, sleeps = _run_script_under_sustained_502(tmp_path)
+
+    # The budget must be exhausted and the unit must fail (pages as designed).
+    assert returncode == 22, (returncode, curls, sleeps)
+    assert curls, "the script never invoked curl"
+
+    # Measured invocation count matches the documented budget: one initial
+    # attempt plus the shipped retry default, and one sleep per retry.
+    retries = _documented_retries()
+    assert len(curls) == retries + 1, (
+        f"measured {len(curls)} curl invocations under sustained 502; "
+        f"documented budget is {retries} retries + 1 initial attempt"
+    )
+    assert len(sleeps) == retries, (
+        f"measured {len(sleeps)} sleeps; expected one per retry ({retries})"
+    )
+
+    # Worst-case simulated wall clock: every curl runs to its own -m timeout
+    # and every sleep runs its full delay — as invoked, not as modelled.
+    worst_case = sum(curls) + sum(sleeps)
     timeout = _timeout_start_sec()
     assert worst_case + MARGIN_SECS <= timeout, (
-        f"worst-case retry wall time {worst_case}s "
-        f"({attempts} curls x -m {curl_timeout} + {retries} sleeps x {delay}s) "
+        f"measured worst-case wall time {worst_case}s "
+        f"({len(curls)} curls at -m {curls} + sleeps {sleeps}) "
         f"+ {MARGIN_SECS}s margin exceeds TimeoutStartSec={timeout}"
     )

--- a/scripts/tests/test_weekend_model_ladder.py
+++ b/scripts/tests/test_weekend_model_ladder.py
@@ -28,131 +28,23 @@ sequence of models actually attempted, not the shape of the script.
 
 from __future__ import annotations
 
-import os
 import re
-import shutil
-import subprocess
 from pathlib import Path
 
 import pytest
 
-REPO = Path(__file__).resolve().parents[2]
-BASH = shutil.which("bash") or "/bin/bash"
-
-# Every nightly loop wrapper. A loop missing here keeps the 2026-09-01
-# failure mode.
-LOOPS = {
-    "reliability": REPO / "scripts" / "reliability_weekend.sh",
-    "testing": REPO / "scripts" / "testing_weekend.sh",
-    "ci-performance": REPO / "scripts" / "ci_performance_nightly.sh",
-    "documentation": REPO / "scripts" / "documentation_nightly.sh",
-    "security": REPO / "scripts" / "security_nightly.sh",
-}
-
-# Best first. The top rung is the operator's own default; the next is the same
-# family one tier down, which is what 2026-09-01 needed and never got.
-LADDER = [
-    "claude-fable-5[1m]",
-    "claude-opus-5[1m]",
-    "claude-opus-5",
-    "claude-sonnet-5",
-]
-
-QUOTA_LINE = (
-    "You're out of usage credits. Switch to another model, or manage usage "
-    "credits at claude.ai/settings/usage?from=cc_cli_limit_message, to continue."
+from _loop_harness import (
+    CAPACITY_LINE,
+    CASUAL_RATE_LIMITS,
+    LADDER,
+    LOOPS,
+    QUOTA_LINE,
+    RATE_LIMIT_LINE,
+    REPO,
+    TOOL_SKIP_OVERLOADED,
+    TOOL_SKIP_RATE_LIMITED,
+    _run,
 )
-RATE_LIMIT_LINE = "Request rejected (429)"
-CAPACITY_LINE = "API Error: Repeated 529 Overloaded errors"
-# Claude Code tool-skip categories. Official docs say retry the SAME model.
-# Bare `overloaded` / `rate.limit` in is_quota_exhausted treated these as a
-# dead rung and walked the ladder, including on timeout 124 whose log merely
-# mentioned rate limits.
-TOOL_SKIP_OVERLOADED = "Claude Code skipped a tool (overloaded)"
-TOOL_SKIP_RATE_LIMITED = "Claude Code skipped a tool (rate-limited)"
-CASUAL_RATE_LIMITS = "the 500 mentioned rate limits in a timeout log"
-# The security wrapper refuses to call a phase OK without this; harmless noise
-# for the other four.
-COMPLETION = "SECURITY-NIGHTLY PHASE COMPLETE: audit"
-
-MARKERS = (
-    ".radon-weekend-runner",
-    ".radon-security-runner",
-    ".radon-reliability-runner",
-    ".radon-testing-runner",
-    ".radon-ci-performance-runner",
-    ".radon-documentation-runner",
-)
-
-
-def _clone(tmp_path: Path, wrapper: Path) -> Path:
-    repo = tmp_path / "clone"
-    (repo / "scripts").mkdir(parents=True)
-    shutil.copy2(wrapper, repo / "scripts" / wrapper.name)
-    (repo / "scripts" / wrapper.name).chmod(0o755)
-    for helper in ("weekend_notify.py", "weekend_redact.py"):
-        (repo / "scripts" / helper).write_text("# stub\n", encoding="utf-8")
-    for marker in MARKERS:
-        (repo / marker).write_text("", encoding="utf-8")
-    return repo
-
-
-def _stub_bin(
-    tmp_path: Path,
-    models_log: Path,
-    exhausted: Path,
-    gh_log: Path,
-    exhausted_line: str = QUOTA_LINE,
-) -> Path:
-    bin_dir = tmp_path / "bin"
-    bin_dir.mkdir()
-    # What the agent's OWN nested `claude` calls would inherit. The wrapper's
-    # `--model` binds only the outer process; the security skill's Stage 4
-    # Claude Security scan is a separate `claude` invocation and reads this.
-    env_models = tmp_path / "env_models.txt"
-    stubs = {
-        "gh": (
-            "#!/bin/sh\n"
-            f'printf "%s\\n" "$*" >> "{gh_log}"\n'
-            'if [ "$1 $2" = "issue list" ]; then echo 4242; fi\n'
-            "exit 0\n"
-        ),
-        # Records the model it was handed, then behaves like a real agent whose
-        # quota for that model is (or is not) gone.
-        "claude": (
-            "#!/bin/bash\n"
-            'model=""\n'
-            "while [ $# -gt 0 ]; do\n"
-            '  if [ "$1" = "--model" ]; then model="$2"; shift 2; continue; fi\n'
-            "  shift\n"
-            "done\n"
-            f'printf "%s\\n" "$model" >> "{models_log}"\n'
-            f'printf "%s\\n" "${{RADON_WEEKEND_MODEL:-<unset>}}" >> "{env_models}"\n'
-            f'if grep -qxF -- "$model" "{exhausted}"; then\n'
-            f"  echo \"{exhausted_line}\"\n"
-            "  exit 1\n"
-            "fi\n"
-            f'echo "{COMPLETION}"\n'
-            "exit 0\n"
-        ),
-        "timeout": (
-            "#!/bin/bash\n"
-            "while [ $# -gt 0 ]; do\n"
-            '  case "$1" in\n'
-            "    -k|--kill-after) shift 2 ;;\n"
-            "    *) shift; break ;;\n"
-            "  esac\n"
-            "done\n"
-            'exec "$@"\n'
-        ),
-        "git": '#!/bin/sh\n# REL-188: the wrapper calls a phase OK only on commit evidence, so the\n# stub reports a fresh HEAD and a current committer date.\ncase "$*" in\n  *"rev-parse HEAD"*) date +%s%N; exit 0 ;;\n  *"--format=%ct"*) date +%s; exit 0 ;;\nesac\nexit 0\n',
-        "python3": "#!/bin/sh\nexit 0\n",
-    }
-    for name, body in stubs.items():
-        exe = bin_dir / name
-        exe.write_text(body, encoding="utf-8")
-        exe.chmod(0o755)
-    return bin_dir
 
 
 def _audit(
@@ -165,42 +57,6 @@ def _audit(
     return _run(
         tmp_path, loop, "audit", exhausted_models, ladder, exhausted_line=exhausted_line
     )
-
-
-def _run(
-    tmp_path: Path,
-    loop: str,
-    phase: str,
-    exhausted_models,
-    ladder: str | None = None,
-    exhausted_line: str = QUOTA_LINE,
-):
-    wrapper = LOOPS[loop]
-    models_log = tmp_path / "models.txt"
-    gh_log = tmp_path / "gh.log"
-    exhausted = tmp_path / "exhausted.txt"
-    exhausted.write_text("".join(f"{m}\n" for m in exhausted_models), encoding="utf-8")
-    bin_dir = _stub_bin(
-        tmp_path, models_log, exhausted, gh_log, exhausted_line=exhausted_line
-    )
-    repo = _clone(tmp_path, wrapper)
-    env = {
-        "PATH": f"{bin_dir}:/usr/bin:/bin",
-        "HOME": str(tmp_path / "home"),
-        "RADON_WEEKEND_REPO": str(repo),
-    }
-    if ladder is not None:
-        env["RADON_WEEKEND_MODEL_LADDER"] = ladder
-    proc = subprocess.run(
-        [BASH, str(repo / "scripts" / wrapper.name), phase],
-        cwd=repo, env=env, capture_output=True, text=True, timeout=180,
-    )
-    models = (
-        models_log.read_text(encoding="utf-8").splitlines()
-        if models_log.exists() else []
-    )
-    calls = gh_log.read_text(encoding="utf-8") if gh_log.exists() else ""
-    return proc, models, calls
 
 
 @pytest.mark.parametrize("loop", sorted(LOOPS))

--- a/web/components/InstrumentDetailModal.tsx
+++ b/web/components/InstrumentDetailModal.tsx
@@ -15,6 +15,7 @@ import {
   riskPriceForOrderType,
 } from "@/lib/order/stopOrder";
 import { useOrderActionsOptional } from "@/lib/OrderActionsContext";
+import { useRealtimePrices } from "@/lib/RealtimePricesContext";
 import type { PortfolioData } from "@/lib/types";
 
 export type InstrumentDetailProps = {
@@ -135,6 +136,9 @@ function LegOrderForm({
   portfolio: PortfolioData | null | undefined;
 }) {
   const orderActions = useOrderActionsOptional();
+  // T-462: the feed-disconnect arm of quoteSubmitGate is dead unless the
+  // owner surface supplies real connectivity.
+  const { connected: feedConnected } = useRealtimePrices();
   const bid = priceData?.bid ?? null;
   const ask = priceData?.ask ?? null;
   const mid = bid != null && ask != null ? (bid + ask) / 2 : null;
@@ -251,6 +255,7 @@ function LegOrderForm({
       bid={bid}
       mid={mid}
       ask={ask}
+      feedConnected={feedConnected}
       showQuickButtonPrices={true}
       isValid={isValid}
       limitPrice={limitPrice}

--- a/web/components/ModifyOrderModal.tsx
+++ b/web/components/ModifyOrderModal.tsx
@@ -534,7 +534,11 @@ export default function ModifyOrderModal({ order, loading, prices, portfolio, op
   const currentQuantity = fillSnapshot
     ? fillSnapshot.total - fillSnapshot.filled
     : remainingQuantity(order);
-  const alreadyFilled = filledQuantity(order);
+  // T-473: the info line must describe the SAME fill count the field's math
+  // uses — the snapshot. A mid-dialog fill advance is flagged, not blended in.
+  const alreadyFilled = fillSnapshot ? fillSnapshot.filled : filledQuantity(order);
+  const liveFilledNow = filledQuantity(order);
+  const fillsAdvanced = fillSnapshot != null && liveFilledNow !== fillSnapshot.filled;
   const parsedNew = parseFloat(newPrice);
   const parsedQuantity = parsePositiveInteger(newQuantity);
   const isComboOrder = order.contract.secType === "BAG" && editableLegs.length >= 2;
@@ -688,6 +692,11 @@ export default function ModifyOrderModal({ order, loading, prices, portfolio, op
           {alreadyFilled > 0 && (
             <span className="modify-order-filled">
               {alreadyFilled} of {order.totalQuantity} filled
+            </span>
+          )}
+          {fillsAdvanced && (
+            <span className="modify-order-fill-stale" role="alert">
+              fills advanced: {liveFilledNow} of {order.totalQuantity} now filled
             </span>
           )}
         </div>

--- a/web/components/PositionTable.tsx
+++ b/web/components/PositionTable.tsx
@@ -558,12 +558,13 @@ function PositionRow({ pos, showExpiry = true, showUnderlying = false, showImpli
           </td>
         )}
         {columns.pnl && (
-          <td className={`right ${pnl != null ? (pnl >= 0 ? "positive" : "negative") : ""}`}>
+          <td data-testid="position-cell-pnl" className={`right ${pnl != null ? (pnl >= 0 ? "positive" : "negative") : ""}`}>
             {pnl != null ? `${pnl >= 0 ? "+" : "-"}${fmtUsd(Math.abs(pnl))}` : "—"}
           </td>
         )}
         {columns.pnl_pct && (
           <td
+            data-testid="position-cell-pnl-pct"
             className={`right ${pnlPct != null ? (pnlPct >= 0 ? "positive" : "negative") : ""}`}
             title={returnTitle}
           >

--- a/web/components/WorkspaceSections.tsx
+++ b/web/components/WorkspaceSections.tsx
@@ -108,6 +108,7 @@ import { computeLegImpliedValue, computeOrderImpliedValue } from "@/lib/impliedV
 import { useRiskFreeRate } from "@/lib/useRiskFreeRate";
 import { useColumnVisibility } from "@/lib/useColumnVisibility";
 import { useViewport } from "@/lib/useViewport";
+import { useRealtimePrices } from "@/lib/RealtimePricesContext";
 import { ColumnsToggle, type ColumnsToggleEntry } from "./ColumnsToggle";
 import MobileOrderList from "./mobile/MobileOrderList";
 import MobileBlotterList from "./mobile/MobileBlotterList";
@@ -2956,6 +2957,9 @@ function OrdersSections({
   portfolio?: PortfolioData | null;
 }) {
   const { pendingCancels, pendingModifies, cancelledOrders, requestCancel, requestModify } = useOrderActions();
+  // T-462: the feed-disconnect arm of quoteSubmitGate is dead unless the
+  // owner surface supplies real connectivity.
+  const { connected: feedConnected } = useRealtimePrices();
   const { isMobile, hasMounted } = useViewport();
   const showMobileOrders = isMobile && hasMounted;
   const riskFreeRate = useRiskFreeRate();
@@ -3260,6 +3264,7 @@ function OrdersSections({
         portfolio={portfolio}
         // R-112: the close-out branch must know what is already working.
         openOrders={orders}
+        feedConnected={feedConnected}
         onConfirm={handleModify}
         onClose={() => setModifyTarget(null)}
       />

--- a/web/components/ticker-detail/BookTab.tsx
+++ b/web/components/ticker-detail/BookTab.tsx
@@ -16,6 +16,7 @@ import {
   riskPriceForOrderType,
 } from "@/lib/order/stopOrder";
 import { useOrderActionsOptional } from "@/lib/OrderActionsContext";
+import { useRealtimePrices } from "@/lib/RealtimePricesContext";
 import { isIndexSymbol, hasFuturesSupport, hasIndexOptionsSupport } from "@/lib/indexSymbols";
 import { FuturesOrderForm } from "@/components/ticker-detail/FuturesOrderForm";
 import { IndexOptionOrderForm } from "@/components/ticker-detail/IndexOptionOrderForm";
@@ -328,6 +329,9 @@ function StockOrderForm({
   priceData: PriceData | null;
 }) {
   const orderActions = useOrderActionsOptional();
+  // T-462: the feed-disconnect arm of quoteSubmitGate is dead unless the
+  // owner surface supplies real connectivity.
+  const { connected: feedConnected } = useRealtimePrices();
   const defaultAction: SingleLegOrderAction = position != null ? "SELL" : "BUY";
   const [action, setAction] = useState<SingleLegOrderAction>(defaultAction);
   const [quantity, setQuantity] = useState(() => {
@@ -406,6 +410,7 @@ function StockOrderForm({
       mid={mid}
       ask={ask}
       priceData={priceData}
+      feedConnected={feedConnected}
       quoteLabel={ticker}
       showQuickButtonPrices={false}
       isValid={isValid}

--- a/web/components/ticker-detail/OrderTab.tsx
+++ b/web/components/ticker-detail/OrderTab.tsx
@@ -31,6 +31,7 @@ import { fmtSignedPrice, toneClass } from "@/lib/format";
 import { isIndexSymbol, hasFuturesSupport, hasIndexOptionsSupport } from "@/lib/indexSymbols";
 import { FuturesOrderForm } from "@/components/ticker-detail/FuturesOrderForm";
 import { IndexOptionOrderForm } from "@/components/ticker-detail/IndexOptionOrderForm";
+import { useRealtimePrices } from "@/lib/RealtimePricesContext";
 
 type OrderTabProps = {
   ticker: string;
@@ -1111,6 +1112,9 @@ export default function OrderTab({ ticker, position, portfolio, prices, openOrde
   const isIndex = isIndexSymbol(ticker);
 
   const { requestModify } = useOrderActions();
+  // T-462: the feed-disconnect arm of quoteSubmitGate is dead unless the
+  // owner surface supplies real connectivity.
+  const { connected: feedConnected } = useRealtimePrices();
   const [modifyTarget, setModifyTarget] = useState<OpenOrder | null>(null);
   const [modifyLoading, setModifyLoading] = useState(false);
 
@@ -1131,6 +1135,7 @@ export default function OrderTab({ ticker, position, portfolio, prices, openOrde
         portfolio={portfolio}
         // R-112: a close-out must count the SELL combos already working.
         openOrders={{ open_orders: openOrders }}
+        feedConnected={feedConnected}
         onConfirm={handleModifyConfirm}
         onClose={() => setModifyTarget(null)}
       />

--- a/web/components/ticker-detail/PositionTab.tsx
+++ b/web/components/ticker-detail/PositionTab.tsx
@@ -284,7 +284,7 @@ function PositionView({
         </div>
         <div className="pos-stat">
           <span className="pos-stat-label">Avg Entry</span>
-          <span className={`pos-stat-value ${avgEntry != null && toneClass(avgEntry) !== "neutral" ? toneClass(avgEntry) : ""}`}>
+          <span data-testid="pos-stat-avg-entry" className={`pos-stat-value ${avgEntry != null && toneClass(avgEntry) !== "neutral" ? toneClass(avgEntry) : ""}`}>
             {avgEntry == null ? "---" : fmtSignedPrice(avgEntry)}
           </span>
         </div>
@@ -296,7 +296,7 @@ function PositionView({
         </div>
         <div className="pos-stat">
           <span className="pos-stat-label">Entry Cost</span>
-          <span className="pos-stat-value" title={blendedBasis ? MIXED_BASIS_TITLE : undefined}>
+          <span data-testid="pos-stat-entry-cost" className="pos-stat-value" title={blendedBasis ? MIXED_BASIS_TITLE : undefined}>
             {entryCost == null ? "---" : fmtUsd(entryCost)}
           </span>
         </div>

--- a/web/lib/order/components/OrderConfirmSummary.tsx
+++ b/web/lib/order/components/OrderConfirmSummary.tsx
@@ -96,6 +96,7 @@ export function OrderConfirmSummary({
     return (
       <div
         className={`order-confirm-summary order-confirm-summary-pending ${className}`.trim()}
+        data-testid="order-confirm-summary"
         data-coverage-status={summary.coverageStatus}
         role="status"
       >
@@ -129,6 +130,7 @@ export function OrderConfirmSummary({
   return (
     <div
       className={`order-confirm-summary ${variantClass} ${className}`.trim()}
+      data-testid="order-confirm-summary"
       data-undefined-risk={hasUndefinedRisk ? "true" : undefined}
     >
       <div className="order-confirm-description">{summary.description}</div>

--- a/web/tests/api-routes.test.ts
+++ b/web/tests/api-routes.test.ts
@@ -95,6 +95,12 @@ const mockMkdir = vi.fn().mockResolvedValue(undefined);
 const mockWriteFile = vi.fn().mockResolvedValue(undefined);
 // Default stat: mtime 5 s ago (fresh) so portfolio GET doesn't trigger background spawn
 const mockStat = vi.fn().mockResolvedValue({ mtimeMs: Date.now() - 5_000 });
+// T-478: the module-load-time default freezes and leaks per-test stubs —
+// re-stamp a fresh window-relative mtime before every test.
+beforeEach(() => {
+  mockStat.mockReset();
+  mockStat.mockResolvedValue({ mtimeMs: Date.now() - 5_000 });
+});
 vi.mock("fs/promises", () => ({
   readFile: mockReadFile,
   readdir: mockReaddir,

--- a/web/tests/api-routes.test.ts
+++ b/web/tests/api-routes.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mostRecentSessionDate } from "../lib/marketSession";
 
 /**
  * API route tests.
@@ -842,14 +843,18 @@ describe("GET /api/regime", () => {
     mockReadFile.mockReset();
     mockStat.mockReset();
     mockStat.mockResolvedValue({ mtimeMs: Date.now() - 5_000 });
+    mockRadonFetch.mockReset();
     const mod = await import("../app/api/regime/route");
     GET = mod.GET;
   });
 
   it("returns cached regime payload when file exists", async () => {
+    // Window-relative date: a hardcoded past date goes stale and re-arms
+    // triggerBackgroundScan() (T-477).
+    const sessionDate = mostRecentSessionDate();
     mockReadFile.mockResolvedValue(JSON.stringify({
-      scan_time: "2026-04-22T14:00:00Z",
-      date: "2026-04-22",
+      scan_time: `${sessionDate}T14:00:00Z`,
+      date: sessionDate,
       market_open: true,
       cri: { score: 24, level: "ELEVATED", components: { vix: 6, vvix: 6, correlation: 6, momentum: 6 } },
       history: [],
@@ -859,8 +864,10 @@ describe("GET /api/regime", () => {
     const res = await GET();
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.date).toBe("2026-04-22");
+    expect(body.date).toBe(sessionDate);
     expect(body.cri.score).toBe(24);
+    // T-477: a fresh cached payload must not fire a background /regime/scan.
+    expect(mockRadonFetch).not.toHaveBeenCalled();
   });
 });
 

--- a/web/tests/demo-headlines-hook.test.tsx
+++ b/web/tests/demo-headlines-hook.test.tsx
@@ -81,7 +81,8 @@ describe("useHeadlines demo transport", () => {
     vi.useFakeTimers();
     const fetchMock = vi.fn()
       .mockResolvedValueOnce({ ok: true, json: async () => SNAPSHOT })
-      .mockRejectedValueOnce(new Error("offline"));
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValue({ ok: true, json: async () => SNAPSHOT });
     vi.stubGlobal("fetch", fetchMock);
     const { useHeadlines } = await import("../lib/useHeadlines");
     const rendered = renderHook(() => useHeadlines());
@@ -99,6 +100,19 @@ describe("useHeadlines demo transport", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(rendered.result.current.status).toBe("down");
     expect(rendered.result.current.items).toEqual(SNAPSHOT.items);
+
+    // T-483: one failure re-arms the poll at POLL_MS * 2**1 = 120s, so 60s
+    // after the rejection NO third fetch may fire...
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // ...and a further 60s (120s since the failure) fires exactly the third.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     rendered.unmount();
   });
 

--- a/web/tests/instrument-detail-buy-to-cover.test.tsx
+++ b/web/tests/instrument-detail-buy-to-cover.test.tsx
@@ -10,6 +10,17 @@ import PositionTable from "../components/PositionTable";
 import type { PortfolioData, PortfolioLeg, PortfolioPosition } from "@/lib/types";
 import type { PriceData } from "@/lib/pricesProtocol";
 
+// T-462: the ticket now reads live-feed connectivity from
+// RealtimePricesContext at the owner surface; these specs exercise
+// pricing/risk with the feed up.
+vi.mock("@/lib/RealtimePricesContext", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useRealtimePrices: () => ({ ...actual.useRealtimePrices(), connected: true }),
+  };
+});
+
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn() }),
 }));

--- a/web/tests/instrument-detail-stp-nan-risk.test.tsx
+++ b/web/tests/instrument-detail-stp-nan-risk.test.tsx
@@ -23,6 +23,17 @@ import { renderHook } from "@testing-library/react";
 import type { PortfolioData, PortfolioLeg, PortfolioPosition } from "@/lib/types";
 import type { PriceData } from "@/lib/pricesProtocol";
 
+// T-462: the ticket now reads live-feed connectivity from
+// RealtimePricesContext at the owner surface; these specs exercise
+// pricing/risk with the feed up.
+vi.mock("@/lib/RealtimePricesContext", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useRealtimePrices: () => ({ ...actual.useRealtimePrices(), connected: true }),
+  };
+});
+
 vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
 
 vi.mock("../components/Modal", () => ({

--- a/web/tests/modify-order-close-pnl.test.tsx
+++ b/web/tests/modify-order-close-pnl.test.tsx
@@ -158,7 +158,7 @@ function renderModifiedOrder(order: OpenOrder, portfolio: PortfolioData, price: 
     />,
   );
   fireEvent.change(screen.getByLabelText(/New Limit Price/i), { target: { value: price } });
-  return within(document.querySelector(".order-confirm-summary") as HTMLElement);
+  return within(screen.getByTestId("order-confirm-summary"));
 }
 
 describe("ModifyOrderModal close-out P&L", () => {
@@ -437,7 +437,7 @@ function renderCbrsModify(price: string, portfolio: PortfolioData) {
     />,
   );
   fireEvent.change(screen.getByLabelText(/New Net Price/i), { target: { value: price } });
-  return within(document.querySelector(".order-confirm-summary") as HTMLElement);
+  return within(screen.getByTestId("order-confirm-summary"));
 }
 
 describe("ModifyOrderModal combo close-out P&L", () => {
@@ -474,7 +474,7 @@ describe("ModifyOrderModal combo close-out P&L", () => {
       />,
     );
     fireEvent.change(screen.getByLabelText(/New Net Price/i), { target: { value: "8" } });
-    const summary = within(document.querySelector(".order-confirm-summary") as HTMLElement);
+    const summary = within(screen.getByTestId("order-confirm-summary"));
 
     expect(summary.getByText("Est. Realized P&L:")).toBeTruthy();
     expect(summary.getByText("$15,000")).toBeTruthy();
@@ -496,7 +496,7 @@ describe("ModifyOrderModal combo close-out P&L", () => {
       />,
     );
     fireEvent.change(screen.getByLabelText(/New Net Price/i), { target: { value: "8" } });
-    const summary = within(document.querySelector(".order-confirm-summary") as HTMLElement);
+    const summary = within(screen.getByTestId("order-confirm-summary"));
 
     expect(summary.queryByText("Est. Realized P&L:")).toBeNull();
     expect(summary.getByText("Max Loss:")).toBeTruthy();
@@ -515,7 +515,7 @@ describe("ModifyOrderModal combo close-out P&L", () => {
     );
     fireEvent.change(screen.getByLabelText(/New Quantity/i), { target: { value: "25" } });
     fireEvent.change(screen.getByLabelText(/New Net Price/i), { target: { value: "8" } });
-    const summary = within(document.querySelector(".order-confirm-summary") as HTMLElement);
+    const summary = within(screen.getByTestId("order-confirm-summary"));
 
     expect(summary.getByText("Close Credit:")).toBeTruthy();
     expect(summary.getByText("$20,000")).toBeTruthy();
@@ -537,7 +537,7 @@ describe("ModifyOrderModal combo close-out P&L", () => {
     );
     fireEvent.change(screen.getByLabelText(/New Quantity/i), { target: { value: "51" } });
     fireEvent.change(screen.getByLabelText(/New Net Price/i), { target: { value: "8" } });
-    const summary = within(document.querySelector(".order-confirm-summary") as HTMLElement);
+    const summary = within(screen.getByTestId("order-confirm-summary"));
 
     expect(summary.queryByText("Est. Realized P&L:")).toBeNull();
     expect(summary.getByText("Max Loss:")).toBeTruthy();

--- a/web/tests/modify-order-quote-gate.test.tsx
+++ b/web/tests/modify-order-quote-gate.test.tsx
@@ -9,7 +9,7 @@
  */
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { OpenOrder, PortfolioData } from "@/lib/types";
 import type { PriceData } from "@/lib/pricesProtocol";
 import type { ModifyOrderRequest } from "@/lib/orderModify";
@@ -30,6 +30,19 @@ afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
 });
+
+// T-480: drain any queued follow-up on FAKE timers so the "nothing fired"
+// window cannot lose a wall-clock race to React's commit/effect flush.
+async function flushTimersFake() {
+  vi.useFakeTimers();
+  try {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+  } finally {
+    vi.useRealTimers();
+  }
+}
 
 type RecordedCall = { url: string; method: string; body: unknown };
 
@@ -173,7 +186,7 @@ describe("ModifyOrderModal quote gate at the wire (R-641)", () => {
     fireEvent.change(priceInput(), { target: { value: "51.25" } });
     expect(submitBtn().disabled).toBe(true);
     fireEvent.click(submitBtn());
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await flushTimersFake();
     expect(orderCalls(calls)).toHaveLength(0);
   });
 
@@ -184,7 +197,7 @@ describe("ModifyOrderModal quote gate at the wire (R-641)", () => {
     fireEvent.change(priceInput(), { target: { value: "51.25" } });
     expect(submitBtn().disabled).toBe(true);
     fireEvent.click(submitBtn());
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await flushTimersFake();
     expect(orderCalls(calls)).toHaveLength(0);
   });
 });

--- a/web/tests/modify-partial-fill-quantity.test.tsx
+++ b/web/tests/modify-partial-fill-quantity.test.tsx
@@ -15,9 +15,10 @@
  */
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { OpenOrder, PortfolioData } from "@/lib/types";
 import ModifyOrderModal from "@/components/ModifyOrderModal";
+import { OrderActionsProvider, useOrderActions } from "@/lib/OrderActionsContext";
 import {
   filledQuantity,
   isPartiallyFilled,
@@ -37,6 +38,7 @@ vi.mock("@/components/Modal", () => ({
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  vi.unstubAllGlobals();
 });
 
 /** The order from the report: VIX C30, 1000 requested, 16 filled. */
@@ -167,5 +169,124 @@ describe("ModifyOrderModal partial-fill wire contract", () => {
 
     expect(onConfirm).toHaveBeenCalledTimes(1);
     expect(onConfirm.mock.calls[0][0]).toEqual({ newQuantity: 400 });
+  });
+});
+
+/**
+ * T-472: the wire path with fills advancing MID-DIALOG. `toIbTotalQuantity`
+ * is only a `fillSnapshot == null` fallback the modal can never reach; the
+ * transmitted total must come from the SNAPSHOT, and a stale-snapshot
+ * quantity submit must hit the fillRaceNotice branch, never the wire.
+ * Wired to the REAL fetch owner (OrderActionsContext.requestModify).
+ */
+type RecordedCall = { url: string; method: string; body: unknown };
+
+function recordFetch(): RecordedCall[] {
+  const calls: RecordedCall[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const body = typeof init?.body === "string" ? JSON.parse(init.body) : init?.body;
+      calls.push({ url, method: init?.method ?? "GET", body });
+      return new Response(JSON.stringify({ status: "ok" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }),
+  );
+  return calls;
+}
+
+function WiredHarness({ order }: { order: OpenOrder }) {
+  const { requestModify } = useOrderActions();
+  return (
+    <ModifyOrderModal
+      order={order}
+      loading={false}
+      portfolio={PORTFOLIO}
+      onConfirm={(request) => {
+        void requestModify(order, request);
+      }}
+      onClose={() => {}}
+    />
+  );
+}
+
+function renderWired(order: OpenOrder) {
+  const calls = recordFetch();
+  const view = render(
+    <OrderActionsProvider>
+      <WiredHarness order={order} />
+    </OrderActionsProvider>,
+  );
+  const rerenderWith = (next: OpenOrder) =>
+    view.rerender(
+      <OrderActionsProvider>
+        <WiredHarness order={next} />
+      </OrderActionsProvider>,
+    );
+  return { calls, rerenderWith, container: view.container };
+}
+
+const priceInput = () =>
+  document.getElementById("modify-price-input") as HTMLInputElement;
+
+describe("T-472: fills advance 16 -> 100 while the dialog is open", () => {
+  it("price-only submit transmits NO newQuantity", async () => {
+    const { calls, rerenderWith } = renderWired(vixOrder());
+    expect(qtyInput().value).toBe("984");
+
+    fireEvent.change(priceInput(), { target: { value: "0.70" } });
+    rerenderWith(vixOrder({ filled: 100, remaining: 900 }));
+
+    await act(async () => {
+      fireEvent.click(submitBtn());
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("/api/orders/modify");
+    expect(calls[0].method).toBe("POST");
+    expect("newQuantity" in (calls[0].body as object)).toBe(false);
+    expect(calls[0].body).toEqual({ orderId: 7, permId: 7007, newPrice: 0.7 });
+  });
+
+  it("quantity submit hits the fillRaceNotice reseed branch, not toIbTotalQuantity", async () => {
+    const { calls, rerenderWith } = renderWired(vixOrder());
+
+    fireEvent.change(qtyInput(), { target: { value: "500" } });
+    rerenderWith(vixOrder({ filled: 100, remaining: 900 }));
+
+    await act(async () => {
+      fireEvent.click(submitBtn());
+    });
+
+    // toIbTotalQuantity(live order, 500) would have sent newQuantity: 600 and
+    // the snapshot arithmetic 516 — neither may reach the wire.
+    expect(calls).toHaveLength(0);
+    // Refuse + reseed: field now shows the CURRENT remainder, operator warned.
+    expect(qtyInput().value).toBe("900");
+    expect(document.querySelector(".modify-fill-race")?.textContent).toMatch(/fill/i);
+  });
+});
+
+describe("T-473: info line and quantity field agree after fills advance", () => {
+  it("both describe the SNAPSHOT fill count, with the live advance flagged", () => {
+    const { rerenderWith, container } = renderWired(vixOrder());
+    rerenderWith(vixOrder({ filled: 100, remaining: 900 }));
+
+    const info = container.querySelector(".modify-order-info");
+    // The field is still seeded from the snapshot remainder...
+    expect(qtyInput().value).toBe("984");
+    expect(info?.textContent).toContain("984x");
+    // ...so the filled figure beside it must be the SAME snapshot count,
+    // not the live 100 the field's math knows nothing about.
+    expect(info?.querySelector(".modify-order-filled")?.textContent).toContain(
+      "16 of 1000 filled",
+    );
+    // The live advance is not hidden: it is visibly flagged as stale.
+    const stale = info?.querySelector(".modify-order-fill-stale");
+    expect(stale?.textContent).toContain("100");
+    expect(stale?.textContent).toMatch(/fill/i);
   });
 });

--- a/web/tests/order-ticket-quote-gate.test.tsx
+++ b/web/tests/order-ticket-quote-gate.test.tsx
@@ -11,7 +11,7 @@
  */
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { PortfolioData } from "@/lib/types";
 import type { PriceData } from "@/lib/pricesProtocol";
 import SingleLegOrderTicket from "../components/SingleLegOrderTicket";
@@ -21,6 +21,19 @@ afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
 });
+
+// T-480: drain any queued follow-up on FAKE timers so the "nothing fired"
+// window cannot lose a wall-clock race to React's commit/effect flush.
+async function flushTimersFake() {
+  vi.useFakeTimers();
+  try {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+  } finally {
+    vi.useRealTimers();
+  }
+}
 
 type RecordedCall = { url: string; method: string; body: unknown };
 
@@ -186,7 +199,7 @@ describe("SingleLegOrderTicket submit gate at the wire (R-641)", () => {
 
     expect(placeButton().disabled).toBe(true);
     await driveSubmit();
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await flushTimersFake();
     expect(calls).toHaveLength(0);
   });
 
@@ -199,7 +212,7 @@ describe("SingleLegOrderTicket submit gate at the wire (R-641)", () => {
 
     expect(placeButton().disabled).toBe(true);
     await driveSubmit();
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await flushTimersFake();
     expect(calls).toHaveLength(0);
   });
 });

--- a/web/tests/playwright-config-clerk-key.test.ts
+++ b/web/tests/playwright-config-clerk-key.test.ts
@@ -21,4 +21,27 @@ describe("playwright.config webServer env — Clerk publishable key", () => {
     const env = (webServer as { env?: Record<string, string> }).env ?? {};
     expect(env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY).toMatch(/^pk_test_/);
   });
+
+  it("forces a pk_test_ key over an ambient pk_live_ key whenever it sets RADON_AUTHLESS_TEST=1 (T-482)", async () => {
+    // middleware.ts throws at import when RADON_AUTHLESS_TEST === "1" and the
+    // publishable key starts with pk_live_. The webServer env must therefore
+    // never let an ambient live key through alongside the authless flag.
+    vi.stubEnv(
+      "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+      "pk_live_bWFsaWNpb3VzLWFtYmllbnQta2V5JA",
+    );
+    vi.resetModules();
+    const config = (await import("../playwright.config")).default;
+    const webServer = config.webServer;
+    expect(webServer).toBeDefined();
+    expect(Array.isArray(webServer)).toBe(false);
+    const env = (webServer as { env?: Record<string, string> }).env ?? {};
+    expect(env.RADON_AUTHLESS_TEST).toBe("1");
+    // With the flag set, the key must be either unset or pinned to pk_test_.
+    const key = env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+    if (key !== undefined && key !== "") {
+      expect(key).toMatch(/^pk_test_/);
+    }
+    expect(key).not.toMatch(/^pk_live_/);
+  });
 });

--- a/web/tests/position-mixed-basis-refuses-aggregate.test.tsx
+++ b/web/tests/position-mixed-basis-refuses-aggregate.test.tsx
@@ -23,7 +23,7 @@
 
 import React from "react";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
 
 import { cleanup as cleanupHooks, renderHook } from "@testing-library/react";
 
@@ -165,11 +165,13 @@ describe("PositionTab renders no basis for a `mixed` position", () => {
     );
   }
 
+  const STAT_TESTIDS: Record<string, string> = {
+    "Entry Cost": "pos-stat-entry-cost",
+    "Avg Entry": "pos-stat-avg-entry",
+  };
+
   function statValue(label: string): string {
-    const el = Array.from(document.querySelectorAll(".pos-stat")).find(
-      (n) => n.querySelector(".pos-stat-label")?.textContent?.trim() === label,
-    );
-    return el?.querySelector(".pos-stat-value")?.textContent?.trim() ?? "";
+    return screen.getByTestId(STAT_TESTIDS[label]).textContent?.trim() ?? "";
   }
 
   it("Entry Cost reads --- rather than the $1,000 blend", () => {
@@ -194,13 +196,14 @@ describe("PositionTable renders no basis for a `mixed` position", () => {
     return Array.from(tr.querySelectorAll("td")).map((td) => td.textContent?.trim() ?? "");
   }
 
+  const CELL_TESTIDS: Record<string, string> = {
+    "P&L": "position-cell-pnl",
+    "Return %": "position-cell-pnl-pct",
+  };
+
   function cellUnder(header: string): string {
-    const headers = Array.from(document.querySelectorAll("thead th")).map(
-      (th) => th.textContent?.trim() ?? "",
-    );
-    const idx = headers.findIndex((h) => h.startsWith(header));
-    expect(idx).toBeGreaterThanOrEqual(0);
-    return cellTexts()[idx];
+    const tr = screen.getByText("META").closest("tr")!;
+    return within(tr as HTMLElement).getByTestId(CELL_TESTIDS[header]).textContent?.trim() ?? "";
   }
 
   it("no Entry Cost / Initial Value / Avg Entry cell carries the blend", () => {

--- a/web/tests/quote-gate-feed-wiring.test.tsx
+++ b/web/tests/quote-gate-feed-wiring.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * T-462: the REL-236 disconnect arm of quoteSubmitGate is dead in
+ * production. `feedConnected` is optional on ModifyOrderModal and
+ * SingleLegOrderTicket, and no production call site supplied it, so a
+ * disconnected feed left the gate OPEN (`undefined !== false`). The leaf
+ * specs pass `feedConnected` from the harness and prove nothing about the
+ * wiring. Per CLAUDE.md, a gated action is tested at the wire: this file
+ * renders OrderTab — the owner surface whose tree owns the modify fetch
+ * via OrderActionsContext — with the realtime feed disconnected, drives
+ * Modify in its otherwise-armed state, and asserts ZERO requests fire and
+ * the blocked reason renders. The armed case pins the exact request so a
+ * wrong URL, method, or payload also reds.
+ */
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { OpenOrder, PortfolioData } from "@/lib/types";
+import type { PriceData } from "@/lib/pricesProtocol";
+import OrderTab from "@/components/ticker-detail/OrderTab";
+import { OrderActionsProvider } from "@/lib/OrderActionsContext";
+
+vi.mock("@/lib/useRiskFreeRate", () => ({
+  useRiskFreeRate: () => 0,
+}));
+
+vi.mock("@/components/Modal", () => ({
+  default: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? React.createElement("div", { className: "mock-modal" }, children) : null,
+}));
+
+/** Feed connectivity the four production surfaces read. Mutable so the
+ *  disconnected and connected cases exercise the SAME call-site wiring. */
+let feedConnectedState = false;
+vi.mock("@/lib/RealtimePricesContext", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/RealtimePricesContext")>();
+  return {
+    ...actual,
+    useRealtimePrices: () => ({
+      ...actual.useRealtimePrices(),
+      connected: feedConnectedState,
+    }),
+  };
+});
+
+beforeEach(() => {
+  feedConnectedState = false;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function aaplStockOrder(): OpenOrder {
+  return {
+    orderId: 11,
+    permId: 1101,
+    symbol: "AAPL",
+    contract: { conId: 265598, symbol: "AAPL", secType: "STK" },
+    action: "SELL",
+    orderType: "LMT",
+    totalQuantity: 100,
+    limitPrice: 171,
+    auxPrice: null,
+    status: "Submitted",
+    filled: 0,
+    remaining: 100,
+    avgFillPrice: 0,
+    tif: "DAY",
+  } as OpenOrder;
+}
+
+function freshAaplQuote(): PriceData {
+  return {
+    symbol: "AAPL",
+    last: 171,
+    lastIsCalculated: false,
+    bid: 170,
+    ask: 172,
+    bidSize: 1,
+    askSize: 1,
+    volume: 1000,
+    high: null,
+    low: null,
+    open: null,
+    close: 171,
+    week52High: null,
+    week52Low: null,
+    avgVolume: null,
+    delta: null,
+    gamma: null,
+    theta: null,
+    vega: null,
+    impliedVol: null,
+    undPrice: null,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+const PORTFOLIO = { positions: [], bankroll: 1_000_000 } as unknown as PortfolioData;
+
+type RecordedCall = { url: string; method: string; body: unknown };
+
+function recordFetch(): RecordedCall[] {
+  const calls: RecordedCall[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const body = typeof init?.body === "string" ? JSON.parse(init.body) : init?.body;
+      calls.push({ url, method: init?.method ?? "GET", body });
+      return { ok: true, status: 200, json: async () => ({}) } as Response;
+    }),
+  );
+  return calls;
+}
+
+/** OrderTab's stock form issues a read (GET /api/short-availability/:sym)
+ *  on mount; the gate governs order mutations, so assert on those. */
+function mutationCalls(calls: RecordedCall[]): RecordedCall[] {
+  return calls.filter((c) => c.method !== "GET");
+}
+
+function renderOrderTab() {
+  return render(
+    <OrderActionsProvider>
+      <OrderTab
+        ticker="AAPL"
+        position={null}
+        portfolio={PORTFOLIO}
+        prices={{ AAPL: freshAaplQuote() }}
+        openOrders={[aaplStockOrder()]}
+      />
+    </OrderActionsProvider>,
+  );
+}
+
+/** Open the modify modal from the open-orders row and arm it by editing
+ *  the limit price — everything short of feed connectivity is satisfied. */
+function openAndArmModify() {
+  fireEvent.click(screen.getByRole("button", { name: /^MODIFY$/ }));
+  const priceInput = document.getElementById("modify-price-input") as HTMLInputElement;
+  fireEvent.change(priceInput, { target: { value: "170.50" } });
+  return screen.getByRole("button", { name: /Modify Order/i }) as HTMLButtonElement;
+}
+
+describe("OrderTab modify gate wired to the live feed (T-462)", () => {
+  it("DISCONNECTED: submit is disarmed, the blocked reason renders, and NO request fires", async () => {
+    feedConnectedState = false;
+    const calls = recordFetch();
+    renderOrderTab();
+
+    const submit = openAndArmModify();
+
+    expect(
+      screen.getByText("Live feed disconnected. Submit disabled until quotes resume."),
+    ).toBeTruthy();
+    expect(submit.disabled).toBe(true);
+    fireEvent.click(submit);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(mutationCalls(calls)).toEqual([]);
+    expect(calls.some((c) => c.url === "/api/orders/modify")).toBe(false);
+  });
+
+  it("CONNECTED: the same armed state submits the exact modify request", async () => {
+    feedConnectedState = true;
+    const calls = recordFetch();
+    renderOrderTab();
+
+    const submit = openAndArmModify();
+
+    expect(submit.disabled).toBe(false);
+    fireEvent.click(submit);
+
+    await waitFor(() => expect(mutationCalls(calls)).toHaveLength(1));
+    const wire = mutationCalls(calls)[0];
+    expect(wire.url).toBe("/api/orders/modify");
+    expect(wire.method).toBe("POST");
+    expect(wire.body).toEqual({ orderId: 11, permId: 1101, newPrice: 170.5 });
+  });
+});

--- a/web/tests/regime-dead-feed-degraded.test.ts
+++ b/web/tests/regime-dead-feed-degraded.test.ts
@@ -29,6 +29,16 @@ vi.mock("fs/promises", () => ({
 
 vi.mock("child_process", () => ({ spawn: mockSpawn }));
 
+// T-485: the real trigger logs from async continuations (`pending.catch`),
+// which leaves a vitest onUserConsoleLog rpc pending at environment teardown
+// and reds the gate with 0 failed tests. Stub it with a synchronous recorder
+// so the stale-payload revalidation attempt is still observable without any
+// post-test console traffic.
+const mockScanTrigger = vi.fn(() => true);
+vi.mock("@/lib/backgroundScan", () => ({
+  createBackgroundScanTrigger: () => mockScanTrigger,
+}));
+
 vi.mock("@/lib/db", () => ({
   resetDb: () => {},
   getDb: () => mockGetDb(),

--- a/web/tests/rel238-scan-failure-surfaced.test.tsx
+++ b/web/tests/rel238-scan-failure-surfaced.test.tsx
@@ -223,3 +223,70 @@ describe("GET /api/gex staleness (R-660)", () => {
     expect(body.is_stale).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// T-470: a 4xx upstream REJECTION must pass through exactly (no 502 rewrite)
+// and must NOT be masked by the >= 500 cache-fallback guard.
+// ---------------------------------------------------------------------------
+
+describe("POST scan routes: 4xx upstream status passthrough (T-470)", () => {
+  it("gex: RadonApiError 429 yields exactly 429 with no cached body", async () => {
+    const { RadonApiError } = await import("@/lib/radonApi");
+    mockRadonFetch.mockRejectedValue(new RadonApiError(429, "rate limited"));
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      scan_time: "2026-09-05T13:00:00Z",
+      ticker: "SPX",
+      net_gex: 321,
+      history: [],
+    }));
+
+    const { POST } = await import("../app/api/gex/route");
+    const res = await POST();
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.scan_succeeded).toBe(false);
+    // No cached snapshot may be served for a client error.
+    expect(body.net_gex).toBeUndefined();
+    expect(body.is_stale).toBeUndefined();
+  });
+
+  it("regime: RadonApiError 429 yields exactly 429 with no cached body", async () => {
+    const { RadonApiError } = await import("@/lib/radonApi");
+    mockRadonFetch.mockRejectedValue(new RadonApiError(429, "rate limited"));
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      scan_time: "2026-09-05T13:00:00Z",
+      date: "2026-09-05",
+      market_open: true,
+      cri: { score: 18, level: "LOW", components: { vix: 4, vvix: 4, correlation: 5, momentum: 5 } },
+      history: [],
+      spy_closes: [],
+    }));
+
+    const { POST } = await import("../app/api/regime/route");
+    const res = await POST();
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.scan_succeeded).toBe(false);
+    expect(body.cri).toBeUndefined();
+    expect(body.is_stale).toBeUndefined();
+  });
+
+  it("gamma-rotation: RadonApiError 429 yields exactly 429 with no cached body", async () => {
+    const { RadonApiError } = await import("@/lib/radonApi");
+    mockRadonFetch.mockRejectedValue(new RadonApiError(429, "rate limited"));
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      scan_time: "2026-09-05T13:00:00Z",
+      signal: { grg_z: 1.23 },
+      assets: { SPY: { ticker: "SPY" }, TLT: { ticker: "TLT" } },
+      history: [],
+    }));
+
+    const { POST } = await import("../app/api/gamma-rotation/route");
+    const res = await POST();
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.scan_succeeded).toBe(false);
+    expect(body.signal).toBeUndefined();
+    expect(body.is_stale).toBeUndefined();
+  });
+});

--- a/web/tests/rel238-scan-failure-surfaced.test.tsx
+++ b/web/tests/rel238-scan-failure-surfaced.test.tsx
@@ -43,6 +43,10 @@ vi.mock("@/lib/db", () => ({ getDb: () => ({ execute: mockExecute }), resetDb: (
 beforeEach(() => {
   vi.resetModules();
   mockReadFile.mockReset();
+  // T-478: re-stamp the stat default per test — the module-load-time value
+  // both freezes (ages as the file runs) and leaks any per-test stub.
+  mockStat.mockReset();
+  mockStat.mockResolvedValue({ mtimeMs: Date.now() });
   mockRadonFetch.mockReset();
   mockExecute.mockReset();
   mockExecute.mockResolvedValue({ rows: [] });
@@ -288,5 +292,22 @@ describe("POST scan routes: 4xx upstream status passthrough (T-470)", () => {
     expect(body.scan_succeeded).toBe(false);
     expect(body.signal).toBeUndefined();
     expect(body.is_stale).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-478: the module-load-time mockStat default must be restored per test —
+// a test that stubs stat stale must not leak into the next test in file order.
+// ---------------------------------------------------------------------------
+
+describe("mockStat default restored between tests (T-478)", () => {
+  it("a test may stub stat stale for its own scenario", async () => {
+    mockStat.mockResolvedValue({ mtimeMs: 0 });
+    expect((await mockStat()).mtimeMs).toBe(0);
+  });
+
+  it("the next test observes a fresh window-relative mtime, not the leak", async () => {
+    const { mtimeMs } = await mockStat();
+    expect(Date.now() - mtimeMs).toBeLessThan(60_000);
   });
 });

--- a/web/tests/rel244-demo-rate-budget.test.ts
+++ b/web/tests/rel244-demo-rate-budget.test.ts
@@ -8,7 +8,6 @@
 // R-661 — /api/trin and /api/dispersion called requireRouteAccess() bare,
 // so demo traffic on them never consumed the durable demo budget.
 import { readdirSync, statSync } from "node:fs";
-import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { join, resolve } from "node:path";
 import { describe, it, expect, vi } from "vitest";
@@ -111,12 +110,67 @@ describe("R-652: tiers A/B gain a daily backstop", () => {
   });
 });
 
+// R-661 behavioural coverage: call the real GETs through a recording
+// requireRouteAccess that delegates to the REAL implementation with an
+// injected durable limiter. A literal moved into a dead branch or dropped
+// from the live call path fails here (the grep it replaces stayed green).
+const recordedAccessOptions: unknown[] = [];
+const mockDurableLimit = vi.fn<
+  (tier: string, key: string) => Promise<DemoRateLimitResult>
+>();
+const mockDbExecute = vi.fn(async () => ({ rows: [] }));
+const mockRouteReadFile = vi.fn(async () => {
+  throw new Error("disk must not be read");
+});
+
+vi.mock("@/lib/routeAccess", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/routeAccess")>("@/lib/routeAccess");
+  return {
+    ...actual,
+    requireRouteAccess: (request?: Request, options?: unknown) => {
+      recordedAccessOptions.push(options);
+      return actual.requireRouteAccess(request, options as never, {
+        authFn: async () => ({ userId: "demo-user", sessionClaims: { metadata: activeMeta } }),
+        env: { NEXT_PUBLIC_RADON_DEMO: "1" },
+        now: NOW,
+        rateLimitFn: (() => ({ ok: true })) as never,
+        durableRateLimitFn: mockDurableLimit as never,
+      });
+    },
+  };
+});
+vi.mock("@/lib/db", () => ({ getDb: () => ({ execute: mockDbExecute }), resetDb: () => {} }));
+vi.mock("fs/promises", () => {
+  const mocked = { readFile: (...args: unknown[]) => mockRouteReadFile(...(args as [])) };
+  return { ...mocked, default: mocked };
+});
+
 describe("R-661: trin and dispersion charge the durable demo budget", () => {
-  for (const route of ["trin", "dispersion"]) {
-    it(`${route} passes rate + durableRateTier to requireRouteAccess`, () => {
-      const text = readFileSync(resolve(WEB_ROOT, `app/api/${route}/route.ts`), "utf8");
-      expect(text, route).toContain(`rate: { key: "${route}:route"`);
-      expect(text, route).toContain('durableRateTier: "A"');
+  for (const route of ["trin", "dispersion"] as const) {
+    it(`${route} GET passes rate + durableRateTier to requireRouteAccess (by value)`, async () => {
+      recordedAccessOptions.length = 0;
+      mockDurableLimit.mockReset();
+      mockDurableLimit.mockResolvedValue(allow);
+      const { GET } = await import(`../app/api/${route}/route.ts`);
+      const res = await GET();
+      expect(res.status).toBe(200);
+      expect(recordedAccessOptions).toEqual([
+        { rate: { key: `${route}:route`, limit: 20, windowMs: 60_000 }, durableRateTier: "A" },
+      ]);
+      expect(mockDurableLimit).toHaveBeenCalledWith("A", `route:${route}:route:demo-user`);
+    });
+
+    it(`${route} GET returns 429 with no upstream read when the durable budget is exhausted`, async () => {
+      recordedAccessOptions.length = 0;
+      mockDurableLimit.mockReset();
+      mockDbExecute.mockClear();
+      mockRouteReadFile.mockClear();
+      mockDurableLimit.mockResolvedValue({ success: false, limit: 1000, remaining: 0, reset: NOW + 2000 });
+      const { GET } = await import(`../app/api/${route}/route.ts`);
+      const res = await GET();
+      expect(res.status).toBe(429);
+      expect(mockDbExecute).not.toHaveBeenCalled();
+      expect(mockRouteReadFile).not.toHaveBeenCalled();
     });
   }
 });

--- a/web/tests/unrealized-breakdown-signed.test.ts
+++ b/web/tests/unrealized-breakdown-signed.test.ts
@@ -208,6 +208,72 @@ describe("computeUnrealizedBreakdown — signed entry and market value", () => {
     expect(rows[0].pnlPct).toBeCloseTo((448_930 - 468_505.27) / 468_505.27 * 100, 6);
   });
 
+  // T-315 blended-basis combo: measurable per-leg P&L, unpublishable entry.
+  // Kept out of makePortfolio so each test opts in explicitly.
+  const blendedPos: PortfolioPosition = {
+    id: 9,
+    ticker: "NVDA",
+    structure: "Vertical (C$170/C$180)",
+    structure_type: "Vertical",
+    risk_profile: "defined",
+    expiry: "2026-10-16",
+    contracts: 10,
+    direction: "LONG",
+    entry_cost: null,
+    basis_source: "mixed",
+    max_risk: null,
+    market_value: 9_000,
+    legs: [
+      {
+        direction: "LONG",
+        contracts: 10,
+        type: "Call",
+        strike: 170,
+        entry_cost: 10_000,
+        avg_cost: 10,
+        market_price: 12,
+        market_value: 12_000,
+      },
+      {
+        direction: "SHORT",
+        contracts: 10,
+        type: "Call",
+        strike: 180,
+        entry_cost: 4_000,
+        avg_cost: 4,
+        market_price: 3,
+        market_value: 3_000,
+      },
+    ],
+    kelly_optimal: null,
+    target: null,
+    stop: null,
+    entry_date: "2026-09-01",
+  } as PortfolioPosition;
+
+  test("blended-basis combo: col1 renders '---' and the eye-check does not NaN", () => {
+    const rows = computeUnrealizedBreakdown(makePortfolio([blendedPos]));
+    expect(rows).toHaveLength(1);
+    const row = rows[0];
+
+    // mv: +12000 - 3000 = 9000; leg basis: +10000 - 4000 = 6000; pnl = 3000
+    expect(row.col1).toBe("---");
+    expect(row.pnl).toBeCloseTo(3_000, 2);
+    expect(row.col2).toBe("+$9,000.00");
+
+    // Guarded eye-check helper: "---" must yield null, never NaN, so the
+    // col2 − col1 reconciliation is skipped (not silently NaN-passed) for
+    // entry-less rows.
+    const parseSigned = (s: string): number | null => {
+      const n = Number(s.replace(/[$,+]/g, ""));
+      return Number.isFinite(n) ? n : null;
+    };
+    expect(Number.isNaN(Number("---".replace(/[$,+]/g, "")))).toBe(true); // raw form NaNs
+    expect(parseSigned(row.col1)).toBeNull(); // guarded form does not
+    // The identity is still verifiable via the legs' P&L basis:
+    expect(parseSigned(row.col2)! - 6_000).toBeCloseTo(row.pnl, 2);
+  });
+
   test("sumUnrealizedBreakdown matches row P&L total", () => {
     const positions: PortfolioPosition[] = [
       {
@@ -268,12 +334,23 @@ describe("computeUnrealizedBreakdown — signed entry and market value", () => {
         stop: null,
         entry_date: "2026-07-09",
       },
+      blendedPos,
     ];
     const portfolio = makePortfolio(positions);
     const rows = computeUnrealizedBreakdown(portfolio);
+    expect(rows).toHaveLength(3); // blended combo keeps its row
     const rowSum = rows.reduce((s, r) => s + r.pnl, 0);
     expect(sumUnrealizedBreakdown(portfolio)).toBeCloseTo(rowSum, 2);
-    expect(rowSum).toBeCloseTo((3_150 - 44_383.38) + (40_040 - 40_076.51), 2);
+    // Independent expectation, not derived from either function under test:
+    // the blended combo's measured leg P&L (+3000) must be in BOTH totals.
+    expect(rowSum).toBeCloseTo(
+      (3_150 - 44_383.38) + (40_040 - 40_076.51) + 3_000,
+      2,
+    );
+    expect(sumUnrealizedBreakdown(portfolio)).toBeCloseTo(
+      (3_150 - 44_383.38) + (40_040 - 40_076.51) + 3_000,
+      2,
+    );
     expect(rows[0].pnlPct).toBeCloseTo((3_150 - 44_383.38) / 44_383.38 * 100, 6);
   });
 });

--- a/web/tests/use-sync-hook-pending-refresh.test.tsx
+++ b/web/tests/use-sync-hook-pending-refresh.test.tsx
@@ -50,6 +50,19 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+// T-480: drain any queued follow-up on FAKE timers so the "nothing fired"
+// window cannot lose a wall-clock race to React's commit/effect flush.
+async function flushTimersFake() {
+  vi.useFakeTimers();
+  try {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
 describe("useSyncHook queues a sync requested while a POST is in flight (R-640)", () => {
   it("re-fires exactly one follow-up POST after the in-flight POST settles", async () => {
     const { calls, postResolvers } = deferredPostFetch();
@@ -82,8 +95,8 @@ describe("useSyncHook queues a sync requested while a POST is in flight (R-640)"
     // consumed, and two mid-flight events coalesced into one refresh.
     await act(async () => {
       postResolvers[1]();
-      await new Promise((resolve) => setTimeout(resolve, 20));
     });
+    await flushTimersFake();
     expect(calls).toHaveLength(3);
   });
 
@@ -95,8 +108,8 @@ describe("useSyncHook queues a sync requested while a POST is in flight (R-640)"
     await waitFor(() => expect(calls).toHaveLength(2));
     await act(async () => {
       postResolvers[0]();
-      await new Promise((resolve) => setTimeout(resolve, 20));
     });
+    await flushTimersFake();
     expect(calls).toHaveLength(2);
   });
 });

--- a/web/tests/use-toast-upsert.test.tsx
+++ b/web/tests/use-toast-upsert.test.tsx
@@ -102,3 +102,50 @@ describe("useToast upsertToast", () => {
     expect(result.current.toasts.map((t) => t.message)).toEqual(["two"]);
   });
 });
+
+describe("useToast hasToastKey (T-465)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reports a keyed toast live while on screen and false once dismissed", () => {
+    const { result } = renderHook(() => useToast());
+
+    expect(result.current.hasToastKey("perm:900777")).toBe(false);
+
+    act(() => {
+      result.current.upsertToast("perm:900777", "success", "FILLED · BUY 2x VIX $30C @ $0.61", 0);
+    });
+    expect(result.current.hasToastKey("perm:900777")).toBe(true);
+
+    // The key must die the moment dismissal STARTS (before the 150ms exit
+    // animation completes) — R-642's fresh-total decision reads it then.
+    act(() => {
+      result.current.dismissToast(result.current.toasts[0].id);
+    });
+    expect(result.current.hasToastKey("perm:900777")).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current.hasToastKey("perm:900777")).toBe(false);
+  });
+
+  it("also forgets the key on removeToast", () => {
+    const { result } = renderHook(() => useToast());
+
+    act(() => {
+      result.current.upsertToast("order:11", "success", "one", 0);
+    });
+    expect(result.current.hasToastKey("order:11")).toBe(true);
+
+    act(() => {
+      result.current.removeToast(result.current.toasts[0].id);
+    });
+    expect(result.current.hasToastKey("order:11")).toBe(false);
+  });
+});

--- a/web/tests/vcg-dead-feed-degraded.test.ts
+++ b/web/tests/vcg-dead-feed-degraded.test.ts
@@ -19,6 +19,11 @@ const mockGetDb = vi.fn();
 vi.mock("fs/promises", () => ({ readFile: mockReadFile }));
 vi.mock("@/lib/db", () => ({ resetDb: () => {}, getDb: () => mockGetDb() }));
 vi.mock("@/lib/radonApi", () => ({ radonFetch: vi.fn(async () => ({})) }));
+// T-485 class: the real trigger logs from async continuations after the test
+// returns; stub it synchronously so no console rpc is pending at teardown.
+vi.mock("@/lib/backgroundScan", () => ({
+  createBackgroundScanTrigger: () => vi.fn(() => true),
+}));
 
 describe("/api/vcg with every source dead", () => {
   beforeEach(() => {

--- a/web/tests/workspace-shell-fill-wire.test.tsx
+++ b/web/tests/workspace-shell-fill-wire.test.tsx
@@ -17,7 +17,7 @@
  * exactly one POST /api/portfolio on the wire.
  */
 import React from "react";
-import { act, cleanup, render } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ExecutedOrder, OrderContract, OrdersData, PortfolioData } from "@/lib/types";
 import { SEEN_STORAGE_KEY } from "@/lib/fillToasts";
@@ -220,5 +220,27 @@ describe("WorkspaceShell fill-driven portfolio refresh (wire)", () => {
     await shell.pushOrders(makeOrders(BASELINE));
     await shell.pushOrders(makeOrders([...BASELINE, makeFill("c.7.01", 900_901)]));
     expect(portfolioPosts()).toHaveLength(0);
+  });
+});
+
+describe("WorkspaceShell dismissed fill toast forgets its running total (T-465 / R-642)", () => {
+  it("shows the next fill's own quantity, not the cumulative total, after dismissal", async () => {
+    const shell = await renderShell();
+    await shell.pushOrders(makeOrders(BASELINE));
+
+    // First fill for the group: toast reads its quantity.
+    await shell.pushOrders(makeOrders([...BASELINE, makeFill("d.1.01", 900_950, 2)]));
+    expect(screen.getByText("FILLED · BUY 2x VIX $30C @ $0.61")).toBeTruthy();
+
+    // Operator dismisses the toast (real ToastContainer, real dismissToast).
+    fireEvent.click(screen.getByLabelText("Dismiss"));
+
+    // Next fill for the SAME order (same permId): a fresh toast must read 3x,
+    // not the 5x cumulative total presented as a new fill.
+    await shell.pushOrders(
+      makeOrders([...BASELINE, makeFill("d.1.01", 900_950, 2), makeFill("d.2.01", 900_950, 3)]),
+    );
+    expect(screen.getByText("FILLED · BUY 3x VIX $30C @ $0.61")).toBeTruthy();
+    expect(screen.queryByText("FILLED · BUY 5x VIX $30C @ $0.61")).toBeNull();
   });
 });

--- a/web/tests/workspace-shell-fill-wire.test.tsx
+++ b/web/tests/workspace-shell-fill-wire.test.tsx
@@ -1,0 +1,224 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * T-464: fill-driven portfolio refresh asserted through WorkspaceShell ITSELF.
+ *
+ * fill-driven-portfolio-refresh-wire.test.tsx renders a hand-cloned harness
+ * that has already drifted from production (it passes useFillToasts three
+ * arguments; WorkspaceShell.tsx:430 passes four, including hasToastKey).
+ * Remove or misorder the onNewFills argument at that call site and the
+ * harness still passes while the positions table silently stops refreshing
+ * on fills (R-640 / T-459).
+ *
+ * This file renders the real WorkspaceShell with only its DATA hooks mocked:
+ * useToast, useFillToasts, usePortfolio (the owner of every /api/portfolio
+ * request), and the line-430 wiring are all production code. fetch is
+ * stubbed at the global; a new execId in the orders payload must produce
+ * exactly one POST /api/portfolio on the wire.
+ */
+import React from "react";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExecutedOrder, OrderContract, OrdersData, PortfolioData } from "@/lib/types";
+import { SEEN_STORAGE_KEY } from "@/lib/fillToasts";
+
+// ---- data-hook / chrome mocks (WorkspaceShell's fill wiring stays real) ----
+
+let ordersData: OrdersData | null = null;
+
+vi.mock("next/navigation", () => ({ usePathname: () => "/dashboard" }));
+vi.mock("next/dynamic", () => ({ default: () => () => null }));
+vi.mock("@/lib/ThemeContext", () => ({ useTheme: () => ({ theme: "dark", toggleTheme: vi.fn() }) }));
+vi.mock("@/lib/useViewport", () => ({ useViewport: () => ({ isMobile: false, hasMounted: true }) }));
+vi.mock("@/lib/useOrders", () => ({
+  useOrders: () => ({
+    data: ordersData,
+    loading: false,
+    syncing: false,
+    error: null,
+    lastSync: null,
+    syncNow: vi.fn(),
+    updateData: vi.fn(),
+  }),
+}));
+vi.mock("@/lib/useMarketHours", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/useMarketHours")>();
+  return { ...actual, useMarketHours: () => actual.MarketState.CLOSED };
+});
+vi.mock("@/lib/useAutoSyncOnStale", () => ({ useAutoSyncOnStale: () => {} }));
+vi.mock("@/lib/useSnapshotStaleness", () => ({
+  useSnapshotStaleness: () => ({ isStale: false, state: "fresh", staleAgeMinutes: 0, tick: 0 }),
+}));
+vi.mock("@/lib/OrderActionsContext", () => ({
+  useOrderActions: () => ({ drainNotifications: () => [], setOrdersUpdater: () => {} }),
+}));
+vi.mock("@/lib/RealtimePricesContext", () => ({
+  useRealtimePrices: () => ({
+    prices: {},
+    fundamentals: {},
+    depths: {},
+    tape: {},
+    connected: false,
+    ibConnected: true,
+    ibIssue: null,
+    ibStatusMessage: null,
+    error: null,
+    publishSubscriptions: () => {},
+  }),
+}));
+vi.mock("@/lib/useIndexQuoteFallback", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/useIndexQuoteFallback")>();
+  return { ...actual, useIndexQuoteFallback: () => ({}) };
+});
+vi.mock("@/lib/useFuturesQuoteFallback", () => ({ useFuturesQuoteFallback: () => ({}) }));
+vi.mock("@/lib/usePreviousClose", () => ({
+  usePreviousClose: (p: Record<string, unknown>) => p,
+}));
+vi.mock("@/lib/futuresSession", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/futuresSession")>();
+  return { ...actual, useGlobexOpen: () => false };
+});
+vi.mock("@/lib/useWatchlist", () => ({ useWatchlist: () => ({ watchlist: [] }) }));
+vi.mock("@/lib/TickerDetailContext", () => ({
+  useTickerDetail: () => ({
+    chainContracts: [],
+    depthSymbol: null,
+    depthSymbols: [],
+    depthFutureExpiry: null,
+    setActiveTicker: () => {},
+    setPrices: () => {},
+    setFundamentals: () => {},
+    setPortfolio: () => {},
+    setOrders: () => {},
+    setDepths: () => {},
+    setTape: () => {},
+  }),
+}));
+vi.mock("@/lib/offline/OfflineStatusContext", () => ({ useOfflineStatus: () => ({ offline: false }) }));
+
+// Presentational chrome only — none of these own the fill wiring or a fetch.
+vi.mock("@/components/Sidebar", () => ({ default: () => null }));
+vi.mock("@/components/Header", () => ({ default: () => null }));
+vi.mock("@/components/MetricCards", () => ({ default: () => null }));
+vi.mock("@/components/dashboard/DashboardSurface", () => ({ default: () => null }));
+vi.mock("@/components/ChatLauncher", () => ({ default: () => null }));
+vi.mock("@/components/DemoWelcomeModal", () => ({ default: () => null }));
+vi.mock("@/components/mobile/MobileShell", () => ({ default: () => null }));
+vi.mock("@/components/FooterTelemetryStrip", () => ({ default: () => null }));
+vi.mock("@/components/CommandPalette", () => ({ default: () => null }));
+vi.mock("@/components/OfflineBanner", () => ({ default: () => null }));
+vi.mock("@/components/FuturesStrip", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/FuturesStrip")>();
+  return { ...actual, default: () => null };
+});
+vi.mock("@/components/ui/InstrumentSkeleton", () => ({ default: () => null }));
+
+import WorkspaceShell from "@/components/WorkspaceShell";
+
+function makeContract(): OrderContract {
+  return { conId: 12345, symbol: "VIX", secType: "OPT", strike: 30, right: "C", expiry: "20261020" };
+}
+
+function makeFill(execId: string, permId = 900_001, quantity = 2): ExecutedOrder {
+  return {
+    execId,
+    permId,
+    symbol: "VIX",
+    contract: makeContract(),
+    side: "BOT",
+    quantity,
+    avgPrice: 0.61,
+    commission: null,
+    realizedPNL: null,
+    time: new Date().toISOString(),
+    exchange: "SMART",
+  } as ExecutedOrder;
+}
+
+function makeOrders(executed: ExecutedOrder[]): OrdersData {
+  return {
+    last_sync: new Date().toISOString(),
+    open_orders: [],
+    executed_orders: executed,
+    open_count: 0,
+    executed_count: executed.length,
+  };
+}
+
+const BASELINE = [makeFill("a.1.01", 900_777), makeFill("a.2.01", 900_778)];
+
+const PORTFOLIO_JSON = {
+  positions: [],
+  bankroll: 1_000_000,
+  last_sync: "2026-09-05T14:00:00Z",
+} as unknown as PortfolioData;
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  window.sessionStorage.removeItem(SEEN_STORAGE_KEY);
+  delete process.env.NEXT_PUBLIC_RADON_DEMO;
+  ordersData = null;
+  fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: new Headers(),
+    json: async () => PORTFOLIO_JSON,
+  });
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+const portfolioPosts = () =>
+  fetchMock.mock.calls.filter(
+    ([url, init]) =>
+      url === "/api/portfolio" && (init as RequestInit | undefined)?.method === "POST",
+  );
+
+async function renderShell() {
+  const view = render(<WorkspaceShell section="dashboard" />);
+  await act(async () => {});
+  return {
+    ...view,
+    pushOrders: async (payload: OrdersData) => {
+      ordersData = payload;
+      view.rerender(<WorkspaceShell section="dashboard" />);
+      await act(async () => {});
+    },
+  };
+}
+
+describe("WorkspaceShell fill-driven portfolio refresh (wire)", () => {
+  it("does not hit the portfolio producer for the baseline payload", async () => {
+    const shell = await renderShell();
+    await shell.pushOrders(makeOrders(BASELINE));
+    expect(portfolioPosts()).toHaveLength(0);
+  });
+
+  it("POSTs /api/portfolio exactly once when a new execId arrives", async () => {
+    const shell = await renderShell();
+    await shell.pushOrders(makeOrders(BASELINE));
+    expect(portfolioPosts()).toHaveLength(0);
+
+    await shell.pushOrders(makeOrders([...BASELINE, makeFill("b.9.01", 900_900)]));
+
+    const posts = portfolioPosts();
+    expect(posts).toHaveLength(1);
+    const [url, init] = posts[0] as [string, RequestInit];
+    expect(url).toBe("/api/portfolio");
+    expect(init.method).toBe("POST");
+  });
+
+  it("keeps the producer off the wire for a fill in demo mode", async () => {
+    process.env.NEXT_PUBLIC_RADON_DEMO = "1";
+    const shell = await renderShell();
+    await shell.pushOrders(makeOrders(BASELINE));
+    await shell.pushOrders(makeOrders([...BASELINE, makeFill("c.7.01", 900_901)]));
+    expect(portfolioPosts()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Issue discovered

- **Order submit gate (P0)**: the disconnect arm of the quote submit gate was dead in production — no call site supplied `feedConnected`, so a dead feed left the gate open (T-462).
- **Order replace (P0)**: the broker-status arm gating replacement placement had no test; a mutation placing a replacement atop a still-working order shipped green (T-463).
- **Modify modal**: display and math read different fill counts after a live fill advance (T-473, real defect), and the partial-fill wire path was untested (T-472).
- **Test-suite health**: 19 further P1/P2 findings from the 2026-09-05 second-pass audit — drifted harnesses, text greps standing in for behaviour, host-config leakage, committer-date guard, mock leaks, CSS-class test hooks, real-timer sleeps, and a PATH-dependent cloud baseline (T-464…T-471, T-474…T-484).
- **vitest gate**: exit-1 with zero failed tests on an uncontended teardown race in the mktnews store-down test (T-485).

## What was done to fix it

- **T-462 fixed at the source**: `feedConnected` now wired from `useRealtimePrices().connected` at all four owner surfaces, pinned by a wire test that reds if any call site drops it.
- **T-473 fixed at the source**: modal display now reads the same frozen fill snapshot as the math, with a visible stale-fill flag.
- **22 test-quality remediations landed** across web/tests, scripts/tests and cloud/tests — every one red/green with a demonstrated mutation or gate-log citation; no assertion weakened, no threshold moved.
- **T-484**: cloud control-plane suites now pin a resolved bash >= 4 (skip with a named install hint when absent); full cloud/tests byte-identical under both PATH orders (1718 passed, 77 skipped ×2).
- **T-485**: mktnews store-down test drains and asserts its stderr writers before teardown; combined runs ×3 with unhandled-error count 0.

## Next

- Merge this PR to deploy; CI green is the deliver phase's gate.
- T-222 remains open: `main` still has no `required_status_checks` (branch-protection change is operator-side).
