### PR TITLE
fix(cloud): release the control-plane trust remediation cluster

### DIFF
--- a/cloud/CLAUDE.md
+++ b/cloud/CLAUDE.md
@@ -88,6 +88,15 @@ narrowing: preflight now renders the INSTALLED compose body, not the incoming
 release's. The incoming body is gated at install time instead, by provenance
 (git blob at the deployed commit) plus `compose_body_is_valid`.
 
+**`publish-caddy` stages from the trusted tip too.** The edge config decides
+which proxy and fetch-metadata headers survive on the way to the API's
+local-trust check, and `radon` both owns the checkout copy and holds a NOPASSWD
+grant for the verb. `caddy validate` proves the candidate parses and nothing
+about what it does, so `stage_caddy_candidate` reads the blob at the commit the
+remote reports for the release branch (`resolve_fetched_main_tip`) rather than
+the working tree - the same anchor the control-plane refresh uses. A
+checkout-only edit never reaches the live configuration.
+
 That validator's deny-list refuses EVERY host-namespace join, not only
 `pid:` — `ipc:`, `userns_mode:`, `uts:` and `cgroup:` widen the container's
 runtime the same way (R-668/REL-249). The three copies (deploy-root-helper,

--- a/cloud/scripts/deploy-root-helper.sh
+++ b/cloud/scripts/deploy-root-helper.sh
@@ -668,13 +668,24 @@ restart_caddy() {
 # world-readable candidate inside the radon-traversable /etc/caddy would then be
 # readable during the validate window. 0600 makes the race unprofitable even
 # when it is won.
+# Same trust boundary as the control-plane refresh: the edge config decides
+# which proxy and fetch-metadata headers survive on the way to the API's
+# local-trust check, and `radon` both owns CADDY_SOURCE and holds a NOPASSWD
+# grant for publish-caddy. `caddy validate` only proves the candidate parses,
+# not that it preserves those headers, so the bytes must come from the commit
+# GitHub reports as main rather than from the writable checkout.
 stage_caddy_candidate() {
   local candidate="$1"
+  local tip
+
+  tip="$(resolve_fetched_main_tip)" || return $?
   if (( HELPER_TEST_MODE == 1 )); then
-    "$INSTALL" -m 0600 "$CADDY_SOURCE" "$candidate"
+    "$INSTALL" -m 0600 /dev/null "$candidate" || return $?
   else
-    "$INSTALL" -m 0600 -o root -g root "$CADDY_SOURCE" "$candidate"
+    "$INSTALL" -m 0600 -o root -g root /dev/null "$candidate" || return $?
   fi
+  git_bounded --git-dir="$RADON_GIT_DIR" cat-file blob \
+    "${tip}:cloud/caddy/Caddyfile" > "$candidate"
 }
 
 # radon publishes Caddy config only through this fixed action. The retired

--- a/cloud/scripts/wipe-vps.sh
+++ b/cloud/scripts/wipe-vps.sh
@@ -34,6 +34,9 @@ echo "  - Docker containers and volumes"
 echo "  - Caddy and its config"
 echo "  - Python 3.13, Node.js 22, Docker CE"
 echo "  - /home/radon/ (repos, venv, data)"
+echo "  - /etc/radon/ secrets and the stored secret-store key"
+echo "  - /var/lib/radon/ host state"
+echo "  - radon sudoers and polkit grants"
 echo "  - The radon user account"
 echo ""
 echo "This will KEEP:"
@@ -118,10 +121,27 @@ log_info "Removing secret-store master credential..."
 rm -f /etc/credstore.encrypted/radon-secret-store-key
 rmdir /etc/credstore.encrypted 2>/dev/null || true
 
-# -- Remove sudoers -----------------------------------------------------------
+# -- Remove sudoers and polkit ------------------------------------------------
 
-log_info "Removing radon sudoers config..."
+log_info "Removing radon sudoers and polkit config..."
 rm -f /etc/sudoers.d/radon-deploy
+rm -f /etc/sudoers.d/radon-monitor
+rm -f /etc/sudoers.d/radon-ops
+rm -f /etc/sudoers.d/radon-caddy
+rm -f /etc/polkit-1/rules.d/50-radon-services.rules
+
+# -- Remove secrets and host state --------------------------------------------
+
+# setup-vps.sh writes the whole production credential set here (/etc/radon/env
+# and /etc/radon/mcp.env), and the API unit loads its secret-store key from the
+# systemd credential store. A reset that leaves these behind hands the next
+# owner of the machine live credentials.
+log_info "Shredding radon secrets and host state..."
+find /etc/radon -type f -exec shred -u {} + 2>/dev/null || true
+rm -rf /etc/radon
+shred -u /etc/credstore.encrypted/radon-secret-store-key 2>/dev/null || true
+rm -f /etc/credstore.encrypted/radon-secret-store-key
+rm -rf /var/lib/radon
 
 # -- Remove packages ----------------------------------------------------------
 

--- a/cloud/tests/test_root_execution_paths.py
+++ b/cloud/tests/test_root_execution_paths.py
@@ -412,6 +412,12 @@ def test_caddy_sudoers_publishes_through_the_fixed_root_helper():
         )
 
 
+def _git(repo: pathlib.Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(repo), *args], check=True, capture_output=True, text=True
+    )
+
+
 def _write_executable(path: pathlib.Path, body: str) -> None:
     path.write_text(body, encoding="utf-8")
     path.chmod(0o755)
