### PR TITLE
docs(research): a Radon-specific harness, a Radon-tailored small model, and how they meet

### DIFF
--- a/docs/research/radon-harness-and-model-roadmap.md
+++ b/docs/research/radon-harness-and-model-roadmap.md
@@ -1,0 +1,106 @@
+# How the Radon harness and a Radon-tailored small model tie together
+
+Date: 2026-09-12
+Companion reports: [`radon-harness.md`](radon-harness.md) (the harness) and [`radon-small-model.md`](radon-small-model.md) (training a small model). This document does not repeat them; it says where they meet, which one comes first, and what a single roadmap looks like.
+
+## Executive summary
+
+The two reports were written independently and arrived at the same seam. The harness report's core deliverable is a hook pipeline that runs the four gates as code on every proposal and a session store that persists every turn, tool call, gate verdict and proposal as a replayable JSONL tree. The training report's core deliverable is a dataset of decision traces with deterministic gate labels, templated facts, and a time-split held-out evaluation. Those are the same artifact seen from two sides. The harness produces, as a by-product of running, exactly the traces the model needs; the model, once it exists, plugs into the harness as one more provider behind `web/lib/llm/provider.ts` and is called as a narrow tool, never as the decision surface. The evaluation suites are shared: evaluate replays, NO_TRADE gate matches, golden-set hit@5 and synthetic gate cases score both "is the harness better than the chat UI" and "is the small model tailored to Radon", with the harness as the eval runner and the model as one variable.
+
+So the order is settled by dependency, not preference: harness extraction and session persistence first, because until sessions are persisted there is no trace source beyond what already sits in the journal and reports; the training report's Phase 0 (dataset from existing artifacts) and Phase 1 (a narrow tagger and drafter) in parallel, because they need nothing from the harness; decision-trace SFT last, because it needs months of persisted harness sessions to be worth running. The end state is one loop, four gates in code, one session store, one eval directory, and a provider list that includes a local model the harness can reach for when the task is formatting, tagging or drafting.
+
+## 1. Where the two reports agree, in their own words
+
+| Theme | Harness report | Training report | Consequence |
+|---|---|---|---|
+| The frontier model plus retrieval is the decision surface | "Order placement stays exactly where it is today: a proposal the harness cannot execute" and the model "fills the typed proposal; the harness's job is to say which gate failed" | "The frontier model plus RAG stays the decision surface; the small model formats and pre-fills" | No surface, in either plan, lets a small model reach `mutate.trading`. That is one pin test, not two. |
+| Daily facts belong in retrieval, not weights or prompts | Context assembly is "just-in-time retrieval" against an attention budget; the knowledge MCP is "LLM-free retrieval primitives" | "Knowledge that changes hourly or daily belongs in retrieval and tools, not weights"; the KB already runs hourly at hit@5 0.917 | The harness's `tool_result` hooks and the training set's fact templating are the same discipline: a fact the model can retrieve at inference time is never baked in. |
+| Gates are code, and code produces the labels | `convexity_gate`, `kelly_gate`, `order_limits`, `trading_halt` inside a `tool_call` block hook, "a failing gate returns `{ block: true, reason: "GATE 1 convexity: 1.4x < 2x" }`" | "The gates are enforced in code; the model's job is to invoke and narrate, not to be the calculator. Score naming accuracy, not arithmetic." | The gate verdicts the harness writes into every session are the ground-truth labels for the model's gate-compliance metric. No human labelling needed. |
+| Today's transcript store is too thin | "Radon records one `assistant_turns` row per turn but does not persist the message array, tool inputs, or tool outputs ... a proposal cannot be replayed" | "`assistant_turns` keeps only 200 characters of the user message ... not usable as traces today" | Both reports independently name the same gap; closing it (harness Phase 1) is the single highest-leverage step for both goals. |
+| Provider swappability is already built | `provider.ts` "normalizes xAI, Anthropic, OpenAI-compatible and Gemini behind one `chat()`"; Pi's `streamFn` is the model | "`provider.ts` already routes Ollama, so a local model can be plugged in without new plumbing" | A fine-tuned Qwen or Gemma adapter served by Ollama is one entry in the same provider list the nightly ladder uses. |
+| Evals from Radon's own history, not synthetic prompts | Evaluate replays, NO_TRADE decisions, proposal gating, golden set, incident reasoning, loop phases, determinism | Format adherence, gate compliance, hallucination probes, held-out decision agreement, and P&L only through the backtest harness | One `evals/` directory; the harness runs it; the model under test is a parameter. |
+| The nightly loops are a harness written in bash | "The five wrappers' phase contract ... is harness policy written in bash. It should become a headless driver of the same core." | The continual pipeline is "nightly trace_builder ... weekly eval_suite ... monthly LoRA" | The trace builder, the eval run and the adapter promotion are three more nightly-loop phases with the same dead-man reporting the loops already have. |
+
+## 2. Where they pull in different directions, and how to resolve it
+
+**Pi as dependency versus reference.** The harness report leans toward adopting Pi's design and optionally its `pi-agent-core` package. The training report needs nothing from Pi. Resolution: adopt the design, not the package, for now. The one thing Radon must own outright is the session entry schema, because the training pipeline reads it; a schema owned by a third-party package would put the dataset format one upstream release away from drift. Revisit the package question after Phase 1 when the schema is pinned by a test.
+
+**Where the Claude Agent SDK fits.** The harness report reserves it for the nightly engineering loops, not the trading agent. The training report notes Anthropic's output-training clause permits narrow tasks (tagging, extraction, summarization) and restricts a competing general model. These agree: the SDK-driven loops can keep producing engineering PRs, and their transcripts are not a training source. The trading harness's sessions are, and they are narrow by construction.
+
+**Cost.** The harness report worries about moving the loops onto API billing; the training report says the local model does not pay for itself in API spend. Both are right and neither changes the plan: the loops stay on the codex/grok ladder, the small model is justified by privacy, latency and offline fallback, and the harness's per-session `max_budget_usd` is what actually bounds spend.
+
+**What "constantly studying" means.** The operator's framing (the model itself becomes tailored) is closest to the training report's category (ii), skills and house rules. The harness report's context assembler and compaction summary are where categories (i) and (iii) live: positions, flow and news are re-injected per turn from retrieval; signal edge stays in the backtest harness. The honest version of "constantly studying" is: the harness re-reads Radon every turn, the small model re-learns Radon's habits monthly from what the harness recorded, and neither ever learns a regime into its weights.
+
+## 3. The shared artifact: a session entry that is also a training example
+
+The harness report proposes JSONL entries with `id` and `parentId`; the training report proposes traces in TRL and mlx-lm conversational form with templated facts. Design the session entry so the trace is a projection of it, not a second pipeline:
+
+```
+session entry (harness writes)                trace (trace_builder reads)
+-------------------------------               -----------------------------
+id, parentId, ts, session_id                  split key = ts (time-split only)
+role: user | assistant | tool_use |           messages[] in chat form
+      tool_result | proposal | gate
+tool_use: name, capability, input             kept if capability is read.*
+tool_result: name, bytes, truncated,          replaced by a placeholder token when
+             untrusted, content               the fact is retrievable at inference
+proposal: structure, legs, max_gain,          assistant target: thesis, gates named,
+          max_loss, kelly_fraction, signal    risk factors, exit and stop
+gate: name, verdict, reason                   label for gate-compliance scoring
+provider, model, usage, cost                  provenance filter (never train on a
+                                              trace produced by the adapter itself)
+```
+
+Three rules fall out of this, and both reports already state them separately:
+
+1. Facts that are retrievable at inference time are templated before they reach the training set (`NVDA at 182` becomes `{{last_price}}`), so the model learns the reasoning shape and not a stale number. The harness's `untrusted` flag on tool results doubles as the "do not memorize" flag.
+2. Entries produced by the small model itself carry its provider and model name and are excluded from its own next training set. Self-distillation loops are how a narrow model drifts.
+3. The time split is the only split. The harness records `ts`; the eval holds out the last 60 to 90 days; the nightly backtest lane already imposes the same walk-forward rule on signal models.
+
+## 4. One roadmap, with the dependency edges made explicit
+
+The phases below reuse the numbering of the two companion reports (H = harness, M = model) so each line traces back to its source.
+
+| Order | Phase | From | Depends on | Produces | Weeks |
+|---|---|---|---|---|---|
+| 1 | H0: extract `loop.ts`, `tools.ts`, `dispatch.ts`, catalog, capabilities into `harness/`; assistant route becomes an adapter; 25 assistant tests pass unchanged | Harness §4.3 | nothing | a loop that is a library | 1 to 2 |
+| 1 (parallel) | M0: `traces.py` from journal, reports and posts; curate the golden set out of `draft: true`; audit 200 newsfeed tags by hand; 200 synthetic gate cases; record the frontier plus RAG baseline | Model §5 | nothing (uses artifacts that exist today) | `eval_suite.py`, the baseline row | 1 (calendar), 1 to 3 days of work |
+| 1 (parallel) | M1: local tagger on Qwen3.5-0.8B or 2B via mlx-lm, served by Ollama behind `provider.ts`; drafter on Qwen3.5-4B | Model §5 | M0 for the acceptance test | a provider entry the harness can call | 1 |
+| 2 | H1: session store (JSONL tree on disk, mirrored to a new Turso `assistant_sessions` table), hook pipeline, compaction, budgets | Harness §4.3 | H0; the entry schema from §3 above | replayable sessions, the trace source | 2 to 3 |
+| 3 | H2: gates as code in the `tool_call` hook; typed registry with `capability`, `readOnly`, `timeoutMs`; structured `signal` object on every proposal; wire tests that a blocked proposal produced zero `/api/orders/place` requests | Harness §4.3 | H1 | gate verdicts in every session; the model's gate labels | 2 |
+| 3 (parallel) | H3 and M4 merged: one `evals/` directory; evaluate replays, NO_TRADE matches, golden set, gate cases, hallucination probes; the harness is the runner, the model is a parameter; determinism reported separately from accuracy | Harness §5, Model §4 | H1, M0 | one scoreboard for both questions | 2, then ongoing |
+| 4 | H4: provider ladder as harness config; nightly loops become headless drivers (`modes/rpc.ts`); Claude rungs via the Agent SDK with `dontAsk`, `disallowedTools` and `PreToolUse` rails; codex and grok via the portable prompts | Harness §4.3 | H1, H2 | wrappers shrink to process supervision | 1 to 2 |
+| 5 | M2: decision-trace SFT on accumulated harness sessions, retrained from scratch monthly on the full set with a replay slice, time-split hold-out, promotion rule (format, gates, hallucination not worse; agreement not worse by more than one standard error), rollback by symlink | Model §3 and §5 | H1 sessions accumulated for at least 60 to 90 days beyond the hold-out; H2 gate labels | a monthly adapter the harness may call as a draft tool | 2 to 3, then monthly |
+| always | M3: signal edge stays in `backtest_runs`, Chronos-2, deflated Sharpe, purged CV; any LLM-derived feature entering a backtest comes from a model whose cutoff predates the window | Model §5 | independent | unchanged lane | ongoing |
+
+Reading the table: nothing in the model track blocks the harness track, and only M2 waits on the harness. The first month delivers a harness that is a library, a dataset, a baseline number, and a local tagger. The third month delivers gates in code and a shared scoreboard. Decision-trace training does not start before month four, and it should not, because before then the traces it would learn from are the pre-harness ones the training report already sized at 150 to 300.
+
+## 5. Definition of done for the combined effort
+
+- Every proposal the assistant renders passed `convexity_gate`, `kelly_gate`, `order_limits` and `trading_halt` inside the harness, and a wire test proves a failing gate produced no `/api/orders/place` request.
+- Every session is replayable from Turso alone, with gate verdicts and provider provenance on each entry.
+- `evals/run` produces one JSON scoreboard with the frontier plus RAG baseline, the current adapter and the candidate adapter side by side, and the nightly loop that runs it posts the same dead-man comment the other loops post.
+- The small model is reachable only through the harness's provider list, only for `read.*` capability tools, and a pin test greps the harness for any path that hands a `mutate.trading` tool to a non-frontier provider.
+- The trace builder excludes entries the adapter produced, templates retrievable facts, and splits by time.
+- No claim of edge is made from the LLM lane; P&L questions route to the backtest lane.
+
+## 6. Decisions only the operator can make
+
+Deduplicated from both reports' open questions, ordered by how early they block.
+
+1. **Session persistence and real account figures.** Storing full transcripts is the enabling step for both tracks, and transcripts contain real positions and P&L. The R-454 and R-457 provenance rules apply; decide whether the Turso mirror stores the full entry or a redacted projection with the full copy on disk only. (Blocks H1 and M2.)
+2. **One gate implementation or two.** Python `gates.py` behind `POST /gates/evaluate`, or a TypeScript twin with a parity test. One implementation keeps the labels the model trains on identical to the ones the harness enforces; a twin saves a hop per proposal. (Blocks H2.)
+3. **Mac Mini memory.** 16, 24, 32 or 64 GB decides 4B LoRA versus 9B LoRA versus 12B QLoRA. (Sizes M1 and M2.)
+4. **Is privacy alone enough to justify a local model**, given the API saving is under $100 a year? If not, M1 is still worth running once as a measured experiment and then parking. (Gates M1.)
+5. **Nightly-loop spend model.** Claude subscription for security, codex/grok for the rest is the current rule; keeping it means the Agent SDK is only ever used for the security loop. (Shapes H4.)
+6. **Pi as a dependency** after the session schema is pinned, or Radon-owned loop with Pi as reference permanently. (Revisit after H1.)
+7. **Fate of the legacy `/api/pi` command route** once the harness's typed tools cover `scanner`, `evaluate` and `sync`. (H2 or later.)
+8. **Gate 2 shape.** Model-assisted with a required structured `signal` object, or a numeric strength threshold enforced by the hook as well. (H2.)
+
+## Sources
+
+This document cites only its two companion reports; every external reference is in their source lists.
+
+- [`radon-harness.md`](radon-harness.md), sections 1 to 5 and the open questions
+- [`radon-small-model.md`](radon-small-model.md), sections 1 to 5 and the open questions
+- Radon code referenced by both: `web/lib/assistant/{loop,tools,dispatch,catalog,capabilities}.ts`, `web/lib/llm/provider.ts`, `scripts/workflow/gates.py`, `scripts/order_limits.py`, `scripts/trading_halt.py`, `scripts/knowledge/{ingest,retrieve,eval_golden,mcp_server}.py`, `scripts/db/migrations/{0030,0065}_assistant_turns*.sql`, `docs/operations.md` (nightly loops)

