### PR TITLE
docs(cloud): record the compose gate's full host-namespace deny-list

### DIFF
--- a/cloud/CLAUDE.md
+++ b/cloud/CLAUDE.md
@@ -88,6 +88,12 @@ narrowing: preflight now renders the INSTALLED compose body, not the incoming
 release's. The incoming body is gated at install time instead, by provenance
 (git blob at the deployed commit) plus `compose_body_is_valid`.
 
+That validator's deny-list refuses EVERY host-namespace join, not only
+`pid:` — `ipc:`, `userns_mode:`, `uts:` and `cgroup:` widen the container's
+runtime the same way (R-668/REL-249). The three copies (deploy-root-helper,
+bootstrap-control-plane, setup-vps) stay byte-identical; a parity test in
+`cloud/tests/test_rel234_compose_gate.py` pins them.
+
 **The broker host gets none of this from CI.** `.github/workflows/ci.yml`
 deploys to a single `secrets.VPS_HOST`, and `sync-control-plane` reads
 `/home/radon/radon/.git`, which the broker does not have. Every control-plane


### PR DESCRIPTION
## Why

main is red on `pytest (cloud al)`… actually on `pytest (scripts-df)`:

```
deploy-provisioning: changed ['cloud/scripts/bootstrap-control-plane.sh',
'cloud/scripts/deploy-root-helper.sh', 'cloud/scripts/setup-vps.sh']
but none of ['cloud/CLAUDE.md']
```

#310 widened `compose_body_is_valid` from `pid:` to every host-namespace join
(`ipc`, `userns_mode`, `uts`, `cgroup`) in all three copies. #311 landed the
new `deploy-provisioning` owners rule naming `cloud/CLAUDE.md` as those
scripts' owner doc. Each was green on its own head; the ordering of the two
merges is what left main red.

## What

Documents the widened deny-list and the three-copy parity pin in
`cloud/CLAUDE.md`, next to the existing `compose_body_is_valid` reference.

`scripts/tests/test_docs_contract.py`: 49 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWTUCU1QEYA9zU6RUJomZp