@@ -449,9 +455,18 @@ exit {0 if caddy_valid else 1}
     fake_rm = tmp_path / "rm"
     _write_executable(fake_rm, '#!/bin/bash\nexec /bin/rm "$@"\n')
 
+    body = "app.radon.run {\n  respond \"ok\"\n}\n"
     source = tmp_path / "checkout" / "caddy" / "Caddyfile"
     source.parent.mkdir(parents=True, exist_ok=True)
-    source.write_text("app.radon.run {\n  respond \"ok\"\n}\n", encoding="utf-8")
+    source.write_text(body, encoding="utf-8")
+    # The trusted content source: a real git repo standing in for the release
+    # branch tip. `radon` owns `source` but cannot forge a blob at that commit.
+    repo = tmp_path / "release"
+    (repo / "cloud" / "caddy").mkdir(parents=True)
+    (repo / "cloud" / "caddy" / "Caddyfile").write_text(body, encoding="utf-8")
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "add", "-A")
+    _git(repo, "-c", "user.email=cp@test", "-c", "user.name=cp", "commit", "-q", "-m", "edge")
     config = tmp_path / "etc" / "caddy" / "Caddyfile"
     config.parent.mkdir(parents=True, exist_ok=True)
     config.write_text("# live known-good\n", encoding="utf-8")
@@ -467,6 +482,8 @@ exit {0 if caddy_valid else 1}
         "RADON_TEST_CADDY_SOURCE": str(source),
         "RADON_TEST_CADDY_CONFIG": str(config),
         "RADON_TEST_CADDY_BIN": str(fake_caddy),
+        "RADON_TEST_GIT_DIR": str(repo / ".git"),
+        "RADON_TEST_UNIT_REMOTE": str(repo),
     }
     return env, source, config, systemctl_log, caddy_log
 
@@ -507,6 +524,29 @@ def test_publish_caddy_refuses_a_symlinked_source(tmp_path):
     assert not systemctl_log.exists() or "reload caddy" not in systemctl_log.read_text(
         encoding="utf-8"
     )
+
+
+def test_publish_caddy_never_publishes_a_checkout_only_edge_config(tmp_path):
+    """The edge config decides which proxy and fetch-metadata headers reach the
+    API's local-trust check, so whoever chooses its bytes chooses that check's
+    answer. `radon` owns the checkout and holds a passwordless grant for this
+    verb, so the content must come from the commit the remote reports for the
+    release branch -- which it cannot forge -- and a checkout-only edit must be
+    inert.
+    """
+    env, source, config, systemctl_log, _caddy_log = _publish_fixture(tmp_path)
+    source.write_text(
+        "app.radon.run {\n  reverse_proxy 127.0.0.1:8321 {\n"
+        "    header_up -X-Forwarded-For\n  }\n}\n",
+        encoding="utf-8",
+    )
+
+    result = _run_publish(env)
+
+    assert "header_up -X-Forwarded-For" not in config.read_text(encoding="utf-8"), (
+        "a checkout-only edge config edit reached the live configuration"
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 def test_publish_caddy_leaves_live_config_untouched_when_validation_fails(tmp_path):

--- a/cloud/tests/test_unit_install_acknowledgment.py
+++ b/cloud/tests/test_unit_install_acknowledgment.py
@@ -124,6 +124,53 @@ def test_changed_units_are_acknowledged_pending_install():
     )
 
 
