### PR TITLE
Caddy site for mcp.radon.run (issue #232)

### DIFF
--- a/cloud/caddy/Caddyfile
+++ b/cloud/caddy/Caddyfile
@@ -240,3 +240,56 @@ media.radon.run {
         }
     }
 }
+
+# mcp.radon.run — dedicated Streamable HTTP MCP host (issue #232).
+# DNS: Vercel A record to the same VPS as app.radon.run. Caddy auto-issues
+# Let's Encrypt TLS on first request, same as media.radon.run.
+# Serves ONLY the MCP process on 8334 — never FastAPI, never Next.js.
+mcp.radon.run {
+    encode zstd gzip
+
+    header {
+        Strict-Transport-Security "max-age=31536000; includeSubDomains"
+        X-Content-Type-Options nosniff
+        X-Frame-Options DENY
+        Referrer-Policy strict-origin-when-cross-origin
+        -Server
+    }
+
+    log {
+        output file /var/log/caddy/mcp.log
+        format json
+    }
+
+    # Same contract as app.radon.run /mcp*: keep the /mcp prefix, bound the
+    # anonymous POST body, no retry loop (POST JSON-RPC has no idempotency key).
+    handle /mcp* {
+        request_body {
+            max_size 1MB
+        }
+        reverse_proxy 127.0.0.1:8334 {
+            transport http {
+                dial_timeout 5s
+                response_header_timeout 30s
+                read_timeout 300s
+            }
+        }
+    }
+
+    # https://mcp.radon.run (no path) is a valid connector URL. Rewrite to
+    # /mcp so FastMCP's streamable_http_path still sees the prefix.
+    @mcp_root path /
+    handle @mcp_root {
+        rewrite * /mcp
+        request_body {
+            max_size 1MB
+        }
+        reverse_proxy 127.0.0.1:8334 {
+            transport http {
+                dial_timeout 5s
+                response_header_timeout 30s
+                read_timeout 300s
+            }
+        }
+    }
+}

--- a/cloud/tests/test_caddyfile.py
+++ b/cloud/tests/test_caddyfile.py
@@ -160,6 +160,50 @@ class TestRouting:
         block = reverse_proxy_block(content, "127.0.0.1:8334")
         assert "lb_try_duration" not in block
 
+    def test_mcp_hostname_has_its_own_site(self, caddy_dir):
+        """Issue #232 dedicated host: mcp.radon.run is its own site, not a
+        path on the app.radon.run catch-all (which would leak Next.js)."""
+        content = strip_comments(read_caddyfile(caddy_dir))
+        assert re.search(r"(?m)^mcp\.radon\.run\s*\{", content)
+
+    def test_mcp_site_proxies_only_to_the_mcp_process(self, caddy_dir):
+        block = site_block(read_caddyfile(caddy_dir), "mcp.radon.run")
+        assert "127.0.0.1:8334" in block
+        assert "127.0.0.1:8321" not in block, "mcp.radon.run must never proxy to FastAPI"
+        assert "127.0.0.1:3000" not in block, "mcp.radon.run must never proxy to Next.js"
+
+    def test_mcp_site_keeps_the_path_prefix(self, caddy_dir):
+        block = site_block(read_caddyfile(caddy_dir), "mcp.radon.run")
+        match = re.search(r"(handle_path|handle)\s+/mcp\*", block)
+        assert match is not None, "mcp.radon.run must handle /mcp*"
+        assert match.group(1) == "handle", (
+            "mcp.radon.run /mcp* must use handle (not handle_path)"
+        )
+
+    def test_mcp_site_bounds_the_request_body(self, caddy_dir):
+        block = handle_block(
+            site_block(read_caddyfile(caddy_dir), "mcp.radon.run"), "/mcp*"
+        )
+        match = re.search(r"request_body\s*\{[^}]*max_size\s+(\d+)(KB|MB)", block)
+        assert match, "mcp.radon.run /mcp* must set request_body { max_size ... }"
+        size, unit = int(match.group(1)), match.group(2)
+        size_bytes = size * (1024 if unit == "KB" else 1024 * 1024)
+        assert size_bytes <= 1024 * 1024
+
+    def test_mcp_site_has_no_retry_loop(self, caddy_dir):
+        block = reverse_proxy_block(
+            site_block(read_caddyfile(caddy_dir), "mcp.radon.run"), "127.0.0.1:8334"
+        )
+        assert "lb_try_duration" not in block
+
+    def test_mcp_root_rewrites_to_mcp_path(self, caddy_dir):
+        """https://mcp.radon.run (no path) is a valid connector URL."""
+        block = site_block(read_caddyfile(caddy_dir), "mcp.radon.run")
+        assert re.search(r"rewrite\s+\*\s+/mcp\b", block), (
+            "mcp.radon.run / must rewrite to /mcp so the hostname itself is "
+            "the Streamable HTTP endpoint"
+        )
+
     def test_edge_health_status_maps_dial_errors_to_200(self, caddy_dir):
         content = read_caddyfile(caddy_dir)
         block = reverse_proxy_block(content, "127.0.0.1:8330")