--- a/docs/research/radon-harness.md
+++ b/docs/research/radon-harness.md
@@ -1,0 +1,317 @@
+# A Radon-Specific Agent Harness: Landscape, Pi Study, and Recommendation
+
+Date: 2026-09-12
+Repo studied (read-only): `radon-security` clone at `.claude/worktrees/loops-session-limit`, HEAD `391aaaea`
+
+## Executive summary
+
+Radon already has most of a harness, it is just spread across four places that do not know about each other: a hand-written tool loop in `web/lib/assistant/` (17 typed tools, a capability catalog, a destructive-tool halt, per-turn telemetry), a set of Python gate and limit modules (`scripts/workflow/gates.py`, `scripts/order_limits.py`, `scripts/trading_halt.py`), a read-only knowledge MCP server, and five unattended nightly loops that drive Claude Code, Codex and Grok through 1,300-line bash wrappers. The chat UI is the thin part. What is missing is the layer the industry now calls the harness: one place that assembles context, owns the tool registry and its permission tiers, enforces domain invariants deterministically before any side effect, records a replayable session, and can be pointed at any model. The recommendation is not to adopt Pi or the Claude Agent SDK wholesale, and not to rewrite from scratch. It is to extract the loop that already exists in `web/lib/assistant/loop.ts` into a standalone, provider-neutral `harness/` package modeled on Pi's minimal core (loop, typed tools, events, JSONL session, extension hooks) while keeping Radon's FastAPI routes, capability pins, gates and MCP knowledge base as the tool surface. Order placement stays exactly where it is today: a proposal the harness cannot execute, confirmed by a human through the existing `OrderRiskGate` and server-side `order_limits` + `trading_halt` chokepoints. Evals come from the trade journal and the reliability audit, not from synthetic prompts.
+
+---
+
+## 1. What an agent harness is (2025 to 2026 practice)
+
+### 1.1 Definition
+
+The term has converged. Addy Osmani's summary, quoting Viv Trivedy: "Agent = Model + Harness. If you're not the model, you're the harness," with the gloss that "a decent model with a great harness beats a great model with a bad harness" ([Osmani, Agent Harness Engineering](https://addyosmani.com/blog/agent-harness-engineering/)). OpenAI's Codex team, describing the open-sourced Codex runtime, defines the harness as "the execution system that sits between a model and a task, which gathers context, invokes tools, enforces sandbox and approval boundaries, streams execution progress, and carries work across multi-turn sessions" ([OpenAI, Unlocking the Codex harness](https://openai.com/index/unlocking-the-codex-harness/); summarized via [floatboat](https://floatboat.ai/blog/codex-harness-open-source) since the original returned 403 to this fetch). Anthropic's Agent SDK docs describe the same thing from the vendor side: "The Agent SDK gives you the same tools, agent loop, and context management that power Claude Code, programmable in Python and TypeScript" ([Agent SDK overview](https://code.claude.com/docs/en/agent-sdk/overview)).
+
+"Harness engineering" as a discipline traces to Mitchell Hashimoto (Feb 2026): "Anytime you find an agent makes a mistake, you take the time to engineer a solution such that the agent never makes that mistake again" ([Hashimoto](https://mitchellh.com/writing/my-ai-adoption-journey)), then OpenAI's post on building ~1M lines with Codex where "Agents are most effective in environments with strict boundaries and predictable structure" and review comments become lint rules ([OpenAI, Harness engineering, via ai-wiki summary](https://businessdatasolutions.github.io/ai-wiki/sources/2026-02-11-lopopolo-codex-harness-engineering)).
+
+So: a **chat UI** renders turns; a **prompt** is one input to one call; a **model** produces tokens. A **harness** is the runtime that turns a model into an agent: it decides what the model sees, what it may do, what actually happens when it asks, and what is written down afterwards.
+
+### 1.2 Component checklist, with primary sources
+
+| Component | What it does | Primary reference |
+|---|---|---|
+| Context assembly | System prompt + project instruction files + just-in-time retrieval, curated against a finite "attention budget" | Anthropic: context engineering is "curating and maintaining the optimal set of tokens" ([Effective context engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)); Pi loads `AGENTS.md`/`CLAUDE.md` walking up the tree, plus `SYSTEM.md` and `APPEND_SYSTEM.md` ([pi README](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/README.md)) |
+| Tool registry + call loop | Typed schemas the model can call; loop runs until a response has no tool calls | Agent SDK: "Claude continues calling tools and processing results until it produces a response with no tool calls" ([Agent loop](https://code.claude.com/docs/en/agent-sdk/agent-loop)); Pi `AgentTool` with TypeBox `parameters` and `execute(toolCallId, params, signal, onUpdate)` ([pi-agent README](https://github.com/badlogic/pi-mono/blob/main/packages/agent/README.md)) |
+| Permission / approval | Ordered evaluation: hooks, deny rules, ask rules, mode, allow rules, callback | Agent SDK permissions: "hooks run before every other step, and a hook deny applies even in `bypassPermissions` mode" ([Permissions](https://code.claude.com/docs/en/agent-sdk/permissions)); OpenAI Agents SDK `needs_approval` pauses the run and serializes `RunState` ([Human in the loop](https://openai.github.io/openai-agents-python/human_in_the_loop/)) |
+| Sandboxing | OS-level isolation of the tool executor | Codex: read-only / workspace-write / danger-full-access, Seatbelt on macOS, Landlock+seccomp on Linux ([Codex security](https://learn.chatgpt.com/docs/security)); OpenHands runs the agent in Docker with a mounted projects dir ([OpenHands](https://github.com/OpenHands/OpenHands)); Pi ships none and says "Run in a container, or build your own confirmation flow" ([pi README](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/README.md)) |
+| Memory (session / project / long-term) | Transcript on disk; project files; editable long-term blocks | Agent SDK sessions under `~/.claude/projects/<cwd>/*.jsonl` with resume/fork ([Sessions](https://code.claude.com/docs/en/agent-sdk/sessions)); Letta memory blocks + archival, "MemFS" git-tracked ([Letta](https://docs.letta.com/concepts/letta)); Anthropic structured note-taking outside the window ([Context engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)) |
+| Compaction | Summarize older history when the window fills | Pi: triggers when `contextTokens > contextWindow - reserveTokens` (16,384 default), keeps last ~20k tokens, tracks read/modified files across compactions, extensions can supply the summary via `session_before_compact` ([pi compaction](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/compaction.md)); Agent SDK emits `compact_boundary` and offers a `PreCompact` hook ([Agent loop](https://code.claude.com/docs/en/agent-sdk/agent-loop)) |
+| Sub-agents / orchestration | Fresh-context workers returning summaries | Anthropic research system: "Each subagent needs an objective, an output format, guidance on the tools and sources to use, and clear task boundaries" ([Multi-agent research](https://www.anthropic.com/engineering/multi-agent-research-system)); LangGraph positions itself as "the orchestration runtime: durable execution, streaming, human-in-the-loop, and persistence" ([LangGraph](https://docs.langchain.com/oss/python/langgraph/overview)); Pi deliberately leaves sub-agents to extensions ("a black box within a black box", [Zechner](https://mariozechner.at/posts/2025-11-30-pi-coding-agent/)) |
+| Evals | Task suites scored on end state | Anthropic: "Evaluate whether it achieved the correct final state" and a single LLM judge with a 0 to 1 rubric "was the most consistent and aligned with human judgements" ([Multi-agent research](https://www.anthropic.com/engineering/multi-agent-research-system)); tool-design eval loop in [Writing tools for agents](https://www.anthropic.com/engineering/writing-tools-for-agents) |
+| Observability / tracing | Event stream per turn and per tool | OpenAI Agents SDK: "Built-in tracing for visualizing, debugging, and monitoring workflows" ([Agents SDK](https://openai.github.io/openai-agents-python/)); Pi emits `agent_start … tool_execution_start/update/end … agent_end` and has a `pi-telemetry` package ([pi-agent README](https://github.com/badlogic/pi-mono/blob/main/packages/agent/README.md)) |
+| Cost / quotas | Turn and dollar caps | Agent SDK `max_turns`, `max_budget_usd`, `ResultMessage.total_cost_usd` ([Agent loop](https://code.claude.com/docs/en/agent-sdk/agent-loop)) |
+| Resumability | Resume by id, fork, cross-host stores | Agent SDK `resume`, `fork_session`, `SessionStore` adapter ([Sessions](https://code.claude.com/docs/en/agent-sdk/sessions)); Pi sessions are a JSONL tree with `id`/`parentId`, `/tree`, `/fork` ([pi README](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/README.md)); OpenAI Agents `RunState.to_json()` "designed to be durable" ([Human in the loop](https://openai.github.io/openai-agents-python/human_in_the_loop/)) |
+
+Two framework observations relevant to Radon. smolagents' pitch is that "the logic for agents fits in ~thousand lines of code" and it is model-agnostic through LiteLLM ([smolagents](https://huggingface.co/docs/smolagents/index)); that is roughly the size of Radon's existing `loop.ts` + `tools.ts` + `dispatch.ts` (1,771 lines). Anthropic's original taxonomy separates "workflows" (LLMs and tools orchestrated through predefined code paths) from "agents" (LLMs dynamically direct their own processes) and recommends "poka-yoke" tool design ([Building effective agents](https://www.anthropic.com/engineering/building-effective-agents)). Radon's 7-milestone evaluate is a workflow; the chat assistant is an agent; a Radon harness has to host both.
+
+---
+
+## 2. Pi, studied
+
+### 2.1 Which Pi
+
+Confirmed: `pi` is the coding agent by Mario Zechner (libGDX author), repo [badlogic/pi-mono](https://github.com/badlogic/pi-mono), site [pi.dev](https://pi.dev), npm `@mariozechner/pi-coding-agent`. The repo README now lists the maintainer as the `earendil-works` GitHub org (Armin Ronacher's company Earendil, per [implicator.ai](https://www.implicator.ai/pi-is-not-a-claude-code-rival-it-is-a-harness-rebellion/)) with Zechner still publishing sessions; the runtime packages are published as `@earendil-works/pi-ai` and friends. MIT license, ~45k stars as of May 2026 ([dev.to](https://dev.to/rigor120000/underrated-ai-coding-agent-harnesses-in-2026-pi-mini-swe-agent-crush-plandex-amp-and-more-5c0a)). Not to be confused with Radon's own `/api/pi` route, which is a legacy command dispatcher (`web/app/api/pi/route.ts`, allowlisted `scanner.py`/`evaluate.py`/`ib_sync.py` via FastAPI `/pi/exec`, see `scripts/api/CLAUDE.md`).
+
+### 2.2 Package split (the harness/agent separation)
+
+| Package | Role (verbatim from README) |
+|---|---|
+| `pi-ai` | "Unified multi-provider LLM API (OpenAI, Anthropic, Google, …)" |
+| `pi-agent-core` | "Agent runtime with tool calling and state management" |
+| `pi-coding-agent` | "Interactive coding agent CLI" |
+| `pi-tui` | "Terminal UI library with differential rendering" |
+| `pi-telemetry` | "Vendor-neutral telemetry contracts, reference adapter, conformance tests" |
+| `chord` | "Standalone application-composition runtime for services, replicated state, RPC, and plugins" |
+
+The important design fact is that the harness is the two bottom layers (`pi-ai` + `pi-agent-core`) and the coding agent is a consumer. Nothing in the agent runtime knows about files or bash; those are tools registered by the coding agent.
+
+### 2.3 Core loop
+
+From the `pi-agent-core` README: the message pipeline is `AgentMessage[] → transformContext() → AgentMessage[] → convertToLlm() → Message[] → LLM`. `transformContext` is an optional hook to "prune old messages, inject external context"; `convertToLlm` is required and "LLMs only understand `user`, `assistant`, and `toolResult`. The `convertToLlm` function bridges this gap." The `AgentState` is small: `systemPrompt, model, thinkingLevel, tools, messages, isStreaming, streamingMessage, pendingToolCalls, errorMessage`. The loop is event-driven (`agent_start`, `turn_start`, `message_start/update/end`, `tool_execution_start/update/end`, `turn_end`, `agent_end`), and the provider is injected as a `streamFn` "allowing implementations via pi-ai providers or proxy wrappers." Zechner's own description: the loop "handles the full orchestration: processing user messages, executing tool calls, feeding results back to the LLM, and repeating until the model produces a response without tool calls," and he "never found a use case" for a max-step cap ([Zechner](https://mariozechner.at/posts/2025-11-30-pi-coding-agent/)).
+
+### 2.4 Tools
+
+```ts
+const readFileTool: AgentTool = {
+  name: "read_file",
+  description: "Read a file's contents",
+  parameters: Type.Object({ path: Type.String({ description: "File path" }) }),
+  execute: async (toolCallId, params, signal, onUpdate) => { /* ... */ },
+};
+```
+Parameters are TypeBox schemas (validated before `execute`), `signal` is an `AbortSignal`, `onUpdate` streams progress, and tools "should throw errors on failure rather than returning error content." The coding agent ships only `read`, `write`, `edit`, `bash` (plus `grep`, `find`, `ls` discoverable), on the argument that "these four tools are all you need for an effective coding agent" and the whole prompt plus tool definitions stays "below 1000 tokens" ([Zechner](https://mariozechner.at/posts/2025-11-30-pi-coding-agent/)).
+
+### 2.5 Extensions, skills, and what is deliberately absent
+
+Extensions are TypeScript modules: `pi.registerTool`, `pi.registerCommand`, `pi.on(event, handler)`, `pi.sendMessage`, `pi.appendEntry` for persisted state. The `tool_call` event fires before execution and **can block**: a handler returns `{ block: true, reason, terminate? }`, and the documented example is a confirmation gate on `rm -rf` via `ctx.ui.confirm` ([extensions.md](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/extensions.md)). Other hooks: `before_agent_start` (modify system prompt, inject messages), `context` (non-destructive message rewrite before each LLM call), `session_start` (rebuild state from custom entries), `session_before_compact`. Skills follow the [Agent Skills](https://agentskills.io) markdown standard and load from `.pi/skills/` or `.agents/skills/`, so Radon's `.claude/skills/*/SKILL.md` are already in a compatible shape.
+
+Excluded from core on purpose, all buildable as extensions: MCP ("7-9% of your context window gone before you even start working"), sub-agents, permission popups, plan mode, to-dos, background bash. Zechner: "if I don't need it, it won't be built."
+
+### 2.6 Sessions, compaction, modes
+
+Sessions are JSONL trees (`id`/`parentId`), branchable in place, auto-saved, exportable to HTML. Compaction is "lossy. The full history remains in the JSONL file; use `/tree` to revisit." Four modes: interactive TUI, `-p` print, `--mode json`, `--mode rpc` (JSONL over stdin/stdout with `prompt`, `steer`, `follow_up`, `abort`, `get_state`, `set_model`, and `extension_ui_request/response` so a host can answer confirmations) plus an SDK (`createAgentSession()`). RPC mode is what makes Pi embeddable behind a web UI without the TUI ([rpc.md](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/rpc.md)).
+
+### 2.7 Why it is a good study for Radon
+
+1. It proves the loop can be small. Radon's `loop.ts` is already close to Pi's loop in shape; the difference is Pi's loop is a library and Radon's is welded to a Next.js route.
+2. The `tool_call` block hook is exactly the seam Radon needs for gates: deterministic code that sees the typed input before execution and can refuse with a reason the model reads.
+3. Provider-agnostic by construction (`streamFn`), which matches the multi-provider ladder Radon already runs in the nightly loops.
+4. JSONL session trees give replay and forking for free, which section 3 shows is the finance-specific requirement.
+5. Its omissions are Radon's omissions: no sandbox (Radon's tools are HTTP calls, not shell), no MCP in core (Radon has one MCP server and can adapt it as a tool set), and no permission popups (Radon has a confirm UI and server chokepoints already).
+
+What not to copy: the four file tools and bash. A Radon harness should have zero shell access in the trading agent; its tools are the FastAPI/Next catalog.
+
+---
+
+## 3. Best practices for domain-specific harnesses
+
+### 3.1 Invariants as code, not prose
+
+The finance literature from 2026 is unanimous. The Lean-Agent Protocol paper argues that guardrail products "rely on probabilistic classifiers and syntactic validators that are fundamentally inadequate for enforcing complex multi-variable regulatory constraints" and proposes that "execution is permitted if and only if" a deterministic kernel proves the action satisfies pre-compiled rules, explicitly modeled on SEC Rule 15c3-5 pre-trade controls ([Type-Checked Compliance, arXiv 2604.01483](https://arxiv.org/abs/2604.01483)). FinHarness wraps "a finance agent end-to-end" with a query monitor, a tool monitor evaluating "each prospective tool call before execution," and a cascade that escalates rather than auto-approves; on FinVault it cut attack success from 38.3% to 15.0% while keeping benign approvals near baseline ([FinHarness, arXiv 2605.27333](https://arxiv.org/abs/2605.27333)). A third paper, "LLM-as-a-Judge Is Not an Oracle," makes the general case that self-improving agents need deterministic guardrails rather than model judges ([arXiv 2609.02246](https://arxiv.org/abs/2609.02246)).
+
+**Radon already does this, partially, and it is the right pattern.** Verified in code:
+- `scripts/workflow/gates.py` encodes Gate 1 as `convexity_gate(max_gain, max_loss)` with `CONVEXITY_MIN_RATIO = 2.0` and "an undefined / unbounded loss always fails," and Gate 3 as `kelly_gate` delegating to the single `kelly.kelly` implementation. `GateResult.gate` is the canonical name "so the executor can name the failing gate exactly as the Four-Gates rule demands."
+- `scripts/evaluate.py` carries `failing_gate: TICKER_VALIDATION | EDGE | CONVEXITY | RISK` and `determine_edge` uses numeric thresholds (aggregate flow strength > 50, direction not NEUTRAL).
+- `scripts/order_limits.py` (REL-005): server-side fat-finger caps on qty, notional, combo worst-case loss, orders per minute, orders per workflow run, "the client-side risk UI remains a display, never the enforcement."
+- `scripts/trading_halt.py` (REL-004): kill switch where "unreadable / malformed → HALTED," checked by `_refuse_if_trading_halted()` at four FastAPI order routes (`server.py:2924, 3106, 3206, 3324`).
+- `web/lib/nakedShortGuard.ts` keeps Gate 4 as `_checkNakedShortRiskImpl` / `_auditOpenOrdersImpl` for re-enable.
+
+What is **not** true today: the chat assistant's system prompt (`web/app/api/assistant/route.ts:SYSTEM_PROMPT`) states the gates as prose ("flags convexity: gain >= 2x loss") and the only structural gate in the loop is "destructive tool halts." Gates 1 to 3 are not evaluated by the harness on a proposal before it reaches the confirm UI; `rank_spreads` computes convexity as a tool output the model may or may not respect.
+
+### 3.2 Typed tools over free-form shell
+
+Anthropic: "More tools don't always lead to better outcomes"; consolidate into "a few thoughtful tools targeting specific high-impact workflows," namespace them, return "only high signal information," and treat descriptions "like you would describe your tool to a new hire" ([Writing tools for agents](https://www.anthropic.com/engineering/writing-tools-for-agents)). Radon's `tools.ts` follows this: 17 named tools with JSON schemas, plus `list_apis`/`call_api` derived from route pins rather than a third handwritten catalog (`web/CLAUDE.md` "Assistant catalog pin"). The Agent SDK adds a useful bit: custom tools default to sequential execution and only run in parallel when annotated `readOnlyHint` ([Agent loop](https://code.claude.com/docs/en/agent-sdk/agent-loop)). Radon's six capability tiers (`read`, `read.spawn`, `mutate.workspace`, `mutate.trading`, `admin`, `internal`, in `web/lib/assistant/capabilities.ts`) are a richer version of that annotation and should become the harness's permission vocabulary.
+
+### 3.3 The harness checks, the model proposes
+
+Anthropic's ground-truth principle: agents need "environmental feedback at each step" and "human checkpoints" with "stopping conditions" ([Building effective agents](https://www.anthropic.com/engineering/building-effective-agents)). OpenAI's Agents SDK formalizes this as input, output and per-tool guardrails with tripwire exceptions, and `run_in_parallel=False` when "the agent never executes, preventing token consumption and tool execution" ([Guardrails](https://openai.github.io/openai-agents-python/guardrails/)). In practice for Radon: every `place_order` proposal must pass `convexity_gate`, `kelly_gate` (with the 2.5% cap), `order_limits`, and `trading_halt` inside the harness, deterministically, before the confirm card renders. The model's job is to fill the typed proposal; the harness's job is to say which gate failed.
+
+### 3.4 Read-only vs write, and irreversible actions
+
+Codex's default posture (read-only or workspace-write sandbox, approval "untrusted"/"on-request"/"never") and the Agent SDK's evaluation order both put deny-before-allow. The OpenAI Agents SDK's `needs_approval` "fail[s] closed when the SDK cannot safely inspect the arguments" ([Human in the loop](https://openai.github.io/openai-agents-python/human_in_the_loop/)). Radon's loop matches: `validateAssistantOrderInput` returns `null` on any malformed field and the loop answers "cannot be confirmed"; `hasExplicitOrderIntent` requires current-turn language; sibling destructive calls are deferred until reads complete. Keep all of it.
+
+### 3.5 Audit logs and replayable sessions
+
+The "Replayable Financial Agents" paper introduces a determinism-faithfulness harness and finds "decision determinism and task accuracy are not detectably correlated (r = -0.11)," so both must be measured, and notes regulators expect an agent to "reproduce a flagged transaction decision with identical inputs" ([arXiv 2601.15322](https://www.alphaxiv.org/abs/2601.15322)). Radon records one `assistant_turns` row per turn (migration `0030`, provenance columns in `0065`: provider, model, error class, image count) but does not persist the message array, tool inputs, or tool outputs; the client owns the transcript (up to 40 messages per request). That is an audit gap: a proposal cannot be replayed from what Turso holds.
+
+### 3.6 Model swappability
+
+Every surveyed framework treats the provider as a plug: Pi `streamFn`, OpenAI Agents via LiteLLM, smolagents via LiteLLM/Transformers/Ollama, Letta "all major frontier model providers." Radon's `web/lib/llm/provider.ts` already normalizes xAI, Anthropic, OpenAI-compatible and Gemini behind one `chat()`, and the nightly loops run a `codex → grok → nvidia → cerebras` ladder with `claude` reserved for security (`docs/operations.md`). One caveat from the Agent SDK docs: "Anthropic does not allow third party developers to offer claude.ai login or rate limits for their products, including agents built on the Claude Agent SDK" ([SDK overview](https://code.claude.com/docs/en/agent-sdk/overview)). Radon's loops deliberately ride the claude.ai subscription through `claude -p` and unset every API-key variable (`docs/operations.md` line 254); an Agent-SDK-based harness would move that spend to API keys.
+
+---
+
+## 4. Recommendation for Radon
+
+### 4.1 Build vs adopt
+
+| Option | Fit | Verdict |
+|---|---|---|
+| Claude Agent SDK | Best-in-class permissions order, hooks, sessions, cost caps, subagents. But tools are Claude Code's file/bash set plus MCP; the trading agent should have none of those. Locks the interactive harness to Claude and API-key billing. | Adopt for the **nightly engineering loops** (replace bash wrappers' `claude -p --dangerously-skip-permissions` with SDK `dontAsk` + `disallowedTools`, `PreToolUse` hooks, `max_budget_usd`). Not for the trading harness. |
+| Pi (as dependency) | Loop, TypeBox tools, JSONL sessions, extension `tool_call` block hook, RPC mode. TypeScript, same language as `web/`. Core is small enough to read. | Adopt the **design**, and optionally `@earendil-works/pi-agent-core` + `pi-ai` as packages, behind Radon's own interfaces. Do not adopt the coding-agent CLI. |
+| OpenAI Agents SDK | Guardrails and `RunState` approvals are the cleanest HITL model surveyed. Python. | Borrow the guardrail/tripwire and durable-interruption ideas; not worth a second runtime. |
+| LangGraph / Letta / OpenHands / smolagents | Orchestration, memory, sandbox, code-agents respectively. | Not needed; Radon's tools are HTTP and its orchestration is milestone-shaped. |
+| Build from scratch | Radon already did, in `loop.ts`. | The work is extraction and hardening, not a rewrite. |
+
+**Recommendation: extract and extend.** Take the existing loop out of the Next.js route into a standalone TypeScript package with Pi's shape, keep every Radon-specific guard already in it, and add the four things it lacks: gates-as-code on proposals, persisted replayable sessions, a hook layer, and compaction.
+
+### 4.2 Target architecture (reusing what exists)
+
+```
+                  +---------------------------------------------+
+  ChatPanel  ---> |  harness/core                                |
+  (web)           |  loop . events . session JSONL . compaction  |
+  nightly job --> |  provider = web/lib/llm/provider.ts chat()   |
+  CLI (-p/rpc)    +---------+--------------+--------------+------+
+                            |              |              |
+                     tool registry    hook pipeline   session store
+                     (typed, tiered)  pre/post tool   (Turso + disk)
+                            |              |
+          +-----------------+--------------+----------------+
+          |                 |                               |
+    FastAPI catalog    radon-kb MCP                   gates-as-code
+    (assistant_catalog  (search/prior evals,           convexity . kelly .
+     + route pins)       SELECT-only)                  order_limits . halt
+          |                                                  |
+          +------ place_order = PROPOSAL only ---------------+
+                            |
+                  OrderRiskGate confirm (human) -> /api/orders/place -> FastAPI -> IB
+```
+
+Verified reuse points:
+- **Tool surface**: `ASSISTANT_TOOLS` in `web/lib/assistant/tools.ts` and the pin-derived catalog (`web/lib/assistant/catalog.ts`, `scripts/api/assistant_catalog.py`, tests `assistant-catalog-pin`, `-freshness`, `-parity`). Capability tiers become the harness permission table; `REFUSED = {admin, internal, mutate.trading}` stays.
+- **Knowledge**: `scripts/knowledge/mcp_server.py` is already "LLM-free retrieval primitives: the agent orchestrates, these tools just retrieve," SELECT-only by pin test. The loop's `isolateKnowledgeResult` (second-model fact extraction, untrusted-content fences) is a prompt-injection boundary worth keeping as a post-tool hook.
+- **Gates**: `scripts/workflow/gates.py` exists in Python; the harness needs the same two functions in TypeScript (or a FastAPI `POST /gates/evaluate` that the harness calls, which keeps one implementation). `order_limits` and `trading_halt` are already server-side and remain the final backstop.
+- **Skills**: `.claude/skills/*/SKILL.md` and `.claude/portable-prompts/*.md` (rendered by `scripts/render_loop_prompt.py`, parity-tested) are the harness's skill files; Pi reads the same Agent Skills format.
+- **Loops**: the five wrappers' phase contract (audit/remediate/deliver, verdict lines, dead-man issue comments, provider ladder, quota regexes) is harness policy written in bash. It should become a headless driver of the same core.
+- **Telemetry**: `assistant_turns` extends to full session entries; `web/lib/agent/turnSteps.ts` already renders tool events as a trace.
+
+### 4.3 Phased plan
+
+**Phase 0: extract from the current assistant (1 to 2 weeks).**
+- Move `loop.ts`, `tools.ts`, `dispatch.ts`, `catalog*.ts`, `capabilities.ts`, `backend.ts` into `harness/` with no behavior change; `web/app/api/assistant/route.ts` becomes a thin adapter. The 25 `web/tests/assistant-*.test.ts` files are the regression net; they must pass unchanged.
+- Replace the inline `SYSTEM_PROMPT` string with a context assembler: base persona + `docs/evaluation.md` gate table + journal conventions, each a file, so the prompt is versioned and the compactor can re-inject it (Agent SDK: "Persistent rules belong in CLAUDE.md … because CLAUDE.md content is re-injected on every request").
+- Emit Pi-style events (`turn_start`, `tool_execution_start/end`, `turn_end`) from the loop and stream them; `turnSteps.ts` consumes them.
+
+**Phase 1: harness core (2 to 3 weeks).**
+- Session store: append every entry (user, assistant blocks, tool_use, tool_result, proposal, gate verdicts) as JSONL with `id`/`parentId` to disk and mirror to a new Turso `assistant_sessions` table (migration + production row check per CLAUDE.md "Data Persistence"). Resume and fork by id.
+- Hook pipeline: `before_agent_start` (context injection), `tool_call` (can block with reason), `tool_result` (knowledge isolation, truncation), `session_before_compact`. Port the existing guards (repeated-call nudge, spawn budget, explicit-intent check) into hooks so they are visible and testable individually.
+- Compaction: Pi's reserve/keep-recent algorithm; preserve tool names, tickers touched, gate verdicts and proposals in the summary.
+- Budgets: per-turn round cap (today `MAX_ROUNDS = 8`), per-session token and dollar cap from `usage`, surfaced in the result like the Agent SDK's `error_max_budget_usd`.
+
+**Phase 2: gates-as-code and tool typing (2 weeks).**
+- `place_order` gains a mandatory `gate_evaluation` step in the `tool_call` hook: compute max gain / max loss from the priced legs (`rank_spreads`/`spreads.ts` already prices verticals), run convexity, Kelly with bankroll from `get_portfolio`, `order_limits`, `trading_halt`. A failing gate returns `{ block: true, reason: "GATE 1 convexity: 1.4x < 2x" }` and the proposal never renders. Test at the wire per CLAUDE.md: assert the blocked call produced no `/api/orders/place` request.
+- Tool schemas move to one typed registry (TypeBox or zod) with `capability`, `readOnly`, `timeoutMs`, `resultCap` metadata; `call_api` keeps the catalog but the harness enforces tier before dispatch, not the tool body.
+- Edge gate (Gate 2) stays model-assisted but structured: require a `signal` object (source, ticker, direction, strength, timestamp, has_moved_price) on every proposal; the hook rejects proposals without one.
+
+**Phase 3: evals from the trade journal (2 weeks, ongoing).** See section 5.
+
+**Phase 4: multi-model (1 to 2 weeks).**
+- Provider ladder from the wrappers becomes harness config (`provider[:model]` rungs, quota and session-limit regexes already captured in `reliability_weekend.sh:970-1005`).
+- Nightly loops: replace `claude -p "/skill phase" --dangerously-skip-permissions` with the harness in headless mode driving either the Claude Agent SDK (Claude rungs, `permissionMode: "dontAsk"`, `disallowedTools` for IB/gateway paths, `PreToolUse` hooks enforcing the "never touch IB Gateway / never place an order" rails from `SKILL.md`) or the Codex/Grok CLIs through the existing portable prompts. The wrappers shrink to process supervision.
+- Local models via OpenAI-compatible base (`provider.ts` already routes Ollama).
+
+### 4.4 Suggested repo layout
+
+```
+harness/
+  package.json                 # @radon/harness, TS, no Next.js imports
+  src/
+    core/loop.ts               # from web/lib/assistant/loop.ts
+    core/events.ts             # Pi-style event union
+    core/session.ts            # JSONL tree + Turso mirror, resume/fork
+    core/compaction.ts
+    core/budget.ts
+    context/assemble.ts        # persona + docs + skills + retrieved notes
+    context/prompts/*.md       # versioned prompt fragments
+    tools/registry.ts          # typed tools + capability + readOnly
+    tools/radon/*.ts           # get_flow, rank_spreads, run_evaluate, ...
+    tools/catalog/*.ts         # list_apis / call_api (pin-derived)
+    tools/knowledge/*.ts       # radon-kb over MCP or HTTP
+    hooks/pipeline.ts
+    hooks/gates.ts             # convexity, kelly, limits, halt (block hook)
+    hooks/intent.ts            # explicit-order-intent, sibling-read deferral
+    hooks/untrusted.ts         # knowledge isolation
+    providers/index.ts         # wraps web/lib/llm/provider.ts chat()
+    modes/rpc.ts               # JSONL stdin/stdout for wrappers
+    modes/print.ts
+  tests/                       # moved assistant-*.test.ts + gate wire tests
+  evals/
+    suites/*.jsonl             # section 5
+    run.ts
+scripts/harness/               # Python side: FastAPI /gates/evaluate, loop drivers
+```
+
+### 4.5 Specific risks
+
+1. **Order placement must never be a free-form tool call.** Today it is a typed proposal and the harness returns before executing; the confirm click hits `/api/orders/place`, which enforces idempotency, demo blockade, `order_limits`, and `trading_halt`. Keep that shape: no harness mode, hook, or "auto-approve" flag may resolve a `mutate.trading` tool. Encode it as a pin test that greps the harness for any dispatch of a `mutate.trading` capability, the same way `mcp_server.py` is pinned SELECT-only.
+2. **`RELIABILITY_AUDIT.md` is the threat model.** Its executive summary: "at least five code paths reach IB `placeOrder` with nothing but `quantity > 0` between them and the margin engine" (since remediated by REL-004/005). A harness adds a sixth path only if it can reach FastAPI order routes; the capability catalog refuses them, and that refusal must be tested at the wire.
+3. **Secrets.** The harness inherits the wrappers' rule: load only what a phase needs, never import `.env` wholesale, and never let a model-readable tool result contain a key. The `PreToolUse` git-commit secret grep in `.claude/settings.json` is the pattern; add a `tool_result` hook that redacts known key shapes.
+4. **Cost.** Moving interactive chat off subscription to API keys is already the case (`web/.env` keys). Moving the nightly loops onto the Agent SDK would move them to API billing; keep the codex/grok ladder on those loops unless the security loop's Claude exclusivity justifies SDK spend. Add `max_budget_usd` per phase.
+5. **Prompt injection through knowledge and newsfeed.** The existing untrusted-content fences and second-model extraction are good; a harness must not lose them in the refactor. Test `assistant-untrusted-knowledge.test.ts` pins it.
+6. **Cwd-coupled context.** Sub-directory `CLAUDE.md` files load on cwd for Claude Code; the harness's context assembler must load them explicitly by path, otherwise the trading agent silently loses `scripts/api/CLAUDE.md`'s order-lane rules.
+7. **radon-kb MCP fragility.** In this session the server failed to spawn (`ENOENT .venv/bin/python`). The harness should call the knowledge functions in-process or over FastAPI rather than depend on a stdio child that a clone without `.venv` cannot start.
+
+---
+
+## 5. Evaluation: how to know the harness beats the chat UI
+
+Build suites from Radon's own history, score end state, and keep a deterministic replay lane alongside an LLM-judge lane.
+
+| Suite | Source (verified) | Task shape | Score |
+|---|---|---|---|
+| Evaluate replays | `scripts/evaluate.py` results persisted to Turso and the radon-kb `evals` source (`reports/*.html`, empty in this credential-free clone); `docs/status.md` now says "Trade evaluations live in Turso and the radon-kb corpus" | "Evaluate TICKER as of DATE" with tool results frozen from the original run | Same `failing_gate` and same PASS/FAIL as the recorded run; structure R:R within tolerance |
+| NO_TRADE decisions | Historical NO_TRADE outcomes in the eval corpus (former `docs/status.md` log) | Same as above where the truth is "stop, name the gate" | Harness must stop at the same gate; any proposal is a fail |
+| Proposal gating | Journal rows (`journal.payload`, lot-matched via `get_realized_pnl`) for executed trades | "Given this flow and chain, propose a structure" | Deterministic: convexity and Kelly gates pass; wire: exactly one proposal, zero `/api/orders/place` requests |
+| Knowledge retrieval | `scripts/knowledge/golden_set.json` (draft, operator to curate), `eval_golden.py` hit@5 >= 0.8 gate | Golden questions | hit@5, already implemented |
+| Incident reasoning | `RELIABILITY_AUDIT.md` (2,458 lines, 253 distinct REL ids) and `tasks/lessons.md` via the docs connector | "What happens when Turso blips during exit-order placement?" | LLM judge with rubric on citing the right finding id and mechanism |
+| Loop phases | Nightly issue comments and PRs (`reliability/<date>` etc.) | Re-run an audit phase against a frozen SHA range | Same finding count and ids as the recorded run |
+| Determinism | Per the replayable-agents paper, run each replay N times | Any suite | Decision determinism rate, reported separately from accuracy |
+
+Comparison protocol: run the current `/api/assistant` route and the harness against the same frozen tool fixtures (the loop already supports `ASSISTANT_MOCK`), same model, and compare per-suite pass rate, tokens per turn (`usage` is already accumulated), rounds per turn, and the number of turns that ended `cap_fallback`. The harness is better when it matches or beats the chat UI on every suite, blocks 100% of gate-violating proposals, and every session can be replayed from Turso alone.
+
+---
+
+## Sources
+
+- https://addyosmani.com/blog/agent-harness-engineering/
+- https://openai.com/index/unlocking-the-codex-harness/ (403 to this fetch; summarized via https://floatboat.ai/blog/codex-harness-open-source)
+- https://openai.com/index/harness-engineering/ (403 to this fetch; summarized via https://businessdatasolutions.github.io/ai-wiki/sources/2026-02-11-lopopolo-codex-harness-engineering)
+- https://mitchellh.com/writing/my-ai-adoption-journey
+- https://code.claude.com/docs/en/agent-sdk/overview
+- https://code.claude.com/docs/en/agent-sdk/agent-loop
+- https://code.claude.com/docs/en/agent-sdk/permissions
+- https://code.claude.com/docs/en/agent-sdk/sessions
+- https://code.claude.com/docs/en/hooks
+- https://claude.com/blog/a-harness-for-every-task-dynamic-workflows-in-claude-code
+- https://www.anthropic.com/engineering/building-effective-agents
+- https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents
+- https://www.anthropic.com/engineering/writing-tools-for-agents
+- https://www.anthropic.com/engineering/multi-agent-research-system
+- https://openai.github.io/openai-agents-python/
+- https://openai.github.io/openai-agents-python/guardrails/
+- https://openai.github.io/openai-agents-python/human_in_the_loop/
+- https://github.com/openai/codex
+- https://learn.chatgpt.com/docs/security
+- https://github.com/badlogic/pi-mono
+- https://pi.dev
+- https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/README.md
+- https://github.com/badlogic/pi-mono/blob/main/packages/agent/README.md
+- https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/extensions.md
+- https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/rpc.md
+- https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/compaction.md
+- https://mariozechner.at/posts/2025-11-30-pi-coding-agent/
+- https://www.implicator.ai/pi-is-not-a-claude-code-rival-it-is-a-harness-rebellion/
+- https://dev.to/rigor120000/underrated-ai-coding-agent-harnesses-in-2026-pi-mini-swe-agent-crush-plandex-amp-and-more-5c0a
+- https://github.com/OpenHands/OpenHands
+- https://huggingface.co/docs/smolagents/index
+- https://docs.langchain.com/oss/python/langgraph/overview
+- https://docs.letta.com/concepts/letta
+- https://arxiv.org/abs/2604.01483 (Type-Checked Compliance / Lean-Agent Protocol)
+- https://arxiv.org/abs/2605.27333 (FinHarness)
+- https://arxiv.org/abs/2609.02246 (LLM-as-a-Judge Is Not an Oracle)
+- https://www.alphaxiv.org/abs/2601.15322 (Replayable Financial Agents)
+- https://agentskills.io
+
+Radon files read (all under the clone root): `CLAUDE.md`, `web/CLAUDE.md`, `scripts/api/CLAUDE.md`, `docs/evaluation.md`, `docs/operations.md` (lines 254 to 350), `docs/status.md`, `web/lib/assistant/{loop,tools,dispatch,catalog,capabilities,backend,telemetry}.ts`, `web/app/api/assistant/route.ts`, `web/lib/llm/{provider,catalog,frontier}.ts`, `web/lib/agent/turnSteps.ts`, `web/lib/order/risk/OrderRiskGate.tsx`, `web/lib/nakedShortGuard.ts`, `web/app/api/orders/place/route.ts`, `scripts/workflow/{gates,__init__,nodes}.py`, `scripts/{order_limits,trading_halt,kelly,evaluate}.py`, `scripts/api/{server,assistant_catalog}.py`, `scripts/knowledge/{mcp_server,eval_golden,golden_set.json}`, `scripts/knowledge/sources/{evals,incidents}.py`, `.claude/settings.json`, `.claude/skills/reliability-weekend/SKILL.md`, `.claude/skills/long-horizon-jobs/SKILL.md`, `scripts/reliability_weekend.sh`, `RELIABILITY_AUDIT.md` (header and sections 1 to 2.4), `scripts/db/migrations/{0001_init,0030_assistant_turns,0065_assistant_turns_provenance}.sql`, `.mcp.json`.
+
+## Open questions for the operator
+
+1. Should the Python gates (`scripts/workflow/gates.py`) be the single implementation exposed over FastAPI, or is a TypeScript twin acceptable with a parity test? One implementation is cleaner; a twin avoids a network hop on every proposal.
+2. Where do historical eval reports live now that `docs/status.md` is not a log and `reports/` is empty in the security clone? The eval suite in section 5 depends on being able to enumerate them from Turso.
+3. Is the nightly-loop spend model (claude.ai subscription for security, codex/grok/nvidia/cerebras for the rest) fixed? It decides whether the Claude Agent SDK is viable for the loops at all.
+4. Should Gate 2 (edge) remain model-assisted with a required structured `signal` object, or do you want a numeric edge threshold (like `determine_edge`'s strength > 50) enforced by the hook as well?
+5. Do you want the harness to own the `/api/pi` legacy command path (`scanner`, `evaluate`, `sync`) or retire it once the harness's typed tools cover the same commands?
+6. Is a Pi dependency (`@earendil-works/pi-agent-core`) acceptable given the ownership change to Earendil, or do you prefer a Radon-owned loop with Pi as reference only?

--- a/docs/research/radon-harness.md
+++ b/docs/research/radon-harness.md
@@ -37,6 +37,8 @@ So: a **chat UI** renders turns; a **prompt** is one input to one call; a **mode
 
 Two framework observations relevant to Radon. smolagents' pitch is that "the logic for agents fits in ~thousand lines of code" and it is model-agnostic through LiteLLM ([smolagents](https://huggingface.co/docs/smolagents/index)); that is roughly the size of Radon's existing `loop.ts` + `tools.ts` + `dispatch.ts` (1,771 lines). Anthropic's original taxonomy separates "workflows" (LLMs and tools orchestrated through predefined code paths) from "agents" (LLMs dynamically direct their own processes) and recommends "poka-yoke" tool design ([Building effective agents](https://www.anthropic.com/engineering/building-effective-agents)). Radon's 7-milestone evaluate is a workflow; the chat assistant is an agent; a Radon harness has to host both.
 
+LangChain's custom-harness guide frames the same checklist as a middleware stack over `create_agent(model, tools, system_prompt)`, with hooks before/after each **model** call and each **tool** call plus startup/teardown ([LangChain, How to build a custom agent harness](https://www.langchain.com/blog/how-to-build-a-custom-agent-harness)). Its catalog maps onto the table above: context overflow (`SummarizationMiddleware`, `ContextEditingMiddleware`), memory (`FilesystemMiddleware`, `MemoryMiddleware`, `SkillsMiddleware`), delegation (`SubAgentMiddleware`, `TodoListMiddleware`), failure handling (`ToolRetryMiddleware`, `ModelRetryMiddleware`, `ModelFallbackMiddleware`), policy (`PIIMiddleware`, `HumanInTheLoopMiddleware`), and cost (`ModelCallLimitMiddleware`, `PromptCachingMiddleware`). Three points it adds that the other sources underweight: deterministic business rules, policy and dynamic model swapping belong in middleware, not prompts; tool setup/teardown is a harness lifecycle concern separate from the agent definition; and "task-harness fit" means the middleware stack is chosen per task, so a trading harness and a coding-loop harness should not share one stack.
+
 ---
 
 ## 2. Pi, studied
@@ -142,6 +144,7 @@ Every surveyed framework treats the provider as a plug: Pi `streamFn`, OpenAI Ag
 | Claude Agent SDK | Best-in-class permissions order, hooks, sessions, cost caps, subagents. But tools are Claude Code's file/bash set plus MCP; the trading agent should have none of those. Locks the interactive harness to Claude and API-key billing. | Adopt for the **nightly engineering loops** (replace bash wrappers' `claude -p --dangerously-skip-permissions` with SDK `dontAsk` + `disallowedTools`, `PreToolUse` hooks, `max_budget_usd`). Not for the trading harness. |
 | Pi (as dependency) | Loop, TypeBox tools, JSONL sessions, extension `tool_call` block hook, RPC mode. TypeScript, same language as `web/`. Core is small enough to read. | Adopt the **design**, and optionally `@earendil-works/pi-agent-core` + `pi-ai` as packages, behind Radon's own interfaces. Do not adopt the coding-agent CLI. |
 | OpenAI Agents SDK | Guardrails and `RunState` approvals are the cleanest HITL model surveyed. Python. | Borrow the guardrail/tripwire and durable-interruption ideas; not worth a second runtime. |
+| LangChain `create_agent` + middleware | Composable before/after model and tool hooks with prebuilt retry, fallback, PII, HITL, call-limit and caching middleware. Pulls in the LangChain runtime; Radon's provider layer and tools already exist. | Borrow the **hook taxonomy** (model-call hooks, lifecycle hooks, per-task stacks); not the dependency. |
 | LangGraph / Letta / OpenHands / smolagents | Orchestration, memory, sandbox, code-agents respectively. | Not needed; Radon's tools are HTTP and its orchestration is milestone-shaped. |
 | Build from scratch | Radon already did, in `loop.ts`. | The work is extraction and hardening, not a rewrite. |
 
@@ -188,8 +191,10 @@ Verified reuse points:
 **Phase 1: harness core (2 to 3 weeks).**
 - Session store: append every entry (user, assistant blocks, tool_use, tool_result, proposal, gate verdicts) as JSONL with `id`/`parentId` to disk and mirror to a new Turso `assistant_sessions` table (migration + production row check per CLAUDE.md "Data Persistence"). Resume and fork by id.
 - Hook pipeline: `before_agent_start` (context injection), `tool_call` (can block with reason), `tool_result` (knowledge isolation, truncation), `session_before_compact`. Port the existing guards (repeated-call nudge, spawn budget, explicit-intent check) into hooks so they are visible and testable individually.
-- Compaction: Pi's reserve/keep-recent algorithm; preserve tool names, tickers touched, gate verdicts and proposals in the summary.
-- Budgets: per-turn round cap (today `MAX_ROUNDS = 8`), per-session token and dollar cap from `usage`, surfaced in the result like the Agent SDK's `error_max_budget_usd`.
+- Model-call hooks, per the LangChain middleware split: `before_model` / `after_model` alongside the tool hooks. `wrap_model_call` owns retry with backoff and provider fallback (the `provider.ts` ladder, today only in the bash wrappers) and prompt-cache breakpoints; `tool_result` also redacts account figures and key shapes (a PII hook, not just secrets). Lifecycle `startup` / `teardown` hooks own tool setup, e.g. the knowledge client (risk 7), so a failed dependency fails the session start instead of the first call.
+- Per-consumer stacks ("task-harness fit"): ChatPanel gets gates, intent, untrusted-content and PII hooks; the nightly driver gets IB/gateway deny rails, budget and fallback hooks. One core, stacks declared per mode.
+- Compaction: first clear stale tool results in place (LangChain `ContextEditingMiddleware`; cheap, lossless for the transcript on disk), then Pi's reserve/keep-recent summarization; preserve tool names, tickers touched, gate verdicts and proposals in the summary.
+- Budgets: per-turn round cap (today `MAX_ROUNDS = 8`), per-session model-call, token and dollar cap from `usage`, surfaced in the result like the Agent SDK's `error_max_budget_usd`.
 
 **Phase 2: gates-as-code and tool typing (2 weeks).**
 - `place_order` gains a mandatory `gate_evaluation` step in the `tool_call` hook: compute max gain / max loss from the priced legs (`rank_spreads`/`spreads.ts` already prices verticals), run convexity, Kelly with bankroll from `get_portfolio`, `order_limits`, `trading_halt`. A failing gate returns `{ block: true, reason: "GATE 1 convexity: 1.4x < 2x" }` and the proposal never renders. Test at the wire per CLAUDE.md: assert the blocked call produced no `/api/orders/place` request.
@@ -298,6 +303,7 @@ Comparison protocol: run the current `/api/assistant` route and the harness agai
 - https://github.com/OpenHands/OpenHands
 - https://huggingface.co/docs/smolagents/index
 - https://docs.langchain.com/oss/python/langgraph/overview
+- https://www.langchain.com/blog/how-to-build-a-custom-agent-harness
 - https://docs.letta.com/concepts/letta
 - https://arxiv.org/abs/2604.01483 (Type-Checked Compliance / Lean-Agent Protocol)
 - https://arxiv.org/abs/2605.27333 (FinHarness)

--- a/docs/research/radon-small-model.md
+++ b/docs/research/radon-small-model.md
@@ -1,0 +1,224 @@
+# Training a small language model on Radon's data: would it even be useful?
+
+Date: 2026-09-12
+Scope: research report for the Radon operator. Repository read-only at `radon-security/.claude/worktrees/loops-session-limit`. No production database was queried; all corpus figures come from repo docs and schema.
+
+## Executive summary
+
+Partly, and not in the way the statement imagines. "AI constantly studying my portfolio, news and trades" conflates three things that need three different mechanisms. Daily-changing knowledge (positions, flow, headlines) belongs in retrieval, and Radon already has that: a 4,933-document hybrid FTS5 + vector knowledge base at hit@5 0.917, refreshed hourly, wired into the assistant and the `radon-kb` MCP server. Fine-tuning weights on that stream would be slower, staler and more hallucination-prone than what exists (the 2024-2026 literature is unambiguous on this). Skills, format and house rules (the four gates, the milestone report shape, the tag taxonomy, the operator's voice) are what fine-tuning captures well, and Radon has just enough decision traces (roughly 150 substantive eval reports and a few hundred thesis-bearing journal entries) for a LoRA on a 4B-9B open model on a Mac Mini to learn them. But the dollar case is weak: the newsfeed tagger costs about $0.003 per post, so a local tagger saves tens of dollars a year, not thousands. Predictive edge ("will this flow signal work") is a classic-ML and backtest question with a tiny sample, and LLM fine-tuning is the single most overfit-prone tool you could point at it. The recommendation: build the decision-trace dataset and eval harness regardless (Phase 0, useful even if no model is ever trained because it makes "tailored to Radon" measurable for the frontier model too), run one bounded distillation experiment on a Qwen3.5-4B or Gemma 4 E4B for tagging and report drafting (Phase 1), and gate any decision-trace SFT on a time-split held-out eval with a rollback rule (Phase 2). Keep signal models in the existing backtest harness (Phase 3). Do not attempt continual weight updates on news or P&L.
+
+## 1. Honest framing: when fine-tuning a small model beats the alternatives
+
+### What is verified in Radon
+
+- Knowledge base shipped 2026-07-20: `tasks/knowledge-base-plan.md` records 4,933 docs from five connectors (819 journal rows, 3,474 newsfeed posts, 183 eval/report files, 86 scan snapshots, 31 docs), golden-set hit@5 0.917 against a 0.8 gate, hourly ingest on the VPS, local bge-small-en-v1.5 embeddings (journal text never leaves the box), Cerebras `gpt-oss-120b` distillation of summaries.
+- Query surfaces: `scripts/knowledge/retrieve.py` (BM25 + cosine + recency, RRF fusion), FastAPI `/knowledge/search`, assistant tools `search_knowledge` and `find_prior_evals`, MCP server `scripts/knowledge/mcp_server.py`.
+- The assistant loop (`web/lib/assistant/loop.ts`) is an Anthropic tool loop; `web/lib/llm/provider.ts` already abstracts OpenAI-compatible bases including Ollama, so a local model can be plugged in without new plumbing.
+- Classic-ML infrastructure exists: `forecast_snapshots` / `forecast_calibration` (Chronos-2 walk-forward, migrations 0015/0016) and `backtest_runs` (0018) with Sharpe, Sortino, Calmar, hit rate, expectancy per run.
+
+### Comparison table
+
+| Option | Where it wins for Radon | Where it loses | Evidence |
+|---|---|---|---|
+| (a) RAG over the same data with a frontier model | Anything time-varying: positions, flow, news, prior theses. Already built and measured. | Long prompts; retrieval quality caps answer quality. | Ovadia et al. found RAG consistently beat unsupervised fine-tuning for knowledge injection ([arXiv 2312.05934](https://arxiv.org/abs/2312.05934)); a Jan 2026 multi-hop study across three 7B models found RAG delivered "substantial and consistent improvements, particularly when answering questions that rely on temporally novel information" while unsupervised fine-tuning yielded minimal gains ([arXiv 2601.07054](https://arxiv.org/abs/2601.07054)). |
+| (b) Long-context prompting | Zero engineering; 1M-token windows on current Claude models make "the whole journal in the prompt" feasible for ad hoc analysis. | Cost per call scales with context; no learning across sessions; not a substitute for retrieval at 5k docs. | Claude Opus 5 and Sonnet 5 offer 1M context ([Anthropic pricing table, claude-api skill cache 2026-06-24](https://docs.claude.com/en/docs/about-claude/pricing)). |
+| (c) Fine-tuned frontier via API | In principle the best of both worlds. | Largely unavailable in 2026 for a solo operator. OpenAI: "OpenAI is winding down the fine-tuning platform. The platform is no longer accessible to new users" ([OpenAI SFT guide](https://developers.openai.com/api/docs/guides/supervised-fine-tuning)). Anthropic: the only supported path remains Claude 3 Haiku SFT on Amazon Bedrock us-west-2, 32K context ([Anthropic blog](https://claude.com/blog/fine-tune-claude-3-haiku)), a 2024-generation model. FineTuneBench measured commercial fine-tuning APIs at 37% average generalization accuracy on new facts and 19% on updated facts, with Gemini's APIs "unable to learn new knowledge" ([arXiv 2411.05059](https://arxiv.org/abs/2411.05059)). | Dead end for knowledge; marginal for style. |
+| (d) Classic ML on tabular / time series | Predictive questions with a measurable label: flow surprise, vol cone width, regime bands. Backtestable with purged CV and deflated Sharpe. | Needs feature engineering; no natural-language interface. | Bailey and Lopez de Prado, Deflated Sharpe Ratio ([SSRN 2460551](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2460551)); Radon's own `tasks/timeseries-model-backlog.md` already mandates "backtest every feature against a dumb baseline". |
+| (e) LoRA SFT on a 1B-9B open model, local | Format, schema adherence, house rules, tone, narrow classification; offline and private; cheap inference. | Poor at absorbing facts; forgets under repeated updates; small-data overfit; base model has memorized market history. | Gekhman et al.: LLMs "struggle to acquire new factual knowledge through fine-tuning" and as new-knowledge examples are learned they "linearly increase the model's tendency to hallucinate" ([EMNLP 2024](https://arxiv.org/abs/2405.05904)). Biderman et al.: LoRA "substantially underperforms full finetuning" on target-domain learning but "better maintains the base model's performance on tasks outside the target domain" ([arXiv 2405.09673](https://arxiv.org/abs/2405.09673)). |
+
+### Data-size thresholds
+
+The practitioner consensus and the vendor docs agree on rough bands. OpenAI's guide (still live) recommends starting with "50 well-crafted demonstrations" and expects visible improvement at 50-100 examples ([OpenAI SFT guide](https://developers.openai.com/api/docs/guides/supervised-fine-tuning)). LIMA showed 1,000 curated examples suffice for alignment-style behaviour on a 65B model ([arXiv 2305.11206](https://huggingface.co/papers/2305.11206)). The MLX practitioner guide places 50-100 examples at "tone/format shifts only", 200-500 as the "practical sweet spot" for specialized tasks, and 500-1,000+ for complex, high-variability tasks ([InsiderLLM MLX guide](https://insiderllm.com/guides/fine-tuning-mac-lora-mlx/)). A 3B-7B SFT recipe paper found larger batch sizes with lower learning rates and that early loss dynamics predict final quality ([arXiv 2412.13337](https://arxiv.org/abs/2412.13337)).
+
+Mapped to Radon: roughly 150 substantive eval reports and a few hundred rationale-bearing journal entries put decision traces in the "tone/format" to "sweet spot" band, not the "complex reasoning" band. Newsfeed tags (3,474 posts times 3 tags) are comfortably enough for a tagger.
+
+### The finance-specific dangers
+
+1. Regime learning. A model fine-tuned on a year of theses learns that year's regime. The financial sentiment literature shows "fine-tuned models suffer from general performance degradation in the presence of temporal distribution shifts" and that temporal shift "is prevalent in the financial text" ([EMNLP 2023, arXiv 2310.12620](https://arxiv.org/abs/2310.12620)). Radon's journal spans roughly Oct 2025 to now (cash-flow rows begin 2025-10 per `docs/performance-refactor-spec.md`), which is one regime.
+2. Lookahead contamination of the base model. Lopez-Lira, Tang and Zhu show GPT-4o recalls S&P 500 closes within 1% for dates inside its training window, and prove that under memorization "the capacity of the model to forecast is non-identified" ([arXiv 2504.14765](https://ideas.repec.org/p/arx/papers/2504.14765.html)). Gao, Jiang and Yan's Lookahead Propensity test finds LLM forecast skill "collapses essentially to zero" after the cutoff ([arXiv 2512.23847](https://arxiv.org/abs/2512.23847)). Any open model released in 2026 has seen at least part of the period Radon's journal covers, so "held-out past decisions" are contaminated as an edge test (they remain valid as a format/gate test).
+3. Continual-update forgetting. A 2026 mechanistic study across twenty models finds continual fine-tuning drives "systemic entropic dispersion" in early attention heads and "localized representation collapse" deeper, and that even the best subspace-regularized method recovers "up to 94.2%" of prior capability, not all of it ([arXiv 2601.18699](https://arxiv.org/abs/2601.18699)). "The Finetuner's Fallacy" argues domain data belongs in pretraining, not repeated fine-tuning, precisely because repetition at the fine-tuning stage invites overfitting and forgetting ([arXiv 2603.16177](https://arxiv.org/abs/2603.16177)). "SFT Memorizes, RL Generalizes" adds that SFT "tends to memorize training data and struggles to generalize out-of-distribution", while noting SFT is still needed to stabilize output format before any RL ([arXiv 2501.17161](https://arxiv.org/abs/2501.17161)).
+
+Recommendation from section 1: fine-tune only for behaviour that is stable across regimes (format, gates, taxonomy, voice), never for facts and never for edge.
+
+## 2. Realistic options for a solo operator with a Mac Mini and frontier API access
+
+### Base models (verified on the model cards, September 2026)
+
+| Model | Params | License | Context | Why it fits |
+|---|---|---|---|---|
+| [Qwen3.5-4B](https://huggingface.co/Qwen/Qwen3.5-4B) | 4B | Apache 2.0 | 262K native | Hybrid thinking on by default (disable for tagging); tool calling; the 0.8B-9B family launched Feb-Mar 2026 with the same architecture, so a tagger can start at 0.8B or 2B and a drafter at 4B or 9B. |
+| [Qwen3.5-9B](https://huggingface.co/Qwen/Qwen3.5-9B) | 9B | Apache 2.0 | 262K | Upper bound of what a 32 GB Mac Mini trains comfortably with QLoRA. |
+| [Gemma 4 E4B](https://ai.google.dev/gemma/docs/core/model_card_4) | 4.5B effective (8B with embeddings) | Apache 2.0 | 128K | Text, image and audio input; the image path matters because the newsfeed vision tagger currently runs on Claude Haiku 4.5 for posts with charts. Gemma 4 12B (256K) is the step up. |
+| SmolLM3 3B, Phi-4 mini | 3B-4B | Apache 2.0 / MIT | 128K | Fine fallbacks; no advantage over Qwen3.5-4B for this workload. |
+
+Llama 4 ships as Scout/Maverick MoE at sizes that do not fit this use case; skip it.
+
+### Tooling
+
+| Tool | Status on Apple Silicon | Notes |
+|---|---|---|
+| [mlx-lm](https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/LORA.md) | Native, first choice | `mlx_lm.lora --model <hf id> --train --data <dir> --iters 600`; supports `lora`, `dora`, `full`; JSONL in chat, prompt/completion or text form; `--mask-prompt` computes loss on assistant turns only; `mlx_lm.fuse` merges adapters. The docs' own datum: Mistral-7B LoRA at "about 250 tokens-per-second" on an M1 Max 32 GB with batch 1 and 4 layers. |
+| [mlx-tune](https://github.com/ARahim3/mlx-tune) (formerly unsloth-mlx) | Community, v0.6 pre-release | Unsloth-compatible API over MLX: SFT, DPO, GRPO, ORPO, KTO, VLM SFT for Gemma 4 and Qwen3.5 vision, QLoRA. GGUF export needs a non-quantized base. Not affiliated with Unsloth. |
+| Unsloth | Studio supports MLX per its [requirements page](https://unsloth.ai/docs/get-started/fine-tuning-for-beginners/unsloth-requirements); the core library is CUDA-first | Use it if you rent a GPU hour; not the Mac path. |
+| [Axolotl](https://github.com/axolotl-ai-cloud/axolotl/issues/295) | Partial M-series support, documented constraints around MPS, bitsandbytes, DeepSpeed | Skip on Mac. |
+| [HF TRL SFTTrainer](https://huggingface.co/docs/trl/sft_trainer) | Works via PyTorch MPS, slower than MLX | Useful as the dataset-format reference: TRL's conversational `messages` JSONL is the same shape mlx-lm accepts, so one dataset serves both. |
+| Ollama / llama.cpp | Inference | `web/lib/llm/provider.ts` already routes to Ollama-style OpenAI-compatible bases. |
+
+### Hardware and time
+
+Memory per the MLX guide: LoRA on 8B needs about 14 GB, QLoRA about 7 GB; 14B needs 24 GB / 12 GB ([InsiderLLM](https://insiderllm.com/guides/fine-tuning-mac-lora-mlx/)). A 16 GB Mac Mini therefore handles QLoRA up to 8B; 32 GB handles LoRA on 9B and QLoRA on 12B-14B; 64 GB is unnecessary for this plan. Throughput numbers quoted in the same guide range 200-320 tok/s for 8B LoRA on M-series Pro/Max chips; an M4 Pro at 273 GB/s bandwidth sits in that band ([DEV Community, Mac chips 2026](https://dev.to/macyou/run-local-llms-on-a-mac-in-2026-which-chip-runs-which-model-and-why-bandwidth-beats-cores-501k)).
+
+Estimate (mine, from those figures): a decision-trace set of 500 examples averaging 1,500 tokens is 750K tokens per epoch; at 250 tok/s that is 50 minutes per epoch on an 8B-9B model, roughly half on a 4B. Three epochs of a 4B drafter is an evening. A tagger on 0.8B-2B with 3,474 short examples trains in under an hour. Iteration count guidance from the guide: 300-600 iters for 200-500 examples, loss should flatten by 300-500.
+
+### Building the SFT dataset from Radon's artifacts
+
+Everything below is derivable from artifacts that already exist; connectors in `scripts/knowledge/sources/` already render most of it to text.
+
+| Source (verified shape) | Volume (verified as of 2026-07-20) | Training pair | Task type |
+|---|---|---|---|
+| `journal` rows: `payload` JSON with `ticker`, `structure`, `action`, `decision`, `thesis`, `gates_passed`, `risk_factors`, `target_exit`, `stop_loss`, `contracts`, `fill_price`, `pct_of_bankroll` (`journal.py:_render_rationale`) | 819 rows, but rows with `decision == "IB_AUTO_IMPORT"` are bare fills; thesis-bearing entries are the minority. `data/trade_log.json` entries with a `thesis` add more (the plan mentions duplicate ranges 1-19 and 635-677, implying roughly 680 entries, many stubs). Realistic: 150-300 usable decision traces. | Input: ticker + structure + flow summary. Output: thesis, gates named, risk factors, exit and stop. | Decision trace |
+| `reports/*.html` trade specs (10 required sections per `docs/reports.md`, chunked ~4,000 chars by `evals.py`) | 183 files minus `tweet-*` cards, minus files under 200 chars; realistic 120-160 substantive reports. | Input: milestone data (flow, options, context). Output: the full report in house format with four-gates summary and NO_TRADE handling. | Report drafting, format |
+| `posts` table: `title`, `content`, `images`, `tags`, `tags_text`, `tags_vision` | 3,474 posts, exactly 3 UPPERCASE-KEBAB tags each (`newsfeed/CLAUDE.md`), so ~10,400 tag labels already produced by Haiku 4.5 (vision) and Cerebras gpt-oss-120b (text). | Input: post title + body (+ image for VLM). Output: 3 tags in taxonomy form. | Classification (distilled from machine labels, see caveat) |
+| `docs/options-structures.{json,md}`, `docs/evaluation.md`, root `CLAUDE.md` gates and signal thresholds | Small, but can be expanded programmatically: synthetic gate cases (R:R below 2:1, Kelly above 2.5%, undefined risk) with the correct "stop, name the gate" answer. | Input: structure + numbers. Output: pass/fail with the named gate. | Rule compliance |
+| `assistant_turns` (migration 0030/0065) | Per-turn telemetry: `user_msg` truncated to 200 chars, tool calls, outcome; assistant text is not stored. | Not usable as traces today; would need a provenance-aware full-transcript store, which is a design decision (real account figures). | n/a |
+
+Caveat on the newsfeed labels: they are already machine outputs, so a local tagger is distilling a distilled label. The right teacher target is the merged `tags` column (post-`__normaliseTags`), with a 200-post operator-audited slice as the true test set.
+
+### Distillation from the frontier model's own Radon outputs
+
+This is the cheapest high-quality label source. The `evaluate` pipeline's milestone reasoning, produced by Claude in Claude Code sessions, is already the format the operator accepts. Two ways to get more of it: (1) harvest existing reports, (2) re-run past tickers through the pipeline with the flow snapshot frozen at the report date (the `scan_snapshots`, `gex_snapshots`, `vcg_snapshots` and `oi_changes` tables make this reproducible). Token cost is small: 3,474 posts at ~1,500 input tokens through Claude Haiku 4.5 ($1 per MTok input, $5 output) is about $5-8; 300 report regenerations at ~20K tokens each through Claude Sonnet 5 ($2 / $10 per MTok) is about $15-25 (prices from the Anthropic table cached 2026-06-24 in the claude-api skill).
+
+Policy check, verified: Anthropic's help center states "Our Terms do not allow the use of Outputs to train models that are competitive with Anthropic's own" and, on the permitted side, "You can use Claude's Outputs to train models that don't compete with Anthropic's own", listing sentiment analysis, content categorization, summarization, information extraction and anomaly detection ([Anthropic support](https://support.claude.com/en/articles/12326764-can-i-use-my-outputs-to-train-an-ai-model)). A newsfeed tagger, a report formatter and a gate-compliance checker are squarely in the permitted list. A general "Radon chatbot" trained on Claude transcripts to replace the assistant loop moves toward the restricted case. That policy boundary coincides with the technically sound boundary: keep the distilled model narrow.
+
+## 3. "Constantly studying my portfolio, news, trades": three different things
+
+| What the operator means | What it actually is | Right mechanism | Radon status |
+|---|---|---|---|
+| (i) "Knows my positions, today's flow, this morning's news" | Knowledge that changes hourly or daily | Retrieval and tools, not weights. Positions come from `portfolio_snapshots` and IB sync; flow from `scan_snapshots` / `gex_snapshots` / UW; news from `posts` and `headlines_ring`. | Built. Hourly KB ingest, assistant tools, MCP. Gap: the golden set is still `draft: true` and the evaluate pipeline's `prior_context` hook (KB plan Phase 4) is unbuilt. |
+| (ii) "Thinks like Radon: four gates, structure taxonomy, report shape, my voice, no rationalizing" | Skills, format, house rules, style | SFT / LoRA on curated traces; also achievable with prompt caching of the rules (Anthropic prompt caching, cache reads at a fraction of input price). | Partly in prompts. Not measured. |
+| (iii) "Learns which signals work" | Predictive edge | Classic ML with walk-forward backtests, purged CV, deflated Sharpe; tiny sample discipline. | Harness exists (`backtest_runs`, `forecast_calibration`, Chronos-2). |
+
+The failure mode to avoid is letting (i) or (iii) leak into (ii)'s training set. A decision trace that includes "NVDA at 182 with DPI 41%" teaches the model a stale fact and a regime; the same trace rewritten as "given DPI pace 1.3x prior and ask-dominant sweeps, gate 2 passes because..." teaches the reasoning pattern. The dataset builder should template facts as placeholders wherever the fact is retrievable at inference time.
+
+### Proposed continual pipeline
+
+```
+hourly   radon-knowledge.timer      ingest -> distill -> embed -> upsert   (exists)
+nightly  trace_builder.py           journal + reports + posts -> traces.jsonl (append, content_hash idempotent, facts templated)
+weekly   eval_suite.py              run frozen eval set against: frontier+RAG baseline, current adapter, candidate adapter
+monthly  mlx_lm.lora (LoRA, base frozen)   train on FULL accumulated trace set + replay, never the delta alone
+         promote adapter only if: format >= prior, gate compliance >= prior, hallucination <= prior, held-out agreement not worse by > 1 s.e.
+         else: keep prior adapter (adapters are small files; rollback = symlink)
+```
+
+Design rules and their sources:
+- Base weights frozen, LoRA only: "forgets less" ([Biderman et al.](https://arxiv.org/abs/2405.09673)). Full fine-tuning on a 4B model is feasible on a Mac but buys nothing here and costs general capability.
+- Retrain from scratch on the full accumulated set each cycle rather than continuing training on the new slice. Sequential continual fine-tuning is where the forgetting mechanisms in [arXiv 2601.18699](https://arxiv.org/abs/2601.18699) bite; a from-scratch LoRA on 500-1,000 examples takes an evening, so there is no reason to accept that risk. Mix in a general instruction replay slice (a few hundred generic chat examples) to hold format capability, which the replay literature reports as the simplest effective mitigation ([arXiv 2506.09428](https://arxiv.org/pdf/2506.09428)).
+- Time-split, never random-split, evaluation. The last 60-90 days of traces are held out; the model never sees them. This is the same walk-forward discipline the timeseries backlog already imposes.
+- Never train on news bodies as text (unsupervised continual pretraining). It is the weakest knowledge-injection method ([arXiv 2601.07054](https://arxiv.org/abs/2601.07054)) and the one most exposed to temporal drift ([arXiv 2310.12620](https://arxiv.org/abs/2310.12620)).
+- Never train on P&L outcomes as labels for the LLM. See section 4.
+
+## 4. Evaluation: measuring "tailored to Radon" honestly
+
+Radon already has one honest eval: the golden-set hit@5 gate. The model eval should have the same shape: a frozen set, a stated gate, a JSON summary on stdout, a systemd oneshot. Five metrics, in decreasing order of trust.
+
+| Metric | How | Automatable | Trust |
+|---|---|---|---|
+| Format adherence | Report has the 10 required sections; tags are exactly 3, match `^[A-Z0-9&-]+$`, dedup case-insensitively; NO_TRADE produces no structure or Kelly section. | Fully (regex + schema). | High |
+| Gate compliance | Synthetic cases: 200+ programmatically generated structures with known R:R and Kelly fraction. Model must say PASS/FAIL and name the gate. Note that the gates are enforced in code (`OrderRiskGate`, `order_limits.py`); the model's job is to invoke and narrate, not to be the calculator. Score naming accuracy, not arithmetic. | Fully. | High |
+| Hallucination rate on Radon facts | Closed-book questions from the golden set ("what was the EWY risk-reversal thesis?"). Correct behaviour for a small model is to call `search_knowledge`, not answer. Score: fabricated ticker, date or number per 100 answers, with and without retrieval. | Mostly (LLM-as-judge with a frontier model against the KB doc). | Medium-high |
+| Held-out decision agreement | Time-split last 60-90 days: does the model reach the same milestone-4 PASS/FAIL and the same structure family as the operator did? Report with a binomial confidence interval. With 30 held-out decisions a 70% agreement rate has a 95% interval of roughly 51-85%, so the metric is a trend indicator, not a verdict. | Semi (structured compare). | Medium; small n |
+| P&L-linked | Only through the existing backtest harness: the model's PASS/FAIL as a filter over a fixed universe, walk-forward, with purged CV and embargo, reported as a deflated Sharpe with the number of trials declared ([Bailey and Lopez de Prado](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2460551)). | Yes, but interpret with humility. | Low until n is in the hundreds of independent decisions per regime |
+
+What not to claim:
+- Not "the model learned my edge". With a few hundred decisions in one regime, any P&L lift is indistinguishable from noise and selection bias; DSR exists precisely because "high simulated performance is easily achievable after backtesting relatively few strategy configurations" ([Bailey and Lopez de Prado](https://sdm.lbl.gov/oapapers/ssrn-id2507040-bailey.pdf)).
+- Not "it predicted past trades correctly" for any date inside the base model's training window; per the memorization results ([Lopez-Lira et al.](https://ideas.repec.org/p/arx/papers/2504.14765.html), [Gao et al.](https://arxiv.org/abs/2512.23847)) forecast skill on that period is non-identified. Use pre-cutoff decisions for format and gate scoring only.
+- Not "it knows my portfolio" from weights. If a closed-book question about a position is answered without a tool call, that is a defect, not a feature.
+- Not "better than Claude". The comparison that matters is task-specific: tagger agreement with the audited slice, report format pass rate, gate naming accuracy. On open-ended analysis a 4B model will lose to the frontier model plus RAG, and the eval should show it.
+
+## 5. Recommendation: phased plan, costs, and what would not be useful
+
+### Recommendation in one paragraph
+
+Do Phase 0 now: it is cheap, it hardens the existing RAG, and it makes every later claim measurable. Do Phase 1 as a bounded experiment because privacy, offline operation and independence from a third-party tagger have some value even though the dollar saving is trivial. Do Phase 2 only if Phase 1's eval harness shows the distilled model holding format and gate compliance at or above the frontier baseline. Keep Phase 3 in the classic-ML lane where it already lives. Do not build a continual weight-update loop on news, positions or P&L.
+
+### Phase 0: dataset and baseline (1-3 days, $0 compute, under $30 API)
+
+1. `scripts/knowledge/traces.py` (new): render journal rationale rows, trade_log theses and substantive reports into `data/traces/traces.jsonl` in TRL/mlx-lm conversational format; template retrievable facts; content-hash idempotent; time-stamped for splits. Reuse `sources/journal.py` and `sources/evals.py` rendering.
+2. Curate the golden set out of `draft: true` (the KB plan already lists this as an operator follow-up). Add 20-30 closed-book hallucination probes.
+3. Audit 200 newsfeed posts' tags by hand; that is the tagger test set.
+4. Generate 200+ synthetic gate cases from `docs/options-structures.json`.
+5. Run the frontier + RAG baseline through the full eval suite and record it. This number is the bar every adapter must clear.
+
+Deliverable: `eval_suite.py` producing `{format, gates, hallucination, agreement}` JSON, plus the baseline row.
+
+### Phase 1: distilled "Radon analyst" for tagging and report drafting (1-2 days, a few Mac hours, $10-30 API)
+
+- Tagger: Qwen3.5-0.8B or 2B, LoRA via mlx-lm, 3,474 examples, target the merged `tags` column; VLM variant on Gemma 4 E4B via mlx-tune only if text-only tagging fails the audited slice. Serve through Ollama behind `provider.ts`. Acceptance: agreement with the audited slice within 3 points of the current pipeline.
+- Drafter: Qwen3.5-4B (or 9B on 32 GB), LoRA, 150-300 report traces plus gate cases plus a replay slice. Acceptance: format adherence and gate naming at or above the frontier baseline; hallucination probes answered by tool call.
+- Cost reality, stated plainly: the vision tagger costs about $0.003 per post (`scripts/newsfeed/CLAUDE.md`); at the observed ~20-25 posts per day (3,474 over roughly five months) that is under $30 a year. Report drafting through the frontier model is maybe a few dollars per evaluation. The local model does not pay for itself in API spend. Its value is latency, privacy for real account figures, and an offline fallback when the Cerebras or Anthropic key is missing (the newsfeed already needs one of the two).
+
+### Phase 2: decision-trace SFT with held-out eval (2-3 days, monthly thereafter)
+
+- Add the templated decision traces to the drafter's training set; retrain from scratch monthly on the full set; time-split hold-out of the last 60-90 days; promotion and rollback rule from section 3.
+- Wire the adapter into the assistant as a "draft" tool the frontier model can call, not as a replacement for the assistant loop. The frontier model plus RAG stays the decision surface; the small model formats and pre-fills.
+- Report agreement with confidence intervals every cycle. Expect it to be noisy for at least a year of accumulation.
+
+### Phase 3: signal models, separately (existing lane)
+
+Flow-surprise residuals, regime bands and the vol cone belong to Chronos-2 / gradient boosting with the `backtest_runs` harness, deflated Sharpe and a dumb-baseline gate, exactly as `tasks/timeseries-model-backlog.md` prescribes. Nothing in this report changes that plan except one addition: any LLM-derived feature (a tag, a sentiment, a PASS/FAIL) entering a backtest must be produced by a model whose training cutoff predates the backtest window, or the walk-forward is contaminated.
+
+### What would not be useful
+
+- Continual weight updates on daily news, positions or flow. Slower and worse than the hourly KB ingest that already exists; documented forgetting and drift risks.
+- Fine-tuning a frontier model via API in 2026. OpenAI is winding its platform down; Anthropic's path is Claude 3 Haiku on Bedrock only; FineTuneBench shows the approach barely injects knowledge anyway.
+- Training an LLM on P&L outcomes to "learn what works". Sample size, regime coverage and lookahead contamination make any result non-identifiable.
+- Full fine-tuning, or anything above 9B on a Mac Mini. More forgetting, more time, no measurable benefit at this data scale.
+- A general Radon chatbot distilled from Claude transcripts to replace the assistant loop. Quality regression on open-ended analysis and tool use, and it drifts toward the "competing model" clause of the provider terms.
+- Renting GPUs. Nothing in this plan needs more than the Mac.
+
+## Sources
+
+Radon repository (verified, read-only): `CLAUDE.md`, `scripts/CLAUDE.md`, `docs/evaluation.md`, `docs/reports.md`, `scripts/newsfeed/CLAUDE.md`, `scripts/db/migrations/0001_init.sql`, `0015_forecast_snapshots.sql`, `0016_forecast_calibration.sql`, `0018_backtest_runs.sql`, `0028_knowledge.sql`, `0030_assistant_turns.sql`, `0065_assistant_turns_provenance.sql`, `scripts/knowledge/{ingest,distill,embed,eval_golden,golden_set.json}`, `scripts/knowledge/sources/{journal,evals,newsfeed}.py`, `tasks/knowledge-base-plan.md`, `tasks/timeseries-model-backlog.md`, `web/lib/llm/provider.ts`, `docs/cloud-services.md` (backup drill: 37 tables / 80,171 rows, 2026-06-12).
+
+External:
+- Ovadia et al., Fine-Tuning or Retrieval? Comparing Knowledge Injection in LLMs: https://arxiv.org/abs/2312.05934
+- Fine-Tuning vs. RAG for Multi-Hop QA with Novel Knowledge (Jan 2026): https://arxiv.org/abs/2601.07054
+- FineTuneBench, commercial fine-tuning APIs and knowledge infusion: https://arxiv.org/abs/2411.05059
+- Gekhman et al., Does Fine-Tuning LLMs on New Knowledge Encourage Hallucinations? (EMNLP 2024): https://arxiv.org/abs/2405.05904
+- Biderman et al., LoRA Learns Less and Forgets Less: https://arxiv.org/abs/2405.09673
+- Chu et al., SFT Memorizes, RL Generalizes: https://arxiv.org/abs/2501.17161
+- Mechanistic Analysis of Catastrophic Forgetting During Continual Fine-tuning (2026): https://arxiv.org/abs/2601.18699
+- The Finetuner's Fallacy (2026): https://arxiv.org/abs/2603.16177
+- Improved SFT to Mitigate Catastrophic Forgetting (replay): https://arxiv.org/pdf/2506.09428
+- Temporal distribution shift in financial sentiment classification (EMNLP 2023): https://arxiv.org/abs/2310.12620
+- Lopez-Lira, Tang, Zhu, The Memorization Problem: https://ideas.repec.org/p/arx/papers/2504.14765.html
+- Gao, Jiang, Yan, Detecting Lookahead Bias in LLM Forecasts: https://arxiv.org/abs/2512.23847
+- Bailey and Lopez de Prado, The Deflated Sharpe Ratio: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2460551
+- LIMA: Less Is More for Alignment: https://huggingface.co/papers/2305.11206
+- Unveiling the Secret Recipe: SFT for Small LLMs: https://arxiv.org/abs/2412.13337
+- OpenAI supervised fine-tuning guide (wind-down notice, 50-100 example guidance): https://developers.openai.com/api/docs/guides/supervised-fine-tuning
+- OpenAI RFT billing ($100 per training hour): https://help.openai.com/en/articles/11323177-billing-guide-for-the-reinforcement-fine-tuning-api
+- Anthropic, Fine-tune Claude 3 Haiku in Amazon Bedrock: https://claude.com/blog/fine-tune-claude-3-haiku
+- Anthropic, Can I use my Outputs to train an AI model?: https://support.claude.com/en/articles/12326764-can-i-use-my-outputs-to-train-an-ai-model
+- Anthropic pricing: https://docs.claude.com/en/docs/about-claude/pricing
+- mlx-lm LoRA documentation: https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/LORA.md
+- InsiderLLM, Fine-Tuning on Mac: LoRA and QLoRA with MLX: https://insiderllm.com/guides/fine-tuning-mac-lora-mlx/
+- mlx-tune (Unsloth-compatible MLX trainer): https://github.com/ARahim3/mlx-tune
+- Unsloth requirements: https://unsloth.ai/docs/get-started/fine-tuning-for-beginners/unsloth-requirements
+- Axolotl Apple Silicon issue: https://github.com/axolotl-ai-cloud/axolotl/issues/295
+- HF TRL SFTTrainer: https://huggingface.co/docs/trl/sft_trainer
+- Qwen3.5-4B model card: https://huggingface.co/Qwen/Qwen3.5-4B
+- Qwen3.5-9B model card: https://huggingface.co/Qwen/Qwen3.5-9B
+- Gemma 4 model card: https://ai.google.dev/gemma/docs/core/model_card_4
+- Mac chips and bandwidth for local LLMs (2026): https://dev.to/macyou/run-local-llms-on-a-mac-in-2026-which-chip-runs-which-model-and-why-bandwidth-beats-cores-501k
+- Fine-tuned compact models vs GPT on classification (Springer): https://link.springer.com/chapter/10.1007/978-3-032-25314-9_5
+
+## Open questions for the operator
+
+1. Mac Mini memory: 16, 24, 32 or 64 GB? It decides 4B-LoRA versus 9B-LoRA versus 12B-QLoRA.
+2. How many journal rows carry a real `thesis` versus `IB_AUTO_IMPORT` stubs? One read-only count on Turso settles whether Phase 2 has 150 or 400 traces.
+3. Should full assistant transcripts be stored (with the R-454/R-457 provenance rules) so operator Q&A becomes a trace source? Today `assistant_turns` keeps only 200 characters of the user message.
+4. Is privacy of real account figures a strong enough reason on its own to run a local tagger and drafter, given the API saving is under $100 a year?
+5. Which surfaces, if any, should ever call the small model directly rather than through the frontier model as a tool? The recommendation is none for decisions.
+6. Golden set curation is still `draft: true` since 2026-07-18; Phase 0 depends on it.


### PR DESCRIPTION
Three research reports under `docs/research/`, requested 2026-09-12.

| Report | Words | Sources | Question it answers |
|---|---|---|---|
| [`radon-harness.md`](https://github.com/joemccann/radon/blob/research/harness-and-small-model/docs/research/radon-harness.md) | 5,109 | 37 | What is a domain-specific agent harness in 2025-2026 practice, what does Pi do that is worth copying, and what should Radon build |
| [`radon-small-model.md`](https://github.com/joemccann/radon/blob/research/harness-and-small-model/docs/research/radon-small-model.md) | 4,748 | 30 | Would training a small model on Radon's data be useful, and if so for what |
| [`radon-harness-and-model-roadmap.md`](https://github.com/joemccann/radon/blob/research/harness-and-small-model/docs/research/radon-harness-and-model-roadmap.md) | ~2,400 | companions only | Where the two meet, which comes first, one roadmap |

## The short version

**Harness:** Radon already has most of one, spread across `web/lib/assistant/` (17 typed tools, capability tiers, a destructive-tool halt), the Python gate and limit modules, the knowledge MCP server and the five nightly loops. Extract the loop into a provider-neutral `harness/` package shaped like Pi's `pi-agent-core`; run the four gates as code on every proposal in a `tool_call` block hook; persist replayable JSONL sessions; keep `place_order` a proposal the harness cannot execute. Claude Agent SDK for the nightly engineering loops only.

**Small model:** Not for knowledge (the hourly KB at hit@5 0.917 already beats weights; the literature is unambiguous). Yes, narrowly, for format, gates, taxonomy and voice: a LoRA on Qwen3.5-4B or Gemma 4 E4B via mlx-lm on the Mac Mini, from the 150-300 decision traces that exist plus ~10k newsfeed tag labels. The dollar case is weak (the tagger costs under $30 a year) and the report says so; the value is privacy, latency and offline fallback. Predictive edge stays in the backtest lane. No continual weight updates on news or P&L.

**Where they meet:** the harness's session store, with gate verdicts on every entry, is the training set; the small model is one provider entry the harness calls as a narrow tool. One `evals/` directory serves both questions. Harness extraction and persistence first; the dataset and a local tagger in parallel (they need nothing from the harness); decision-trace SFT last, after sessions have accumulated.

## Reading order

Roadmap first (it is short and points into the other two), then whichever track you want to start.

## Operator decisions the roadmap ends with

Eight, deduplicated from both reports, ordered by how early they block. The first two (full-transcript persistence with real account figures; one gate implementation or a TS twin) gate the first phase of each track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWTUCU1QEYA9zU6RUJomZp