+def _unit_mismatch_acks() -> set[str]:
+    """`unit-mismatch:<unit>` -> the units whose install-copy is still owed."""
+    acks: set[str] = set()
+    for line in ALLOWLIST.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        drift_id, _, _reason = line.partition(" ")
+        if drift_id.startswith("unit-mismatch:"):
+            acks.add(drift_id[len("unit-mismatch:"):])
+    return acks
+
+
+def test_a_unit_mismatch_ack_pins_the_content_the_installer_will_promote():
+    """A `unit-mismatch:` ack promises a bounded pending-install window.
+
+    `install-units` reads the unit blob at the verified main tip and refuses to
+    promote it unless its hash equals the manifest entry
+    (deploy-root-helper.sh, `manifest-mismatch`). So a pin that matches neither
+    the host nor the repo does not describe a pending install at all -- no
+    automated path can ever clear it, while the ack keeps the drift audit green
+    and suppresses the only signal that an internet-facing unit is running
+    without the hardening that already landed in the repo.
+
+    The manifest header already states the rule ("that hash is pre-recorded at
+    the content the operator is expected to install"); this asserts it.
+    """
+    installed = _manifest_hashes()
+    units = _unit_files()
+    unreachable = []
+    for name in sorted(_unit_mismatch_acks()):
+        pinned = installed.get(name)
+        if pinned is None:
+            continue
+        path = units.get(name)
+        if path is None:
+            continue
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        if pinned != digest:
+            unreachable.append(f"{name} (pinned {pinned[:8]}, repo {digest[:8]})")
+    assert not unreachable, (
+        "unit-mismatch acknowledgments whose manifest pin matches neither the "
+        "repo content nor anything install-units can promote, so the pending "
+        f"install can never complete: {unreachable}"
+    )
+
+
 # --- REL-045 (R-092, R-113): the `not-installed:` ack is a trapdoor.
 #
 # R-092: radon-ivrank.{service,timer} took the ack path instead of a manifest

--- a/cloud/tests/test_wipe_vps_clears_secrets.py
+++ b/cloud/tests/test_wipe_vps_clears_secrets.py
@@ -94,7 +94,19 @@ def test_setup_has_not_added_a_secret_path_the_wipe_does_not_know_about():
         match
         for match in re.findall(r"/etc/(?:radon|credstore\.encrypted)[\w./-]*", setup)
     }
