### PR TITLE
Documentation 2026-09-08: Documentation index: the social-share voice provenance owner was not discoverable from the documentation index.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ Archived session artifacts live in [`docs/archive/`](archive/).
 |-------|-----|
 | Regime and scanner indicator specs | [`docs/indicators/README.md`](indicators/README.md) |
 | AI infrastructure evidence, source verification and rollout | [Design](ai-infrastructure-plan.md) · [Collection](ai-infrastructure-operations.md) · [Verification](ai-infrastructure-verification.md) |
+| Social-share voice provenance and export constraints | [`docs/joe-mccann-social-voice.md`](joe-mccann-social-voice.md) |
 | Equibles market-structure API | [`docs/equibles-api.md`](equibles-api.md) |
 | Strategy specs | [`docs/strategies.md`](strategies.md) |
 | VCG-R research notes | [`docs/cross_asset_volatility_credit_gap_spec_(VCG).md`](cross_asset_volatility_credit_gap_spec_(VCG).md) |


### PR DESCRIPTION
## Issue discovered

- **Documentation index**: the social-share voice provenance owner was not discoverable from the documentation index.

## What was done to fix it

- **Documentation index**: linked the existing social-share voice provenance and export-constraints owner.

## Next

Fixed with green deployment