@@ -312,6 +356,14 @@ def _balanced_block(text, start):
             if depth == 0:
                 return text[start:index + 1]
     raise AssertionError("unbalanced braces")
+
+
+def site_block(content, hostname):
+    """Brace-balanced body of the named site block (active config only)."""
+    active = strip_comments(content)
+    match = re.search(r"(?m)^" + re.escape(hostname) + r"\s*\{", active)
+    assert match, f"no site block for {hostname}"
+    return _balanced_block(active, match.end() - 1)
 
 
 def reverse_proxy_block(content, upstream):

--- a/docs/cloud-services.md
+++ b/docs/cloud-services.md
@@ -400,16 +400,20 @@ JSON-RPC), documented for consumers at radon.run `/developers/mcp`.
   `setup-vps.sh`) derives from `/etc/radon/env` on every deploy; the unit
   never loads the full secret set and runs with `/etc/radon/env`
   inaccessible. Optional overrides `RADON_MCP_{HOST,PORT,SITE_BASE,EDGE_BASE,APP_BASE,DEMO_BASE}`
-  and `RADON_MCP_ALLOWED_HOSTS` (comma list; default
-  `app.radon.run,app.radon.run:*,127.0.0.1:*,localhost:*` — the SDK's
-  DNS-rebinding protection 421s any Host not on it, so a serving-host change
-  must update this list) are copied through when present in `/etc/radon/env`.
+  `RADON_MCP_ALLOWED_HOSTS` (comma list; default
+  `app.radon.run,app.radon.run:*,mcp.radon.run,mcp.radon.run:*,127.0.0.1:*,localhost:*`
+  — the SDK's DNS-rebinding protection 421s any Host not on it), and
+  `RADON_MCP_ALLOWED_ORIGINS` (default
+  `https://app.radon.run,https://mcp.radon.run`) are copied through when
+  present in `/etc/radon/env`.
 - **First enable** (install-units only auto-enables new timers):
   `sudo systemctl enable --now radon-mcp.service`, then
   `curl -s -X POST https://app.radon.run/mcp -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'`.
-- **`mcp.radon.run` does not exist** (no DNS record, no Caddy site block);
-  the published URL is the path-based one above. Moving to a dedicated host
-  needs a human DNS record first, then a Caddyfile site block.
+- **Dedicated host `mcp.radon.run`**: Vercel A record to the same VPS as
+  `app.radon.run`. Caddy site block proxies only `/mcp*` (and `/` rewritten
+  to `/mcp`) to `127.0.0.1:8334` — no Next.js, no FastAPI. The published
+  consumer URL remains `https://app.radon.run/mcp` until TLS on the dedicated
+  host is verified.
 
 ## MenthorQ Playwright session refresh
 

--- a/scripts/mcp_hosted/server.py
+++ b/scripts/mcp_hosted/server.py
@@ -234,15 +234,23 @@ def _operator_read_impl(
 # ── MCP registration ─────────────────────────────────────────────────
 
 # Keep the SDK's DNS-rebinding protection ON, but name the real fronting
-# hosts: Caddy forwards the original Host header (app.radon.run), which the
-# loopback-only default would 421.
+# hosts: Caddy forwards the original Host header (app.radon.run or
+# mcp.radon.run), which the loopback-only default would 421.
 _ALLOWED_HOSTS = [
     host.strip()
     for host in os.environ.get(
         "RADON_MCP_ALLOWED_HOSTS",
-        "app.radon.run,app.radon.run:*,127.0.0.1:*,localhost:*",
+        "app.radon.run,app.radon.run:*,mcp.radon.run,mcp.radon.run:*,127.0.0.1:*,localhost:*",
     ).split(",")
     if host.strip()
+]
+_ALLOWED_ORIGINS = [
+    origin.strip()
+    for origin in os.environ.get(
+        "RADON_MCP_ALLOWED_ORIGINS",
+        "https://app.radon.run,https://mcp.radon.run",
+    ).split(",")
+    if origin.strip()
 ]
 
 mcp = FastMCP(
@@ -262,7 +270,7 @@ mcp = FastMCP(
     transport_security=TransportSecuritySettings(
         enable_dns_rebinding_protection=True,
         allowed_hosts=_ALLOWED_HOSTS,
-        allowed_origins=["https://app.radon.run"],
+        allowed_origins=_ALLOWED_ORIGINS,
     ),
 )
 

--- a/scripts/tests/test_mcp_hosted.py
+++ b/scripts/tests/test_mcp_hosted.py
@@ -361,6 +361,17 @@ class TestHostedServerPins:
                     "never touch service secrets"
                 )
 
+    def test_default_allowed_hosts_include_mcp_hostname(self):
+        """Caddy forwards Host: mcp.radon.run on the dedicated site. The
+        SDK 421s any Host not on this list."""
+        assert "mcp.radon.run" in hosted._ALLOWED_HOSTS
+        assert "mcp.radon.run:*" in hosted._ALLOWED_HOSTS
+
+    def test_default_allowed_origins_include_mcp_hostname(self):
+        origins = hosted.mcp.settings.transport_security.allowed_origins
+        assert "https://mcp.radon.run" in origins
+        assert "https://app.radon.run" in origins
+
     def test_stateless_http_binds_loopback_by_default(self):
         assert hosted.mcp.settings.host == "127.0.0.1"
         assert hosted.mcp.settings.port == 8334

--- a/site/lib/developer-pages.test.ts
+++ b/site/lib/developer-pages.test.ts
@@ -61,8 +61,8 @@ describe("developer resource pages", () => {
     expect(markdown).toContain(HOSTED_MCP_URL);
     expect(markdown).toContain("Streamable HTTP");
     expect(markdown).toContain("read-only");
-    // mcp.radon.run has no DNS record or Caddy site block yet; the docs must
-    // not point agents at a host that does not resolve.
+    // Dedicated host exists (DNS + Caddy) but is not the published consumer
+    // URL until live TLS is verified; keep agents on app.radon.run/mcp.
     expect(markdown).not.toContain("https://mcp.radon.run");
     // The hosted rungs are named, and the corpus stays local-only.
     expect(markdown).toContain("radon_identity");

--- a/site/lib/developer-pages.ts
+++ b/site/lib/developer-pages.ts
@@ -10,8 +10,9 @@ import {
 export const AGENT_SURFACES_LAST_MODIFIED = "2026-09-05";
 
 // The hosted Streamable HTTP MCP endpoint (issue #232 chunk 1). Served by a
-// dedicated process behind the app.radon.run edge; mcp.radon.run does not
-// exist yet, so this path URL is the published one.
+// dedicated process behind the app.radon.run edge. mcp.radon.run has DNS and
+// a Caddy site; the published consumer URL stays this path until TLS on the
+// dedicated host is verified live.
 export const HOSTED_MCP_URL = "https://app.radon.run/mcp";
 
 export type AgentPage = {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,21 @@
+# Task: Caddy site for mcp.radon.run (issue #232)
+
+Vercel DNS already points mcp.radon.run at 5.78.148.38. Add a dedicated Caddy site that serves only MCP, and admit that Host on the FastMCP allowlist.
+
+## Dependency graph
+
+- T1 depends_on: [] - Failing Caddyfile + allowed-hosts tests for mcp.radon.run.
+- T2 depends_on: [T1] - Caddy site, FastMCP Host/Origin allowlist, cloud-services runbook.
+- T3 depends_on: [T2] - Focused tests, PR against main. Do not flip HOSTED_MCP_URL until live TLS.
+
+## Checklist
+
+- [x] T1 Failing tests
+- [x] T2 Caddy site + allowlist
+- [ ] T3 Verify and open PR
+
+---
+
 # Task: CI performance deliver before/after/% [IN PROGRESS]
 
 Issue #196 deliver/report must cite before, after, and % change for time-saving fixes.


### PR DESCRIPTION
Part of #232 (dedicated host after the Vercel A record). Do **not** close the issue; chunk 2 and the published-URL flip are later.

## What ships

A dedicated Caddy site for `mcp.radon.run` on the same VPS as `app.radon.run`. DNS already points there (`rec_ea85b596532a587a1f1ba1cb`, A `5.78.148.38`).

- Site proxies **only** `/mcp*` to `127.0.0.1:8334` (same body cap, no retry loop, no Next.js, no FastAPI).
- `/` rewrites to `/mcp` so `https://mcp.radon.run` is a valid connector URL.
- FastMCP Host/Origin allowlist admits `mcp.radon.run` so the SDK does not 421 the dedicated Host header.
- Published consumer URL stays `https://app.radon.run/mcp` until live TLS on the dedicated host is verified.

## Verification

- `cloud/tests/test_caddyfile.py`: **39 passed, 1 skipped**
- `scripts/tests/test_mcp_hosted.py`: **49 passed**
- Local `caddy adapt` not run (no caddy binary on PATH); CI cloud-tests shard owns that.

## After merge

Caddy publish on deploy issues the Let's Encrypt cert on first request (same as `media.radon.run`). Then verify:

```
curl -sS -X POST https://mcp.radon.run/mcp -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
```

Do not flip `HOSTED_MCP_URL` until that is HTTP 200 with 9 tools.