-    unwiped = sorted(target for target in referenced if not _removes(body, target))
+    # /etc/credstore.encrypted is the SHARED systemd credential store, not ours:
+    # the wipe removes this deployment's key from inside it and rmdirs the
+    # directory only if that left it empty. A path is therefore also covered
+    # when the wipe removes something beneath it.
+    def _covered(target: str) -> bool:
+        if _removes(body, target):
+            return True
+        return any(
+            other.startswith(target.rstrip("/") + "/") and _removes(body, other)
+            for other in referenced
+        )
+
+    unwiped = sorted(target for target in referenced if not _covered(target))
     assert not unwiped, (
         "setup-vps.sh creates or reads these secret paths and wipe-vps.sh does "
         f"not remove them: {unwiped}"

--- a/cloud/tests/test_wipe_vps_clears_secrets.py
+++ b/cloud/tests/test_wipe_vps_clears_secrets.py
@@ -1,0 +1,101 @@
+"""`wipe-vps.sh` must actually clear the surfaces `setup-vps.sh` creates.
+
+The script advertises a destructive reset ("Removes: all radon services,
+repos, packages, user data") and closes by declaring the machine ready for a
+fresh setup. Anything it silently keeps is a credential or privilege surface
+left behind on a host the operator believes is clean -- typically one about to
+be handed back to the provider, re-imaged, or re-bootstrapped from a different
+account.
+
+These assertions are deliberately path-level and read the two scripts as text:
+the wipe path cannot be exercised anywhere but a disposable host.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+CLOUD_ROOT = pathlib.Path(__file__).resolve().parents[1]
+WIPE = CLOUD_ROOT / "scripts" / "wipe-vps.sh"
+SETUP = CLOUD_ROOT / "scripts" / "setup-vps.sh"
+
+
+def _body(path: pathlib.Path) -> str:
+    """The script's executable lines, without comments or banner echoes."""
+    lines = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if re.match(r"^echo\b", stripped):
+            continue
+        lines.append(stripped)
+    return "\n".join(lines)
+
+
+def _removes(body: str, target: str) -> bool:
+    """True when the script removes `target` (or a directory containing it)."""
+    for line in body.splitlines():
+        if not re.match(r"^(rm|shred)\b", line):
+            continue
+        for token in line.split():
+            token = token.strip("\"'")
+            if not token.startswith("/"):
+                continue
+            if target == token or target.startswith(f"{token.rstrip('/')}/"):
+                return True
+    return False
+
+
+def test_wipe_removes_the_secret_directories_setup_creates():
+    """/etc/radon holds every production credential the units load."""
+    body = _body(WIPE)
+    missing = [
+        target
+        # Not /etc/credstore.encrypted itself: that store is systemd-wide and
+        # may hold credentials this deployment did not put there.
+        for target in (
+            "/etc/radon",
+            "/var/lib/radon",
+            "/etc/credstore.encrypted/radon-secret-store-key",
+        )
+        if not _removes(body, target)
+    ]
+    assert not missing, (
+        "wipe-vps.sh advertises a destructive reset but leaves these credential "
+        f"and state surfaces on disk: {missing}"
+    )
+
+
+def test_wipe_removes_every_privilege_grant_setup_installs():
+    """A leftover sudoers or polkit grant survives the account it was for."""
+    body = _body(WIPE)
+    grants = [
+        f"/etc/sudoers.d/{path.name}"
+        for path in sorted((CLOUD_ROOT / "config" / "sudoers.d").glob("radon-*"))
+    ]
+    grants += [
+        f"/etc/polkit-1/rules.d/{path.name}"
+        for path in sorted((CLOUD_ROOT / "config" / "polkit").glob("*.rules"))
+    ]
+    missing = [target for target in grants if not _removes(body, target)]
+    assert not missing, (
+        "wipe-vps.sh leaves privilege grants installed by setup-vps.sh in "
+        f"place: {missing}"
+    )
+
+
+def test_setup_has_not_added_a_secret_path_the_wipe_does_not_know_about():
+    """Catches the next /etc/radon-shaped path before it outlives a wipe."""
+    setup = SETUP.read_text(encoding="utf-8")
+    body = _body(WIPE)
+    referenced = {
+        match
+        for match in re.findall(r"/etc/(?:radon|credstore\.encrypted)[\w./-]*", setup)
+    }
+    unwiped = sorted(target for target in referenced if not _removes(body, target))
+    assert not unwiped, (
+        "setup-vps.sh creates or reads these secret paths and wipe-vps.sh does "
+        f"not remove them: {unwiped}"
+    )

--- a/scripts/api/assistant_catalog.py
+++ b/scripts/api/assistant_catalog.py
@@ -100,9 +100,13 @@ CATALOG: dict[CatalogKey, Capability] = {
     ("POST", "/pi/exec"): "internal",
     ("POST", "/portfolio/background-sync"): "mutate.workspace",
     ("POST", "/portfolio/sync"): "mutate.workspace",
-    ("GET", "/preferences"): "read",
-    ("DELETE", "/preferences/{key}"): "mutate.workspace",
-    ("PUT", "/preferences/{key}"): "mutate.workspace",
+    # The preference registry holds the order-risk caps the placement funnel
+    # enforces (RADON_MAX_ORDER_NOTIONAL and friends in
+    # scripts/app_preferences.py), each with a hard_max well above its default.
+    # Chat must never reach this surface: same treatment as /credentials.
+    ("GET", "/preferences"): "admin",
+    ("DELETE", "/preferences/{key}"): "admin",
+    ("PUT", "/preferences/{key}"): "admin",
     ("GET", "/quote/{ticker}"): "read",
     ("GET", "/redoc"): "internal",
     ("POST", "/regime/scan"): "read.spawn",

--- a/scripts/api/tests/test_assistant_catalog.py
+++ b/scripts/api/tests/test_assistant_catalog.py
@@ -71,6 +71,27 @@ class TestAssistantCatalog:
             ):
                 assert cap == "admin", f"{method} {path} must be admin"
 
+    def test_order_risk_cap_preferences_are_refused_to_the_assistant(self):
+        """/preferences is the order-risk cap surface, not workspace state.
+
+        scripts/app_preferences.py registers RADON_MAX_ORDER_NOTIONAL,
+        RADON_MAX_ORDER_QTY, RADON_MAX_ORDERS_PER_MIN and
+        RADON_MAX_COMBO_LOSS_DOLLARS there, each with a hard_max far above its
+        default. A capability the assistant may call is reachable from
+        prompt-injectable content, so widening the placement funnel's own caps
+        must be refused the same way /credentials is.
+        """
+        from scripts.api.assistant_catalog import capability_for, is_refused
+
+        for method, path in (
+            ("GET", "/preferences"),
+            ("PUT", "/preferences/{key}"),
+            ("DELETE", "/preferences/{key}"),
+        ):
+            cap = capability_for(method, path)
+            assert cap == "admin", f"{method} {path} pinned {cap!r}, must be admin"
+            assert is_refused(cap), f"{method} {path} must be refused to the assistant"
+
     def test_scan_posts_are_read_spawn(self):
         from scripts.api.assistant_catalog import capability_for
 

--- a/web/app/api/preferences/route.ts
+++ b/web/app/api/preferences/route.ts
@@ -56,7 +56,9 @@ function validationFailure(
   );
 }
 
-export const radonCapability = { GET: "read", PUT: "mutate.workspace", DELETE: "mutate.workspace" };
+// The preference registry holds the order-risk caps the placement funnel
+// enforces, so chat must never reach this surface (same pin as /credentials).
+export const radonCapability = { GET: "admin", PUT: "admin", DELETE: "admin" };
 
 export async function GET(): Promise<Response> {
   const access = await requireRouteAccess();

--- a/web/app/api/profile/route.ts
+++ b/web/app/api/profile/route.ts
@@ -209,6 +209,20 @@ export async function PUT(req: Request): Promise<Response> {
       JSON.parse(uiResult.value ?? "{}") as Record<string, unknown>,
     );
     nextUiPreferences = JSON.stringify(merged);
+    // The per-request check above bounds only the incoming body. Preferences
+    // merge across requests, so an unbounded number of small, individually
+    // legal updates would otherwise grow the stored row without limit.
+    if (nextUiPreferences.length > MAX_UI_PREFERENCES_LENGTH) {
+      return setNoStoreResponseHeaders(
+        jsonApiError({
+          status: 400,
+          code: "VALIDATION_ERROR",
+          message: "ui_preferences exceeds size limit",
+          requestId,
+        }),
+        requestId,
+      );
+    }
   }
 
   let nextUsername: string | null = null;

--- a/web/lib/assistant/catalogBuild.ts
+++ b/web/lib/assistant/catalogBuild.ts
@@ -33,6 +33,7 @@ const DENY_PREFIXES = [
   "/ws-ticket",
   "/demo",
   "/admin",
+  "/preferences",
   "/ib",
   "/trading",
   "/pi",

--- a/web/tests/assistant-catalog-pin.test.ts
+++ b/web/tests/assistant-catalog-pin.test.ts
@@ -109,7 +109,7 @@ const PINNED: Record<string, PinnedCapability> = {
   "performance": { GET: "read", POST: "read.spawn" },
   "pi": "internal",
   "portfolio": { GET: "read", POST: "mutate.workspace" },
-  "preferences": { GET: "read", PUT: "mutate.workspace", DELETE: "mutate.workspace" },
+  "preferences": { GET: "admin", PUT: "admin", DELETE: "admin" },
   "previous-close": "read",
   "prices": { GET: "read", POST: "read" },
   "probe/freshness": "internal",

--- a/web/tests/profile-bookmarks-watchlist-api.test.ts
+++ b/web/tests/profile-bookmarks-watchlist-api.test.ts
@@ -246,6 +246,57 @@ describe("profile", () => {
       avatar_url: "https://media.radon.run/parallel.png",
     });
   });
+
+  it("rejects ui_preferences whose MERGED result exceeds the size limit", async () => {
+    const { PUT, GET } = await import("../app/api/profile/route");
+    const putPrefs = (tableId: string) =>
+      PUT(
+        req("http://localhost/api/profile", {
+          method: "PUT",
+          body: JSON.stringify({
+            ui_preferences: { columns: { [tableId]: { widths: "x".repeat(2000) } } },
+          }),
+        }),
+      );
+
+    // Each individual body is well under the 8KB per-request cap, so the
+    // incoming-only check accepts every one of them. The accumulated merge is
+    // what has to be bounded.
+    let rejected: Response | null = null;
+    for (let i = 0; i < 8; i += 1) {
+      const res = await putPrefs(`table_${i}`);
+      if (res.status !== 200) {
+        rejected = res;
+        break;
+      }
+    }
+    expect(rejected).not.toBeNull();
+    expect(rejected!.status).toBe(400);
+    expect((await jsonOf(rejected!)).code).toBe("VALIDATION_ERROR");
+
+    // The over-cap write must not have landed.
+    const stored = await db.execute("SELECT ui_preferences FROM user_profiles WHERE user_id = 'user_test_1'");
+    const raw = (stored.rows[0] as unknown as { ui_preferences: string | null }).ui_preferences ?? "";
+    expect(raw.length).toBeLessThanOrEqual(8 * 1024);
+    expect((await jsonOf(await GET())).ui_preferences).toBeTruthy();
+  });
+
+  it("still merges successive small ui_preferences updates", async () => {
+    const { PUT, GET } = await import("../app/api/profile/route");
+    for (const tableId of ["orders", "journal"]) {
+      const res = await PUT(
+        req("http://localhost/api/profile", {
+          method: "PUT",
+          body: JSON.stringify({ ui_preferences: { columns: { [tableId]: { pnl: true } } } }),
+        }),
+      );
+      expect(res.status).toBe(200);
+    }
+    const body = await jsonOf(await GET());
+    expect(body.ui_preferences).toMatchObject({
+      columns: { orders: { pnl: true }, journal: { pnl: true } },
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Releases the private `security-private/2026-09-04-control-plane-trust` branch, rebased from `2b936ebc` onto `4cfb7df6`.

## One of the six was already fixed in public

`9663a4b2` ("take control-plane content from the trusted tip, not the checkout") is **already on main** and is deliberately **not** included. `refresh_control_plane` there resolves the deployed commit, stages the git blobs into a root-owned `control-plane-src.XXXXXX`, points `CONTROL_PLANE_SOURCE_ROOT` at it, installs from there, and fails closed. That arrived through the public R-084 lineage while this branch sat private. Cherry-picking it produced 13 conflicts that were entirely a rename of the same mechanism, so it was dropped rather than re-litigated.

Five commits remain.

## What lands

| commit | surface |
|---|---|
| `90eb7f3a` | `/api/profile` merged `ui_preferences` payload was unbounded |
| `b8d84fbb` | the order-risk preference surface was reachable from chat |
| `0b92a9e3` | an acknowledged pending unit install had become unreachable |
| `da4ee190` | the host reset left `/etc/radon`, `/var/lib/radon` and three of four privilege grants on disk |
| `d1ad1bdd` | the edge config was published from the account-writable checkout |

`d1ad1bdd` is the one that still mattered most: `stage_caddy_candidate` on main reads `$CADDY_SOURCE` straight out of the checkout that `radon` owns, behind a NOPASSWD grant, with `caddy validate` as the only gate — which proves the candidate parses and nothing about which proxy and fetch-metadata headers survive on the way to the API's local-trust check. It now reads the blob at the commit the remote reports for the release branch, the same anchor the control-plane path uses.

`da4ee190` partially overlapped main's R-618 work; the conflict was resolved to keep both — main's secret-store master credential removal and this branch's `/etc/radon` shredding, `/var/lib/radon` removal, and the sudoers + polkit grants.

## One test adjustment

`test_setup_has_not_added_a_secret_path_the_wipe_does_not_know_about` derives expected paths from `setup-vps.sh` and flagged `/etc/credstore.encrypted`. That store is shared with systemd: the wipe removes this deployment's key from inside it and `rmdir`s only if that left it empty, which is the documented intent. The check now also counts a path as covered when the wipe removes something beneath it.

## Verification

- `cloud/tests`: **1753 passed, 76 skipped, 0 failed**
- `scripts/api/tests/test_assistant_catalog.py`: 7 passed
- `cloud/scripts/deploy-root-helper.sh`, `wipe-vps.sh`: `bash -n` clean
- web vitest specs could not run locally (no `node_modules` in this worktree — `Cannot find package 'next/server'`); CI installs deps and is the gate for those two files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWTUCU1QEYA9zU6RUJomZp